### PR TITLE
persist: component migration registry (W-4) (P5) (#2216)

### DIFF
--- a/engine/asset/include/irreden/asset/binary_io.hpp
+++ b/engine/asset/include/irreden/asset/binary_io.hpp
@@ -39,6 +39,8 @@ enum class BinaryIOError {
     ChunkOutOfBounds, ///< chunk-table entry points outside the file
     WriteFailed,      ///< fwrite returned fewer bytes than requested
     UnknownTag,       ///< unrecognized value/record discriminant byte (likely a newer writer)
+    MigratorMissing,  ///< a known component's on-disk version has no registered reader/migrator
+                      ///< (world snapshot P5)
 };
 
 /// Status payload returned by void-typed binary operations.

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -274,6 +274,47 @@ Deferring the *parse* to the final phase (which must run after phase 3, since
 live on a failed load — the "no partial world mutation on error" contract
 (Rule #5) is why only the mutation, not the parse, waits for phase 3.
 
+## Component migration registry (persist P5, #2216, epic #667)
+
+`engine/world/include/irreden/world/save_migration.hpp` declares
+`IRWorld::SaveMigration<C>` — the `(component, oldVersion) → reader`
+customization point that lets an old `IRWS` snapshot load into a newer build
+whose component has since bumped `SaveTrait<C>::kSaveVersion` (Save Format
+Extensibility Rule #3). It fills the seam P2 already stamped: every `ARCH`/`SNGL`
+column carries a `u32 saveVersion` header, and before P5 the loader **ignored
+it** — always reading at the current layout, which silently corrupts an old
+column. Now `SaveComponentEntry::readerForVersion(diskVersion)` dispatches four
+cases at load, in the mutation-free phase-2 gate (so any failure aborts with a
+pristine world, Rule #5):
+
+- **disk == current `kSaveVersion`** — the `SaveSerialize<C>::read` fast path
+  (`SaveComponentEntry::reader_`); no migrator lookup. Regresses nothing.
+- **disk < current** — the registered `SaveMigration<C>` reader for that
+  version, or (miss) a hard `BinaryIOError::MigratorMissing`. This is the **one
+  non-recoverable case**: reading old bytes at the current layout can't be
+  recovered from, so a known component at an unmigrated older version errors
+  out rather than degrading. Every other mismatch degrades gracefully.
+- **disk > current** — `BinaryIOError::VersionTooNew` (a future writer),
+  reusing the existing shape, naming the component + both versions.
+- **unknown component name** — resolves to no registry entry; the column skips
+  by byte length (`columnsSkipped_`), never reaching the version dispatch
+  (Rule #1 forward-compat, P2 behavior).
+
+**Direct per-version readers, never chained.** Each `SaveMigration<C>` entry
+decodes exactly its era's bytes straight to a current-build `C` (fields added
+since defaulted, renamed fields remapped); a v3 bump leaves the v1/v2 readers
+untouched. The current version is **not** listed in `SaveMigration<C>` —
+`SaveSerialize<C>::read` owns it; list only the retired `[1 .. kSaveVersion-1]`.
+The registry keys migrators on the current session-local `ComponentId` and the
+disk column key stays `SaveTrait<C>::kSaveName` (Rule #2) — never
+`typeid(C).name()`, which is compiler-mangled and would make a macOS save
+unreadable on Windows. Registration is `if constexpr`-gated on `shouldSave<C>()`
+(like `SaveSerialize<C>`), so an opted-out component never needs a migrator.
+The `SaveMigration<C>` header block has the worked specialization example; the
+generic loader path is proven end-to-end (v1→v2, `VersionTooNew`,
+`MigratorMissing`, unknown-skip compose, current fast path) in
+`test/world/component_migration_test.cpp`.
+
 ## Responsibilities
 
 `World(const char* configFileName)`:

--- a/engine/world/include/irreden/world/save_migration.hpp
+++ b/engine/world/include/irreden/world/save_migration.hpp
@@ -1,0 +1,84 @@
+#ifndef SAVE_MIGRATION_H
+#define SAVE_MIGRATION_H
+
+/// Per-component schema-migration customization point for the ECS world
+/// snapshot (persist P5, #2216, epic #667). P1 (`save_trait.hpp`) decides
+/// *whether* a component is saved and its current `kSaveVersion`; P2's
+/// `save_serialize.hpp` decides *how* the current version's bytes read; this
+/// header decides how a **retired** on-disk version reads.
+///
+/// The `ARCH`/`SNGL` chunks stamp every column with the `kSaveVersion` it was
+/// written at. When an old snapshot is loaded into a newer build whose
+/// component has since bumped its version, the load-time dispatch (see
+/// `save_registry.hpp`'s `SaveComponentEntry::readerForVersion`) needs a reader
+/// for the *disk-side* layout — reading old bytes at the current layout would
+/// silently corrupt (Save Format Extensibility Rule #3). `SaveMigration<C>`
+/// is where a component declares that reader.
+///
+/// The primary template declares **no** migrators — correct for any component
+/// that has never changed its serialized schema (`kSaveVersion == 1`, or a
+/// later version reached purely by additive fields the current
+/// `SaveSerialize<C>::read` still parses). A component that retires a version
+/// specializes this, mirroring the `SaveSerialize<C>` pattern:
+///
+/// ```cpp
+/// // C_Foo evolved v1 -> v2 by appending a defaulted `damping_` field.
+/// namespace IRWorld {
+/// template <> struct SaveMigration<C_Foo> {
+///     static std::vector<std::pair<std::uint32_t, ColumnMigratorFn<C_Foo>>>
+///     migrators() {
+///         return {
+///             {1u, [](IRAsset::BinaryReader &r) -> IRAsset::Result<C_Foo> {
+///                  // read exactly the v1 layout; default the appended field
+///                  IRAsset::Result<float> vel = r.readF32();
+///                  if (!vel.ok())
+///                      return IRAsset::Result<C_Foo>::error(vel.status_.code_,
+///                                                           vel.status_.message_);
+///                  return IRAsset::Result<C_Foo>::success(C_Foo{vel.value_, 0.0f});
+///              }},
+///         };
+///     }
+/// };
+/// } // namespace IRWorld
+/// ```
+///
+/// Contract:
+///   - **Direct per-version readers, never chained.** Each reader decodes its
+///     own era's bytes straight to a current-build `C`; a v3 bump leaves the
+///     v1/v2 readers untouched. No `v1 -> v2 -> v3` composition.
+///   - **The current version is NOT listed here** — `SaveSerialize<C>::read`
+///     handles `kSaveVersion`; list only the retired versions
+///     (`[1 .. kSaveVersion - 1]`).
+///   - A disk version below `kSaveVersion` with no entry here is a hard
+///     `BinaryIOError::MigratorMissing` on load (never a silent read-at-current);
+///     a disk version above `kSaveVersion` is `VersionTooNew`.
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace IRWorld {
+
+/// Reader for one retired on-disk version of component `C`: consumes exactly
+/// that version's bytes from @p r and yields a fully-populated current-build
+/// `C` (fields added since are defaulted, renamed fields remapped). Type-bound
+/// to `C`; the registry erases it into the generic column-read hooks.
+template <typename C>
+using ColumnMigratorFn = std::function<IRAsset::Result<C>(IRAsset::BinaryReader &)>;
+
+/// Customization point declaring how to read component `C` at each retired
+/// on-disk version. Specialize for a component that has bumped
+/// `SaveTrait<C>::kSaveVersion`; the primary template declares none.
+template <typename C> struct SaveMigration {
+    /// `(fromVersion, reader)` pairs — one per retired version. Default: none.
+    static std::vector<std::pair<std::uint32_t, ColumnMigratorFn<C>>> migrators() {
+        return {};
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* SAVE_MIGRATION_H */

--- a/engine/world/include/irreden/world/save_registry.hpp
+++ b/engine/world/include/irreden/world/save_registry.hpp
@@ -30,6 +30,7 @@
 /// needs a `SaveSerialize<C>` specialization for its non-POD fields — is
 /// downstream work, not this slice.
 
+#include <irreden/world/save_migration.hpp>
 #include <irreden/world/save_serialize.hpp>
 #include <irreden/world/save_trait.hpp>
 
@@ -46,6 +47,25 @@
 
 namespace IRWorld {
 
+/// The three type-erased read hooks for one on-disk *version* of a component
+/// — how its bytes turn back into a live value. The current version and each
+/// retired version (a P5 migrator) share this shape, so the load-time version
+/// dispatch (`SaveComponentEntry::readerForVersion`) can hand back whichever
+/// applies as one uniform handle. The zero-mutation `decodeRow_` dry run the
+/// load's phase-2 gate runs over every column exercises the exact same read
+/// path as `appendRow_` / `readIntoEntity_`, so a length-valid-but-corrupt
+/// column fails validation rather than aborting mid-apply.
+struct ColumnReadHooks {
+    // Deserialize one instance and append it to a live column.
+    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::IComponentData *)>
+        appendRow_;
+    // Decode one serialized instance and discard it, reporting only the status.
+    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &)> decodeRow_;
+    // Deserialize one instance and overwrite it onto a live entity (SNGL read).
+    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::EntityId)>
+        readIntoEntity_;
+};
+
 /// One opted-in component's type-erased save/load hooks. Function objects
 /// are stateless (they close over the compile-time type only), so building
 /// the registry is a handful of small allocations done once per save/load
@@ -57,24 +77,73 @@ struct SaveComponentEntry {
 
     // Serialize the component at `row` of a live column.
     std::function<void(IRAsset::BinaryWriter &, IREntity::IComponentData *, int)> writeRow_;
-    // Deserialize one instance and append it to a live column.
-    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::IComponentData *)>
-        appendRow_;
-    // Decode one serialized instance and discard it, reporting only the
-    // status. The zero-mutation dry run the load's phase-2 gate runs over
-    // every column before phase 3 touches the live graph: it exercises the
-    // exact `SaveSerialize<C>::read` path `appendRow_` / `readIntoEntity_`
-    // take, so a length-valid-but-corrupt column fails validation rather than
-    // aborting mid-apply after entities are already spliced in.
-    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &)> decodeRow_;
+
+    // Read hooks for the *current* schema version (`saveVersion_`) — the
+    // `SaveSerialize<C>::read` fast path.
+    ColumnReadHooks reader_;
+    // Read hooks for each retired on-disk version, keyed by that version
+    // (persist P5, #2216). Populated from `SaveMigration<C>::migrators()`; a
+    // component that never changed its schema leaves this empty. The current
+    // version is NOT keyed here — `reader_` owns it.
+    std::unordered_map<std::uint32_t, ColumnReadHooks> migratorReaders_;
 
     // Lazily get-or-create the singleton entity owning this component.
     std::function<IREntity::EntityId()> getOrCreateSingletonEntity_;
     // Serialize the component value held by a live entity (SNGL write).
     std::function<void(IRAsset::BinaryWriter &, IREntity::EntityId)> writeSingleton_;
-    // Deserialize one instance and overwrite it onto a live entity (SNGL read).
-    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::EntityId)>
-        readIntoEntity_;
+
+    /// Resolve the read hooks for a column/singleton written at @p diskVersion,
+    /// the P5 migration dispatch. Four cases (the unknown-component name case —
+    /// no entry at all — is handled by the loader before this is reached):
+    ///   - `diskVersion == saveVersion_` — current fast path (`reader_`).
+    ///   - `diskVersion <  saveVersion_` — a registered migrator, or (miss) a
+    ///     hard `MigratorMissing` error: reading old bytes at the current
+    ///     layout silently corrupts, so this is the one case that must fail.
+    ///   - `diskVersion >  saveVersion_` — `VersionTooNew` (a future writer).
+    /// On success returns non-null and leaves @p status untouched; on failure
+    /// returns nullptr and sets @p status to the diagnostic.
+    const ColumnReadHooks *
+    readerForVersion(std::uint32_t diskVersion, IRAsset::BinaryStatus &status) const {
+        if (diskVersion == saveVersion_) {
+            return &reader_;
+        }
+        if (diskVersion > saveVersion_) {
+            status = IRAsset::BinaryStatus::error(
+                IRAsset::BinaryIOError::VersionTooNew,
+                saveName_ + ": on-disk version " + std::to_string(diskVersion) +
+                    " is newer than this build reads (v" + std::to_string(saveVersion_) + ")"
+            );
+            return nullptr;
+        }
+        const auto it = migratorReaders_.find(diskVersion);
+        if (it != migratorReaders_.end()) {
+            return &it->second;
+        }
+        status = IRAsset::BinaryStatus::error(
+            IRAsset::BinaryIOError::MigratorMissing,
+            missingMsg(diskVersion)
+        );
+        return nullptr;
+    }
+
+  private:
+    // Diagnostic for a known component at an older version with no migrator.
+    std::string missingMsg(std::uint32_t diskVersion) const {
+        std::string msg = saveName_ + ": no migrator for on-disk version " +
+                          std::to_string(diskVersion) + " (this build reads v" +
+                          std::to_string(saveVersion_) +
+                          "; register a SaveMigration<C> reader for it)";
+        if (!migratorReaders_.empty()) {
+            std::uint32_t lowest = diskVersion;
+            for (const auto &kv : migratorReaders_) {
+                if (kv.first < lowest) {
+                    lowest = kv.first;
+                }
+            }
+            msg += " — registered migrators start at v" + std::to_string(lowest);
+        }
+        return msg;
+    }
 };
 
 class SaveRegistry {
@@ -99,34 +168,24 @@ class SaveRegistry {
                     IREntity::castComponentDataPointer<C>(col)->dataVector[row]
                 );
             };
-            entry.appendRow_ = [](IRAsset::BinaryReader &r,
-                                  IREntity::IComponentData *col) -> IRAsset::BinaryStatus {
-                IRAsset::Result<C> res = SaveSerialize<C>::read(r);
-                if (!res.ok()) {
-                    return res.status_;
-                }
-                IREntity::castComponentDataPointer<C>(col)->dataVector.push_back(
-                    std::move(res.value_)
+            // Current-version reader: the SaveSerialize<C>::read fast path.
+            entry.reader_ =
+                buildReader<C>([](IRAsset::BinaryReader &r) { return SaveSerialize<C>::read(r); });
+            // Retired-version readers (persist P5, #2216) — one erased reader
+            // per SaveMigration<C> entry. Empty for a component whose schema
+            // never changed; SaveMigration<C> is instantiated only inside this
+            // shouldSave<C>() branch, so an opted-out C never needs one.
+            for (auto &versioned : SaveMigration<C>::migrators()) {
+                entry.migratorReaders_.emplace(
+                    versioned.first,
+                    buildReader<C>(std::move(versioned.second))
                 );
-                return IRAsset::BinaryStatus::success();
-            };
-            entry.decodeRow_ = [](IRAsset::BinaryReader &r) -> IRAsset::BinaryStatus {
-                return SaveSerialize<C>::read(r).status_;
-            };
+            }
             entry.getOrCreateSingletonEntity_ = []() -> IREntity::EntityId {
                 return IREntity::singletonEntity<C>();
             };
             entry.writeSingleton_ = [](IRAsset::BinaryWriter &w, IREntity::EntityId entity) {
                 SaveSerialize<C>::write(w, IREntity::getComponent<C>(entity));
-            };
-            entry.readIntoEntity_ = [](IRAsset::BinaryReader &r,
-                                       IREntity::EntityId entity) -> IRAsset::BinaryStatus {
-                IRAsset::Result<C> res = SaveSerialize<C>::read(r);
-                if (!res.ok()) {
-                    return res.status_;
-                }
-                IREntity::setComponent<C>(entity, std::move(res.value_));
-                return IRAsset::BinaryStatus::success();
             };
 
             const std::size_t index = m_entries.size();
@@ -161,6 +220,37 @@ class SaveRegistry {
     }
 
   private:
+    // Erase a per-version read function (the SaveSerialize<C>::read current
+    // fast path, or a SaveMigration<C> retired-version reader) into the three
+    // generic column-read hooks. Shared so the current reader and every
+    // migrator are built identically — the only difference is which `readFn`
+    // decodes the bytes.
+    template <typename C> static ColumnReadHooks buildReader(ColumnMigratorFn<C> readFn) {
+        ColumnReadHooks hooks;
+        hooks.appendRow_ = [readFn](IRAsset::BinaryReader &r, IREntity::IComponentData *col)
+            -> IRAsset::BinaryStatus {
+            IRAsset::Result<C> res = readFn(r);
+            if (!res.ok()) {
+                return res.status_;
+            }
+            IREntity::castComponentDataPointer<C>(col)->dataVector.push_back(std::move(res.value_));
+            return IRAsset::BinaryStatus::success();
+        };
+        hooks.decodeRow_ = [readFn](IRAsset::BinaryReader &r) -> IRAsset::BinaryStatus {
+            return readFn(r).status_;
+        };
+        hooks.readIntoEntity_ =
+            [readFn](IRAsset::BinaryReader &r, IREntity::EntityId entity) -> IRAsset::BinaryStatus {
+            IRAsset::Result<C> res = readFn(r);
+            if (!res.ok()) {
+                return res.status_;
+            }
+            IREntity::setComponent<C>(entity, std::move(res.value_));
+            return IRAsset::BinaryStatus::success();
+        };
+        return hooks;
+    }
+
     std::vector<SaveComponentEntry> m_entries;
     std::unordered_map<std::string, std::size_t> m_byName;
     std::unordered_map<IREntity::ComponentId, std::size_t> m_byComponentId;

--- a/engine/world/include/irreden/world/save_registry.hpp
+++ b/engine/world/include/irreden/world/save_registry.hpp
@@ -38,6 +38,7 @@
 #include <irreden/entity/i_component_data.hpp>
 #include <irreden/entity/ir_entity_types.hpp>
 #include <irreden/ir_entity.hpp>
+#include <irreden/ir_profile.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -176,9 +177,15 @@ class SaveRegistry {
             // never changed; SaveMigration<C> is instantiated only inside this
             // shouldSave<C>() branch, so an opted-out C never needs one.
             for (auto &versioned : SaveMigration<C>::migrators()) {
-                entry.migratorReaders_.emplace(
-                    versioned.first,
-                    buildReader<C>(std::move(versioned.second))
+                const bool inserted =
+                    entry.migratorReaders_
+                        .emplace(versioned.first, buildReader<C>(std::move(versioned.second)))
+                        .second;
+                IR_ASSERT(
+                    inserted,
+                    "SaveMigration<{}>::migrators() lists fromVersion {} more than once",
+                    name,
+                    versioned.first
                 );
             }
             entry.getOrCreateSingletonEntity_ = []() -> IREntity::EntityId {

--- a/engine/world/include/irreden/world/world_snapshot.hpp
+++ b/engine/world/include/irreden/world/world_snapshot.hpp
@@ -25,7 +25,11 @@
 ///     IDs (ascending raw ids), then one column per component
 ///     (`u32 saveVersion` + `varuint byteLength` + rows in entity order).
 ///     The per-column `(version, byteLength)` header is the P5 migration
-///     seam: an unresolvable column is skipped by byte length, not fatal.
+///     seam: the load dispatches the `saveVersion` through
+///     `SaveComponentEntry::readerForVersion` (`save_migration.hpp`) —
+///     current fast path, a registered migrator, or a `MigratorMissing` /
+///     `VersionTooNew` error — and an unresolvable component name is skipped
+///     by byte length, not fatal.
 ///   - **`SNGL`** — singleton components, restored *by value* onto the
 ///     live (post-reset preserved) singleton entity, not by re-inserting
 ///     an archetype row. Per entry: local index + saved raw entity id +

--- a/engine/world/src/world_snapshot.cpp
+++ b/engine/world/src/world_snapshot.cpp
@@ -576,13 +576,22 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
                 continue;
             }
             const StagedColumn &column = staged.columns_[c];
+            // P5 migration dispatch: resolve the reader for the column's
+            // on-disk version (current, migrator, or a VersionTooNew /
+            // MigratorMissing error). Runs in the zero-mutation phase, so an
+            // unmigratable version aborts before phase 3 touches the world.
+            IRAsset::BinaryStatus versionStatus;
+            const ColumnReadHooks *reader = entry->readerForVersion(column.version_, versionStatus);
+            if (reader == nullptr) {
+                return loadFail(versionStatus);
+            }
             IRAsset::MemoryBinaryReader r(arch->data_.data(), arch->data_.size(), "ARCH");
             IRAsset::BinaryStatus seek = r.seek(column.dataOffset_);
             if (!seek.ok()) {
                 return loadFail(seek);
             }
             for (std::size_t e = 0; e < staged.entityIds_.size(); ++e) {
-                IRAsset::BinaryStatus rowStatus = entry->decodeRow_(r);
+                IRAsset::BinaryStatus rowStatus = reader->decodeRow_(r);
                 if (!rowStatus.ok()) {
                     return loadFail(rowStatus);
                 }
@@ -594,12 +603,18 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
         if (entry == nullptr) {
             continue;
         }
+        IRAsset::BinaryStatus versionStatus;
+        const ColumnReadHooks *reader =
+            entry->readerForVersion(staged.column_.version_, versionStatus);
+        if (reader == nullptr) {
+            return loadFail(versionStatus);
+        }
         IRAsset::MemoryBinaryReader r(sngl->data_.data(), sngl->data_.size(), "SNGL");
         IRAsset::BinaryStatus seek = r.seek(staged.column_.dataOffset_);
         if (!seek.ok()) {
             return loadFail(seek);
         }
-        IRAsset::BinaryStatus valueStatus = entry->decodeRow_(r);
+        IRAsset::BinaryStatus valueStatus = reader->decodeRow_(r);
         if (!valueStatus.ok()) {
             return loadFail(valueStatus);
         }
@@ -658,6 +673,14 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
                 ++result.columnsSkipped_; // unresolvable component — skipped by byte length
                 continue;
             }
+            // Same P5 version dispatch phase 2b already validated; re-resolve
+            // for the append hooks (a version error here would be a phase-2b
+            // bug, but the null-check keeps the apply path honest).
+            IRAsset::BinaryStatus versionStatus;
+            const ColumnReadHooks *reader = entry->readerForVersion(column.version_, versionStatus);
+            if (reader == nullptr) {
+                return loadFail(versionStatus);
+            }
             IRAsset::MemoryBinaryReader r(arch->data_.data(), arch->data_.size(), "ARCH");
             IRAsset::BinaryStatus seek = r.seek(column.dataOffset_);
             if (!seek.ok()) {
@@ -665,7 +688,7 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
             }
             IREntity::IComponentData *col = node->components_.at(entry->componentId_).get();
             for (std::size_t e = 0; e < staged.entityIds_.size(); ++e) {
-                IRAsset::BinaryStatus rowStatus = entry->appendRow_(r, col);
+                IRAsset::BinaryStatus rowStatus = reader->appendRow_(r, col);
                 if (!rowStatus.ok()) {
                     return loadFail(rowStatus);
                 }
@@ -684,13 +707,22 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
             ++result.singletonsSkipped_;
             continue;
         }
+        // Resolve the versioned reader before the lazy singleton get-or-create,
+        // so a (phase-2b-validated) version can't strand a freshly-minted
+        // singleton entity on an error path.
+        IRAsset::BinaryStatus versionStatus;
+        const ColumnReadHooks *reader =
+            entry->readerForVersion(staged.column_.version_, versionStatus);
+        if (reader == nullptr) {
+            return loadFail(versionStatus);
+        }
         const EntityId liveEntity = entry->getOrCreateSingletonEntity_();
         IRAsset::MemoryBinaryReader r(sngl->data_.data(), sngl->data_.size(), "SNGL");
         IRAsset::BinaryStatus seek = r.seek(staged.column_.dataOffset_);
         if (!seek.ok()) {
             return loadFail(seek);
         }
-        IRAsset::BinaryStatus valueStatus = entry->readIntoEntity_(r, liveEntity);
+        IRAsset::BinaryStatus valueStatus = reader->readIntoEntity_(r, liveEntity);
         if (!valueStatus.ok()) {
             return loadFail(valueStatus);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ add_executable(IrredenEngineTest
   world/world_snapshot_test.cpp
   world/world_snapshot_relations_test.cpp
   world/persist_round_trip_test.cpp
+  world/component_migration_test.cpp
 )
 
 FetchContent_Declare(

--- a/test/world/component_migration_test.cpp
+++ b/test/world/component_migration_test.cpp
@@ -1,0 +1,343 @@
+#include <gtest/gtest.h>
+
+#include <irreden/world/save_migration.hpp>
+#include <irreden/world/save_registry.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_trait.hpp>
+#include <irreden/world/world_snapshot.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+// Persist P5 (#2216, epic #667): the `(ComponentId, oldVersion) -> reader`
+// component-migration registry. The `ARCH`/`SNGL` chunks stamp each column
+// with the `kSaveVersion` it was written at (persist P2's migration seam);
+// this suite proves the load-time dispatch on that stamp — current fast path,
+// a registered v1->v2 migrator, and the two hard-failure diagnostics
+// (`VersionTooNew`, `MigratorMissing`) — over hand-built `IRWS` files, since
+// `saveWorld` can only ever emit the *current* version.
+//
+// A dedicated test-local component (`C_Mig`) carries the worked v1->v2
+// migration rather than mutating a real gameplay component with a
+// permanently-dead field — the committed fallback in the plan's acceptance
+// note, exercised through the identical generic loader path.
+namespace MigTest {
+// Current build: C_Mig is at v2 = { kept_, added_ }, evolved from the retired
+// v1 = { kept_ } by appending a defaulted `added_`.
+struct C_Mig {
+    std::int32_t kept_ = 0;
+    std::int32_t added_ = 0;
+};
+// At v2 but declares NO migrator: a retired-version column of it must
+// hard-fail `MigratorMissing`, never silently read old bytes at the current
+// layout. Trivially copyable -> the default raw-image SaveSerialize.
+struct C_NoMigrator {
+    std::int32_t value_ = 0;
+};
+// Never registered in the load registry -> its column skips by byte length.
+struct C_Unknown {
+    std::int32_t junk_ = 0;
+};
+} // namespace MigTest
+
+IR_SAVE_OPT_IN(MigTest::C_Mig, 2)
+IR_SAVE_OPT_IN(MigTest::C_NoMigrator, 2)
+IR_SAVE_OPT_IN(MigTest::C_Unknown, 1)
+
+namespace IRWorld {
+// Current (v2) serializer: kept_ then added_.
+template <> struct SaveSerialize<MigTest::C_Mig> {
+    static void write(IRAsset::BinaryWriter &w, const MigTest::C_Mig &value) {
+        w.writeI32(value.kept_);
+        w.writeI32(value.added_);
+    }
+    static IRAsset::Result<MigTest::C_Mig> read(IRAsset::BinaryReader &r) {
+        IRAsset::Result<std::int32_t> kept = r.readI32();
+        if (!kept.ok()) {
+            return IRAsset::Result<MigTest::C_Mig>::error(
+                kept.status_.code_,
+                kept.status_.message_
+            );
+        }
+        IRAsset::Result<std::int32_t> added = r.readI32();
+        if (!added.ok()) {
+            return IRAsset::Result<MigTest::C_Mig>::error(
+                added.status_.code_,
+                added.status_.message_
+            );
+        }
+        return IRAsset::Result<MigTest::C_Mig>::success(MigTest::C_Mig{kept.value_, added.value_});
+    }
+};
+// The retired v1 reader: reads only kept_ off the v1 layout, defaults added_.
+// Direct per-version reader (Rule #3) — yields a current-build C_Mig.
+template <> struct SaveMigration<MigTest::C_Mig> {
+    static std::vector<std::pair<std::uint32_t, ColumnMigratorFn<MigTest::C_Mig>>> migrators() {
+        return {
+            {1u, [](IRAsset::BinaryReader &r) -> IRAsset::Result<MigTest::C_Mig> {
+                 IRAsset::Result<std::int32_t> kept = r.readI32();
+                 if (!kept.ok()) {
+                     return IRAsset::Result<MigTest::C_Mig>::error(
+                         kept.status_.code_,
+                         kept.status_.message_
+                     );
+                 }
+                 return IRAsset::Result<MigTest::C_Mig>::success(
+                     MigTest::C_Mig{kept.value_, 0 /* defaulted */}
+                 );
+             }},
+        };
+    }
+};
+} // namespace IRWorld
+
+namespace {
+
+using namespace MigTest;
+using IREntity::EntityId;
+
+// One serialized column of an `IRWS` file: the disk save-name, the on-disk
+// version stamp, and every row's bytes already laid out in entity order.
+struct BuiltColumn {
+    std::string saveName_;
+    std::uint32_t version_ = 1;
+    std::vector<std::uint8_t> bytes_;
+};
+
+class MigrationTest : public testing::Test {
+  protected:
+    std::string tempPath(const char *name) const {
+        return testing::TempDir() + "/ir_mig_" + name + ".irws";
+    }
+
+    // Emit a minimal single-archetype `IRWS` file matching world_snapshot.cpp's
+    // chunk layout (CMPN + ARCH + META; SNGL/RELN absent are a clean no-op).
+    // `cmpnNames` is the local-index key space; `columns` are one-per
+    // `archLocalIndices`, in the same order.
+    void writeIrws(
+        const std::string &path,
+        const std::vector<std::string> &cmpnNames,
+        const std::vector<std::uint32_t> &archLocalIndices,
+        const std::vector<EntityId> &entityIds,
+        const std::vector<BuiltColumn> &columns,
+        EntityId watermark
+    ) const {
+        IRAsset::MemoryBinaryWriter cmpn;
+        cmpn.writeVarUInt(cmpnNames.size());
+        for (const std::string &name : cmpnNames) {
+            cmpn.writeString(name);
+        }
+
+        IRAsset::MemoryBinaryWriter arch;
+        arch.writeVarUInt(1); // one archetype group
+        arch.writeVarUInt(archLocalIndices.size());
+        for (const std::uint32_t li : archLocalIndices) {
+            arch.writeVarUInt(li);
+        }
+        arch.writeVarUInt(entityIds.size());
+        for (const EntityId id : entityIds) {
+            arch.writeVarUInt(id);
+        }
+        for (const BuiltColumn &col : columns) {
+            arch.writeU32(col.version_);
+            arch.writeVarUInt(col.bytes_.size());
+            arch.writeBytes(col.bytes_.data(), col.bytes_.size());
+        }
+
+        IRAsset::MemoryBinaryWriter meta;
+        meta.writeVarUInt(watermark);
+        meta.writeVarUInt(entityIds.size());
+
+        std::vector<IRAsset::ChunkPayload> chunks;
+        chunks.push_back({IRAsset::makeTag("CMPN"), cmpn.takeBuffer()});
+        chunks.push_back({IRAsset::makeTag("ARCH"), arch.takeBuffer()});
+        chunks.push_back({IRAsset::makeTag("META"), meta.takeBuffer()});
+
+        IRAsset::FileBinaryWriter w(path);
+        ASSERT_TRUE(w.ok());
+        ASSERT_TRUE(
+            IRAsset::writeChunked(
+                w,
+                IRWorld::kWorldSnapshotMagic,
+                IRWorld::kWorldSnapshotVersion,
+                chunks
+            )
+                .ok()
+        );
+    }
+
+    // Restore ids well above IR_RESERVED_ENTITIES (0xFF) + the handful of
+    // backing entities registration mints, so they are guaranteed free.
+    IREntity::EntityManager m_em; // ctor sets g_entityManager -> this
+};
+
+// Acceptance #1: worked v1->v2 migration — the retired reader preserves the v1
+// field and defaults the field appended in v2, end-to-end through the loader.
+TEST_F(MigrationTest, WorkedV1ToV2Migration) {
+    const std::vector<EntityId> ids{1000, 1001, 1002};
+    const std::vector<std::int32_t> kept{11, 22, 33};
+    IRAsset::MemoryBinaryWriter col;
+    for (const std::int32_t k : kept) {
+        col.writeI32(k); // v1 layout: kept_ only
+    }
+    const std::string path = tempPath("v1_to_v2");
+    ASSERT_NO_FATAL_FAILURE(writeIrws(
+        path,
+        {IRWorld::saveName<C_Mig>()},
+        {0},
+        ids,
+        {BuiltColumn{IRWorld::saveName<C_Mig>(), 1u, col.takeBuffer()}},
+        2000
+    ));
+
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_Mig>();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.entitiesRestored_, 3u);
+
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        ASSERT_TRUE(m_em.entityExists(ids[i])) << "missing id " << ids[i];
+        const C_Mig &m = m_em.getComponent<C_Mig>(ids[i]);
+        EXPECT_EQ(m.kept_, kept[i]); // v1 field preserved exactly
+        EXPECT_EQ(m.added_, 0);      // v2's appended field defaulted
+    }
+}
+
+// Acceptance #5: a current-version column dispatches straight to the current
+// reader (never the migrator) — the fast path regresses nothing. `added_`
+// comes back as the real saved value, proving the migrator did NOT run.
+TEST_F(MigrationTest, CurrentVersionFastPath) {
+    const std::vector<EntityId> ids{1000, 1001};
+    const std::vector<std::pair<std::int32_t, std::int32_t>> vals{{5, 6}, {7, 8}};
+    IRAsset::MemoryBinaryWriter col;
+    for (const auto &v : vals) {
+        col.writeI32(v.first);  // v2 layout: kept_
+        col.writeI32(v.second); //            added_
+    }
+    const std::string path = tempPath("current");
+    ASSERT_NO_FATAL_FAILURE(writeIrws(
+        path,
+        {IRWorld::saveName<C_Mig>()},
+        {0},
+        ids,
+        {BuiltColumn{IRWorld::saveName<C_Mig>(), 2u, col.takeBuffer()}},
+        2000
+    ));
+
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_Mig>();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.entitiesRestored_, 2u);
+
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        const C_Mig &m = m_em.getComponent<C_Mig>(ids[i]);
+        EXPECT_EQ(m.kept_, vals[i].first);
+        EXPECT_EQ(m.added_, vals[i].second); // real saved value, not defaulted
+    }
+}
+
+// Acceptance #2: a column newer than this build fails with VersionTooNew,
+// naming the component, and leaves the world untouched.
+TEST_F(MigrationTest, NewerThanBuildRejectedVersionTooNew) {
+    const std::vector<EntityId> ids{1000};
+    IRAsset::MemoryBinaryWriter col;
+    col.writeI32(1); // bytes never read — the version check fires first
+    col.writeI32(2);
+    const std::string path = tempPath("too_new");
+    ASSERT_NO_FATAL_FAILURE(writeIrws(
+        path,
+        {IRWorld::saveName<C_Mig>()},
+        {0},
+        ids,
+        {BuiltColumn{IRWorld::saveName<C_Mig>(), 3u, col.takeBuffer()}}, // v3 > build v2
+        2000
+    ));
+
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_Mig>();
+    const EntityId before = m_em.getLiveEntityCount();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.status_.code_, IRAsset::BinaryIOError::VersionTooNew);
+    EXPECT_NE(result.status_.message_.find("C_Mig"), std::string::npos);
+    EXPECT_EQ(result.entitiesRestored_, 0u);
+    EXPECT_EQ(m_em.getLiveEntityCount(), before); // zero world mutation
+}
+
+// Acceptance #3: a known component at an older version with no registered
+// migrator is the one non-recoverable case — MigratorMissing, world untouched
+// (never a silent read at the current layout).
+TEST_F(MigrationTest, MissingMigratorHardFails) {
+    const std::vector<EntityId> ids{1000, 1001};
+    IRAsset::MemoryBinaryWriter col;
+    col.writeI32(7); // a "v1" row for a component whose build is at v2
+    col.writeI32(8); // with no v1 migrator declared
+    const std::string path = tempPath("no_migrator");
+    ASSERT_NO_FATAL_FAILURE(writeIrws(
+        path,
+        {IRWorld::saveName<C_NoMigrator>()},
+        {0},
+        ids,
+        {BuiltColumn{IRWorld::saveName<C_NoMigrator>(), 1u, col.takeBuffer()}},
+        2000
+    ));
+
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_NoMigrator>();
+    const EntityId before = m_em.getLiveEntityCount();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.status_.code_, IRAsset::BinaryIOError::MigratorMissing);
+    EXPECT_NE(result.status_.message_.find("C_NoMigrator"), std::string::npos);
+    EXPECT_EQ(result.entitiesRestored_, 0u);      // out-component never materialized
+    EXPECT_EQ(m_em.getLiveEntityCount(), before); // zero world mutation
+}
+
+// Acceptance #4 (compose): a migrated column and an unresolvable column in the
+// same archetype — the unknown one skips by byte length while the migrated one
+// restores. Proves migration and the forward-compat skip coexist per entity.
+TEST_F(MigrationTest, MigrationComposesWithUnknownSkip) {
+    const std::vector<EntityId> ids{1000, 1001};
+    IRAsset::MemoryBinaryWriter migCol;
+    migCol.writeI32(41); // C_Mig v1 rows (kept_ only)
+    migCol.writeI32(42);
+    IRAsset::MemoryBinaryWriter unkCol;
+    unkCol.writeI32(999); // C_Unknown rows — never resolved, skipped by length
+    unkCol.writeI32(999);
+
+    const std::string path = tempPath("compose_skip");
+    // CMPN order fixes local indices: C_Mig=0, C_Unknown=1.
+    ASSERT_NO_FATAL_FAILURE(writeIrws(
+        path,
+        {IRWorld::saveName<C_Mig>(), IRWorld::saveName<C_Unknown>()},
+        {0, 1},
+        ids,
+        {BuiltColumn{IRWorld::saveName<C_Mig>(), 1u, migCol.takeBuffer()},
+         BuiltColumn{IRWorld::saveName<C_Unknown>(), 1u, unkCol.takeBuffer()}},
+        2000
+    ));
+
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_Mig>(); // C_Unknown deliberately NOT registered
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.entitiesRestored_, 2u);
+    EXPECT_GT(result.columnsSkipped_, 0u); // the unknown column was skipped
+
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        ASSERT_TRUE(m_em.entityExists(ids[i])) << "missing id " << ids[i];
+        const C_Mig &m = m_em.getComponent<C_Mig>(ids[i]);
+        EXPECT_EQ(m.kept_, 41 + static_cast<std::int32_t>(i)); // migrated
+        EXPECT_EQ(m.added_, 0);
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
Persist P5 (epic #667, W-4): the `(component, oldVersion) → reader` migration registry, so an older `IRWS` world snapshot loads into a newer build whose component has since bumped `SaveTrait<C>::kSaveVersion` (Save Format Rule #3).

P2 already stamped every `ARCH`/`SNGL` column with a `u32 saveVersion` header (the migration seam), but the loader **ignored it** — always reading at the current layout, which silently corrupts an old column. The load now dispatches on that stamp in the mutation-free phase-2 gate (so any failure aborts with a pristine world, Rule #5):

- **disk == current `kSaveVersion`** → `SaveSerialize<C>::read` fast path (regresses nothing).
- **disk < current** → the registered `SaveMigration<C>` reader, or (miss) a hard `BinaryIOError::MigratorMissing` — the one non-recoverable case.
- **disk > current** → `VersionTooNew`.
- **unknown component name** → skipped by byte length (P2 behavior, unchanged).

### Design
- New `SaveMigration<C>` customization point (`save_migration.hpp`) mirrors `SaveSerialize<C>`; primary template = no migrators. Direct per-version readers, never chained.
- Current + each retired version share one `ColumnReadHooks` shape; `SaveComponentEntry::readerForVersion` returns whichever applies as a uniform handle. The three read hooks fold into a shared `buildReader<C>`, **removing** the prior per-hook duplication in `registerComponent`.
- One-line `BinaryIOError::MigratorMissing`.

### Reconciliation with the plan
Filenames differ from the plan's *assumed* names (it flagged them as such): reconciled against the landed P1–P4 API — `save_migration.hpp` (matches the `save_*` sibling convention, header-only, no new `.cpp`/CMake), and the migrator dispatch lives on `SaveComponentEntry` where the erased hooks already are. Worked example uses a **test-local** component (the plan's committed fallback) rather than adding a permanently-dead field to a real gameplay component.

## Test plan
- [x] `component_migration_test.cpp` (5 cases): worked v1→v2 migration, current-version fast path, `VersionTooNew`, `MigratorMissing` (zero world mutation), migration-composes-with-unknown-skip.
- [x] All existing persist/snapshot/save-trait tests green — 56/56 (`macos-debug`, current-version fast path unchanged).

### Notes
- `optimize` N/A: one-shot save/load deserialization, not a per-frame path (the plan notes the migrators are "allocation-light, no per-frame hot path").
- simplify flagged a **medium** structural overlap — the 4 loader sites share a resolve-reader→seek preamble (largely pre-existing in P4). Reported, not applied: extracting a `resolveSeekedReader` helper would refactor the approved-base loop skeleton and expand this focused diff. Candidate follow-up.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2238

Closes #2216