### PR TITLE
persist: IRPersist Lua bindings + IR_PERSIST_DUMP world dump (#2218)

### DIFF
--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -995,6 +995,39 @@ IRSave.has("highscores", "top1"); IRSave.remove("highscores", "top1"); IRSave.cl
 - Coverage: `test/script/lua_persistence_test.cpp` (in-memory surface) +
   `test/asset/key_value_store_test.cpp` (format round-trip + corruption).
 
+## World snapshot (`IRPersist.*`)
+
+`bindLuaDrivenEcs()` also exposes the ECS **world snapshot** (persist P7, #2218,
+epic #667) as the `IRPersist` table — whole-world binary save/load, distinct
+from `IRSave` (the flat KV store above). `lua_world_snapshot_bindings.hpp` is
+**include-only glue** (`bindWorldSnapshotApi`): a thin forward to
+`IRWorld::saveWorld/loadWorld(path)` over `makeDefaultSaveRegistry()`, wired via
+the same generator-expression include of `IrredenEngineWorld` as the render/
+audio glue — no link edge (World links Scripting; a link back would cycle).
+
+```lua
+IRPersist.saveWorld("scene.irws")   -- serialize the live world (+ .json sidecar).
+                                    -- returns ok? (false on I/O failure, logged)
+IRWorld.resetGameplay()             -- clear the world at a frame boundary FIRST
+IRPersist.loadWorld("scene.irws")   -- restore into the cleared world. returns ok?
+```
+
+- **`path` is a raw filesystem path** (world snapshots are dev/tool artifacts),
+  NOT routed through `userDataDir` like `IRSave`.
+- **Frame-boundary contract (documented, not enforced — mirrors
+  `IRWorld.resetGameplay`).** Both calls touch the whole archetype graph, so
+  call them from a startup script / command handler / scene-transition step,
+  **never** from a Lua system tick or `DISPATCH_LUA_*` callback. `loadWorld`
+  does NOT reset first — call `IRWorld.resetGameplay()` immediately before it,
+  or the restore aborts on an id collision and returns `false`.
+- **Coverage subset.** The default registry persists only components with a
+  landed `SaveSerialize<C>` (`C_VoxelSetNew` + a few PODs today); see
+  `engine/world/CLAUDE.md` "Process-default registry". A `.json.txt` debug dump
+  is available behind the `IR_PERSIST_DUMP` env flag.
+- **Errors:** an I/O failure returns `false` (logged); a non-string argument
+  raises a Lua error via sol coercion (the same split `IRSave` uses).
+- Coverage: `test/script/lua_world_snapshot_test.cpp`.
+
 ## Prefab format (`Prefab.register`, `Prefab.spawn`)
 
 `bindLuaDrivenEcs()` also exposes the `Prefab` Lua table — the runtime

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -53,6 +53,15 @@ target_include_directories(
     IrredenEngineScripting PRIVATE
     $<TARGET_PROPERTY:IrredenEngineAudio,INTERFACE_INCLUDE_DIRECTORIES>
 )
+# lua_world_snapshot_bindings.hpp includes <irreden/world/world_snapshot.hpp>
+# (IRPersist world save/load, persist P7 #2218). Same include-only generator-
+# expression pattern — IRWorld:: symbols resolve at final exe link through
+# IrredenEngineWorld. NO library link: World links Scripting, so a link back
+# would form a cycle.
+target_include_directories(
+    IrredenEngineScripting PRIVATE
+    $<TARGET_PROPERTY:IrredenEngineWorld,INTERFACE_INCLUDE_DIRECTORIES>
+)
 # Force sol2 to use its try/catch trampoline rather than letting C++
 # exceptions propagate through the LuaJIT VM. With LuaJIT 2.1 sol2's
 # default is exception propagation; in practice the exception message

--- a/engine/script/include/irreden/script/lua_world_snapshot_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_world_snapshot_bindings.hpp
@@ -48,6 +48,13 @@ namespace IRScript::detail {
 // routed through userDataDir like IRSave. A non-string argument raises a Lua
 // error via sol coercion — the same I/O-fails->bool / misuse->error split the
 // sibling IRSave persistence bindings use.
+//
+// A reloaded C_VoxelSetNew lands in staged mode (pendingVoxels_ populated,
+// numVoxels_ == 0) — this binding does not attach it to a live pool. The
+// caller's UPDATE pipeline must run SEED_STAGED_VOXELS (see
+// system_seed_staged_voxels.hpp / engine/prefabs/irreden/voxel/CLAUDE.md
+// "C_VoxelSetNew headless / staged mode") for the set to seed a pool span and
+// render on a later frame; without it a loaded voxel set stays invisible.
 inline void bindWorldSnapshotApi(LuaScript &script) {
     sol::state &lua = script.lua();
     if (!lua["IRPersist"].valid()) {

--- a/engine/script/include/irreden/script/lua_world_snapshot_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_world_snapshot_bindings.hpp
@@ -1,0 +1,79 @@
+#ifndef LUA_WORLD_SNAPSHOT_BINDINGS_H
+#define LUA_WORLD_SNAPSHOT_BINDINGS_H
+
+#include <irreden/script/lua_script.hpp>
+#include <irreden/world/world_snapshot.hpp>
+
+#include <irreden/ir_profile.hpp>
+
+#include <sol/sol.hpp>
+
+#include <string>
+
+namespace IRScript::detail {
+
+// Exposes the ECS world snapshot (persist P7, #2218, epic #667) as the
+// `IRPersist` Lua table: whole-world binary save/load over the process-default
+// SaveRegistry (IRWorld::makeDefaultSaveRegistry). Include-only glue mirroring
+// bindRenderGlue / bindAudioApi — every binding is a thin forward to an
+// IRWorld:: entry point; no persistence logic lives here, and there is no link
+// edge to IrredenEngineWorld (World links Scripting; a link back would cycle —
+// IRWorld:: symbols resolve at final-executable link, the same generator-
+// expression include-only pattern the render/audio glue uses).
+//
+// Surface:
+//   IRPersist.saveWorld(path) -> bool   serialize the live world to `path`
+//                                       (+ a `.json` sidecar). false (logged)
+//                                       on I/O failure; never throws for a
+//                                       string path.
+//   IRPersist.loadWorld(path) -> bool   restore an IRWS file into the live
+//                                       world. false (logged) on a
+//                                       missing/corrupt file or an id
+//                                       collision; the world is left unmodified
+//                                       on any failure (Save Format Rule #5).
+//
+// FRAME-BOUNDARY CONTRACT (documented, not enforced — exactly like the
+// IRWorld.resetGameplay binding this mirrors): loadWorld is a structural
+// teardown+rebuild and saveWorld reads the whole archetype graph, so BOTH must
+// run at a frame boundary — a startup script, a command handler, or a
+// scene-transition step — and NEVER from inside a Lua system tick /
+// DISPATCH_LUA_* callback (the getComponent-mid-iteration UB engine/entity
+// CLAUDE.md flags for resetGameplay applies identically). loadWorld does NOT
+// reset the world itself: call `IRWorld.resetGameplay()` immediately before it,
+// so the restore lands into the cleared graph the snapshot was projected
+// against — loading into a still-populated world aborts on an id collision and
+// returns false.
+//
+// `path` is a raw filesystem path (world snapshots are dev/tool artifacts), NOT
+// routed through userDataDir like IRSave. A non-string argument raises a Lua
+// error via sol coercion — the same I/O-fails->bool / misuse->error split the
+// sibling IRSave persistence bindings use.
+inline void bindWorldSnapshotApi(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRPersist"].valid()) {
+        lua["IRPersist"] = lua.create_table();
+    }
+    sol::table persist = lua["IRPersist"];
+
+    persist["saveWorld"] = [](const std::string &path) -> bool {
+        const IRAsset::BinaryStatus status = IRWorld::saveWorld(path);
+        if (!status.ok()) {
+            IRE_LOG_ERROR("IRPersist.saveWorld({}) failed: {}", path, status.message_);
+            return false;
+        }
+        return true;
+    };
+
+    persist["loadWorld"] = [](const std::string &path) -> bool {
+        const IRWorld::LoadResult result = IRWorld::loadWorld(path);
+        if (!result.ok()) {
+            IRE_LOG_ERROR("IRPersist.loadWorld({}) failed: {}", path, result.status_.message_);
+            return false;
+        }
+        return true;
+    };
+}
+
+} // namespace IRScript::detail
+
+#endif /* LUA_WORLD_SNAPSHOT_BINDINGS_H */

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -18,6 +18,7 @@
 #include <irreden/script/lua_sim_bindings.hpp>
 #include <irreden/script/lua_spatial_bindings.hpp>
 #include <irreden/script/lua_widget_bindings.hpp>
+#include <irreden/script/lua_world_snapshot_bindings.hpp>
 #include <irreden/script/prefab_api.hpp>
 #include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
@@ -663,6 +664,7 @@ void LuaScript::bindLuaDrivenEcs() {
     detail::bindSimApi(*this);
     detail::bindAudioApi(*this);
     detail::bindPersistenceApi(*this);
+    detail::bindWorldSnapshotApi(*this);
 }
 
 void LuaScript::bindLuaCommands() {

--- a/engine/utility/CLAUDE.md
+++ b/engine/utility/CLAUDE.md
@@ -26,6 +26,10 @@ functions for reading files and composing paths. Used by `asset/`,
   for save files that must survive a clean reinstall. Like `joinPath`, it
   composes the path only — it does **not** create the directory. Used by
   the `.irkv` key/value store (`engine/asset/`).
+- `IRUtility::envFlagSet(name)` — true iff env var `name` is set and
+  non-empty (both "unset" and "present but empty" read as false). The one
+  place a boolean env toggle is read; e.g. `IR_PERSIST_DUMP` gates the world
+  snapshot's `.json.txt` debug dump (`engine/world/`).
 
 ## Gotchas
 

--- a/engine/utility/include/irreden/utility/path_utils.hpp
+++ b/engine/utility/include/irreden/utility/path_utils.hpp
@@ -5,11 +5,8 @@
 
 namespace IRUtility {
 
-std::string joinPath(
-    const std::string &directory,
-    const std::string &filename,
-    const std::string &extension
-);
+std::string
+joinPath(const std::string &directory, const std::string &filename, const std::string &extension);
 
 std::string pathWithExtension(const std::string &path, const std::string &extension);
 
@@ -25,11 +22,14 @@ std::string pathWithExtension(const std::string &path, const std::string &extens
 std::string userDataDir(const std::string &appName);
 
 std::string formatNumberedFilename(
-    const std::string &prefix,
-    int index,
-    int width,
-    const std::string &extension
+    const std::string &prefix, int index, int width, const std::string &extension
 );
+
+/// True iff environment variable @p name is set and non-empty. The single
+/// place the engine reads a boolean env toggle (e.g. `IR_PERSIST_DUMP`), so
+/// "present but empty" and "unset" both read as false and callers don't each
+/// re-derive the getenv-null-and-empty check.
+bool envFlagSet(const char *name);
 
 } // namespace IRUtility
 

--- a/engine/utility/src/ir_utility.cpp
+++ b/engine/utility/src/ir_utility.cpp
@@ -36,11 +36,8 @@ std::string readFileAsString(const std::string &filepath) {
     return {};
 }
 
-std::string joinPath(
-    const std::string &directory,
-    const std::string &filename,
-    const std::string &extension
-) {
+std::string
+joinPath(const std::string &directory, const std::string &filename, const std::string &extension) {
     std::filesystem::path path = std::filesystem::path(directory) / filename;
     path += normalizedExtension(extension);
     return path.string();
@@ -87,11 +84,12 @@ std::string userDataDir(const std::string &appName) {
     return appName;
 }
 
+bool envFlagSet(const char *name) {
+    return nonEmptyEnv(name) != nullptr;
+}
+
 std::string formatNumberedFilename(
-    const std::string &prefix,
-    int index,
-    int width,
-    const std::string &extension
+    const std::string &prefix, int index, int width, const std::string &extension
 ) {
     std::ostringstream filename;
     filename << prefix;

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -234,10 +234,12 @@ component names skip with counts.
 
 **P2 scope is the mechanism.** It ships one headless gtest
 (`test/world/world_snapshot_test.cpp`) proving the round-trip with
-trivially-copyable *test* components. Registering every engine component in
-`AllEngineComponents` — each needs a `SaveSerialize<C>` specialization for
-its non-POD fields, and a `(path)`-only convenience wrapper over a
-process-default registry for the P7 Lua binding — is downstream work.
+trivially-copyable *test* components. The `(path)`-only convenience wrapper
+over a process-default registry (for the P7 Lua binding) has since landed —
+see "Process-default registry" below — but only over a **curated subset**;
+registering every engine component in `AllEngineComponents` (each needs a
+`SaveSerialize<C>` specialization for its non-POD fields) is still downstream
+work.
 
 **Relation chunk `RELN` (persist P3, #2214).** `CHILD_OF` entity relations
 round-trip through one self-describing chunk: a `Relation`-enum name table at
@@ -353,6 +355,33 @@ Because `engine/world` must not depend on the voxel/render prefabs (layering),
 the seed pass is driven by the **caller**, not baked into `loadWorld`: a
 creation that loads a snapshot registers `SEED_STAGED_VOXELS` in its UPDATE
 pipeline (see `creations/demos/persist_roundtrip`).
+
+## Process-default registry + `(path)` overloads (persist P7, #2218, epic #667)
+
+`makeDefaultSaveRegistry()` (`src/world_default_registry.cpp`) builds the
+process-default `SaveRegistry` the no-registry-argument overloads
+`saveWorld(path)` / `loadWorld(path)` forward to — the surface the `IRPersist`
+Lua binding (`engine/script`) needs, since Lua passes no registry. It is
+**deliberately a curated subset** of `AllEngineComponents`: only components
+with a working `SaveSerialize<C>` today — `C_VoxelSetNew` (P6's explicit
+serializer, so `voxel_set_serialize.hpp` must be included there) plus
+trivially-copyable plain-data components (`C_LocalTransform`,
+`C_PositionInt3D`, `C_SizeInt3D`). Registering the **full** inventory does not
+compile: the heap-owning opted-in components (`C_Name`, `C_Skeleton`,
+`C_MidiSequence`, `C_TextSegment`, ...) still lack a serializer and hit the
+primary-template `static_assert`. Add each component to the curated list as its
+serializer lands; the full-inventory path (a per-component serializer pass + a
+`HasExplicitSaveSerialize<C>` filter over `AllEngineComponents`) is tracked
+downstream. The registry is built **fresh per call** — cheap (a few
+allocations, never a per-frame path) and, unlike a process-static, its
+session-local `ComponentId`s always match the live `EntityManager`.
+
+The `.json.txt` **debug dump** (W-11) is a second, richer writer over the same
+save walk (archetype members + `CHILD_OF` edges), gated by the
+`IR_PERSIST_DUMP` env flag (`IRUtility::envFlagSet`) and emitted *after* the
+binary — a pure side-output, so the binary is byte-identical flag-on or
+flag-off (W-8 parity holds). It is distinct from the always-on lightweight
+`.json` sidecar (a magic/version/count summary).
 
 ## Responsibilities
 

--- a/engine/world/CMakeLists.txt
+++ b/engine/world/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(IrredenEngineWorld STATIC
     src/chunk_persistence.cpp
     src/world_snapshot.cpp
     src/world_snapshot_relations.cpp
+    src/world_default_registry.cpp
 )
 
 target_link_libraries(IrredenEngineWorld PUBLIC

--- a/engine/world/include/irreden/world/world_snapshot.hpp
+++ b/engine/world/include/irreden/world/world_snapshot.hpp
@@ -139,6 +139,36 @@ IRAsset::BinaryStatus saveWorld(const SaveRegistry &registry, const std::string 
 /// then apply. Call after `IREntity::resetGameplay()` at a frame boundary.
 LoadResult loadWorld(const SaveRegistry &registry, const std::string &path);
 
+/// Build the process-default `SaveRegistry` — the curated subset of engine
+/// components that currently have a working `SaveSerialize<C>`: `C_VoxelSetNew`
+/// (explicit serializer, persist P6) plus trivially-copyable plain-data
+/// components (`C_LocalTransform`, `C_PositionInt3D`, `C_SizeInt3D`). This is
+/// the registry the no-registry-argument `saveWorld/loadWorld` overloads (and
+/// the P7 `IRPersist` Lua binding) forward to.
+///
+/// It is deliberately a **subset** of `AllEngineComponents`
+/// (`save_component_inventory.hpp`): registering the full inventory does not
+/// compile today because most opted-in heap-owning components
+/// (`C_Name`, `C_Skeleton`, `C_MidiSequence`, ...) still lack a
+/// `SaveSerialize<C>` specialization and would hit the primary template's
+/// `static_assert`. Growing this to the full inventory (a per-component
+/// serializer pass + a `HasExplicitSaveSerialize<C>` filter over
+/// `AllEngineComponents`) is tracked as downstream work; add each component
+/// here as its serializer lands.
+///
+/// Built fresh per call (a handful of allocations — never a per-frame path, and
+/// save/load are one-shot load-time ops), so the entries' session-local
+/// `ComponentId` resolution always matches the live `EntityManager` rather than
+/// caching a stale id from an earlier world.
+SaveRegistry makeDefaultSaveRegistry();
+
+/// `(path)`-only convenience over `makeDefaultSaveRegistry()`, for callers that
+/// don't build their own registry (the `IRPersist` Lua binding, tools).
+/// `loadWorld` carries the same frame-boundary contract as the
+/// `(registry, path)` form — call after `IREntity::resetGameplay()`.
+IRAsset::BinaryStatus saveWorld(const std::string &path);
+LoadResult loadWorld(const std::string &path);
+
 } // namespace IRWorld
 
 #endif /* WORLD_SNAPSHOT_H */

--- a/engine/world/src/world_default_registry.cpp
+++ b/engine/world/src/world_default_registry.cpp
@@ -1,0 +1,43 @@
+#include <irreden/world/world_snapshot.hpp>
+
+// Heavy include: the audited per-component save-policy table + every component
+// type's definition. Confined to this one TU (never a widely-included header,
+// per save_component_inventory.hpp's own note) so promoting the process-default
+// registry to more components only recompiles this file.
+#include <irreden/world/save_component_inventory.hpp>
+
+// The SaveSerialize<C_VoxelSetNew> specialization (persist P6) — NOT pulled by
+// the component header, so it must be in scope wherever a registry registers
+// C_VoxelSetNew, else registerComponent instantiates the primary template and
+// the static_assert (not trivially copyable) fires.
+#include <irreden/voxel/voxel_set_serialize.hpp>
+
+namespace IRWorld {
+
+// The curated process-default registry (persist P7, #2218). Only components
+// with a working SaveSerialize<C> today: C_VoxelSetNew (explicit serializer,
+// P6) plus trivially-copyable plain-data components. Registering the full
+// AllEngineComponents tuple does NOT compile — the heap-owning opted-in
+// components (C_Name, C_Skeleton, C_MidiSequence, C_TextSegment, ...) have no
+// SaveSerialize<C> yet and would hit the primary template's static_assert.
+// Extend this list as each component grows a serializer; the full-inventory
+// filter (a HasExplicitSaveSerialize<C> trait over AllEngineComponents) is
+// deferred downstream work. See world_snapshot.hpp for the rationale.
+SaveRegistry makeDefaultSaveRegistry() {
+    SaveRegistry registry;
+    registry.registerComponent<IRComponents::C_VoxelSetNew>();
+    registry.registerComponent<IRComponents::C_LocalTransform>();
+    registry.registerComponent<IRComponents::C_PositionInt3D>();
+    registry.registerComponent<IRComponents::C_SizeInt3D>();
+    return registry;
+}
+
+IRAsset::BinaryStatus saveWorld(const std::string &path) {
+    return saveWorld(makeDefaultSaveRegistry(), path);
+}
+
+LoadResult loadWorld(const std::string &path) {
+    return loadWorld(makeDefaultSaveRegistry(), path);
+}
+
+} // namespace IRWorld

--- a/engine/world/src/world_snapshot.cpp
+++ b/engine/world/src/world_snapshot.cpp
@@ -14,11 +14,15 @@
 
 #include <irreden/common/components/component_persistent.hpp>
 
+#include <irreden/utility/path_utils.hpp>
+
 #include <algorithm>
 #include <map>
 #include <span>
 #include <typeinfo>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace IRWorld {
@@ -55,6 +59,123 @@ struct SavedSingleton {
     const SaveComponentEntry *entry_;
     EntityId savedId_;
 };
+
+// A saved archetype projection's component local indices, ascending — the
+// order the ARCH chunk writes columns. Shared by the deterministic archetype
+// sort, the ARCH writer, and the debug dump so all three agree.
+std::vector<std::uint32_t> sortedLocalIndices(
+    const IREntity::Archetype &projection,
+    const std::unordered_map<ComponentId, std::uint32_t> &localIndexByComponentId
+) {
+    std::vector<std::uint32_t> indices;
+    indices.reserve(projection.size());
+    for (const ComponentId componentId : projection) {
+        indices.push_back(localIndexByComponentId.at(componentId));
+    }
+    std::sort(indices.begin(), indices.end());
+    return indices;
+}
+
+// Emit the component save-name array (CMPN name-table order) under the current
+// JSON key. Shared by the `.json` sidecar and the `.json.txt` debug dump.
+void writeComponentsArray(
+    IRAsset::JsonSidecarWriter &json, const std::vector<const SaveComponentEntry *> &orderedEntries
+) {
+    json.beginArray();
+    for (const SaveComponentEntry *entry : orderedEntries) {
+        json.valueString(entry->saveName_);
+    }
+    json.endArray();
+}
+
+// Human-readable `.json.txt` debug dump (persist W-11, #2218), gated by
+// IR_PERSIST_DUMP. A *second writer over the same walk* — it reads the data
+// already collected for the binary write (archetype groups, component name
+// order, singletons, CHILD_OF edges) rather than re-parsing the binary bytes,
+// so it stays a pure side-output: the binary at `path` is byte-identical
+// whether the flag is set or not (the epic's W-8 byte-parity is unaffected).
+// Best-effort — a write failure never fails the save. This is a richer view
+// than the always-on `.json` sidecar (a magic/version/count summary): it lists
+// each archetype's members and every parent→child edge, for eyeballing a save.
+void writeWorldDump(
+    const std::string &path,
+    IREntity::EntityManager &em,
+    const std::unordered_set<EntityId> &servedIds,
+    const std::vector<SavedArchetype> &groups,
+    const std::vector<const SaveComponentEntry *> &orderedEntries,
+    const std::vector<SavedSingleton> &singletons,
+    const std::unordered_map<ComponentId, std::uint32_t> &localIndexByComponentId,
+    std::uint64_t totalEntities
+) {
+    IRAsset::JsonSidecarWriter json;
+    json.beginObject();
+    json.key("format");
+    json.valueString("IRWS-dump");
+    json.key("version");
+    json.valueUInt(kWorldSnapshotVersion);
+    json.key("entities");
+    json.valueUInt(totalEntities);
+
+    json.key("components");
+    writeComponentsArray(json, orderedEntries);
+
+    json.key("archetypes");
+    json.beginArray();
+    for (const SavedArchetype &group : groups) {
+        // Component save-names for this projection, in ascending local index —
+        // the same order the binary writes the columns.
+        const std::vector<std::uint32_t> indices =
+            sortedLocalIndices(group.projection_, localIndexByComponentId);
+
+        json.beginObject();
+        json.key("components");
+        json.beginArray();
+        for (const std::uint32_t li : indices) {
+            json.valueString(orderedEntries[li]->saveName_);
+        }
+        json.endArray();
+        json.key("entities");
+        json.beginArray();
+        for (const SavedEntityRef &ref : group.entities_) {
+            json.valueUInt(ref.maskedId_);
+        }
+        json.endArray();
+        json.endObject();
+    }
+    json.endArray();
+
+    json.key("singletons");
+    json.beginArray();
+    for (const SavedSingleton &singleton : singletons) {
+        json.beginObject();
+        json.key("component");
+        json.valueString(singleton.entry_->saveName_);
+        json.key("id");
+        json.valueUInt(singleton.savedId_);
+        json.endObject();
+    }
+    json.endArray();
+
+    // Relations: only CHILD_OF materializes edges today (mirrors the RELN
+    // chunk writer, which writes CHILD_OF as the constant relation id), so the
+    // literal type name is emitted per edge.
+    json.key("relations");
+    json.beginArray();
+    for (const auto &[child, parent] : detail::collectChildParentEdges(em, servedIds)) {
+        json.beginObject();
+        json.key("type");
+        json.valueString("CHILD_OF");
+        json.key("child");
+        json.valueUInt(child);
+        json.key("parent");
+        json.valueUInt(parent);
+        json.endObject();
+    }
+    json.endArray();
+    json.endObject();
+
+    IRAsset::writeJsonSidecarToFile(path + ".json.txt", json.str());
+}
 
 } // namespace
 
@@ -178,13 +299,7 @@ IRAsset::BinaryStatus saveWorld(const SaveRegistry &registry, const std::string 
 
     // Deterministic archetype order: by ascending local-index list.
     auto localIndexList = [&](const SavedArchetype &g) {
-        std::vector<std::uint32_t> out;
-        out.reserve(g.projection_.size());
-        for (const ComponentId componentId : g.projection_) {
-            out.push_back(localIndexByComponentId.at(componentId));
-        }
-        std::sort(out.begin(), out.end());
-        return out;
+        return sortedLocalIndices(g.projection_, localIndexByComponentId);
     };
     std::sort(groups.begin(), groups.end(), [&](const SavedArchetype &a, const SavedArchetype &b) {
         return localIndexList(a) < localIndexList(b);
@@ -309,13 +424,26 @@ IRAsset::BinaryStatus saveWorld(const SaveRegistry &registry, const std::string 
     json.key("singletons");
     json.valueUInt(singletons.size());
     json.key("components");
-    json.beginArray();
-    for (const SaveComponentEntry *entry : orderedEntries) {
-        json.valueString(entry->saveName_);
-    }
-    json.endArray();
+    writeComponentsArray(json, orderedEntries);
     json.endObject();
     IRAsset::writeJsonSidecarToFile(path + ".json", json.str());
+
+    // Optional detailed human-readable dump (W-11), gated by IR_PERSIST_DUMP.
+    // A pure side-output over the same collected data — never alters the binary
+    // (flag-off byte-parity holds), so it sits after the binary write like the
+    // sidecar above.
+    if (IRUtility::envFlagSet("IR_PERSIST_DUMP")) {
+        writeWorldDump(
+            path,
+            em,
+            servedIds,
+            groups,
+            orderedEntries,
+            singletons,
+            localIndexByComponentId,
+            totalEntities
+        );
+    }
 
     return IRAsset::BinaryStatus::success();
 }

--- a/engine/world/src/world_snapshot_internal.hpp
+++ b/engine/world/src/world_snapshot_internal.hpp
@@ -19,9 +19,21 @@
 #include <span>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace IRWorld::detail {
+
+/// Collect the live world's saved `CHILD_OF` edges as sorted `(child, parent)`
+/// masked-id pairs. Only edges whose **both** endpoints are in @p servedIds —
+/// the exact set of masked ids P2 wrote to `ARCH` + `SNGL` — are kept, so every
+/// edge round-trips. Sorted by `(child, parent)` for a deterministic order
+/// (each `CHILD_OF` child has exactly one parent, a total order). Shared by
+/// `makeRelationChunk` (binary `RELN` body) and the `IR_PERSIST_DUMP`
+/// `.json.txt` writer, so both describe the identical edge set.
+std::vector<std::pair<IREntity::EntityId, IREntity::EntityId>> collectChildParentEdges(
+    IREntity::EntityManager &entityManager, const std::unordered_set<IREntity::EntityId> &servedIds
+);
 
 /// Serialize the live world's `CHILD_OF` edge set into a self-describing
 /// `RELN` chunk (name table at the head + `(relationTypeId, child, parent)`

--- a/engine/world/src/world_snapshot_relations.cpp
+++ b/engine/world/src/world_snapshot_relations.cpp
@@ -67,7 +67,7 @@ IREntity::Relation relationForName(std::string_view name) {
 
 } // namespace
 
-IRAsset::ChunkPayload makeRelationChunk(
+std::vector<std::pair<EntityId, EntityId>> collectChildParentEdges(
     IREntity::EntityManager &entityManager, const std::unordered_set<EntityId> &servedIds
 ) {
     // Every entity sharing an archetype node shares that node's CHILD_OF
@@ -79,9 +79,9 @@ IRAsset::ChunkPayload makeRelationChunk(
     // saved ids and are skipped rather than dangling.
     // Only CHILD_OF is a materialized edge set, so the collection holds bare
     // (child, parent) pairs and CHILD_OF is written as the constant relation
-    // id below — the on-disk triple stays generic (a future OWNS relation
-    // would append its own (relationId, A, B) triples) without this pass
-    // carrying a column of one repeated value.
+    // id at the call site — the on-disk triple stays generic (a future OWNS
+    // relation would append its own (relationId, A, B) triples) without this
+    // pass carrying a column of one repeated value.
     std::vector<std::pair<EntityId, EntityId>> childParentEdges;
     for (const auto &nodePtr : entityManager.getArchetypeNodes()) {
         IREntity::ArchetypeNode *node = nodePtr.get();
@@ -106,10 +106,18 @@ IRAsset::ChunkPayload makeRelationChunk(
         }
     }
 
-    // Deterministic write order: a CHILD_OF child has exactly one parent, so
+    // Deterministic order: a CHILD_OF child has exactly one parent, so
     // ordering by (child, parent) is a total order and the double-save is
     // byte-identical.
     std::sort(childParentEdges.begin(), childParentEdges.end());
+    return childParentEdges;
+}
+
+IRAsset::ChunkPayload makeRelationChunk(
+    IREntity::EntityManager &entityManager, const std::unordered_set<EntityId> &servedIds
+) {
+    const std::vector<std::pair<EntityId, EntityId>> childParentEdges =
+        collectChildParentEdges(entityManager, servedIds);
 
     IRAsset::MemoryBinaryWriter w;
     const std::vector<IRAsset::NameTableEntry> relationNames = buildCurrentRelationNameTable();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(IrredenEngineTest
   script/lua_component_register_test.cpp
   script/lua_enum_register_test.cpp
   script/lua_persistence_test.cpp
+  script/lua_world_snapshot_test.cpp
   script/lua_pipeline_register_test.cpp
   script/lua_render_bindings_test.cpp
   script/lua_rotation_target_lua_test.cpp

--- a/test/script/lua_world_snapshot_test.cpp
+++ b/test/script/lua_world_snapshot_test.cpp
@@ -8,10 +8,12 @@
 #include <irreden/common/components/component_local_transform.hpp>
 #include <irreden/common/components/component_position_int_3d.hpp>
 #include <irreden/common/components/component_size_int_3d.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
 
 #include <sol/sol.hpp>
 
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -21,14 +23,16 @@
 // (`m_lua.bindLuaDrivenEcs()`) against a live EntityManager built like
 // world_snapshot_test, so a Lua `saveWorld`/`loadWorld` round-trips real engine
 // components through the process-default registry (C_LocalTransform,
-// C_PositionInt3D, C_SizeInt3D — the trivially-copyable members of
-// makeDefaultSaveRegistry).
+// C_PositionInt3D, C_SizeInt3D — the trivially-copyable POD members, plus
+// C_VoxelSetNew, the one component with an explicit SaveSerialize<C>).
 
 namespace {
 
 using IRComponents::C_LocalTransform;
 using IRComponents::C_PositionInt3D;
 using IRComponents::C_SizeInt3D;
+using IRComponents::C_Voxel;
+using IRComponents::C_VoxelSetNew;
 using IREntity::EntityId;
 
 std::vector<std::uint8_t> readFileBytes(const std::string &path) {
@@ -172,6 +176,55 @@ TEST_F(LuaWorldSnapshotTest, RoundTripThroughLua) {
 
     // CHILD_OF edge restored.
     EXPECT_EQ(parentOf(child), parent) << "CHILD_OF edge lost on reload";
+}
+
+// `makeDefaultSaveRegistry()` registers C_VoxelSetNew (world_default_registry.cpp)
+// alongside the trivially-copyable PODs above — the one component with an
+// explicit SaveSerialize<C> (persist P6, #2217) rather than the default
+// byte-copy path. Round-trips a headless, pool-free set (StagedInit — no
+// VoxelPool/canvas needed) through the Lua binding; reload always
+// reconstructs in staged mode (numVoxels_ == 0, pendingVoxels_ populated) —
+// attaching it to a live pool is a separate step the caller's UPDATE
+// pipeline performs via SEED_STAGED_VOXELS (lua_world_snapshot_bindings.hpp).
+TEST_F(LuaWorldSnapshotTest, RoundTripsVoxelSetNew) {
+    const IRMath::ivec3 size{2, 1, 2};
+    const IRMath::ivec3 boundsMin{3, -1, 5};
+    const IREntity::EntityId canvas = 777;
+    std::vector<C_Voxel> voxels(4);
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+        voxels[i].color_ = IRMath::Color{
+            static_cast<std::uint8_t>(i * 10 + 1),
+            static_cast<std::uint8_t>(i * 20 + 2),
+            static_cast<std::uint8_t>(i * 30 + 3),
+            255
+        };
+    }
+
+    const EntityId entity = m_entity_manager.createEntity(
+        C_VoxelSetNew{C_VoxelSetNew::StagedInit{}, size, boundsMin, voxels, canvas}
+    );
+
+    const std::string path = tempPath("voxelset");
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + path + "'))"));
+
+    m_entity_manager.destroyAllEntities();
+    ASSERT_TRUE(runOk("assert(IRPersist.loadWorld('" + path + "'))"));
+
+    ASSERT_TRUE(m_entity_manager.entityExists(entity));
+    const C_VoxelSetNew &reloaded = m_entity_manager.getComponent<C_VoxelSetNew>(entity);
+    EXPECT_EQ(reloaded.size_.x, size.x);
+    EXPECT_EQ(reloaded.size_.y, size.y);
+    EXPECT_EQ(reloaded.size_.z, size.z);
+    EXPECT_EQ(reloaded.pendingBoundsMin_.x, boundsMin.x);
+    EXPECT_EQ(reloaded.pendingBoundsMin_.y, boundsMin.y);
+    EXPECT_EQ(reloaded.pendingBoundsMin_.z, boundsMin.z);
+    EXPECT_EQ(reloaded.canvasEntity_, canvas);
+    EXPECT_EQ(reloaded.numVoxels_, 0) << "reload must stay staged — never touches a pool";
+    ASSERT_EQ(reloaded.pendingVoxels_.size(), voxels.size());
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+        EXPECT_EQ(0, std::memcmp(&reloaded.pendingVoxels_[i], &voxels[i], sizeof(C_Voxel)))
+            << "voxel record " << i << " differs after round-trip";
+    }
 }
 
 // Missing/corrupt path -> false with no Lua error (I/O failure is a bool, not

--- a/test/script/lua_world_snapshot_test.cpp
+++ b/test/script/lua_world_snapshot_test.cpp
@@ -1,0 +1,228 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/common/components/component_position_int_3d.hpp>
+#include <irreden/common/components/component_size_int_3d.hpp>
+
+#include <sol/sol.hpp>
+
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// Persist P7 (#2218, epic #667): the `IRPersist` Lua binding (W-9) + the
+// IR_PERSIST_DUMP `.json.txt` debug dump (W-11). Drives the real Lua surface
+// (`m_lua.bindLuaDrivenEcs()`) against a live EntityManager built like
+// world_snapshot_test, so a Lua `saveWorld`/`loadWorld` round-trips real engine
+// components through the process-default registry (C_LocalTransform,
+// C_PositionInt3D, C_SizeInt3D — the trivially-copyable members of
+// makeDefaultSaveRegistry).
+
+namespace {
+
+using IRComponents::C_LocalTransform;
+using IRComponents::C_PositionInt3D;
+using IRComponents::C_SizeInt3D;
+using IREntity::EntityId;
+
+std::vector<std::uint8_t> readFileBytes(const std::string &path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::vector<std::uint8_t>(
+        std::istreambuf_iterator<char>(in),
+        std::istreambuf_iterator<char>()
+    );
+}
+
+bool fileExists(const std::string &path) {
+    std::ifstream in(path, std::ios::binary);
+    return in.good();
+}
+
+// Portable IR_PERSIST_DUMP toggle so the flag-on / flag-off dump test runs on
+// Linux/macOS (setenv/unsetenv) and native Windows (_putenv_s).
+void setDumpFlag(bool on) {
+#if defined(_WIN32)
+    _putenv_s("IR_PERSIST_DUMP", on ? "1" : "");
+#else
+    if (on) {
+        setenv("IR_PERSIST_DUMP", "1", 1);
+    } else {
+        unsetenv("IR_PERSIST_DUMP");
+    }
+#endif
+}
+
+class LuaWorldSnapshotTest : public testing::Test {
+  protected:
+    LuaWorldSnapshotTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        m_lua.bindLuaDrivenEcs();
+    }
+
+    void TearDown() override {
+        setDumpFlag(false); // never leak the flag into a sibling test
+    }
+
+    bool evalTrue(const std::string &expr) {
+        auto result = m_lua.lua().safe_script(
+            "return (" + expr + ") and true or false",
+            sol::script_pass_on_error
+        );
+        return result.valid() && result.get<bool>();
+    }
+
+    bool runOk(const std::string &stmt) {
+        return m_lua.lua().safe_script(stmt, sol::script_pass_on_error).valid();
+    }
+
+    bool raisesError(const std::string &stmt) {
+        return !m_lua.lua().safe_script(stmt, sol::script_pass_on_error).valid();
+    }
+
+    // The CHILD_OF parent of @p child, or kNullEntity (matches the query
+    // world_snapshot_relations_test uses).
+    EntityId parentOf(EntityId child) {
+        return m_entity_manager.getParentEntityFromArchetype(
+            m_entity_manager.getEntityArchetype(child)
+        );
+    }
+
+    std::string tempPath(const char *name) const {
+        return testing::TempDir() + "/ir_ws_lua_" + name + ".irws";
+    }
+
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(LuaWorldSnapshotTest, SurfaceBound) {
+    EXPECT_TRUE(evalTrue("type(IRPersist) == 'table'"));
+    EXPECT_TRUE(evalTrue("type(IRPersist.saveWorld) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRPersist.loadWorld) == 'function'"));
+}
+
+// The core W-9 acceptance: a non-trivial world (multiple archetypes +
+// CHILD_OF) built in C++, saved and reloaded entirely through the Lua binding,
+// with exact component + relation parity on restore.
+TEST_F(LuaWorldSnapshotTest, RoundTripThroughLua) {
+    // Archetype {C_LocalTransform} — the relation parent + a bare peer.
+    const EntityId parent =
+        m_entity_manager.createEntity(C_LocalTransform{IRMath::vec3(1.0f, 2.0f, 3.0f)});
+    const EntityId peer =
+        m_entity_manager.createEntity(C_LocalTransform{IRMath::vec3(-4.0f, 5.0f, 6.0f)});
+    // Archetype {C_PositionInt3D, C_SizeInt3D} — the relation child.
+    const EntityId child =
+        m_entity_manager.createEntity(C_PositionInt3D{4, 5, 6}, C_SizeInt3D{7, 8, 9});
+    // Archetype {C_PositionInt3D} and {C_LocalTransform, C_PositionInt3D} so the
+    // save spans 4 distinct projected archetypes.
+    const EntityId gridOnly = m_entity_manager.createEntity(C_PositionInt3D{10, 11, 12});
+    const EntityId both = m_entity_manager.createEntity(
+        C_LocalTransform{IRMath::vec3(7.0f, 8.0f, 9.0f)},
+        C_PositionInt3D{13, 14, 15}
+    );
+    IREntity::setParent(child, parent);
+    ASSERT_EQ(parentOf(child), parent);
+
+    const std::string path = tempPath("roundtrip");
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + path + "'))"))
+        << "Lua IRPersist.saveWorld raised or returned false";
+
+    // Clear the world (the reset the loadWorld contract expects), then reload
+    // through the Lua binding.
+    m_entity_manager.destroyAllEntities();
+    ASSERT_EQ(m_entity_manager.getLiveEntityCount(), 0u);
+    ASSERT_TRUE(runOk("assert(IRPersist.loadWorld('" + path + "'))"))
+        << "Lua IRPersist.loadWorld raised or returned false";
+
+    // Exact-id restoration + component parity.
+    ASSERT_TRUE(m_entity_manager.entityExists(parent));
+    ASSERT_TRUE(m_entity_manager.entityExists(child));
+    ASSERT_TRUE(m_entity_manager.entityExists(peer));
+    ASSERT_TRUE(m_entity_manager.entityExists(gridOnly));
+    ASSERT_TRUE(m_entity_manager.entityExists(both));
+
+    const C_LocalTransform &parentXform = m_entity_manager.getComponent<C_LocalTransform>(parent);
+    EXPECT_FLOAT_EQ(parentXform.translation_.x, 1.0f);
+    EXPECT_FLOAT_EQ(parentXform.translation_.y, 2.0f);
+    EXPECT_FLOAT_EQ(parentXform.translation_.z, 3.0f);
+
+    const IRMath::ivec3 childPos = m_entity_manager.getComponent<C_PositionInt3D>(child).pos_;
+    EXPECT_EQ(childPos.x, 4);
+    EXPECT_EQ(childPos.y, 5);
+    EXPECT_EQ(childPos.z, 6);
+    const IRMath::ivec3 childSize = m_entity_manager.getComponent<C_SizeInt3D>(child).size_;
+    EXPECT_EQ(childSize.x, 7);
+    EXPECT_EQ(childSize.y, 8);
+    EXPECT_EQ(childSize.z, 9);
+    const IRMath::ivec3 gridPos = m_entity_manager.getComponent<C_PositionInt3D>(gridOnly).pos_;
+    EXPECT_EQ(gridPos.x, 10);
+    EXPECT_EQ(gridPos.z, 12);
+    const IRMath::ivec3 bothPos = m_entity_manager.getComponent<C_PositionInt3D>(both).pos_;
+    EXPECT_EQ(bothPos.x, 13);
+    EXPECT_EQ(bothPos.z, 15);
+
+    // CHILD_OF edge restored.
+    EXPECT_EQ(parentOf(child), parent) << "CHILD_OF edge lost on reload";
+}
+
+// Missing/corrupt path -> false with no Lua error (I/O failure is a bool, not
+// an exception). evalTrue would report failure if the call raised, so this
+// covers both halves of the contract. (Zero *gameplay* mutation on a failed
+// load is the world layer's own guarantee, exercised by world_snapshot_test;
+// here loadWorld still mints the default registry's component-backing entities,
+// which is not saved-content mutation.)
+TEST_F(LuaWorldSnapshotTest, MissingPathReturnsFalseNoThrow) {
+    EXPECT_TRUE(evalTrue("IRPersist.loadWorld('" + tempPath("does_not_exist") + "') == false"));
+}
+
+// A non-string argument is a misuse -> Lua error (sol coercion), not a silent
+// false — mirrors the IRSave binding's I/O-fails->bool / misuse->error split.
+TEST_F(LuaWorldSnapshotTest, NonStringArgRaises) {
+    EXPECT_TRUE(raisesError("IRPersist.saveWorld({})"));
+    EXPECT_TRUE(raisesError("IRPersist.loadWorld({})"));
+}
+
+// W-11: with IR_PERSIST_DUMP set, saveWorld emits a `<path>.json.txt` detailed
+// dump containing a known entity id + the CHILD_OF relation name; with the flag
+// unset the dump is absent AND the binary is byte-identical (side-output only).
+TEST_F(LuaWorldSnapshotTest, DumpModeAndByteParity) {
+    const EntityId parent =
+        m_entity_manager.createEntity(C_LocalTransform{IRMath::vec3(1.0f, 1.0f, 1.0f)});
+    const EntityId child = m_entity_manager.createEntity(C_PositionInt3D{2, 3, 4});
+    IREntity::setParent(child, parent);
+    const EntityId maskedChild = child & IREntity::IR_ENTITY_ID_BITS;
+
+    const std::string dumpPath = tempPath("dump_on");
+    const std::string plainPath = tempPath("dump_off");
+
+    setDumpFlag(true);
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + dumpPath + "'))"));
+    setDumpFlag(false);
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + plainPath + "'))"));
+
+    // Flag-off byte parity: the binary is identical regardless of the dump.
+    EXPECT_EQ(readFileBytes(dumpPath), readFileBytes(plainPath));
+
+    // Flag-on produced the dump; flag-off did not.
+    ASSERT_TRUE(fileExists(dumpPath + ".json.txt"));
+    EXPECT_FALSE(fileExists(plainPath + ".json.txt"));
+
+    const std::vector<std::uint8_t> dumpBytes = readFileBytes(dumpPath + ".json.txt");
+    const std::string dump(dumpBytes.begin(), dumpBytes.end());
+    ASSERT_FALSE(dump.empty());
+    EXPECT_EQ(dump.front(), '{'); // JSON object shape
+    EXPECT_NE(dump.find("\"format\""), std::string::npos);
+    EXPECT_NE(dump.find("CHILD_OF"), std::string::npos);                  // relation name
+    EXPECT_NE(dump.find(std::to_string(maskedChild)), std::string::npos); // known id
+}
+
+} // namespace

--- a/test/world/persist_round_trip_test.cpp
+++ b/test/world/persist_round_trip_test.cpp
@@ -218,7 +218,10 @@ TEST_F(PersistRoundTrip, ParityAcrossFreshWorld) {
         ASSERT_TRUE(m_em.entityExists(expected.archetype3_[i]));
         EXPECT_EQ(m_em.getComponent<C_PA>(expected.archetype3_[i]).a_, 200 + i);
         EXPECT_EQ(m_em.getComponent<C_PB>(expected.archetype3_[i]).b_, i * 3);
-        EXPECT_EQ(m_em.getComponent<C_PC>(expected.archetype3_[i]).c_, static_cast<std::uint32_t>(i));
+        EXPECT_EQ(
+            m_em.getComponent<C_PC>(expected.archetype3_[i]).c_,
+            static_cast<std::uint32_t>(i)
+        );
 
         ASSERT_TRUE(m_em.entityExists(expected.archetype4_[i]));
         EXPECT_EQ(m_em.getComponent<C_PMark>(expected.archetype4_[i]).marker_, i);


### PR DESCRIPTION
## Summary
- Persist P7 / W-9 + W-11 (epic #667), the chain tail — exposes the ECS world snapshot to Lua as the `IRPersist` table and adds an env-gated human-readable dump.
- `IRWorld::makeDefaultSaveRegistry()` + `(path)`-only `saveWorld`/`loadWorld` overloads: the landed P6 API takes a `SaveRegistry&`, but Lua passes none, so the binding forwards to a process-default registry. It is a **curated subset** — only components with a working `SaveSerialize` today (`C_VoxelSetNew` + trivially-copyable PODs); the full inventory doesn't compile (heap-owning opted-in components lack serializers). Full-coverage is deferred to #2242. Built fresh per call so `ComponentId`s match the live `EntityManager`.
- `IRPersist.saveWorld/loadWorld` Lua binding: include-only glue (no link edge to World, which links Scripting), same frame-boundary contract as `IRWorld.resetGameplay` (loadWorld does not reset first — call `IRWorld.resetGameplay()` before it).
- W-11 `.json.txt` dump: an `IR_PERSIST_DUMP`-gated second writer over the save walk (archetype members + `CHILD_OF` edges) — pure side-output, so the binary is byte-identical flag-on/off. Factored `collectChildParentEdges` out of `makeRelationChunk` (+ `sortedLocalIndices` / `writeComponentsArray` helpers) so the dump and binary share one source of truth.
- Added `IRUtility::envFlagSet` as a new public wrapper over the existing private `nonEmptyEnv`.

## Test plan
- [x] `test/script/lua_world_snapshot_test.cpp` (new): surface bound; full round-trip through the Lua binding (4 archetypes + `CHILD_OF`, exact id/component/relation parity); missing-path → false-no-throw; non-string arg → Lua error; dump-mode content + flag-off byte parity.
- [x] Existing persist/snapshot suites green (incl. `DoubleSaveIsByteIdentical`) — the `localIndexList` extraction preserves exact binary output.
- [x] Builds clean on `macos-debug` (Metal). Backend-agnostic (no render/GL/Metal code) — needs Linux/GL smoke.

## Notes for reviewer
The design decision (curated-subset default registry vs full inventory) resolves the sonnet→opus escalation on #2218: option 1 (MVP + deferred #2242), forward-compatible with the eventual `HasExplicitSaveSerialize<C>` filter.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2240

Closes #2218

🤖 Generated with [Claude Code](https://claude.com/claude-code)