### PR TITLE
fleet: don't replay architect startup banner on session resume

### DIFF
--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -88,9 +88,10 @@ removed (#2108, guarded by `tests/test_babysit_launch.sh` T1/T3 for both
 `opus-architect` and `game-architect`). So on a resume: **print nothing on your
 own; wait for the human's next input and answer it from the context you already
 hold.** The one action that is about code freshness rather than context — the
-worktree sync (step 1) — still applies before your next piece of merge-sensitive
-work, because the worktree may be many merges behind even though your
-conversation is intact; treat resuming-then-being-handed-real-work as the "fresh
+worktree sync (step 1) — still applies before your next merge-state-sensitive
+action: filing a plan, citing a PR or merge state, or touching core code.
+The worktree may be many merges behind even though your conversation is
+intact; treat resuming-then-being-handed-real-work as the "fresh
 engagement" that step 1's trigger already covers. Everything below (banner,
 summary, cache read) is for the fresh-start case.
 

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -76,6 +76,24 @@ prompt suggests:
 
 ## Startup actions (do these immediately, in order)
 
+**These are cold-start orientation — they run on a *fresh* engagement only: a
+first boot (no persisted session), or any new prompt after a context `/clear`.
+Do NOT replay them on a resumed session.** When the fleet goes down and back
+up, `fleet-babysit` relaunches architects with `claude --resume <session-id>`
+and **no prompt** — your prior conversation, its context, and your last
+standing-by summary are all still in the transcript. Re-printing the banner and
+re-running the summary there is pure cold-start token + request burn (it fed the
+fleet-up short-window 429 burst), which is exactly why the resume nudge was
+removed (#2108, guarded by `tests/test_babysit_launch.sh` T1/T3 for both
+`opus-architect` and `game-architect`). So on a resume: **print nothing on your
+own; wait for the human's next input and answer it from the context you already
+hold.** The one action that is about code freshness rather than context — the
+worktree sync (step 1) — still applies before your next piece of merge-sensitive
+work, because the worktree may be many merges behind even though your
+conversation is intact; treat resuming-then-being-handed-real-work as the "fresh
+engagement" that step 1's trigger already covers. Everything below (banner,
+summary, cache read) is for the fresh-start case.
+
 0. Print your role banner: the **role-banner** delta.
 1. **Sync the worktree to current `origin/master` — ALWAYS, on every fresh
    engagement (first boot AND every new prompt after a context `/clear`).**


### PR DESCRIPTION
## Summary
- Scope the architect-protocol **Startup actions** to *fresh* engagements only (first boot / post-`/clear`) and spell out the **resumed-session** case, so a resumed architect does not replay its banner + summary on the human's first message.
- Consolidates the resume behavior in the one doc both `opus-architect` and `game-architect` point at — no per-role duplication.

## Why
The launcher side was already fixed: `fleet-babysit` resumes architects with `claude --resume` and **no prompt** (#2108, guarded by `tests/test_babysit_launch.sh` T1/T3 for both roles). But the protocol's startup section still read as unconditional ("do these immediately, in order"), so a resumed architect could re-run the whole banner + summary anyway — the exact cold-start token/request burn (fleet-up short-window 429s) that #2108 removed. This closes that doc gap so it can't recur by hand.

The one code-freshness action — the worktree sync (step 1) — is explicitly kept as still-required before the next merge-sensitive work; only the context-orientation steps are skipped on resume.

## Test plan
- [ ] Docs-only change; render/build unaffected.
- [ ] `docs/agents/architect-protocol.md` reads coherently: startup actions now scoped to fresh engagements, resume case handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)