### PR TITLE
fleet: review-fleet-feedback — install-symlink-lag signature

### DIFF
--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -67,6 +67,15 @@ ENTRY_HEAD_FILE = re.compile(
 # Pattern bank — order matters; first match wins. Widen aggressively;
 # uncategorized noise drowns the signal otherwise.
 SIGNATURES: list[tuple[str, re.Pattern]] = [
+    # A fleet script merged to master but the host's ~/bin symlink pass never
+    # re-ran, so the tool is "command not found" / missing on PATH. Must sit
+    # before label-absent-after-verdict: these entries often name the verdict
+    # wrapper and would otherwise be swallowed by that signature.
+    ("install-symlink-lag", re.compile(
+        r"(?=.*(~?/bin|symlink|install\.sh|\bPATH\b))"
+        r"(?=.*(not\s+(on\s+PATH|symlinked|linked|present|installed)"
+        r"|missing|doesn.t\s+exist|command\s+not\s+found|stale[- ]symlink"
+        r"|install[- ]lag|un-?symlinked))", re.I | re.S)),
     ("label-absent-after-verdict", re.compile(
         r"(label\s+(absent|missing|never\s+set|stripped|cleared|left\s+stale)"
         r"|verdict\s+labels?\s+(absent|missing|never|stripped)"


### PR DESCRIPTION
## What

Adds an `install-symlink-lag` pattern to the `SIGNATURES` table in `scripts/fleet/review-fleet-feedback`, placed ahead of `label-absent-after-verdict` so install-lag entries that mention the verdict wrapper aren't swallowed by that signature.

## Why

Seven feedback entries (opus-reviewer + sonnet-reviewer, all 2026-07-04) about `fleet-review-verdict` being missing from `~/bin` / not on PATH after PR #2193 merged were invisible to the review loop — all landed as uncategorized singletons, below the cluster threshold. With this signature they cluster and stay tracked by the closed-loop fix-log.

The underlying install-lag fix (auto re-run `install.sh` when `scripts/fleet/` is newer than the last symlink pass) is queued separately as #2262 — this PR only makes the pattern visible to the feedback reviewer.

## Verification

- `python3 -m py_compile` clean.
- Re-ran `review-fleet-feedback digest` against the live feedback dir with this change: the 7 entries cluster as `install-symlink-lag` (fresh-proposable), and `label-absent-after-verdict` correctly retains its 2 genuinely label-related entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)