### PR TITLE
fleet: mtime-guarded install.sh auto-refresh — end symlink-lag (#2262)

### DIFF
--- a/.fleet/plans/issue-2262.md
+++ b/.fleet/plans/issue-2262.md
@@ -1,0 +1,102 @@
+# Plan — Issue #2262: fleet/install-symlink-lag — mtime-guarded auto-refresh of install.sh
+
+- **Issue:** #2262 (surfaced by `review-fleet-feedback`; signature `install-symlink-lag`, 7 occurrences)
+- **Model:** opus
+- **Blocked by:** (none)
+
+## Scope
+
+Fleet scripts / role slash-commands / `ir-*` tools that merge to master never
+refresh a host's `~/bin` symlinks while a fleet run is live, so a freshly-added
+tool is `command not found` on first use. `fleet-review-verdict` (merged
+2026-07-03, PR #2193) stranded every reviewer on 2026-07-04 — 7 feedback
+entries, each re-inventing the manual `install.sh --no-zshrc` re-run. Same
+family as the `fleet_*.py` stale-symlink pattern.
+
+Fix: an **mtime-guarded auto-refresh** of `install.sh` at two hook points —
+(1) fleet-up bring-up (covers a fleet restart after a merge) and (2) the
+per-pane dispatch wrapper (covers a tool merged *while* the fleet is already
+running — the actual stranding case in the feedback).
+
+Out of scope: changing what `install.sh` symlinks; the 7-day feedback
+quiet-window verification (that's post-merge monitoring, not PR-gated).
+
+## Approach
+
+1. **Stamp file** `~/.fleet/state/.install-stamp` (empty touch-file).
+   `install.sh` `touch`es it as its final successful action (right at the
+   closing `echo "install.sh: done."`). Both manual and auto runs bump it, so
+   the stamp always reflects the last real symlink pass.
+2. **Shared staleness check** in `scripts/fleet/fleet-common.sh` (already
+   symlinked into `~/bin` and available to fleet-up + the dispatch wrapper):
+   `fleet_install_stale <main-clone-root>` returns 0 (stale) when the stamp is
+   missing **or** any source is newer than it — resolved against the **main
+   clone** (the symlink target the scout keeps fresh via `git pull`), using a
+   short-circuiting `find "$dir" -newer "$stamp" -print -quit` over:
+   - `scripts/fleet/` (tool sources)
+   - `engine/tools/bin/ir-*` (ir-* tool sources — install.sh symlinks these)
+   - `.claude/commands/role-*.md` + `creations/game/.claude/commands/role-*.md`
+     (role slash-commands, install.sh Steps 2/3)
+3. **fleet-up preflight** — new "Step 0.4" before Step 1: if
+   `fleet_install_stale`, run `install.sh --no-zshrc` (it re-stamps). Gives a
+   clean-symlink baseline to every pane fleet-up then launches.
+4. **Per-pane refresh** in `scripts/fleet/fleet-dispatch-wrap` (the wrapper the
+   dispatcher `tmux send-keys`-invokes per pane), before it starts the pane's
+   `claude`: same `fleet_install_stale` check; on stale, run
+   `install.sh --no-zshrc` under an **atomic mkdir-lock** (reuse the
+   `_acquire`-style `mkdir`-as-lock primitive fleet-claim already uses — NOT
+   `flock`, absent on macOS) so concurrent pane dispatches don't race the
+   symlink writes + stamp. This is the hook that fixes the mid-run stranding.
+
+## Acceptance
+
+- After a new script lands in the main clone's `scripts/fleet/` (mtime newer
+  than the stamp), the next pane dispatch symlinks it into `~/bin` before that
+  pane's `claude` starts — no `command not found`.
+- No newer-than-stamp source ⇒ zero re-link work: the `find` short-circuits and
+  `install.sh` is not invoked (idempotent, sub-ms common path).
+- Concurrent dispatches never corrupt `~/bin` or the stamp (mkdir-lock +
+  `install.sh`'s idempotent `ln -sf`).
+- New `scripts/fleet/tests/test_install_refresh.sh` (sibling of
+  `test_clone_freshness.sh`): builds a temp repo + `HOME`, asserts
+  (a) stamp-missing ⇒ stale; (b) touch a `scripts/fleet` file newer than the
+  stamp ⇒ stale ⇒ refresh creates the symlink and bumps the stamp;
+  (c) re-run with no newer file ⇒ not stale, `install.sh` not invoked.
+- Post-merge monitoring: `review-fleet-feedback digest` stops re-surfacing the
+  `install-symlink-lag` cluster across the 7-day quiet window.
+
+## Affected files
+
+- `scripts/fleet/install.sh` — `touch` the stamp as the final success step.
+- `scripts/fleet/fleet-common.sh` — add `fleet_install_stale()` + a main-clone
+  resolver (reuse install.sh's worktree→main-clone `git worktree list
+  --porcelain` logic).
+- `scripts/fleet/fleet-up` — Step 0.4 preflight refresh.
+- `scripts/fleet/fleet-dispatch-wrap` — per-pane guarded refresh under the
+  mkdir-lock (the primary fix).
+- `scripts/fleet/tests/test_install_refresh.sh` — new test.
+- **Not gated**: everything is under `scripts/fleet/` — the commit gate covers
+  only `.claude/commands/role-*.md`, `.claude/agents/*`,
+  `.claude/skills/**/SKILL.md`, so a worker can push the whole change.
+
+## Gotchas
+
+- **git-checkout mtime semantics**: `git pull` bumps mtime only on files it
+  actually changes/adds — which is exactly the signal we want (a new/updated
+  tool gets a fresh mtime; untouched files don't). Don't assume mtime is
+  preserved across a pull.
+- **macOS has no `flock`**: use the fleet-claim `mkdir`-as-lock primitive for
+  the dispatch-wrap refresh lock, not `flock`.
+- **Windows native-symlink failure path**: `install.sh` hard-exits when the
+  MSYS2 shell can't create native symlinks. The auto-refresh must **not**
+  re-run `install.sh` (and re-print that failure) on every dispatch on such a
+  host — bump the stamp on an *attempted* refresh even when `install.sh` exits
+  non-zero, so a symlink-incapable host degrades to one warning per
+  new-tool-merge, not one per dispatch.
+- **Main clone vs worktree**: the stale-check must resolve the **main clone**
+  (the symlink target the scout pulls into), never the pane's worktree — reuse
+  install.sh's main-clone resolution so a linked-worktree cwd doesn't compare
+  against a stale/reset tree.
+- **Latency**: the per-pane check is a `find -newer -print -quit` over ~3 small
+  dirs — sub-ms in the common not-stale case; the expensive `install.sh` fires
+  only on the rare stale hit.

--- a/scripts/fleet/fleet-common.sh
+++ b/scripts/fleet/fleet-common.sh
@@ -70,3 +70,114 @@ canonicalize_path_spelling() {
     fi
     printf '%s' "$p"
 }
+
+# --- install-symlink freshness (#2262) --------------------------------------
+# New fleet scripts / role slash-commands / ir-* tools merge to master, but a
+# host's ~/bin symlinks are only (re)created by install.sh — so a tool added
+# mid-run is `command not found` on first use (fleet-review-verdict stranded
+# every reviewer on 2026-07-04). The scout keeps the main clone fresh via
+# `git pull`, which bumps a file's mtime ONLY when it changes/adds it, so
+# "any install source newer than the last install.sh pass" is exactly "a
+# tool ~/bin has not linked yet". fleet-up (bring-up) and fleet-dispatch-wrap
+# (per pane) call fleet_install_maybe_refresh before launching a claude.
+#
+# Overridable for tests: FLEET_INSTALL_STAMP, FLEET_INSTALL_LOCK.
+
+# fleet_main_clone_root [root] — resolve the MAIN clone from a repo root that
+# may be a linked worktree (a worktree's `.git` is a file, not a dir). Mirrors
+# install.sh's worktree->main-clone resolution so the stale-check compares the
+# symlink target the scout pulls into, never an ephemeral/reset worktree tree.
+fleet_main_clone_root() {
+    local root="${1:-}"
+    [[ -n "$root" ]] || root="$(detect_engine_root)"
+    if [[ -f "$root/.git" ]]; then
+        local main
+        main="$(git -C "$root" worktree list --porcelain 2>/dev/null \
+            | awk '/^worktree /{print $2; exit}')"
+        [[ -n "$main" && -d "$main" ]] && root="$main"
+    fi
+    printf '%s' "$root"
+}
+
+# fleet_install_stale [main-clone-root] — exit 0 (stale) when the stamp is
+# missing or any symlinked source is newer than it; exit 1 (fresh) otherwise.
+# `find -print -quit` short-circuits on the first newer file, so the fresh
+# common path is a handful of sub-ms stat walks. `-type f` skips the dirs
+# themselves (e.g. scripts/fleet/__pycache__, whose mtime bumps on every .pyc
+# write and would false-positive). Name globs mirror what install.sh links:
+# every top-level scripts/fleet file, ir-* under engine/tools/bin, role-*.md
+# under the engine + game commands dirs.
+fleet_install_stale() {
+    local root="${1:-$(fleet_main_clone_root)}"
+    local stamp="${FLEET_INSTALL_STAMP:-$HOME/.fleet/state/.install-stamp}"
+    [[ -f "$stamp" ]] || return 0   # never installed / stamp cleared -> stale
+    local hit dir
+    if [[ -d "$root/scripts/fleet" ]]; then
+        hit=$(find "$root/scripts/fleet" -maxdepth 1 -type f -newer "$stamp" -print -quit 2>/dev/null)
+        if [[ -n "$hit" ]]; then return 0; fi
+    fi
+    if [[ -d "$root/engine/tools/bin" ]]; then
+        hit=$(find "$root/engine/tools/bin" -maxdepth 1 -type f -name 'ir-*' -newer "$stamp" -print -quit 2>/dev/null)
+        if [[ -n "$hit" ]]; then return 0; fi
+    fi
+    for dir in "$root/.claude/commands" "$root/creations/game/.claude/commands"; do
+        [[ -d "$dir" ]] || continue
+        hit=$(find "$dir" -maxdepth 1 -type f -name 'role-*.md' -newer "$stamp" -print -quit 2>/dev/null)
+        if [[ -n "$hit" ]]; then return 0; fi
+    done
+    return 1
+}
+
+# fleet_install_refresh [main-clone-root] — run install.sh --no-zshrc to re-link
+# ~/bin, then bump the stamp. The stamp is bumped REGARDLESS of install.sh's
+# exit code (install.sh also stamps on success): a host that CANNOT symlink
+# (the Windows native-symlink hard-exit) still advances the stamp, so it
+# degrades to one warning per new-tool-merge instead of one per dispatch.
+# Callers guard with fleet_install_stale, so this only fires on a real change.
+fleet_install_refresh() {
+    local root="${1:-$(fleet_main_clone_root)}"
+    local stamp="${FLEET_INSTALL_STAMP:-$HOME/.fleet/state/.install-stamp}"
+    local installer="$root/scripts/fleet/install.sh"
+    if [[ -x "$installer" ]]; then
+        # --no-zshrc: an automated refresh must never edit the user's ~/.zshrc.
+        IRREDEN_INSTALL_SKIP_ZSHRC=1 "$installer" --no-zshrc \
+            || echo "fleet: install.sh auto-refresh exited non-zero (see above)" >&2
+    fi
+    mkdir -p "$(dirname "$stamp")" 2>/dev/null || true
+    touch "$stamp" 2>/dev/null || true
+}
+
+# fleet_install_maybe_refresh [main-clone-root] — the guarded entry point both
+# hooks call. Stale-check first (sub-ms common path); if stale, take an atomic
+# mkdir-lock (same primitive fleet-claim uses; NOT flock, absent on macOS) so
+# concurrent pane dispatches don't race install.sh's `ln -sf` + stamp, re-check
+# under the lock (double-checked locking — a peer may have just refreshed), and
+# refresh. Never blocks dispatch: a crashed lock holder is stolen after 1 min,
+# and a live holder is waited on only briefly before proceeding anyway.
+fleet_install_maybe_refresh() {
+    local root="${1:-$(fleet_main_clone_root)}"
+    fleet_install_stale "$root" || return 0   # fresh -> zero work
+
+    local lock="${FLEET_INSTALL_LOCK:-$HOME/.fleet/state/.install-refresh.lock}"
+    local wait_secs="${FLEET_INSTALL_WAIT_SECS:-1}"
+    local wait_max="${FLEET_INSTALL_WAIT_MAX:-12}"
+    mkdir -p "$(dirname "$lock")" 2>/dev/null || true
+    local waited=0
+    while ! mkdir "$lock" 2>/dev/null; do
+        # Steal a lock a crashed holder left behind (install.sh finishes in a
+        # couple seconds, so >1 min old means the holder died).
+        if [[ -n "$(find "$lock" -maxdepth 0 -mmin +1 2>/dev/null)" ]]; then
+            rmdir "$lock" 2>/dev/null || true
+            continue
+        fi
+        # A live peer holds it. If its refresh already made us fresh, we're done.
+        fleet_install_stale "$root" || return 0
+        sleep "$wait_secs"
+        waited=$((waited + 1))
+        if (( waited >= wait_max )); then return 0; fi   # cap -> proceed, don't wedge dispatch
+    done
+    if fleet_install_stale "$root"; then
+        fleet_install_refresh "$root"
+    fi
+    rmdir "$lock" 2>/dev/null || true
+}

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -46,6 +46,21 @@ unset _mode_arg
 STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
 RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
 
+# Install-symlink freshness (#2262): a tool/role-cmd merged WHILE the fleet is
+# running only reaches ~/bin when install.sh re-links — otherwise it's
+# `command not found` on first use. Source the shared helper (symlinked into
+# ~/bin next to this script); the per-pane refresh runs just before the claude
+# launch below, guarded so it's a sub-ms no-op unless a source is newer than
+# the last install pass.
+_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fleet-common.sh"
+if [[ -f "$_FLEET_COMMON_SH" ]]; then
+    # shellcheck source=/dev/null
+    source "$_FLEET_COMMON_SH"
+else
+    fleet_install_maybe_refresh() { :; }  # helper not installed yet — no-op
+fi
+unset _FLEET_COMMON_SH
+
 # Expose the iteration's model class so fleet-claim can enforce the
 # model-tag gate. Classes are literal — fable | opus | sonnet — and the
 # gate exact-matches against the task's fleet:<class> label / Model:
@@ -179,6 +194,12 @@ if [[ -n "${FLEET_DISPATCH_PRINT_LAUNCH:-}" ]]; then
     printf 'resumed=%s prompt=%s argv=claude %s\n' "$RESUMED" "$PROMPT" "${CLAUDE_ARGS[*]}"
     exit 0
 fi
+
+# Re-link ~/bin if a fleet source merged since the last install pass, so this
+# iteration's claude sees every tool/role-cmd (the mid-run stranding fix, #2262).
+# Runs after the FLEET_DISPATCH_PRINT_LAUNCH test hook so launch-decision tests
+# never trigger a real install.sh. Best-effort: never block the dispatch.
+fleet_install_maybe_refresh || true
 
 claude "${CLAUDE_ARGS[@]}" "$PROMPT" | fleet-claude-stream
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -47,6 +47,19 @@ else
 fi
 unset _FLEET_CLONE_FRESHNESS_SH
 
+# Install-symlink freshness helper (#2262): re-links ~/bin when a merged
+# fleet tool / role-cmd / ir-* is newer than the last install.sh pass, so a
+# freshly-added tool is not `command not found` on first use. Sourced by-dir,
+# same as fleet-clone-freshness.sh above (both are symlinked into ~/bin).
+_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fleet-common.sh"
+if [[ -f "$_FLEET_COMMON_SH" ]]; then
+    # shellcheck source=/dev/null
+    source "$_FLEET_COMMON_SH"
+else
+    fleet_install_maybe_refresh() { :; }  # helper not installed yet — no-op
+fi
+unset _FLEET_COMMON_SH
+
 # Model classes — change these when bumping the fleet to a new release.
 #
 # The queue routes work by model CLASS: fable | opus | sonnet. Tasks carry
@@ -537,6 +550,13 @@ warn_legacy_worktree() {
 }
 warn_legacy_worktree "$ENGINE/.claude/worktrees/opus-worker"
 warn_legacy_worktree "$GAME/.claude/worktrees/game-sonnet"
+
+# Refresh ~/bin symlinks now that both main clones are advanced, so every pane
+# this session launches starts with links for every merged tool / role-cmd /
+# ir-*. One install.sh run covers engine + game role files (install.sh reaches
+# into $GAME for them). Guarded: a no-op sub-ms stat walk when nothing is newer
+# than the last install pass. (#2262)
+fleet_install_maybe_refresh "$ENGINE" || true
 
 # ----------------------------------------------------------------------
 # Step 1.5: reconcile reservations against world state

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -655,5 +655,13 @@ if [[ -f "$FLEET_ZSH_COMP_SRC" ]]; then
     echo "  Then \`fleet-run IR<Tab>\` lists built executables, not cwd files."
 fi
 
+# Stamp this successful symlink pass so fleet-up / fleet-dispatch-wrap can skip
+# re-linking until a fleet source (tool / role-cmd / ir-*) is newer than the
+# stamp — see fleet_install_stale in fleet-common.sh (#2262). Overridable for
+# tests via FLEET_INSTALL_STAMP.
+_install_stamp="${FLEET_INSTALL_STAMP:-$HOME/.fleet/state/.install-stamp}"
+mkdir -p "$(dirname "$_install_stamp")" 2>/dev/null || true
+touch "$_install_stamp" 2>/dev/null || true
+
 echo
 echo "install.sh: done."

--- a/scripts/fleet/tests/test_install_refresh.sh
+++ b/scripts/fleet/tests/test_install_refresh.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Tests for the install-symlink freshness helpers in fleet-common.sh (#2262):
+#   fleet_main_clone_root       — worktree -> main-clone resolution
+#   fleet_install_stale         — stamp-vs-source mtime staleness check
+#   fleet_install_refresh       — run install.sh + bump stamp (even on failure)
+#   fleet_install_maybe_refresh — guarded, mkdir-locked entry point
+#
+# Uses a throwaway "main clone" tree with a STUB install.sh that records each
+# invocation (so we can assert invoked / not-invoked) and stamps like the real
+# one. mtimes are set explicitly with `touch -t` (POSIX, portable across BSD +
+# GNU) so staleness is deterministic without sleeps.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+HELPER="$SCRIPT_DIR/fleet-common.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+    echo "SKIP: helper not found at $HELPER" >&2
+    exit 0
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "SKIP: git not available" >&2
+    exit 0
+fi
+
+# shellcheck source=/dev/null
+source "$HELPER"
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+ok()   { echo "  ok: $1";   PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# --- throwaway main clone + stub install.sh ---------------------------------
+ROOT="$TMPROOT/clone"
+mkdir -p "$ROOT/scripts/fleet/tests" \
+         "$ROOT/scripts/fleet/__pycache__" \
+         "$ROOT/engine/tools/bin" \
+         "$ROOT/.claude/commands" \
+         "$ROOT/creations/game/.claude/commands"
+
+export FLEET_INSTALL_STAMP="$TMPROOT/state/.install-stamp"
+export FLEET_INSTALL_LOCK="$TMPROOT/state/.install-refresh.lock"
+export INSTALL_LOG="$TMPROOT/install-invocations.log"
+mkdir -p "$TMPROOT/state"
+: > "$INSTALL_LOG"
+
+# Stub install.sh: mimic the real one's contract — record the call, stamp on
+# success. STUB_EXIT lets a test force a non-zero exit (Windows-degradation).
+cat > "$ROOT/scripts/fleet/install.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "invoked $*" >> "$INSTALL_LOG"
+mkdir -p "$(dirname "$FLEET_INSTALL_STAMP")"
+touch "$FLEET_INSTALL_STAMP"
+exit "${STUB_EXIT:-0}"
+STUB
+chmod +x "$ROOT/scripts/fleet/install.sh"
+
+# Seed source files. All OLD (2026-01-01) so a MIDDLE-dated stamp is fresh.
+touch -t 202601010000 "$ROOT/scripts/fleet/install.sh"
+touch -t 202601010000 "$ROOT/scripts/fleet/fleet-existing-tool"
+touch -t 202601010000 "$ROOT/engine/tools/bin/ir-foo"
+touch -t 202601010000 "$ROOT/.claude/commands/role-worker.md"
+touch -t 202601010000 "$ROOT/creations/game/.claude/commands/role-game-architect.md"
+
+log_count() { wc -l < "$INSTALL_LOG" | tr -d ' '; }
+
+# Monotonic mtimes: every stamp/touch advances a shared minute counter, so a
+# `stamp_fresh` is strictly newer than all prior touches (fresh baseline) and a
+# following `make_newer` is strictly newer than that stamp (stale). Fixed
+# timestamps leaked staleness across tests (a stamp older than a leftover file);
+# a strictly-increasing clock can't. Seeds above sit at minute 00, before any.
+_ts_seq=0
+# Sets $TS (not echo — a $(...) subshell wouldn't persist the counter). <60 calls.
+_next_ts() { _ts_seq=$((_ts_seq + 1)); TS=$(printf '2026010100%02d' "$_ts_seq"); }
+stamp_fresh() { _next_ts; touch -t "$TS" "$FLEET_INSTALL_STAMP"; }
+make_newer()  { _next_ts; touch -t "$TS" "$1"; }
+
+# --- T1: stamp missing -> stale ---------------------------------------------
+echo "T1: missing stamp is stale"
+rm -f "$FLEET_INSTALL_STAMP"
+if fleet_install_stale "$ROOT"; then ok "stale when stamp absent"; else fail "not stale with no stamp"; fi
+
+# --- T2: stamp newer than every source -> fresh -----------------------------
+echo "T2: all sources older than stamp -> fresh"
+stamp_fresh
+if fleet_install_stale "$ROOT"; then fail "reported stale when current"; else ok "fresh when nothing newer"; fi
+
+# --- T3: a scripts/fleet file newer than the stamp -> stale -----------------
+echo "T3: newer scripts/fleet tool -> stale"
+make_newer "$ROOT/scripts/fleet/fleet-review-verdict"   # the real stranding case
+if fleet_install_stale "$ROOT"; then ok "stale when a tool is newer"; else fail "missed a newer tool"; fi
+
+# --- T4: maybe_refresh on stale -> runs install.sh, stamps, becomes fresh ----
+echo "T4: maybe_refresh refreshes when stale"
+before=$(log_count)
+fleet_install_maybe_refresh "$ROOT"
+after=$(log_count)
+[[ "$after" -gt "$before" ]] && ok "install.sh invoked on stale" || fail "install.sh not invoked ($before->$after)"
+if fleet_install_stale "$ROOT"; then fail "still stale after refresh"; else ok "fresh after refresh (stamp bumped)"; fi
+[[ ! -d "$FLEET_INSTALL_LOCK" ]] && ok "lock released after refresh" || fail "lock left behind"
+
+# --- T5: maybe_refresh when fresh -> install.sh NOT invoked ------------------
+echo "T5: maybe_refresh is a no-op when fresh"
+before=$(log_count)
+fleet_install_maybe_refresh "$ROOT"
+after=$(log_count)
+[[ "$after" -eq "$before" ]] && ok "install.sh not invoked when fresh" || fail "re-ran install.sh needlessly ($before->$after)"
+
+# --- T6: each source set independently triggers staleness -------------------
+echo "T6: ir-* and role-*.md also trigger staleness"
+stamp_fresh
+make_newer "$ROOT/engine/tools/bin/ir-bar"
+if fleet_install_stale "$ROOT"; then ok "newer ir-* is stale"; else fail "missed a newer ir-* tool"; fi
+stamp_fresh
+make_newer "$ROOT/creations/game/.claude/commands/role-game-worker.md"
+if fleet_install_stale "$ROOT"; then ok "newer game role-*.md is stale"; else fail "missed a newer game role file"; fi
+
+# --- T7: scoping — non-source churn does NOT false-positive -----------------
+echo "T7: subdir / non-matching files do not trigger staleness"
+stamp_fresh
+make_newer "$ROOT/scripts/fleet/tests/test_new.sh"        # depth 2 -> ignored
+make_newer "$ROOT/scripts/fleet/__pycache__"              # dir mtime bump -> ignored
+make_newer "$ROOT/engine/tools/bin/not-an-ir-tool"        # wrong name -> ignored
+make_newer "$ROOT/.claude/commands/not-a-role.md"         # wrong name -> ignored
+if fleet_install_stale "$ROOT"; then fail "false-positive on non-source churn"; else ok "ignores test/pycache/non-matching churn"; fi
+
+# --- T8: Windows-degradation — failed install.sh still bumps the stamp ------
+echo "T8: a failing install.sh still stamps (no per-dispatch re-run)"
+stamp_fresh
+make_newer "$ROOT/scripts/fleet/fleet-win-tool"
+before=$(log_count)
+STUB_EXIT=1 fleet_install_maybe_refresh "$ROOT"   # simulate symlink-incapable host
+after=$(log_count)
+[[ "$after" -gt "$before" ]] && ok "install.sh attempted on stale" || fail "install.sh not attempted"
+if fleet_install_stale "$ROOT"; then fail "still stale after a failed refresh (would re-run every dispatch)"; else ok "stamp bumped despite non-zero exit"; fi
+before=$(log_count)
+fleet_install_maybe_refresh "$ROOT"               # nothing newer now
+after=$(log_count)
+[[ "$after" -eq "$before" ]] && ok "no re-run on a symlink-incapable host once stamped" || fail "re-ran despite fresh stamp"
+
+# --- T9: stale lock (crashed holder) is stolen, refresh still happens -------
+echo "T9: a stale lock is stolen"
+stamp_fresh
+make_newer "$ROOT/scripts/fleet/fleet-after-crash"
+mkdir -p "$FLEET_INSTALL_LOCK"
+touch -t 202601010000 "$FLEET_INSTALL_LOCK"        # >1 min old -> stealable
+before=$(log_count)
+FLEET_INSTALL_WAIT_SECS=0 FLEET_INSTALL_WAIT_MAX=2 fleet_install_maybe_refresh "$ROOT"
+after=$(log_count)
+[[ "$after" -gt "$before" ]] && ok "stole stale lock and refreshed" || fail "did not steal a stale lock"
+[[ ! -d "$FLEET_INSTALL_LOCK" ]] && ok "stolen lock released after refresh" || fail "lock left behind after steal"
+
+# --- T10: a live lock is respected — proceed without a double-refresh --------
+echo "T10: a live (fresh) lock is not stolen; caller proceeds without refresh"
+stamp_fresh
+make_newer "$ROOT/scripts/fleet/fleet-contended"
+mkdir -p "$FLEET_INSTALL_LOCK"                     # fresh mtime -> a live peer's lock
+before=$(log_count)
+FLEET_INSTALL_WAIT_SECS=0 FLEET_INSTALL_WAIT_MAX=2 fleet_install_maybe_refresh "$ROOT"
+after=$(log_count)
+[[ "$after" -eq "$before" ]] && ok "did not double-run install.sh under a live lock" || fail "ran install.sh while a peer held the lock"
+[[ -d "$FLEET_INSTALL_LOCK" ]] && ok "live peer's lock left intact" || fail "removed a lock we did not own"
+rmdir "$FLEET_INSTALL_LOCK"
+
+# --- T11: fleet_main_clone_root returns a plain (non-worktree) root as-is ----
+echo "T11: main-clone resolution — non-worktree root unchanged"
+mkdir -p "$ROOT/.git"                               # a real clone has .git as a DIR
+resolved=$(fleet_main_clone_root "$ROOT")
+[[ "$resolved" == "$ROOT" ]] && ok "plain clone root returned unchanged" || fail "mangled a non-worktree root: $resolved"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- New fleet scripts / role slash-commands / `ir-*` tools reach a host's `~/bin` only when `install.sh` re-links, so a tool merged **while the fleet is running** was `command not found` on first use (`fleet-review-verdict` stranded every reviewer on 2026-07-04 — 7 feedback entries). This adds an **mtime-guarded auto-refresh** of `install.sh` at two hooks.
- `install.sh` stamps `~/.fleet/state/.install-stamp` on every successful symlink pass.
- `fleet_install_stale` (new in `fleet-common.sh`) short-circuits a `find … -print -quit` over the symlinked source sets (top-level `scripts/fleet`, `engine/tools/bin/ir-*`, engine + game `role-*.md`) against that stamp — sub-ms in the common not-stale path; `-type f` skips `__pycache__` etc.
- **fleet-up bring-up** refreshes once after both main clones advance (baseline for the panes it launches). **fleet-dispatch-wrap** refreshes per pane just before the `claude` launch (the mid-run stranding fix), under an atomic `mkdir`-lock (macOS has no `flock`) with double-checked locking + a stale-lock breaker so a crashed holder can't wedge dispatch.
- The stamp is bumped **even when `install.sh` exits non-zero**, so a symlink-incapable Windows host (native-symlink hard-exit) degrades to one warning per new-tool-merge, not one per dispatch.
- `fleet-common.sh` is itself a pre-existing symlink, so `git pull` refreshes its helper content live — the fix's own delivery is never subject to the stranding it fixes (no bootstrap gap).

## Test plan
- [x] `scripts/fleet/tests/test_install_refresh.sh` — 18 assertions: stamp-missing → stale; each source set (tool / `ir-*` / `role-*.md`) triggers staleness; subdir/`__pycache__`/non-matching churn does **not**; `maybe_refresh` refreshes-then-becomes-fresh and is a no-op when fresh; failed-install still stamps (no per-dispatch re-run); stale lock stolen; live lock respected without double-refresh.
- [x] `bash -n` clean on all four modified scripts.
- [x] `test_dispatch_wrap_session.sh` still green (18/18) — the per-pane hook sits after the `FLEET_DISPATCH_PRINT_LAUNCH` test hook, so launch-decision tests never trigger a real `install.sh`.

Closes #2262

🤖 Generated with [Claude Code](https://claude.com/claude-code)