### PR TITLE
render: extract sunBakeFrustumUVBounds shared helper (#2258 prep)

### DIFF
--- a/engine/prefabs/irreden/render/sun_shadow_constants.hpp
+++ b/engine/prefabs/irreden/render/sun_shadow_constants.hpp
@@ -8,6 +8,8 @@
 #include <irreden/render/components/component_light_source.hpp>
 #include <irreden/render/cull_viewport_state.hpp>
 
+#include <limits>
+
 namespace IRPrefab::SunShadow {
 
 // Maximum shadow throw distance in voxels. Drives both the sun-depth-map
@@ -85,15 +87,52 @@ inline IRMath::IsoBounds2D shadowFeederCullViewport(int margin, const ShadowFeed
 }
 
 inline IRMath::IsoBounds2D shadowFeederCullViewport(
-    int margin,
-    const ShadowFeederParams &params,
-    const IRRender::CullViewportState &cull
+    int margin, const ShadowFeederParams &params, const IRRender::CullViewportState &cull
 ) {
     return IRMath::shadowFeederIsoBounds(
         cull.isoViewport(margin),
         params.sunDir_,
         params.sweepDistance_
     );
+}
+
+// Sun-UV bounding box of the iso-frustum depth slab [@p depthMin, @p depthMax]
+// over @p isoBounds, with every corner ALSO offset by @p sweep (world-frame,
+// = -sunDir * sweepDistance) so off-screen casters within shadow range are
+// enclosed — the box BAKE_SUN_SHADOW_MAP fits its depth map to before the
+// texel-grid snap. Each corner is lifted from the rasterYaw-rotated canvas frame
+// into world frame (rotateCardinalZInv) before projecting onto the sun basis, so
+// the sweep (a world-frame vector) shares the corners' frame; no-op at
+// rasterYaw == 0. @p uHat / @p vHat are the sun-perpendicular basis from
+// buildOrthonormalBasis; @p cardinalIndex is the rasterYaw cardinal snap. Lives
+// in the shared sun-shadow header so a sun-space feeder-density consumer can
+// reuse the bake's exact derivation rather than re-deriving it.
+inline IRMath::IsoBounds2D sunBakeFrustumUVBounds(
+    const IRMath::IsoBounds2D &isoBounds,
+    float depthMin,
+    float depthMax,
+    const IRMath::vec3 &uHat,
+    const IRMath::vec3 &vHat,
+    IRMath::CardinalIndex cardinalIndex,
+    const IRMath::vec3 &sweep
+) {
+    IRMath::vec2 uvMin(std::numeric_limits<float>::max());
+    IRMath::vec2 uvMax(std::numeric_limits<float>::lowest());
+    for (float depth : {depthMin, depthMax}) {
+        for (int y : {isoBounds.min_.y, isoBounds.max_.y}) {
+            for (int x : {isoBounds.min_.x, isoBounds.max_.x}) {
+                const IRMath::vec3 corner =
+                    IRMath::rotateCardinalZInv(IRMath::isoPixelToPos3D(x, y, depth), cardinalIndex);
+                for (const IRMath::vec3 &offset : {IRMath::vec3(0.0f), sweep}) {
+                    const IRMath::vec3 p = corner + offset;
+                    const IRMath::vec2 uv(IRMath::dot(p, uHat), IRMath::dot(p, vHat));
+                    uvMin = IRMath::min(uvMin, uv);
+                    uvMax = IRMath::max(uvMax, uv);
+                }
+            }
+        }
+    }
+    return IRMath::IsoBounds2D{uvMin, uvMax};
 }
 
 } // namespace IRPrefab::SunShadow

--- a/engine/prefabs/irreden/render/systems/system_bake_sun_shadow_map.hpp
+++ b/engine/prefabs/irreden/render/systems/system_bake_sun_shadow_map.hpp
@@ -40,7 +40,6 @@
 
 #include <utility>
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -59,7 +58,6 @@ constexpr int kSunShadowMapDim = 1024;
 // both producers stay in lockstep.
 using IRPrefab::SunShadow::kSunShadowMaxDistance;
 constexpr int kBakeSunShadowGroupSize = 16;
-constexpr int kIsoFrustumCornerCount = 8;
 constexpr int kSunShadowCascadeCount = 2;
 constexpr float kCascadeSplitRatio = 0.4f;
 
@@ -549,35 +547,23 @@ template <> struct System<BAKE_SUN_SHADOW_MAP> {
         const float dimF = static_cast<float>(kSunShadowMapDim);
 
         // isoPixelToPos3D returns corners in the rasterYaw-rotated canvas
-        // frame. The sun-direction sweep below is in world frame. Lift corners
-        // into world frame once, before the per-cascade AABB sweep, so both
-        // sides share the same coordinate frame. No-op at rasterYaw == 0.
+        // frame; sunBakeFrustumUVBounds lifts them into world frame
+        // (rotateCardinalZInv) before the per-cascade AABB sweep, so both sides
+        // share the same coordinate frame. No-op at rasterYaw == 0.
         const auto cardinalIndex = IRMath::rasterYawCardinalIndex(IRPrefab::Camera::getRasterYaw());
 
         for (int ci = 0; ci < kSunShadowCascadeCount; ++ci) {
-            std::array<vec3, kIsoFrustumCornerCount> corners{};
-            int idx = 0;
-            for (float depth : {cascadeRanges[ci].min_, cascadeRanges[ci].max_}) {
-                for (int y : {isoBounds.min_.y, isoBounds.max_.y}) {
-                    for (int x : {isoBounds.min_.x, isoBounds.max_.x}) {
-                        corners[idx++] = IRMath::isoPixelToPos3D(x, y, depth);
-                    }
-                }
-            }
-            for (auto &c : corners) {
-                c = IRMath::rotateCardinalZInv(c, cardinalIndex);
-            }
-
-            vec2 sunUVMin = vec2(std::numeric_limits<float>::max());
-            vec2 sunUVMax = vec2(std::numeric_limits<float>::lowest());
-            for (const vec3 &c : corners) {
-                for (const vec3 &offset : {vec3(0.0f), sweep}) {
-                    const vec3 p3 = c + offset;
-                    const vec2 sunUV = vec2(IRMath::dot(p3, uHat), IRMath::dot(p3, vHat));
-                    sunUVMin = IRMath::min(sunUVMin, sunUV);
-                    sunUVMax = IRMath::max(sunUVMax, sunUV);
-                }
-            }
+            const IsoBounds2D sunUV = IRPrefab::SunShadow::sunBakeFrustumUVBounds(
+                isoBounds,
+                cascadeRanges[ci].min_,
+                cascadeRanges[ci].max_,
+                uHat,
+                vHat,
+                cardinalIndex,
+                sweep
+            );
+            vec2 sunUVMin = sunUV.min_;
+            vec2 sunUVMax = sunUV.max_;
 
             sunUVMin -= vec2(kAABBPad);
             sunUVMax += vec2(kAABBPad);


### PR DESCRIPTION
## Summary

Byte-identical extraction of `BAKE_SUN_SHADOW_MAP`'s per-cascade swept
sun-space AABB corner math into
`IRPrefab::SunShadow::sunBakeFrustumUVBounds` (`sun_shadow_constants.hpp`).
The corner enumeration and `min`/`max` reduction order are preserved
exactly, so the baked sun-shadow map is bit-identical — this is a pure
readability + shared-source-of-truth refactor.

## Why this is narrowed from the original scope

This PR started as #2258's Lever-1 (cap the off-screen shadow-feeder
subdivision at high zoom). Measurement (in the PR thread) showed that
lever is **dispatch-bound-dead**: forcing *every* voxel to a 1×1 micro-tap
left `voxelStage1` GPU time unchanged, so no shader-side subdivision cap
can move it. Per architect direction, this PR keeps only the
independently-correct refactor and drops the dead plumbing:

- **Kept:** `sunBakeFrustumUVBounds` in `sun_shadow_constants.hpp`;
  `BAKE_SUN_SHADOW_MAP` calls it (removing its inline corner loop,
  `<array>` include, and `kIsoFrustumCornerCount`).
- **Dropped:** the stage-1 GLSL+Metal feeder early-return, the CPU
  `feederSubCap` derivation, the `FrameDataVoxelToCanvas::feederSubCap_`
  field/uniform, and the `visibleIsoBounds → stage-1` plumbing.

The real high-zoom-feeder fix needs a GPU sub-stage attribution table
first — filed as **#2280** — so #2258 stays open (`Blocked by: #2280`).

## Verification

- Byte-identity by construction: the extracted helper visits the same
  `(depth, y, x)` corners in the same order, applies the same
  `rotateCardinalZInv(isoPixelToPos3D(...))` per corner, and reduces
  `min`/`max` over the identical `{0, sweep}` offset sequence — `min`/`max`
  are exact ops, so the result is bit-identical to the former inline loop.
- `fleet-build --target IRShapeDebug` — clean.

Note: `format-changed` normalized the pre-existing `shadowFeederCullViewport`
overload signature to one line (clang-format on a file this PR touches);
that hunk is cosmetic and unrelated to the extraction.

Part of #2258.
