### PR TITLE
docs/fleet: absorb coding-improvement triage batch (11 tickets)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -476,6 +476,16 @@ exit cleanly:
          - `gh pr edit <N> --remove-label "fleet:awaiting-base"`
          - `gh pr edit <N> --remove-label "fleet:stacked"`
          - `gh pr edit <N> --remove-label "fleet:needs-base-update"`
+         - **Strip the now-stale `Stacked on:` line from the PR body** in
+           the same step. review-pr's stacked-PR detection *reads* that
+           marker; a `base == master` PR still carrying it is a
+           contradiction that can misroute a now-standalone PR into
+           stacked review handling (#2231):
+           `gh pr view <N> --json body -q .body | sed '/^Stacked on:/d' > .merger-body-edit.md`
+           `gh pr edit <N> --body-file .merger-body-edit.md`
+           `rm -f .merger-body-edit.md`
+           (A `## Stack context` heading left with only a `Full chain:`
+           line is history and may stay.)
          - `git rebase origin/master`
          - Branch on the rebase result:
 

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -370,6 +370,12 @@ Do the work, then exit cleanly:
        silently doesn't fire — e.g. the parent was amended during review after
        you forked, so its recorded `headRefOid` is no longer an ancestor of
        your head (#1791).
+       After the drop lands the branch on master, check the PR body: a
+       leftover `Stacked on:` line is now stale (review-pr's stacked
+       detection reads it; base==master + `Stacked on:` is a contradiction,
+       #2231). Strip it in the same iteration:
+       `gh pr view <N> --json body -q .body | sed '/^Stacked on:/d' > /tmp/pr-body-<N>.md`
+       `gh pr edit <N> --body-file /tmp/pr-body-<N>.md`
     d''. **Gated-conflict guard — check before resolving.** List the
        conflicted files (`git diff --name-only --diff-filter=U`). If **every**
        one is a gated self-config file (`.claude/commands/role-*.md`,

--- a/.claude/rules/cpp-ecs.md
+++ b/.claude/rules/cpp-ecs.md
@@ -89,6 +89,10 @@ It carries every cost the boolean does — it bloats the component (hurting arch
 
 Worked example (#1288): `SYSTEM_REBUILD_GRID_VOXELS` cached `lastRebuildWorld{Rotation,Scale,Translation}_` on `C_VoxelSetNew` and early-returned when the live `C_WorldTransform` matched. That snapshot was a dirty flag wearing component-field clothing. The fix dropped the snapshot entirely: on-screen voxel sets re-rasterize every frame, and the system instead skips sets whose pool chunks are outside the cull viewport (`C_VoxelPool::isRangeVisible`). The cull gate answers "is this work observable?" — the honest question — instead of "did the inputs change?".
 
+### Multi-field honest gates must stay consistent across failure paths
+
+When an honest state gate is composed of **multiple coupled fields** (e.g. `C_VoxelSetNew`'s staged gate: `numVoxels_ == 0` **and** `pendingVoxels_` non-empty), every failure / early-return path must leave those fields mutually consistent — a shared mutator that zeroes one gate field on failure must zero (or preserve) **all** of them together. A partial state satisfies neither the "staged" nor the "resident" invariant, and the per-frame driver that re-reads the gate silently mis-processes it (#2240: a retry path preserved the payload but not the extent, producing a silent zero-voxel seed over a right-sized allocation).
+
 ### Live deviations
 
 - `engine/prefabs/irreden/render/components/component_canvas_fog_of_war.hpp` — `C_CanvasFogOfWar::dirty_` and `allUnexplored_` gate the per-frame `subImage2D` upload of the 256² fog texture. The upload is performed by `VOXEL_TO_TRIXEL_STAGE_1` (#2008), which both reads the fog to cull unexplored-column voxels and runs earlier in the pipeline; `FOG_TO_TRIXEL` is now a read-only consumer of the already-uploaded texture. Documented exception (CPU-authored, GPU-read-only, full-texture upload). T-161 evaluated migration to per-region `subImage2D` and deferred; see [`docs/design/fog-of-war-upload-strategy.md`](../../docs/design/fog-of-war-upload-strategy.md) for the analysis, the trigger conditions for revisiting, and the mechanical Strategy C migration sketch.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -100,6 +100,17 @@ any `c_compute_*shadow*.glsl` / `.metal`)
 - A new serialized record type with no `// IRAsset: serialized` annotation —
   the simplify and review-pr checks cannot guard it without the annotation.
   Add the annotation and set `kSaveVersion = 1` on the struct.
+- A loader that mutates live state (entity splice, `setParent`, id-watermark
+  advance) with a fallible decode positioned **after** its first mutation —
+  a mid-apply decode failure leaves the world partially mutated. All decoding
+  must complete (into staged buffers) before the first live mutation; see
+  `engine/asset/CLAUDE.md` Extensibility Rule #5 (recurred #2228 → #2230).
+- `SaveSerialize<C>::write` reading a per-frame-**derived** field instead of
+  the authored source-of-truth. When a system re-derives the component's live
+  representation each frame (rotation re-voxelize, GPU-owned state), the
+  primary field holds a derived arrangement and the authored data sits in a
+  companion field (`*Source*` / `*Snapshot*` / `pending*`, e.g.
+  `rotationSourceVoxels_`) — verify the write reads the companion (PR #2240).
 
 **Naming / style** — follow the table in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming.
 - Private members take `m_`; public members take a trailing `_`. The reversed
@@ -150,11 +161,17 @@ verdict footer if any of these surfaces are touched)
   creation's `CLAUDE.md` is the delta. Apply both. If the subdirectory has a
   dedicated `REVIEW.md`, prefer it for review-specific rules.
 
-**Fleet scripts** (if the diff renames pane IDs, role names, or other
-identifiers in `scripts/fleet/`)
+**Fleet scripts** (if the diff touches `scripts/fleet/`)
 - Inline comments — layout diagrams, role-list blocks, `--help` banners —
-  still naming the old identifiers. `grep` the renamed-from names across the
-  touched scripts; comment blocks drift silently because nothing compiles them.
+  still naming the old identifiers after a rename. `grep` the renamed-from
+  names across the touched scripts; comment blocks drift silently because
+  nothing compiles them.
+- A `~/.fleet/state/state.json` consumer judging cache freshness from file
+  mtime instead of the in-file `generated_at` (UTC epoch; `st_mtime` fallback
+  only when `generated_at` is missing/unparseable) — followers rewrite the
+  file each tick with the leader's `generated_at` preserved, so mtime lies.
+  Shared helper: `fleet_poll_topology.state_age_seconds`; rule + rationale in
+  `docs/agents/FLEET-RUNTIME.md` (recurred: fleet-dispatcher, #2231).
 
 ## Verdict-label swap commands (shared-flow step 5b)
 

--- a/.claude/skills/review-pr/procedures/stacked-pr-review.md
+++ b/.claude/skills/review-pr/procedures/stacked-pr-review.md
@@ -13,6 +13,8 @@ Detect stacking from the metadata already fetched in `SKILL.md` step 1:
 
 If the base is `master` and there's no `Stacked on:` line, this is a standalone PR — return to `SKILL.md` step 1c (churn audit) and continue normally.
 
+If the base is `master` but the body **still carries** a `Stacked on:` line, the marker is stale — the PR was un-stacked (parent merged, base re-targeted) and the strip step was missed. Review it as a standalone PR, and flag the stale line as a nit so it gets removed.
+
 ## What changes when the PR is stacked
 
 - **Review only this PR's own diff.** `gh pr diff <N>` already scopes to the changes this PR introduces on top of its base branch — it does NOT include the parent's changes. Trust that output; don't manually expand the range.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -314,6 +314,18 @@ site (`<name><`, `<name>(`) outside the definition itself. No hit → flag:
 headless test in this PR." Report, don't auto-fix — where the instantiation
 belongs is a design call.
 
+**Check 10: new `scripts/fleet/` executable with no test.**
+
+The review checklist's "new feature with no new test" rule applies to fleet
+tooling, where it's mechanically checkable at authoring time (PR #2232's
+`fleet-gh-token` burned a review round-trip on it). For each newly-added
+executable file under `scripts/fleet/` (not under `tests/`), look for a
+matching `scripts/fleet/tests/test_<name>.{sh,py}` (hyphens → underscores)
+or any test file exercising the tool by name. No hit → flag: "new fleet
+tool with no test_*; add one against a stubbed environment (see
+`scripts/fleet/CLAUDE.md` §Authoring rules for the hermeticity bar)."
+Report, don't auto-fix.
+
 ### 2c. Serialized-struct version-bump check
 
 See `engine/asset/CLAUDE.md` §"Automated version-bump detection" for the full
@@ -484,6 +496,12 @@ Remove:
   common in render code. Cut the forensic prose, keep the durable
   invariant, and leave at most a `// see #N` backref. Task-reference
   comments (`#NNN`) are mechanically caught by §2b Check 7.
+  The per-block judgment call turns **mechanical** when the same
+  multi-line comment/prose block appears near-verbatim at ≥3 sites in
+  the diff (PR #2211 retyped one ~35-line narrative at five) — that is
+  always the hoist case: consolidate into a `docs/design/<topic>.md`
+  and trim every site to the present-tense invariant + a one-line
+  backref, never N near-copies.
 - Location-reference narration that points at other code instead of
   explaining why — `// ... (set above)`, `// see below`, `// called
   from X`. Mechanically caught by §2b Check 4; delete the

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -200,7 +200,12 @@ fleet feedback — **except when the entire fix surface is gated self-config**
 If a `fleet:needs-fix` PR's **entire** changed-file set matches the
 auto-mode self-edit gate (`.claude/commands/role-*.md`, `.claude/agents/*`,
 `.claude/skills/**/SKILL.md`), no worker class can amend it — the gate
-is deterministic and escalating class does not help. This is the PR-feedback
+is deterministic and escalating class does not help. The gate is also
+**content-based**, not only path-based: an edit that grants a fleet role a
+new oversight/review bypass (e.g. a `fleet-state-machine.json` transition
+letting a class self-approve its own plan, #2192) can be blocked on a path
+*outside* that list — treat such a block exactly like a path gate hit
+(comment the precise fix for a human; don't retry via another tool). This is the PR-feedback
 analogue of role-worker.md step 8b. Take the DEFER path, **not** AMEND:
 
 1. Comment the **precise** human fix — exact file(s) and the change needed:

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -412,8 +412,15 @@ worked examples live in `docs/design/entity-editor-epic.md`. The summary:
 5. **Unknown is recoverable, never fatal.** Bad magic, truncated
    file, version newer than the loader knows about → clear diagnostic
    with file path + offset, return an empty/default value, never
-   crash. Test fixtures: corrupt-magic, truncated-mid-chunk,
-   version-too-new, unknown-chunk-tag, unknown-enum-value.
+   crash. A loader that mutates live engine state must fully
+   decode-validate the entire payload **before its first mutation**
+   (or stage-and-splice, applying to the live structures only on full
+   success) so a decode error leaves zero mutation behind —
+   length/id/header checks alone do not satisfy this; a
+   content-corrupt column or chunk must fail before the first entity
+   splice or `setParent` (#2228, #2230). Test fixtures: corrupt-magic,
+   truncated-mid-chunk, version-too-new, unknown-chunk-tag,
+   unknown-enum-value, content-corrupt-but-length-valid.
 6. **JSON sidecar is regenerated from the binary, never the source
    of truth.** Emit on save, ignore on load.
 7. **Save/load surface is documented in one place per format.** Each

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -22,8 +22,12 @@ depth (vec3 → int):
 Helpers:
 
 - `IRMath::pos3DtoPos2DIso(pos3D)` — the projection above.
-- `IRMath::pos3DtoPos2DScreen(pos3D)` — scales + sign-flips the iso result
-  for screen coordinates (backend-dependent Y direction).
+- `IRMath::pos3DtoPos2DScreen(pos3D)` — scales the iso result and maps it to
+  screen coordinates: it **unconditionally negates iso X** (`screen.x =
+  -iso.x`, so increasing `iso.x` is screen-*left*; world `+x` → screen-right,
+  world `+y` → screen-left) and applies the backend-dependent Y sign. The X
+  negation is invisible in the equations above — never derive on-screen X
+  direction from `pos3DtoPos2DIso` alone.
 - `IRMath::pos3DtoDistance(pos3D)` — the depth scalar.
 - `IRMath::isoDepthShift(pos, d)` — returns `pos + (d, d, d)`, which shifts
   depth without affecting the 2D projection. Used for stacked depth layers

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -1017,9 +1017,12 @@ constexpr ivec2 size3DtoOriginOffset2DZ1(const uvec3 size) {
 ///   canvasPixel = canvasOriginOffset + floor(cameraIso) + pos3DtoPos2DIso(world)
 /// @endcode
 ///
-/// Iso Y increases upward; the backend's canvas-to-screen flip is applied
-/// outside these helpers.  **Never inline these equations** — always use
-/// this helper so there is one place to fix coordinate-system bugs.
+/// Iso Y increases upward, and the canvas-to-screen mapping NEGATES iso X
+/// (`screen.x = -iso.x`, see pos3DtoPos2DScreen) — increasing iso.x is
+/// screen-LEFT, so never derive on-screen X direction from these equations
+/// alone.  Both screen adjustments are applied outside this helper.
+/// **Never inline these equations** — always use this helper so there is
+/// one place to fix coordinate-system bugs.
 constexpr ivec2 pos3DtoPos2DIso(const ivec3 position) {
     return ivec2(-position.x + position.y, -position.x - position.y + (2 * position.z));
 }
@@ -1095,7 +1098,9 @@ constexpr vec2 cameraMoveRelativeToYaw(const vec2 isoDelta, const float visualYa
 }
 
 /// Projects @p position to screen space by scaling the iso result by
-/// @p triangleStepSizeScreen and applying the backend-specific Y sign from
+/// @p triangleStepSizeScreen, negating X (`screen.x = -iso.x`: increasing
+/// iso.x is screen-left, so world +x is screen-right and world +y
+/// screen-left), and applying the backend-specific Y sign from
 /// IRPlatform::kGfx.
 constexpr vec2 pos3DtoPos2DScreen(const vec3 position, const vec2 triangleStepSizeScreen) {
     return pos3DtoPos2DIso(position) * triangleStepSizeScreen *

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -1,0 +1,29 @@
+# scripts/fleet/ — fleet tooling
+
+Bash + Python tooling for the autonomous fleet (scout, dispatcher, claim,
+install, per-tool wrappers) and its tests under `tests/`. Python style is
+ruff-enforced (`ruff check scripts/`, CI-gated); the engine comment policy
+applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
+
+## Authoring rules
+
+- **Tests are hermetic — no live GitHub, no live `~/.fleet`.** Mock network
+  fetchers at a seam that *fails closed*: a mock miss must raise, never fall
+  through to `urllib`/`gh` (#2227 shipped tests that silently hit the live
+  API and wrote the production scout's ETag cache). Never let a test share
+  `fleet_gh_poll.DEFAULT_CACHE_DIR` (`~/.fleet/state/etag`) — inject a
+  `tempfile.TemporaryDirectory()` `cache_dir` instead. When migrating a
+  fetcher's transport (e.g. `run_capture(gh)` → `conditional_get`), re-point
+  *every* test mock at the new seam in the same PR.
+- **Dual-spelling options validate both arms identically.** A wrapper that
+  accepts `--opt val` and `--opt=val` has two independent case arms: reject
+  an empty `--opt=` exactly as the space form rejects a missing value. A
+  diverging equals arm lets `--opt=$UNSET_VAR` slip an empty string past
+  downstream `[[ -n "$var" ]]` guards (#2193: bypassed a claim check).
+- **`state.json` staleness comes from the in-file `generated_at`, never file
+  mtime.** Canonical rule + rationale: `docs/agents/FLEET-RUNTIME.md`.
+  Shared helper: `fleet_poll_topology.state_age_seconds` (a heredoc consumer
+  that can't import mirrors it inline, commented as such).
+- **A new executable ships with a `tests/test_<name>.{sh,py}`** in the same
+  PR — the fleet-tooling form of the review checklist's "new feature with no
+  new test"; the `simplify` pre-commit pass flags the omission.


### PR DESCRIPTION
## Summary

Human-cued `triage-coding-improvements` run: swept 13 open `fleet:coding-improvement` tickets, triaged each with the human, and bundled the accepted convention-surface changes into this one PR. Diff maps 1:1 to the digest below — no engine/creation code changes.

## Triage digest

| Ticket | Verdict | Applied where |
|---|---|---|
| #2233 validate-before-mutate loaders (recurred 2× on PR #2230) | ACCEPT + escalate | `engine/asset/CLAUDE.md` Rule #5 tightening + content-corrupt fixture; review-pr checklist backstop bullet |
| #2241 SaveSerialize persists authored source-of-truth | ACCEPT | review-pr checklist (Serialization) |
| #2243 multi-field honest gates consistent across failure paths | ACCEPT | `.claude/rules/cpp-ecs.md` (No-dirty-flags section corollary) |
| #2252 iso docs must state screen.x = -iso.x | ACCEPT | `engine/math/CLAUDE.md` + `ir_math.hpp` doc comments on `pos3DtoPos2DIso` / `pos3DtoPos2DScreen` |
| #2250 strip stale `Stacked on:` marker on un-stack | ACCEPT | role-merger sub-case ii, role-worker step-1c d', stacked-pr-review detection backstop |
| #2237 new fleet executable needs a test | ACCEPT | simplify Check 10 |
| #2235 state.json staleness via generated_at (2 occurrences) | RESCOPE | review-pr checklist (Fleet scripts) + `scripts/fleet/CLAUDE.md` pointer; mechanical lint flag split out to #2267 |
| #2229 hermetic fleet tests (fail-closed mocks, isolated cache_dir) | ACCEPT | new `scripts/fleet/CLAUDE.md` |
| #2205 dual-spelling bash options validate `--opt=` empty | ACCEPT | new `scripts/fleet/CLAUDE.md` |
| #2224 same comment block duplicated ≥3 sites → hoist | RESCOPE | simplify §7 bullet extension (no new subagent) |
| #2202 self-edit gate is also content-based | RESCOPE (one-liner) | `docs/agents/FLEET-FEEDBACK-HANDLING.md` DEFER section |
| #2261 registry additions extend IRPersist round-trip test | DEFER | blocked on PR #2244 (target doc section ships with it); noted on ticket |
| #1865 device-backend graceful-degradation tests | DEFER (unchanged) | prior human defer stands; unblocks on recurrence |

Rejected: none this run (the two REJECT candidates, #2202/#2224, were rescoped to one-liners instead per triage).

Split-outs: #2267 (best-effort `st_mtime`-near-`state.json` lint flag — the mechanical remainder of #2235).

Gated self-config files in the diff (`role-*.md`, two `SKILL.md`s) are expected for this skill — reviewer checks the changes match this digest.

## Test plan

- [ ] `fleet-build --target format-changed` clean (run pre-commit; no rewrites)
- [ ] Doc cross-refs verified: `fleet_poll_topology.state_age_seconds`, `scripts/fleet/tests/`, §Authoring rules anchor, Rule #5 naming all resolve

Closes #2233
Closes #2241
Closes #2243
Closes #2252
Closes #2250
Closes #2237
Closes #2235
Closes #2229
Closes #2224
Closes #2205
Closes #2202

🤖 Generated with [Claude Code](https://claude.com/claude-code)