### PR TITLE
render: per-axis compute indirect-dispatch over compacted cells (#2256)

### DIFF
--- a/.fleet/plans/issue-2256.md
+++ b/.fleet/plans/issue-2256.md
@@ -1,0 +1,76 @@
+# Plan: render — close the remaining yaw-vs-cardinal frame gap (per-axis lighting + scatter stages)
+
+- **Issue:** #2256
+- **Model:** opus — heavy render-pipeline work, but it *applies an established indirect-compute-over-compacted-cells pattern* (already shipped for the voxel raster in `system_voxel_to_trixel.hpp`) to four more stages, rather than inventing a new algorithm. Multi-shader + GL/Metal parity + byte-identity/ordering judgment put it above sonnet; the existing reference impl keeps it below fable.
+- **Date:** 2026-07-05
+- **Blocked by:** PR #2254 (stack #2249 → #2251 → #2254). The settled baselines in this issue were measured on that stack; implement on top of it. Plan is complete now; start once the stack merges. (Merged as of implementation — commit `5b2079b3`.)
+
+## Verified current state (source-checked, not assumed)
+
+The per-axis (split-mode, rotating) path runs **four** GPU compute stages, each dispatched over the **full worst-case per-axis grid** — never clipped to what is actually populated — with empty cells skipped only *in-shader* by a `0x7FFFFFFF` sentinel test:
+
+| stage | dispatch site | grid |
+|---|---|---|
+| `COMPUTE_VOXEL_AO` | `system_compute_voxel_ao.hpp:120-168` (`dispatchPerAxisAO`, grid @137-138, 3-axis loop @139-144) | `divCeil(axes.size_, 16)` × 3 |
+| `COMPUTE_SUN_SHADOW` | `system_compute_sun_shadow.hpp:85-132` (grid @102-103, loop @104-109) | `divCeil(axes.size_, 16)` × 3 |
+| `LIGHTING_TO_TRIXEL` | `system_lighting_to_trixel.hpp:224-280` (grid @242-243, loop @244-251) | `divCeil(axes.size_, 16)` × 3 |
+| `RESOLVE_PER_AXIS_SCREEN_DEPTH` pass 1 (scatter) | `system_resolve_per_axis_screen_depth.hpp:138-149` | `divCeil(axisSize, 16)` × 3 |
+
+`axes.size_` is the worst-case rotated footprint `≈ (2W, W+H)` (`per_axis_canvas.hpp:41`, stored `component_per_axis_trixel_canvases.hpp:67`). At zoom 8 + yaw the canvas is large, so this is `~3 × 4 = 12` full-`(2W)(W+H)` compute sweeps whose invocations mostly hit the sentinel and early-return — the un-scoped GPU work that the issue's profiling attributes the ~6 ms yaw delta to (raster stage-1 is already at/under cardinal parity there).
+
+**The occupied-cell list needed to fix this already exists** but only feeds the *raster scatter*, not the compute stages:
+- `c_per_axis_cell_compact.glsl` (`engine/render/src/shaders/`) scans one per-axis distance canvas and, per occupied cell (`rawDist < 0x7FFFFFFF`), `atomicAdd`s a count and appends the cell's linear index into a per-axis SSBO region (slots 25/26).
+- Driven by `compactPerAxisCells()` (`system_trixel_to_framebuffer.hpp:438-480`), run in that system's **`beginTick`** (line 509) — i.e. at the **end** of the render pipeline, *after* the four compute stages above. It fills a `PerAxisCellDrawCommand` (draw-indirect) consumed by `drawElementsInstancedIndirect` in `drawPerAxisScatter` (`:337-354`).
+
+**Indirect compute is already a first-class primitive on both backends** — `RenderDevice::dispatchComputeIndirect(buffer, offset)` (`render_device.hpp:30`), implemented at `opengl_render_impl.cpp:36` and `metal_render_impl.cpp:422`. A **direct reference implementation** of "GPU-count a per-axis compacted cell set → indirect-compute one workgroup per N cells indexing the list" already ships for the voxel raster at `system_voxel_to_trixel.hpp:564,577`, using a `VoxelIndirectDispatchParams` buffer (`ir_render_types.hpp:1193`, `numGroupsX/Y/Z + visibleCount`).
+
+**Why byte-identity is the correctness gate:** downstream consumers of the per-axis lighting/depth only ever *read occupied cells* — the scatter draw draws only compacted cells (#1961), and the resolve scatter contributes only sentinel-guarded cells via order-independent `imageAtomicMin`. So dispatching a compute stage over *exactly* the occupied cells (instead of the full grid) removes only invocations that wrote nothing that is ever read ⇒ the final framebuffer is bit-for-bit unchanged. This is the load-bearing invariant the implementer must re-confirm (below), and it doubles as the test.
+
+## Approach (single, committed)
+
+Feed the four per-axis **compute** stages from the same occupied-cell compaction that already feeds the scatter, via indirect compute — so each stage processes only occupied cells rather than the full `(2W)(W+H)` grid.
+
+1. **Move the per-axis compaction earlier in the pipeline.** It must run *after* per-axis routing (T2, inside `VOXEL_TO_TRIXEL_STAGE_1`) and *before* `COMPUTE_VOXEL_AO`, so the compacted list is available to the compute stages this frame. Preferred: run `compactPerAxisCells()` in `VOXEL_TO_TRIXEL_STAGE_1::endTick` (no new `SystemName`, no per-creation pipeline reorder). **Verify first** that the per-axis distance canvas is fully written by the end of STAGE_1's tick (STAGE_1 runs compact+stage1+stage2 in one tick per `render/CLAUDE.md`); if T2's routing barrier isn't complete there, fall back to a dedicated tiny system registered between `VOXEL_TO_TRIXEL_STAGE_1` and `COMPUTE_VOXEL_AO` (add its `SystemName` first, and insert it in every render pipeline that lists the per-axis stages — canonical list `creations/demos/shape_debug/main.cpp:511-533`). Remove the now-redundant late build in `TRIXEL_TO_FRAMEBUFFER::beginTick`; the scatter consumes the earlier-built list unchanged.
+2. **Extend the compaction to also emit compute-indirect params.** It already writes a `PerAxisCellDrawCommand` (draw-indirect) per axis. Add a sibling `VoxelIndirectDispatchParams`-shaped write per axis: `numGroupsX = divCeil(occupiedCount, tile)`, `numGroupsY = numGroupsZ = 1`, plus `visibleCount = occupiedCount` for the in-shader bound guard. Reuse the slot-26 indirect-params region (`kBufferIndex_PerAxisCellIndirect = kBufferIndex_IndirectDispatchParams = 26`) with the same per-axis stride discipline the draw command already uses; if draw-args and dispatch-args can't share the exact bytes, append a second aligned per-axis block (mirror `kPerAxisSsboAlignBytes`).
+3. **Convert the four compute dispatches to indirect over the compacted list.** For each of AO / sun-shadow / lighting / resolve-scatter, replace the `dispatchCompute(divCeil(axes.size_,16))` inside the 3-axis loop with `dispatchComputeIndirect(perAxisIndirectBuf, axisOffset)` (template: `system_voxel_to_trixel.hpp:564`). Each kernel gains a 1-D global invocation → `idx`; guard `if (idx >= visibleCount) return;`; read `cell = compactedList[axisBase + idx]`; decode `(x,y)` from the linear cell index; then run the **unchanged** per-cell body (`perAxisRoute` handling, `perAxisCellToWorld3D` recovery — no lighting-math change). Bind the per-axis compacted-list + params SSBOs before each loop. Kernels touched: `c_compute_voxel_ao.glsl`, `c_compute_sun_shadow.glsl`, `c_lighting_to_trixel.glsl`, `c_resolve_per_axis_screen_depth.glsl` — **and their `.metal` twins** (backend parity is mandatory; see Gotchas).
+4. **Preserve the main-canvas image-rebind restore** after each 3-axis loop (`system_lighting_to_trixel.hpp:274-279` and the AO/sun-shadow siblings) — Metal's image-binding table persists across frames and dangles at the next cardinal `release()` (#1311). The restore must stay; converting the loop body must not drop it.
+
+Leaves untouched: the scatter composite (already tight via #1961), the resolve **pass 2** blit (main-canvas-sized, not per-axis, not the target), all lighting/AO/shadow *math*, and the cardinal fast path (per-axis textures freed at cardinals ⇒ every guard false ⇒ byte-identical).
+
+## Affected files
+- `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp` — relocate/relet `compactPerAxisCells()`; emit compute-indirect params alongside the draw command; drop the late build.
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel_stage_1.hpp` (or a new interstitial system) — host the early compaction call; if new system, add its `SystemName`.
+- `engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp`, `system_compute_sun_shadow.hpp`, `system_lighting_to_trixel.hpp`, `system_resolve_per_axis_screen_depth.hpp` — indirect-dispatch the per-axis loops; bind the list/params SSBOs.
+- `engine/render/src/shaders/c_compute_voxel_ao.glsl`, `c_compute_sun_shadow.glsl`, `c_lighting_to_trixel.glsl`, `c_resolve_per_axis_screen_depth.glsl` — 1-D invocation → list index → cell decode; bound guard.
+- The matching `engine/render/src/metal/…/*.metal` kernels — same transform (register threadgroup sizes, see Gotchas).
+- `engine/render/include/irreden/render/ir_render_types.hpp` — a per-axis compute-indirect params struct/region if not shareable with `PerAxisCellDrawCommand`.
+- `engine/system/include/irreden/system/ir_system_types.hpp` + the render pipeline lists — only if a new interstitial `SystemName` is chosen in step 1.
+- `engine/render/src/shaders/c_per_axis_cell_compact.glsl` — write the dispatch-params if the compaction kernel emits them (vs a CPU-side derive).
+
+## Cross-system audit (dispatch-iteration change to a shared per-axis surface)
+
+Consumers of the per-axis compacted-cell list / indirect-params region (slots 25/26) and the per-axis compute outputs:
+- **`drawPerAxisScatter`** (`system_trixel_to_framebuffer.hpp:337-354`) — already consumes the draw-command; must keep reading the *same* list after it's built earlier. No behavior change intended; verify the earlier build produces byte-identical scatter.
+- **AO / sun-shadow / lighting** per-axis outputs (`ao_`, `sunShadow_`, per-axis color) — read only by the scatter at occupied cells; safe under the invariant.
+- **`RESOLVE_PER_AXIS_SCREEN_DEPTH` → `BAKE_SUN_SHADOW_MAP`** (`system_bake_sun_shadow_map.hpp:292-314` reads `resolveDepth_`) — resolve pass 1 scatters occupied cells via `imageAtomicMin` into the slot-28 scratch; occupied-only dispatch is byte-identical (atomicMin is order-independent, empties contribute nothing). Pass 2 blit unchanged.
+- **Slot budget (0–30 is full).** Slots 25/26 (compacted list / indirect params) and 28 (resolve scratch, aliased to `LightOcclusionGrid`/sun depth map) are already in use with a transient-rebind discipline. Any new params block must fit the existing slots or reuse transiently — do **not** claim a new permanent binding (`render/CLAUDE.md` "GPU buffer bind-point budget is full").
+
+## Sibling / in-flight reconciliation
+- **Two different "compact" passes — do not confuse them.** #2251/#2254 (the blocker stack) change the **stage-1 voxel compact** (`roundHalfUp` cell conversion; fully-interior voxel drop). This task changes the **#1961 per-axis cell compact** (`c_per_axis_cell_compact.glsl`) — a distinct pass. The issue's baselines already include #2254's stage-1 changes.
+- **Sun-shadow bake PRs #2140 (analytic edge-aware coverage, fable, design-blocked) and #2204 (cardinal footprint-splat, design-blocked)** touch `BAKE_SUN_SHADOW_MAP` / shadow *quality*. This task changes only per-axis compute *dispatch iteration*, not shadow-sampling math, and is byte-identity-preserving — so it composes with whatever the bake produces regardless of those PRs' resolution. Coordinate ordering with the merger if both land near each other, but there is no design conflict.
+
+## Acceptance criteria
+- **Cardinal poses byte-identical** before/after (per-axis path is off at cardinals — confirms no fast-path regression). Use `--auto-screenshot` cardinal shots, byte-compared.
+- **Yaw poses: no visual regression** — but **not** an exact byte-compare (see #2255 in Gotchas). Use a thresholded render-verify at `--yaw 0.35`, zoom 1/8, plus opus visual inspection for missing lit/shadowed regions (a dropped occupied cell shows as an unlit hole).
+- **Measured GPU-time reduction** at the target pose: `fleet-run IRPerfGrid --auto-profile 300 --zoom 8 --yaw 0.35` shows a lower frame time and lower per-axis-stage GPU time than the #2254-stack baseline (13.8 ms / 81 FPS today). Report the before/after table in the PR.
+- No new nondeterminism introduced (occupied-only dispatch must not change atomicMin tie outcomes — it can't, but confirm run-to-run yaw noise is no worse than the #2255 floor).
+
+## Gotchas
+- **#2255: per-axis output is already run-to-run nondeterministic at a fixed yaw.** Do **not** gate on exact yaw byte-identity — it will flake independent of this change. Byte-compare **cardinal** shots only; use thresholded compare + inspection for yaw (per the shader-A/B staged-swap workflow).
+- **GL + Metal parity is mandatory** — every `.glsl` kernel edited here has a `.metal` twin that must get the identical index-through-list transform. New/changed Metal compute kernels default to a 1×1×1 threadgroup unless registered in the threadgroup-size map (`metal_pipeline.cpp`), which silently under-dispatches — register them.
+- **Metal image-binding restore** after each per-axis loop (#1311) must be preserved verbatim; the loop-body rewrite is the exact place it's easy to drop.
+- **Resolve scratch seeding** (`system_resolve_per_axis_screen_depth.hpp:96-99`) currently uses a CPU-sized staging vector + `subData` (a flagged live deviation). Not required by this task, but if the resolve pass is touched, migrate it to a GPU-side clear per `render/CLAUDE.md` ("Seed GPU-buffer sentinels GPU-side").
+- **Ordering barrier:** the early compaction reads the per-axis distance canvas written by T2 — ensure a memory/image barrier between T2's write and the compaction read (STAGE_1 already barriers between its sub-dispatches; confirm the compaction sits after that barrier).
+- **Empty-scene / zero-occupied guard:** `numGroups = 0` must issue a no-op indirect dispatch cleanly on both backends (the voxel reference at `system_voxel_to_trixel.hpp:564` already handles this — mirror it).
+
+*(Note: `RESOLVE_PER_AXIS_SCREEN_DEPTH` runs GL-and-Metal-portable compute — no image atomics — so this is verifiable on the macOS/Metal host the baselines were taken on.)*

--- a/engine/prefabs/irreden/render/components/component_per_axis_trixel_canvases.hpp
+++ b/engine/prefabs/irreden/render/components/component_per_axis_trixel_canvases.hpp
@@ -4,10 +4,13 @@
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_render.hpp>
 
+#include <irreden/render/buffer.hpp>
+#include <irreden/render/ir_render_types.hpp>
 #include <irreden/render/texture.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 
 #include <array>
+#include <cstdint>
 #include <utility>
 
 using namespace IRMath;
@@ -77,6 +80,21 @@ struct C_PerAxisTrixelCanvases {
     // worst-case sized) — this is a single screen-space resolve.
     std::pair<ResourceId, Texture2D *> resolveDepth_{0, nullptr};
 
+    // #2256: per-axis occupied-cell compaction outputs. VOXEL_TO_TRIXEL_STAGE_1's
+    // endTick scans each axis distance canvas and writes them; the per-axis
+    // COMPUTE stages (AO / sun-shadow / lighting / resolve) dispatchComputeIndirect
+    // over them, and the framebuffer scatter draws them — so every stage processes
+    // only occupied cells instead of the full worst-case (2W)(W+H) grid. Owned
+    // here (not by a single system) so all consumers reach them via the per-axis
+    // component they already resolve; same rotation-only lifecycle as the textures.
+    //   cellCompacted_ — per-axis regions of occupied linear cell indices (slot 25).
+    //   cellIndirect_  — per-axis 256 B blocks carrying BOTH the draw-indirect
+    //                    command (bytes 0..31) and the compute-indirect dispatch
+    //                    params (byte 32; see ir_render_types.hpp).
+    std::pair<ResourceId, Buffer *> cellCompacted_{0, nullptr};
+    std::pair<ResourceId, Buffer *> cellIndirect_{0, nullptr};
+    int cellRegionStride_ = 0; // uints per axis in cellCompacted_ (>= axis cells, 64-aligned)
+
     // Allocation state is the texture handles themselves — no separate bool to
     // drift out of sync (cf. the no-dirty-flags rule in .claude/rules/cpp-ecs.md).
     bool isAllocated() const {
@@ -104,6 +122,27 @@ struct C_PerAxisTrixelCanvases {
             axis.sunShadow_ = detail::makeCanvasColorTexture(size);
         }
         resolveDepth_ = detail::makeCanvasDistanceTexture(mainSize);
+        // #2256: per-axis compaction buffers, sized to the per-axis canvas. The
+        // occupied-cell region stride is 64-uint (256 B) aligned so each axis's
+        // bindRange offset is SSBO-alignment-safe (mirrors the #1961 sizing that
+        // previously lived in TRIXEL_TO_FRAMEBUFFER::ensurePerAxisCellBuffers).
+        cellRegionStride_ = IRMath::divCeil(size.x * size.y, 64) * 64;
+        cellCompacted_ = IRRender::createResource<Buffer>(
+            nullptr,
+            static_cast<std::size_t>(cellRegionStride_) * static_cast<std::size_t>(kAxisCount) *
+                sizeof(std::uint32_t),
+            BUFFER_STORAGE_DYNAMIC,
+            BufferTarget::SHADER_STORAGE,
+            kBufferIndex_PerAxisCellCompacted
+        );
+        cellIndirect_ = IRRender::createResource<Buffer>(
+            nullptr,
+            static_cast<std::size_t>(kAxisCount) *
+                static_cast<std::size_t>(kPerAxisCellIndirectStrideBytes),
+            BUFFER_STORAGE_DYNAMIC,
+            BufferTarget::SHADER_STORAGE,
+            kBufferIndex_PerAxisCellIndirect
+        );
         // Clear to the empty sentinel so a creation that allocates per-axis
         // canvases but does NOT register RESOLVE_PER_AXIS_SCREEN_DEPTH still
         // reads "no per-axis caster" from BAKE rather than garbage — the
@@ -132,6 +171,15 @@ struct C_PerAxisTrixelCanvases {
         }
         IRRender::destroyResource<Texture2D>(resolveDepth_.first);
         resolveDepth_ = {0, nullptr};
+        if (cellCompacted_.second != nullptr) {
+            IRRender::destroyResource<Buffer>(cellCompacted_.first);
+            cellCompacted_ = {0, nullptr};
+        }
+        if (cellIndirect_.second != nullptr) {
+            IRRender::destroyResource<Buffer>(cellIndirect_.first);
+            cellIndirect_ = {0, nullptr};
+        }
+        cellRegionStride_ = 0;
         size_ = ivec2{0, 0};
     }
 

--- a/engine/prefabs/irreden/render/systems/system_resolve_per_axis_screen_depth.hpp
+++ b/engine/prefabs/irreden/render/systems/system_resolve_per_axis_screen_depth.hpp
@@ -137,14 +137,36 @@ template <> struct System<RESOLVE_PER_AXIS_SCREEN_DEPTH> {
         // scratch (front-most per screen pixel via atomicMin).
         scatterProgram_->use();
         scratch_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_PerAxisResolveScratch);
-        const ivec2 axisSize = perAxisCanvases_->size_;
-        const int axisGroupsX = IRMath::divCeil(axisSize.x, kResolvePerAxisGroupSize);
-        const int axisGroupsY = IRMath::divCeil(axisSize.y, kResolvePerAxisGroupSize);
+        // #2256: dispatch each axis over ONLY its occupied cells via the per-axis
+        // compaction list (built in VOXEL_TO_TRIXEL_STAGE_1::endTick) instead of
+        // the full worst-case per-axis grid. Byte-identical — the compacted set is
+        // exactly the occupied cells the old full sweep processed (empties
+        // early-returned) and the atomicMin scatter is order-independent.
         for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
             perAxisCanvases_->axes_[axis].distances_.second->bindAsImage(
                 0, TextureAccess::READ_ONLY, TextureFormat::R32I
             );
-            IRRender::device()->dispatchCompute(axisGroupsX, axisGroupsY, 1);
+            perAxisCanvases_->cellCompacted_.second->bindRange(
+                BufferTarget::SHADER_STORAGE,
+                kBufferIndex_PerAxisCellCompacted,
+                static_cast<std::ptrdiff_t>(axis) * perAxisCanvases_->cellRegionStride_ *
+                    static_cast<int>(sizeof(std::uint32_t)),
+                static_cast<size_t>(perAxisCanvases_->cellRegionStride_) * sizeof(std::uint32_t)
+            );
+            // Bind the whole 256 B block (256-aligned) so the shader reads
+            // visibleCount at uint index 11; dispatch-indirect reads numGroups at
+            // the compute record's byte offset within the same block.
+            perAxisCanvases_->cellIndirect_.second->bindRange(
+                BufferTarget::SHADER_STORAGE,
+                kBufferIndex_PerAxisCellIndirect,
+                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
+                static_cast<size_t>(kPerAxisCellIndirectStrideBytes)
+            );
+            IRRender::device()->dispatchComputeIndirect(
+                perAxisCanvases_->cellIndirect_.second,
+                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
+                    kPerAxisCellComputeDispatchOffsetBytes
+            );
         }
         IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
 

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -50,30 +50,19 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
     IREntity::EntityId perAxisCanvasEntity_ = IREntity::kNullEntity;
     const C_PerAxisTrixelCanvases *perAxisCanvases_ = nullptr;
 
-    // Per-axis empty-cell compaction (#1961). A compute pre-pass in beginTick
-    // appends each per-axis canvas's occupied cells into per-axis SSBO regions
-    // and sets the indirect instanced-draw arg counts, so drawPerAxisScatter
-    // rasterizes only occupied cells instead of sweeping the whole worst-case
-    // grid. Buffers alias slots 25/26 (free at this stage) and are lazily sized
-    // to the per-axis canvas (cellCompactedBuf_ reallocates on size change; the
-    // fixed-size indirect-args buffer is created once). All inert at a cardinal
-    // (per-axis canvases unallocated → compaction skipped → byte-identical).
-    ShaderProgram *cellCompactProgram_ = nullptr;
-    ResourceId cellCompactedId_ = 0;
-    Buffer *cellCompactedBuf_ = nullptr;
-    ResourceId cellIndirectId_ = 0;
-    Buffer *cellIndirectBuf_ = nullptr;
-    ivec2 cellBufAxisSize_ = ivec2(0, 0);
-    int perAxisCellRegionStride_ = 0; // uints per axis region (>= axis cells, 64-aligned)
-    static constexpr int kPerAxisCellCompactGroupSize = 16;
-    // Voxel-compaction buffers (VOXEL_TO_TRIXEL_STAGE_1's named resources) that
-    // own slots 25/26. STAGE_1's single-canvas compact relies on those slots
-    // staying bound to these across frames; since the cell compaction transiently
-    // rebinds 25/26, it must restore them afterward — the same discipline STAGE_1's
-    // own per-axis path follows. Looked up lazily (STAGE_1's create() runs first,
-    // but deferring to the first rotating frame avoids a creation-order dependency);
-    // null only if no voxel system is registered, in which case no per-axis path
-    // runs either, so the restore never fires.
+    // Per-axis empty-cell compaction (#1961). The compaction pre-pass now runs in
+    // VOXEL_TO_TRIXEL_STAGE_1::endTick (#2256) so its compacted list + indirect
+    // args are available to the per-axis COMPUTE stages this frame, not just this
+    // scatter; the buffers live on C_PerAxisTrixelCanvases. drawPerAxisScatter
+    // reads them off the per-axis component. All inert at a cardinal (per-axis
+    // canvases unallocated → compaction skipped → byte-identical).
+    //
+    // The cell compaction (in STAGE_1) transiently rebinds slots 25/26, and this
+    // scatter's per-axis bindRange leaves the cell buffers bound there; restore
+    // STAGE_1's voxel-compaction buffers afterward so the next frame's single-canvas
+    // compact still reads its own buffers (the #1961 center-cube regression).
+    // Looked up lazily by name; null only if no voxel system is registered, in
+    // which case no per-axis path runs either, so the restore never fires.
     Buffer *voxelCompactedBuf_ = nullptr;
     Buffer *voxelIndirectBuf_ = nullptr;
 
@@ -329,26 +318,28 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
 
         scatterProgram_->use();
         IRRender::device()->setPolygonMode(PolygonMode::FILL);
-        // #1961: instance over only the compacted occupied cells (filled by the
-        // beginTick compaction pre-pass) via an indirect draw whose instance
-        // count is the GPU-written occupied-cell count — instead of the full
-        // worst-case grid (axes.size_.x * axes.size_.y, mostly empty). Each axis
-        // binds its own compacted-list region + indirect-args struct.
+        // #1961: instance over only the compacted occupied cells (filled by
+        // VOXEL_TO_TRIXEL_STAGE_1's endTick compaction pre-pass, #2256) via an
+        // indirect draw whose instance count is the GPU-written occupied-cell count
+        // — instead of the full worst-case grid (axes.size_.x * axes.size_.y,
+        // mostly empty). The compacted-list + indirect-args buffers live on the
+        // per-axis component (shared with the compute stages); each axis binds its
+        // own region + reads the draw-args at that axis's block offset (byte 0).
         for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
             const C_PerAxisTrixelCanvases::AxisTextures &tex = axes.axes_[axis];
             tex.colors_.second->bind(0);
             tex.distances_.second->bind(1);
-            cellCompactedBuf_->bindRange(
+            axes.cellCompacted_.second->bindRange(
                 BufferTarget::SHADER_STORAGE,
                 kBufferIndex_PerAxisCellCompacted,
-                static_cast<std::ptrdiff_t>(axis) * perAxisCellRegionStride_ *
+                static_cast<std::ptrdiff_t>(axis) * axes.cellRegionStride_ *
                     static_cast<int>(sizeof(std::uint32_t)),
-                static_cast<size_t>(perAxisCellRegionStride_) * sizeof(std::uint32_t)
+                static_cast<size_t>(axes.cellRegionStride_) * sizeof(std::uint32_t)
             );
             IRRender::device()->drawElementsInstancedIndirect(
                 DrawMode::TRIANGLES,
                 IndexType::UNSIGNED_SHORT,
-                cellIndirectBuf_,
+                axes.cellIndirect_.second,
                 static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes
             );
         }
@@ -387,98 +378,6 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         }
     }
 
-    // Per-axis empty-cell compaction (#1961). (Re)allocate the compacted-cell
-    // SSBO to @p axisSize (one region per axis, sized to the per-axis canvas)
-    // and create the fixed-size indirect-args buffer once. The compacted region
-    // is rounded up to a 64-uint (256 B) multiple so each axis's bindRange offset
-    // is SSBO-alignment-safe. Reallocates only on a size change (window/canvas
-    // resize), never per frame.
-    void ensurePerAxisCellBuffers(ivec2 axisSize) {
-        if (cellIndirectBuf_ == nullptr) {
-            auto created = IRRender::createResource<Buffer>(
-                nullptr,
-                static_cast<size_t>(C_PerAxisTrixelCanvases::kAxisCount) *
-                    static_cast<size_t>(kPerAxisCellIndirectStrideBytes),
-                BUFFER_STORAGE_DYNAMIC,
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellIndirect
-            );
-            cellIndirectId_ = created.first;
-            cellIndirectBuf_ = created.second;
-        }
-        if (cellCompactedBuf_ != nullptr && cellBufAxisSize_ == axisSize) {
-            return;
-        }
-        if (cellCompactedBuf_ != nullptr) {
-            IRRender::destroyResource<Buffer>(cellCompactedId_);
-            cellCompactedBuf_ = nullptr;
-        }
-        const int axisCells = axisSize.x * axisSize.y;
-        perAxisCellRegionStride_ = IRMath::divCeil(axisCells, 64) * 64;
-        const size_t totalUints = static_cast<size_t>(perAxisCellRegionStride_) *
-                                  static_cast<size_t>(C_PerAxisTrixelCanvases::kAxisCount);
-        auto created = IRRender::createResource<Buffer>(
-            nullptr,
-            totalUints * sizeof(std::uint32_t),
-            BUFFER_STORAGE_DYNAMIC,
-            BufferTarget::SHADER_STORAGE,
-            kBufferIndex_PerAxisCellCompacted
-        );
-        cellCompactedId_ = created.first;
-        cellCompactedBuf_ = created.second;
-        cellBufAxisSize_ = axisSize;
-    }
-
-    // Per-axis empty-cell compaction (#1961). Scan each per-axis distance canvas
-    // and append its occupied cells into that axis's compacted-list region,
-    // setting the indirect instanced-draw arg count drawPerAxisScatter issues
-    // from. Runs in beginTick BEFORE the framebuffer render pass (a pure compute
-    // prelude) — slots 25/26 are free here (the voxel compaction finished stages
-    // ago). Caller guarantees perAxisCanvases_ is non-null + allocated.
-    void compactPerAxisCells() {
-        const ivec2 axisSize = perAxisCanvases_->size_;
-        ensurePerAxisCellBuffers(axisSize);
-
-        // Reset each axis's draw-args struct: indexCount = quad index count,
-        // instanceCount = 0 (the compaction atomic-appends), firstIndex /
-        // baseVertex / baseInstance = 0.
-        PerAxisCellDrawCommand resetCmd{};
-        resetCmd.indexCount = static_cast<std::uint32_t>(IRShapes2D::kQuadIndicesLength);
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            cellIndirectBuf_->subData(
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                sizeof(PerAxisCellDrawCommand),
-                &resetCmd
-            );
-        }
-
-        cellCompactProgram_->use();
-        const int groupsX = IRMath::divCeil(axisSize.x, kPerAxisCellCompactGroupSize);
-        const int groupsY = IRMath::divCeil(axisSize.y, kPerAxisCellCompactGroupSize);
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            cellCompactedBuf_->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellCompacted,
-                static_cast<std::ptrdiff_t>(axis) * perAxisCellRegionStride_ *
-                    static_cast<int>(sizeof(std::uint32_t)),
-                static_cast<size_t>(perAxisCellRegionStride_) * sizeof(std::uint32_t)
-            );
-            cellIndirectBuf_->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                sizeof(PerAxisCellDrawCommand)
-            );
-            perAxisCanvases_->axes_[axis]
-                .distances_.second->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
-        }
-        // The scatter vertex shader reads the compacted list (SHADER_STORAGE) and
-        // the indirect instanced draw reads the args buffer (COMMAND).
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-        IRRender::device()->memoryBarrier(BarrierType::COMMAND);
-    }
-
     void beginTick() {
         HoveredEntityIdLayout resetData;
         hoveredIdBuf_->subData(0, sizeof(resetData), &resetData);
@@ -499,14 +398,6 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
             if (perAxis.has_value() && (*perAxis.value()).isAllocated()) {
                 perAxisCanvases_ = perAxis.value();
             }
-        }
-
-        // #1961: compact each per-axis canvas's occupied cells into an indirect
-        // draw BEFORE binding the framebuffer (a pure compute prelude; slots
-        // 25/26 are free here). cellCompactProgram_ is restored to the gather
-        // program just below.
-        if (perAxisCanvases_ != nullptr) {
-            compactPerAxisCells();
         }
 
         program_->use();
@@ -532,11 +423,6 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
                 ShaderStage{IRRender::kFileVertPerAxisScatter, ShaderType::VERTEX},
                 ShaderStage{IRRender::kFileFragPerAxisScatter, ShaderType::FRAGMENT}
             }
-        );
-        // Per-axis empty-cell compaction pre-pass (#1961) — see compactPerAxisCells.
-        IRRender::createNamedResource<ShaderProgram>(
-            "PerAxisCellCompactProgram",
-            std::vector{ShaderStage{IRRender::kFileCompPerAxisCellCompact, ShaderType::COMPUTE}}
         );
         IRRender::createNamedResource<Buffer>(
             "TrixelToFramebufferFrameData",
@@ -571,8 +457,6 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         sys->hoveredIdBuf_ = IRRender::getNamedResource<Buffer>("HoveredEntityIdBuffer");
         sys->program_ = IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram");
         sys->scatterProgram_ = IRRender::getNamedResource<ShaderProgram>("PerAxisScatterProgram");
-        sys->cellCompactProgram_ =
-            IRRender::getNamedResource<ShaderProgram>("PerAxisCellCompactProgram");
         sys->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAO");
         IRRender::tagGpuStage(id, "trixelToFb");
         return id;

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -27,6 +27,7 @@
 #include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
 #include <irreden/render/components/component_detached_revoxelize_buffer.hpp>
 #include <irreden/render/components/component_canvas_fog_of_war.hpp>
+#include <irreden/render/shapes_2d.hpp>
 
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
@@ -218,6 +219,14 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
     ShaderProgram *compactProgram_ = nullptr;
     ShaderProgram *stage1Program_ = nullptr;
     ShaderProgram *stage2Program_ = nullptr;
+    // Per-axis occupied-cell compaction (#1961/#2256). endTick scans each per-axis
+    // distance canvas (written by this frame's per-canvas tick) and builds the
+    // compacted cell list + draw/compute indirect args on the per-axis component,
+    // BEFORE COMPUTE_VOXEL_AO — so every per-axis compute stage + the scatter
+    // process only occupied cells. Moved here from TRIXEL_TO_FRAMEBUFFER (which
+    // runs at the end of the pipeline, too late to feed the compute stages).
+    ShaderProgram *cellCompactProgram_ = nullptr;
+    static constexpr int kPerAxisCellCompactGroupSize = 16; // == the compaction shader local_size
     // Detached re-voxelize GPU scatter (#1556): fills binding 5 for a
     // DETACHED_REVOXELIZE pool from its resident locals + the canvas quat, in
     // place of the CPU flushStaticPositionRanges.
@@ -1264,6 +1273,85 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         }
     }
 
+    // #2256: build the per-axis occupied-cell compaction (list + draw/compute
+    // indirect args) right after per-canvas voxel rasterization wrote the per-axis
+    // distances, and BEFORE COMPUTE_VOXEL_AO. Scans each per-axis distance canvas,
+    // atomic-appends its occupied cells into that axis's region, and — via the
+    // shader's last-workgroup finalize — derives the compute-indirect dispatch
+    // grid from the occupied count. The buffers live on the per-axis component
+    // (rotation-only lifecycle); the per-axis compute stages dispatchComputeIndirect
+    // over them and TRIXEL_TO_FRAMEBUFFER's scatter draws the same list unchanged.
+    void compactPerAxisCells(C_PerAxisTrixelCanvases &perAxis) {
+        const ivec2 axisSize = perAxis.size_;
+
+        // Reset each axis's 256 B PerAxisCellIndirect block: draw-args
+        // (indexCount = quad index count, instanceCount = 0 — the compaction
+        // atomic-appends) plus the compute-indirect params (numGroups /
+        // visibleCount / completedGroups = 0). One combined write covers both
+        // records so the completedGroups finalize barrier starts clean each frame.
+        struct PerAxisCellIndirectBlock {
+            PerAxisCellDrawCommand draw_{};
+            VoxelIndirectDispatchParams compute_{};
+        } resetBlock;
+        resetBlock.draw_.indexCount = static_cast<std::uint32_t>(IRShapes2D::kQuadIndicesLength);
+        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+            perAxis.cellIndirect_.second->subData(
+                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
+                sizeof(resetBlock),
+                &resetBlock
+            );
+        }
+
+        cellCompactProgram_->use();
+        const int groupsX = IRMath::divCeil(axisSize.x, kPerAxisCellCompactGroupSize);
+        const int groupsY = IRMath::divCeil(axisSize.y, kPerAxisCellCompactGroupSize);
+        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+            perAxis.cellCompacted_.second->bindRange(
+                BufferTarget::SHADER_STORAGE,
+                kBufferIndex_PerAxisCellCompacted,
+                static_cast<std::ptrdiff_t>(axis) * perAxis.cellRegionStride_ *
+                    static_cast<int>(sizeof(std::uint32_t)),
+                static_cast<size_t>(perAxis.cellRegionStride_) * sizeof(std::uint32_t)
+            );
+            // Bind the full per-axis 256 B block so the shader writes the
+            // compute-indirect params (byte 32) alongside the draw command (byte 0).
+            perAxis.cellIndirect_.second->bindRange(
+                BufferTarget::SHADER_STORAGE,
+                kBufferIndex_PerAxisCellIndirect,
+                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
+                static_cast<size_t>(kPerAxisCellIndirectStrideBytes)
+            );
+            perAxis.axes_[axis].distances_.second->bindAsImage(
+                0, TextureAccess::READ_ONLY, TextureFormat::R32I
+            );
+            IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+        }
+        // The compacted list + compute-indirect params feed the per-axis compute
+        // stages (dispatch-indirect reads them); the scatter reads the draw-args
+        // (COMMAND). STORAGE covers the SSBO list read; COMMAND covers both the
+        // indirect draw and dispatch-indirect arg reads.
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+        IRRender::device()->memoryBarrier(BarrierType::COMMAND);
+        // Leave the full voxel compaction buffers rebound to 25/26 for the next
+        // canvas's compact + downstream single-canvas readers (the bindRange loop
+        // above left the per-axis cell buffers bound there).
+        if (compactedBuf_ != nullptr) {
+            compactedBuf_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_CompactedVoxelIndices);
+        }
+        if (indirectBuf_ != nullptr) {
+            indirectBuf_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_IndirectDispatchParams);
+        }
+    }
+
+    void endTick() {
+        // Only the main canvas owns per-axis canvases, and only at a non-cardinal
+        // yaw — at a cardinal they are released and the byte-identical
+        // single-canvas path runs, so this compaction is skipped entirely.
+        if (perAxisCanvases_ != nullptr && perAxisCanvases_->isAllocated()) {
+            compactPerAxisCells(*perAxisCanvases_);
+        }
+    }
+
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
             "VoxelCompactProgram",
@@ -1276,6 +1364,15 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         IRRender::createNamedResource<ShaderProgram>(
             "SingleVoxel2",
             std::vector{ShaderStage{IRRender::kFileCompVoxelToTrixelStage2, ShaderType::COMPUTE}}
+        );
+        // Per-axis empty-cell compaction pre-pass (#1961/#2256) — see
+        // compactPerAxisCells / endTick. Created here (not in TRIXEL_TO_FRAMEBUFFER,
+        // where it lived pre-#2256) because STAGE_1 runs the compaction now and its
+        // create() runs before TRIXEL_TO_FRAMEBUFFER's; the scatter still fetches
+        // this named program.
+        IRRender::createNamedResource<ShaderProgram>(
+            "PerAxisCellCompactProgram",
+            std::vector{ShaderStage{IRRender::kFileCompPerAxisCellCompact, ShaderType::COMPUTE}}
         );
         // Chunk-occlusion HZB pre-pass program (#1294 child 2/3).
         IRRender::createNamedResource<ShaderProgram>(
@@ -1465,6 +1562,8 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         p->compactProgram_ = IRRender::getNamedResource<ShaderProgram>("VoxelCompactProgram");
         p->stage1Program_ = IRRender::getNamedResource<ShaderProgram>("SingleVoxelProgram1");
         p->stage2Program_ = IRRender::getNamedResource<ShaderProgram>("SingleVoxel2");
+        p->cellCompactProgram_ =
+            IRRender::getNamedResource<ShaderProgram>("PerAxisCellCompactProgram");
         p->revoxelizeProgram_ =
             IRRender::getNamedResource<ShaderProgram>("RevoxelizeDetachedProgram");
         p->revoxelizeParamsBuf_ =

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -1219,6 +1219,25 @@ struct PerAxisCellDrawCommand {
 };
 constexpr std::ptrdiff_t kPerAxisCellIndirectStrideBytes = 256;
 
+// #2256: the same per-axis compaction that feeds the scatter draw-indirect also
+// feeds the per-axis COMPUTE stages (AO / sun-shadow / lighting / resolve) via
+// dispatchComputeIndirect, so each processes only occupied cells instead of the
+// full worst-case (2W)(W+H) per-axis grid. Each 256 B PerAxisCellIndirect block
+// carries the DrawElementsIndirectCommand at bytes [0,32); a
+// VoxelIndirectDispatchParams (numGroupsX/Y/Z + visibleCount + completedGroups)
+// lives at this sub-offset. The compaction's last-workgroup finalize writes it
+// (numGroupsX = divCeil(occupiedCount, kPerAxisCellComputeGroupSize), Y=Z=1);
+// each compute stage dispatches at `axis*kPerAxisCellIndirectStrideBytes + this`.
+// The two indirect records share the block because a draw-indirect (5 uints) and
+// a compute-indirect (3 uints) can't overlay the same bytes.
+constexpr std::ptrdiff_t kPerAxisCellComputeDispatchOffsetBytes = 32;
+// uint index of the same sub-offset, for the compaction shader's flat SSBO view.
+constexpr std::uint32_t kPerAxisCellComputeDispatchOffsetUints = 8;
+// 1-D workgroup size the per-axis compute stages iterate the compacted list with.
+// The compaction finalize derives numGroupsX from it, so all converted per-axis
+// compute kernels must declare local_size_x == this.
+constexpr int kPerAxisCellComputeGroupSize = 64;
+
 // TODO: Future culling optimization constants
 // Chunk-level frustum culling: voxel pool is partitioned into chunks of
 // this size. A CPU-side visibility pass writes a per-chunk mask that the

--- a/engine/render/src/metal/metal_pipeline.cpp
+++ b/engine/render/src/metal/metal_pipeline.cpp
@@ -73,8 +73,12 @@ MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
         functionName == "c_clear_sun_shadow_map") {
         return MTL::Size(16, 16, 1);
     }
-    if (functionName == "c_resolve_per_axis_screen_depth" ||
-        functionName == "c_resolve_per_axis_blit" ||
+    // #2256: the resolve scatter now dispatches 1-D over the per-axis compacted
+    // occupied-cell list (local_size_x = 64), not a 2-D sweep of the axis grid.
+    if (functionName == "c_resolve_per_axis_screen_depth") {
+        return MTL::Size(64, 1, 1);
+    }
+    if (functionName == "c_resolve_per_axis_blit" ||
         functionName == "c_resolve_world_placed_depth") {
         return MTL::Size(16, 16, 1);
     }

--- a/engine/render/src/shaders/c_per_axis_cell_compact.glsl
+++ b/engine/render/src/shaders/c_per_axis_cell_compact.glsl
@@ -39,28 +39,57 @@ layout(std430, binding = 25) writeonly buffer PerAxisCellCompacted {
 // This axis's indirect instanced-draw args (bindRange'd per axis). Flat layout
 // matches PerAxisCellDrawCommand / DrawElementsIndirectCommand:
 //   [0] = indexCount (quad index count, CPU-reset each frame)
-//   [1] = instanceCount (atomic append counter — number of occupied cells)
+//   [1] = instanceCount (atomic append counter = occupied cells)  ┘ (bytes 0..31)
 //   [2..4] = firstIndex / baseVertex / baseInstance = 0
-// The CPU resets the struct each frame; this kernel only bumps instanceCount.
+//   [8]  = numGroupsX  ┐ compute-indirect (#2256, bytes 32..63) derived by the
+//   [9]  = numGroupsY  │ last-workgroup finalize below so the per-axis COMPUTE
+//   [10] = numGroupsZ  │ stages (AO/sun-shadow/lighting/resolve) dispatch only
+//   [11] = visibleCount│ over occupied cells instead of the full grid.
+//   [12] = completedGroups (cross-group finalize barrier)  ┘
+// The CPU resets the block each frame; this kernel bumps instanceCount and, once
+// the whole grid is scanned, writes the compute-indirect dispatch grid.
 layout(std430, binding = 26) buffer PerAxisCellIndirect {
     uint drawArgs[];
 };
 
+// #2256: compute-indirect sub-record indices + the 1-D group size the per-axis
+// compute stages iterate the list with (mirrors ir_render_types.hpp constants:
+// kPerAxisCellComputeDispatchOffsetUints / kPerAxisCellComputeGroupSize).
+const uint kComputeBaseIdx = 8u;
+const uint kComputeCompletedIdx = 12u; // kComputeBaseIdx + VoxelIndirectDispatchParams::completedGroups
+const uint kComputeGroupSize = 64u;
+
 void main() {
     const ivec2 cell = ivec2(gl_GlobalInvocationID.xy);
     const ivec2 size = imageSize(perAxisDistances);
-    if (cell.x >= size.x || cell.y >= size.y) {
-        return;
+
+    // Append occupied cells. NO early return — every invocation must reach the
+    // finalize barrier below uniformly (out-of-range / empty cells just skip the
+    // append). Same convention the scatter recovers (ij = cell % size.x).
+    if (cell.x < size.x && cell.y < size.y) {
+        const int rawDist = imageLoad(perAxisDistances, cell).x;
+        if (rawDist < kEmptyDistanceEncoded) {
+            const uint slot = atomicAdd(drawArgs[1], 1u);
+            compactedCells[slot] = uint(cell.y * size.x + cell.x);
+        }
     }
 
-    const int rawDist = imageLoad(perAxisDistances, cell).x;
-    if (rawDist >= kEmptyDistanceEncoded) {
-        return; // empty cell — not drawn
+    // Last-workgroup finalize (#2256): derive the compute-indirect dispatch grid
+    // from the final occupied count so the per-axis compute stages walk only
+    // occupied cells. Mirrors c_voxel_visibility_compact.glsl's completedGroups
+    // pattern; the count read is atomic so the last group sees every append.
+    barrier();
+    memoryBarrierBuffer();
+    if (gl_LocalInvocationIndex == 0u) {
+        uint finished = atomicAdd(drawArgs[kComputeCompletedIdx], 1u) + 1u;
+        uint totalGroups = gl_NumWorkGroups.x * gl_NumWorkGroups.y;
+        if (finished == totalGroups) {
+            uint count = atomicAdd(drawArgs[1], 0u);
+            drawArgs[kComputeBaseIdx + 0u] =
+                max((count + kComputeGroupSize - 1u) / kComputeGroupSize, 1u);
+            drawArgs[kComputeBaseIdx + 1u] = 1u;
+            drawArgs[kComputeBaseIdx + 2u] = 1u;
+            drawArgs[kComputeBaseIdx + 3u] = count;
+        }
     }
-
-    // Append the cell's linear index in the SAME convention the scatter recovers
-    // it (ij = cell % size.x, cell / size.x), and bump the instance count. The
-    // append slot is this cell's instance id in the indirect draw.
-    const uint slot = atomicAdd(drawArgs[1], 1u);
-    compactedCells[slot] = uint(cell.y * size.x + cell.x);
 }

--- a/engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl
+++ b/engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl
@@ -19,7 +19,11 @@
 // canvases are only allocated at non-zero residual yaw, so this stage never
 // runs at a cardinal.
 
-layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+// #2256: 1-D over the compacted occupied-cell list (one invocation per occupied
+// cell), not a 2-D sweep of the whole per-axis grid. local_size_x must equal
+// kPerAxisCellComputeGroupSize so the compaction's numGroupsX = divCeil(count, 64)
+// covers exactly the occupied cells.
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 #include "ir_iso_common.glsl"
 
@@ -47,6 +51,20 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
 // Input: ONE per-axis voxel canvas (face-local in-plane store, R32I).
 layout(r32i, binding = 0) readonly uniform iimage2D perAxisDistances;
 
+// #2256: this axis's occupied-cell list + dispatch params, built by
+// VOXEL_TO_TRIXEL_STAGE_1's per-axis compaction (bindRange'd per axis, so index 0
+// is this axis's base). The list holds each occupied cell's linear index in the
+// SAME convention the compaction wrote (cell.y * size.x + cell.x); the indirect
+// block's compute record carries visibleCount at uint index
+// kPerAxisCellComputeDispatchOffsetUints + 3 (numGroups precede it).
+layout(std430, binding = 25) readonly buffer PerAxisCellCompacted {
+    uint compactedCells[];
+};
+layout(std430, binding = 26) readonly buffer PerAxisCellIndirect {
+    uint cellIndirectArgs[];
+};
+const uint kVisibleCountIdx = 11u; // kPerAxisCellComputeDispatchOffsetUints(8) + 3
+
 // Output scratch: main-canvas-sized, front-most iso-depth via atomicMin.
 // Aliases kBufferIndex_SunShadowDepthMap (slot 28) — the whole resolve stage
 // runs strictly before BAKE rebinds slot 28 to the sun depth map.
@@ -55,15 +73,19 @@ layout(std430, binding = 28) restrict buffer PerAxisResolveScratch {
 };
 
 void main() {
-    const ivec2 cell = ivec2(gl_GlobalInvocationID.xy);
-    const ivec2 perAxisSize = imageSize(perAxisDistances);
-    if (cell.x >= perAxisSize.x || cell.y >= perAxisSize.y) {
+    // #2256: one invocation per occupied cell. Past the occupied count this
+    // axis's list holds stale entries, so the visibleCount guard is required.
+    const uint idx = gl_GlobalInvocationID.x;
+    if (idx >= cellIndirectArgs[kVisibleCountIdx]) {
         return;
     }
+    const ivec2 perAxisSize = imageSize(perAxisDistances);
+    const uint cellLinear = compactedCells[idx];
+    const ivec2 cell = ivec2(int(cellLinear) % perAxisSize.x, int(cellLinear) / perAxisSize.x);
 
     const int rawDist = imageLoad(perAxisDistances, cell).x;
     if (rawDist >= kEmptyDistanceEncoded) {
-        return; // empty per-axis cell
+        return; // empty per-axis cell (compaction is an exact superset — defensive)
     }
     // Per-axis encoding (#1458): rawDepth in world units at bits [31:10].
     const int rawDepth = rawDist >> 10;

--- a/engine/render/src/shaders/metal/c_per_axis_cell_compact.metal
+++ b/engine/render/src/shaders/metal/c_per_axis_cell_compact.metal
@@ -15,26 +15,55 @@ using namespace metal;
 // Per-axis canvas empty sentinel (#1458) — mirror of the GLSL.
 constant int kEmptyDistanceEncoded = 0x7FFFFFFF;
 
+// #2256: compute-indirect sub-record indices in the 256 B PerAxisCellIndirect
+// block + the 1-D group size the per-axis compute stages iterate the list with
+// (mirror of the GLSL / ir_render_types.hpp constants).
+constant uint kComputeBaseIdx = 8u;
+constant uint kComputeCompletedIdx = 12u; // kComputeBaseIdx + completedGroups
+constant uint kComputeGroupSize = 64u;
+
 kernel void c_per_axis_cell_compact(
     texture2d<int, access::read> perAxisDistances [[texture(0)]],
     device uint* compactedCells [[buffer(25)]],
     device atomic_uint* drawArgs [[buffer(26)]],
-    uint3 globalId [[thread_position_in_grid]]
+    uint3 globalId [[thread_position_in_grid]],
+    uint3 groupCount [[threadgroups_per_grid]],
+    uint localIndex [[thread_index_in_threadgroup]]
 ) {
     const int2 cell = int2(globalId.xy);
     const int2 size =
         int2(int(perAxisDistances.get_width()), int(perAxisDistances.get_height()));
-    if (cell.x >= size.x || cell.y >= size.y) {
-        return;
+
+    // Append occupied cells. NO early return — every invocation must reach the
+    // finalize barrier below uniformly. drawArgs layout matches
+    // PerAxisCellDrawCommand: [1] = instanceCount (= append slot / occupied cell).
+    if (cell.x < size.x && cell.y < size.y) {
+        const int rawDist = perAxisDistances.read(uint2(cell)).x;
+        if (rawDist < kEmptyDistanceEncoded) {
+            const uint slot = atomic_fetch_add_explicit(&drawArgs[1], 1u, memory_order_relaxed);
+            compactedCells[slot] = uint(cell.y * size.x + cell.x);
+        }
     }
 
-    const int rawDist = perAxisDistances.read(uint2(cell)).x;
-    if (rawDist >= kEmptyDistanceEncoded) {
-        return; // empty cell — not drawn
+    // Last-threadgroup finalize (#2256): derive the compute-indirect dispatch
+    // grid from the final occupied count so the per-axis compute stages walk only
+    // occupied cells. Mirrors c_voxel_visibility_compact.metal's completedGroups
+    // pattern (atomic count read so the last group sees every append).
+    threadgroup_barrier(mem_flags::mem_device);
+    if (localIndex == 0u) {
+        const uint finished =
+            atomic_fetch_add_explicit(&drawArgs[kComputeCompletedIdx], 1u, memory_order_relaxed) + 1u;
+        const uint totalGroups = groupCount.x * groupCount.y;
+        if (finished == totalGroups) {
+            const uint count = atomic_load_explicit(&drawArgs[1], memory_order_relaxed);
+            atomic_store_explicit(
+                &drawArgs[kComputeBaseIdx + 0u],
+                max((count + kComputeGroupSize - 1u) / kComputeGroupSize, 1u),
+                memory_order_relaxed
+            );
+            atomic_store_explicit(&drawArgs[kComputeBaseIdx + 1u], 1u, memory_order_relaxed);
+            atomic_store_explicit(&drawArgs[kComputeBaseIdx + 2u], 1u, memory_order_relaxed);
+            atomic_store_explicit(&drawArgs[kComputeBaseIdx + 3u], count, memory_order_relaxed);
+        }
     }
-
-    // drawArgs layout matches PerAxisCellDrawCommand: [1] = instanceCount. The
-    // append slot is this cell's instance id in the indirect draw.
-    const uint slot = atomic_fetch_add_explicit(&drawArgs[1], 1u, memory_order_relaxed);
-    compactedCells[slot] = uint(cell.y * size.x + cell.x);
 }

--- a/engine/render/src/shaders/metal/c_resolve_per_axis_screen_depth.metal
+++ b/engine/render/src/shaders/metal/c_resolve_per_axis_screen_depth.metal
@@ -12,22 +12,33 @@
 // Per-axis-only shader; canvas clears to INT_MAX per #1458 encoding.
 constant int kEmptyDistanceEncoded = 0x7FFFFFFF;
 
+// #2256: visibleCount index in this axis's PerAxisCellIndirect block (compute
+// record — numGroups precede it). Mirror of the GLSL kVisibleCountIdx.
+constant uint kVisibleCountIdx = 11u;
+
 kernel void c_resolve_per_axis_screen_depth(
     constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
     texture2d<int, access::read> perAxisDistances [[texture(0)]],
+    device const uint* compactedCells [[buffer(25)]],
+    device const uint* cellIndirectArgs [[buffer(26)]],
     device atomic_int* resolveScratch [[buffer(28)]],
     uint3 globalId [[thread_position_in_grid]]
 ) {
-    const int2 cell = int2(globalId.xy);
-    const int2 perAxisSize =
-        int2(int(perAxisDistances.get_width()), int(perAxisDistances.get_height()));
-    if (cell.x >= perAxisSize.x || cell.y >= perAxisSize.y) {
+    // #2256: one invocation per occupied cell from the per-axis compaction list.
+    // Past the occupied count the list holds stale entries → visibleCount guard.
+    const uint listIndex = globalId.x;
+    if (listIndex >= cellIndirectArgs[kVisibleCountIdx]) {
         return;
     }
+    const int2 perAxisSize =
+        int2(int(perAxisDistances.get_width()), int(perAxisDistances.get_height()));
+    const uint cellLinear = compactedCells[listIndex];
+    const int2 cell =
+        int2(int(cellLinear) % perAxisSize.x, int(cellLinear) / perAxisSize.x);
 
     const int rawDist = perAxisDistances.read(uint2(cell)).x;
     if (rawDist >= kEmptyDistanceEncoded) {
-        return; // empty per-axis cell
+        return; // empty per-axis cell (compaction is an exact superset — defensive)
     }
     // Per-axis encoding (#1458): rawDepth in world units at bits [31:10].
     const int rawDepth = rawDist >> 10;


### PR DESCRIPTION
Closes #2256.

WIP — implementing the architect plan (committed as first commit): feed the four
per-axis GPU compute stages (AO, sun-shadow, lighting-to-trixel, resolve-per-axis
screen-depth) from the existing #1961 occupied-cell compaction via
`dispatchComputeIndirect`, so each stage processes only occupied cells instead of
the full worst-case `(2W)(W+H)` per-axis grid. Byte-identity-preserving (empty
cells wrote nothing that is ever read); targets the ~6ms unscoped yaw GPU delta.

Verification (macOS/Metal): cardinal shots byte-compared; yaw thresholded +
inspection; `IRPerfGrid --auto-profile 300 --zoom 8 --yaw 0.35` before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)