### PR TITLE
render: per-voxel occlusion culling in the compact pass — capture the 0.97 ceiling (#1812)

### DIFF
--- a/.fleet/plans/issue-1812.md
+++ b/.fleet/plans/issue-1812.md
@@ -55,18 +55,70 @@ Keep the chunk pre-pass as the cheap coarse pre-filter (it already ANDs into `ch
 - **binding 0** — fog image (`canvasFogOfWar`, GL image unit) and `hiZLevels[0]` (GL texture unit) coexist in GL; **Metal needs distinct argument-table indices** (the one real parity hazard).
 - **`system_build_light_occlusion_grid`** — **NOT touched** (lighting invariant 1: it iterates the full pool, never the compacted list). Do not wire the cull into it.
 
-### Acceptance criteria
+### Acceptance criteria (updated round 6 — positive-fire + marginal isolation)
 
-- On `voxel_set` zoom8, per-voxel cull captures a **clear majority** of the 0.97 `occludedExposedFraction` (target: far above the ~3 % per-chunk realizes); realized `voxelStage1` ms reduction recorded in the PR body.
-- **Bit-identical** cull-on vs cull-off (`IRPerfGrid --mode voxel_set --no-overlay --auto-screenshot`, md5 A/B) — a fully-occluded voxel writes nothing anyway, so any diff is a cull bug.
-- **Net-positive across the perf_grid zoom range**, or gated so no view regresses (the per-voxel sample must not cost more than it saves at low zoom, the failure mode the per-chunk cull hit).
-- **Zero added cost** when `getVoxelOcclusionCullEnabled()==false` (default-config profile unchanged; Hi-Z not bound, branch not taken).
-- Both backends build; `render-debug-loop` + `attach-screenshots`; carries both cross-host smoke labels.
+The `--no-per-voxel-occlusion` split gate lets the per-voxel test be A/B'd in
+isolation against the #1294 chunk cull. Both gates below compare
+**chunk+per-voxel (`--occlusion-cull`) vs chunk-only
+(`--occlusion-cull --no-per-voxel-occlusion`)** — the *marginal* delta the
+per-voxel refine adds over the chunk cull — NOT cull-on vs cull-off (a
+cull-off comparison folds in the chunk cull's own behavior; on Metal the chunk
+cull is not itself byte-identical to cull-off — see "Root cause" — so only the
+marginal isolation is a clean per-voxel gate).
+
+- **Positive-fire gate (required).** Marginal capture > 0 at amp 0,
+  `--no-sun-shadows`, zooms 1/4/8 — chunk+per-voxel vs chunk-only `avgVisible`
+  (`--auto-profile`), non-zero. Zero = not done (a cull that never fires passes
+  every byte-identity gate; #1812 was a zero-fire no-op for six rounds because
+  the Hi-Z read returned the cleared sentinel — see "Root cause"). Record the
+  numbers. **Measured: zoom1 233527→28200, zoom4 227847→27036, zoom8
+  166666→19373 (marginal 205k/201k/147k).**
+- **Marginal byte-identity (required).** chunk+per-voxel vs chunk-only md5 A/B
+  (`IRPerfGrid --mode voxel_set --no-overlay --auto-screenshot
+  --subdivision-mode none --wave-amplitude 0 --occlusion-cull` ±
+  `--no-per-voxel-occlusion`) — byte-identical across the shot table now that
+  the cull fires. Any diff is a too-tight emission-hull window (the
+  counterexample-dump case). This became a *real* test of the emission-hull
+  window + margin only once the cull fired. **Measured: byte-identical, 7/7.**
+- **Net-positive / no per-view regression** — perf ms deferred to Linux/GL via
+  the owed smoke (Metal timer rows read 0.000; the capture stat is the Metal
+  gate).
+- **Zero added cost** when `getVoxelOcclusionCullEnabled()==false` (default-config
+  profile unchanged; the compact never reads the Hi-Z when
+  `occlusionCullMipCount==0`, regardless of which texture is bound at its unit).
+- Both backends build; carries both cross-host smoke labels.
+
+### Root cause (round 6) — the Hi-Z read was a stale-image-shadowed sampler bind on Metal
+
+The compact bound the finest Hi-Z (`getHiZMip(0)`) at texture unit 1 via a
+SAMPLER bind (`Texture2D::bind`), but the Metal shader declared it `access::read`
+(image) and `bindComputeResources` flushes the sticky image-binding table AFTER
+the sampler table at the same encoder texture index. The prior frame's
+stage-1/stage-2 leave `trixelDistances` bound as an IMAGE at unit 1 (sticky,
+never cleared), and at compact time `trixelDistances` was just cleared to the
+65535 sentinel — so the stale image bind shadowed the Hi-Z sampler bind and the
+compact read all-sentinel, so the per-voxel test never fired (marginal capture
+0 — the exact "unit collision with `trixelDistances`" the architect predicted).
+**Fix:** bind the Hi-Z as a read-only IMAGE (matching the Metal `access::read`
+declaration) so it occupies — and wins — that same table slot. GL is unaffected
+(separate image/texture-unit namespaces). The SAME mechanism latently corrupts
+the #1294 chunk cull's fine Hi-Z levels (0-3, shadowed by fog/distances/entityId
+images) on Metal — so cull-on ≠ cull-off on Metal at cardinal poses (0.18-2.76%
+drift, pre-existing, GL-verified-only) — filed as a follow-up (the chunk cull
+reads coarse levels for 256-voxel chunks, so the corruption was never noticed).
+
+### Design-doc lesson (i): identity gates require a paired positive-fire gate
+
+Added to `docs/design/voxel-occlusion-culling.md` — a cull that never fires
+passes every byte-identity test. #1812 surfaced three vacuous-PASS variants
+(mode-gated-off, union mis-attribution, zero-fire) plus a stale-encoding fix a
+fire gate would have caught. Cross-references the "default-off features need a
+positive enabled-path test" rule in `engine/render/CLAUDE.md`.
 
 ### Gotchas
 
 - **Shadow-feeder coverage (the #1 correctness hazard).** The chunk cull's eligibility guard only tests chunks fully inside the VISIBLE viewport, so it never drops an off-screen shadow feeder. The per-voxel test **must preserve the same safety**: it runs only inside the visible-frustum gate (`cullIsoMin/Max`), and a voxel in the shadow-feeder-widened swept region but outside the visible viewport is never per-voxel-culled. Do not sample the Hi-Z (which covers only the visible viewport) for shadow-feeder voxels — dropping a camera-occluded but shadow-relevant caster loses its sun shadow (design § "The one real hazard").
-- **Encoding must match the Hi-Z.** `encoded = rawDepth * 4` (bits [31:2]); use `isoDepthAlongAxis` with the uploaded `voxelDepthAxis`, not a hand-rolled depth, or the compare desyncs from `trixelDistances`.
+- **Encoding must match the Hi-Z.** Route through `encodeDepthWithFace(pos3DtoDistance(voxelPos), 0)` — the shared cardinal encode (depth [31:3] | flip [2] | slot [1:0], `* kDepthEncodeShift`), NOT an open-coded `* 4` (#2207 changed the cardinal layout; a hard-coded `*4` compares a half-scale depth against the Hi-Z's `*8` values so the test never fires). Margin = `kDepthEncodeShift` absorbs the low bits.
 - **Cardinal / NONE-mode only.** Gate exactly on the chunk dispatch's conditions (`residualYaw==0`, NONE render mode, not rotating, no re-voxelize buffer); the continuous-yaw and per-axis paths keep every voxel (conservative), matching the shipped chunk cull.
 - **Per-voxel cost in the hottest loop** (design § 1 flags this explicitly). One Hi-Z sample per surviving voxel per frame. Keep it behind the enable flag and on survivors only; the net-positive acceptance gate is the guard against shipping a regression.
 - **One-frame-lag silhouette pop** — acceptable, same class as the chunk cull; note it as intentional drift so reviewers don't read it as a regression.

--- a/.fleet/plans/issue-1812.md
+++ b/.fleet/plans/issue-1812.md
@@ -1,0 +1,73 @@
+## Plan: render — per-voxel occlusion culling (capture the 0.97 ceiling the per-chunk cull leaves)
+
+- **Issue:** #1812 (follow-on to epic #1294; children #1798 Hi-Z / #1799 chunk pre-pass / #1800 gate all merged)
+- **Model:** opus — hot-path GPU compute-shader work in the voxel-to-trixel pipeline with bit-identical + shadow-feeder + backend-parity invariants. The *mechanism* is documented (design § 1), so this is bounded implementation, not novel stage design (not fable); the perf/correctness judgment and the render-pipeline surface put it above sonnet.
+- **Date:** 2026-07-03
+- **Design source of truth:** `docs/design/voxel-occlusion-culling.md` § 1 "Granularity" (per-voxel row), § "Downstream-consumer matrix"; parent plan `.fleet/plans/issue-1294.md` § "Granularity gap".
+
+### Verified current state + confirmed premise
+
+Read the shipped code on `origin/master`, not just the design sketch:
+
+- **Per-chunk cull shipped and is weak.** `dispatchChunkOcclusion` (`engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp:604`) authors one CPU `ChunkQuery` per 256-voxel pool-chunk and `c_chunk_occlusion_cull.glsl` ANDs `0` into `chunkVisible[]` (binding 24) iff `encodedNearest_ > hiZMax + 4`. Measured realized `voxelStage1` reduction on `voxel_set` zoom8 is **−6.6 ms (~3 %)**, net-negative (+1.2 ms) at zoom1 — far below the **0.97 per-voxel `occludedExposedFraction`** ceiling (#1294 measurement table). Two structural causes (issue body): a 256-slot chunk spanning depth is rarely *fully* occluded, and the "chunk AABB fully inside the VISIBLE viewport" eligibility guard (`system_voxel_to_trixel.hpp:637-641`) excludes most chunks at high zoom.
+- **Every piece the per-voxel path needs already exists** — this follow-on is refinement, not new infra:
+  - Hi-Z max-depth mip chain (#1798): `C_TriangleCanvasTextures::hiZMips_`, accessors `hiZMipCount()` / `getHiZMip(int)` (`component_triangle_canvas_textures.hpp:146-155`); built by `System<COMPUTE_DISTANCE_HIZ>` after stage-2+AO. R32I encoding = rawDepth in bits [31:2], face slot [1:0], `65535` background sentinel = "never occlude".
+  - Per-voxel depth metric primitive (#1462): the `voxelDepthAxis` uniform (`c_voxel_to_trixel_stage_1.glsl:58-64`, binding-7 offset 144) + GPU mirror `isoDepthAlongAxis(pos, axis)` in `ir_iso_common.{glsl,metal}`, collapsing to `pos3DtoDistance` for the identity/GRID canvas. This is exactly the front-most depth the Hi-Z compare needs, per-voxel.
+  - Hi-Z sampling helpers `pickHiZLevel` / `hiZTexel` and `kOcclusionDepthMargin=4` in `c_chunk_occlusion_cull.glsl:74-109`.
+  - Gate (#1800): `getVoxelOcclusionCullEnabled()` (default **false**, `render_manager.hpp:187`; enabled only by `perf_grid`/`shape_debug`), the NONE-mode/cardinal/non-rotating dispatch guard (`system_voxel_to_trixel.hpp:914-917`), and the one-frame camera-cut disable `occlusionLagSourceStale_` (`:1254-1264`).
+- **Compact pass is the documented home** (design:60-65): `c_voxel_visibility_compact.glsl` main() already computes `voxelPosRaw` + `isoPos` and tests `chunkVisible[chunkIdx]` (b24), the active-mask bit (b8), the frustum (`cullIsoMin/Max`), and fog — the per-voxel Hi-Z test drops in right after those gates pass, before the survivor `atomicAdd` append.
+- **No in-flight / sibling conflict.** No open engine PR touches the compact / Hi-Z / chunk-occlusion surface (checked all 11). #1294's three children are merged. This is the sanctioned single follow-on (#1294 §"Granularity gap": "per-voxel culling is the documented follow-on if chunk capture proves weak").
+
+### Scope
+
+Add a **per-voxel** Hi-Z occlusion test inside the compact pass, layered on top of the existing per-chunk pre-pass (coarse→fine hierarchical occlusion), so a voxel that is locally-exposed and in-frustum but globally occluded by closer geometry is dropped from the compacted list — capturing a clear majority of the 0.97 per-voxel ceiling on `voxel_set` zoom8, where the per-chunk cull realizes only ~3 %. Output stays bit-identical cull-on vs cull-off; the feature stays off by default. `dense_set` (0.00 cullable, solid-volume/LOD problem) stays out of scope.
+
+### Approach (single committed path)
+
+Keep the chunk pre-pass as the cheap coarse pre-filter (it already ANDs into `chunkVisible[]` *before* the compact), and refine per-voxel inside the compact loop on the survivors only.
+
+1. **Factor the Hi-Z sampling helpers into a shared include.** Move `pickHiZLevel`, `hiZTexel` (the constant-index sampler-array ladder) and `kOcclusionDepthMargin` from `c_chunk_occlusion_cull.glsl` into `ir_iso_common.glsl` (+ the Metal mirror), so the chunk pre-pass and the compact pass share one copy. Chunk shader keeps byte-identical behavior (include instead of inline).
+2. **Bind the Hi-Z chain for the compact dispatch.** In `system_voxel_to_trixel.hpp`, when the cull is active, bind Hi-Z levels `[0, mipCount)` (units 0..11, surplus → coarsest, same as `dispatchChunkOcclusion:665-667`) immediately before the compact `use()`+dispatch. Do **not** rely on the chunk pre-pass's residual bindings. Upload the new gate uniform (below) and `mipCount` into the binding-7 FrameData.
+3. **Add the per-voxel test to `c_voxel_visibility_compact.glsl`** (declare `layout(binding=0) uniform isampler2D hiZLevels[12];` — GL image-unit vs texture-unit namespaces are separate, so this coexists with the `canvasFogOfWar` image at binding 0). Insert after the existing frustum+fog gate pass, before the append:
+   - Guard on a new `occlusionCullActive` flag packed into binding-7 FrameData (1 only when `getVoxelOcclusionCullEnabled() && !occlusionLagSourceStale_ && NONE-mode && residualYaw==0` — the exact conditions the chunk dispatch already gates on) AND `mipCount > 0`. When 0, skip the branch → byte-identical to master.
+   - Compute the voxel's encoded nearest depth: `int encoded = int(round(isoDepthAlongAxis(vec3(voxelPos), voxelDepthAxis.xyz))) * 4;` (matches `dispatchChunkOcclusion`'s `minDepth_ * 4` and the Hi-Z R32I encoding; identity canvas collapses to `pos3DtoDistance`). Use the same cardinal-rotated `voxelPos` the frustum test used.
+   - Footprint ≈ 1 iso px → `pickHiZLevel(1, mipCount)` selects the finest level; sample `hiZTexel` over the 1-texel-expanded footprint at `isoPos`, take the max.
+   - Cull (skip both the single-list and per-axis appends) iff `encoded > hiZMax + kOcclusionDepthMargin`. Conservative: background `65535` keeps `hiZMax` large → never culls a voxel that still sees background; a false positive is a hole, a false negative only lost savings.
+4. **Metal mirror** `c_voxel_visibility_compact.metal` identically, using relaxed atomics as the existing occlusion shaders do, and **allocate `[[texture(n)]]` indices for the Hi-Z array that do not collide with `canvasFogOfWar`'s texture index** — Metal's argument table is one shared namespace, unlike GL's split image/sampler units. No new kernel → no `metal_pipeline.cpp` threadgroup entry.
+5. **Gating stays as-is** — the `occlusionCullActive` uniform is derived from the already-computed `getVoxelOcclusionCullEnabled()` + `occlusionLagSourceStale_` in `beginTick`; zero added cost when disabled (branch not taken, Hi-Z not bound).
+6. **Measure + verify:** record realized `voxelStage1` reduction on `voxel_set` zoom8 in the PR body; confirm net-positive across the perf_grid zoom range (or note the per-view gate). Add/refresh a `render-verify` baseline proving bit-identical cull-on vs cull-off.
+
+### Affected files
+
+- `engine/render/src/shaders/c_voxel_visibility_compact.glsl` — per-voxel Hi-Z test + `hiZLevels[12]` sampler + gate uniform (core change)
+- `engine/render/src/shaders/metal/c_voxel_visibility_compact.metal` — Metal mirror (distinct texture indices)
+- `engine/render/src/shaders/ir_iso_common.glsl` + `metal/ir_iso_common.metal` — hoist `pickHiZLevel`/`hiZTexel`/`kOcclusionDepthMargin` for reuse
+- `engine/render/src/shaders/c_chunk_occlusion_cull.{glsl,metal}` — include the hoisted helpers (behavior unchanged)
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` — bind Hi-Z levels before the compact dispatch when active; pack `occlusionCullActive` + `mipCount` into binding-7 FrameData
+- `engine/render/src/shaders/` FrameData UBO struct (binding 7) — new gate field (mirror the CPU `FrameDataVoxelToTrixel` layout)
+- `render-verify` baseline fixture for `voxel_set` cull-on/off bit-identity; optional perf-overlay note in `creations/demos/perf_grid/main.cpp`
+
+### Cross-system audit (shared GPU resources touched)
+
+- **`ChunkVisibility` SSBO (b24)** — unchanged producer/consumer; the per-voxel test reads it only to skip work (chunk-visible survivors), never writes it. No consumer migration.
+- **Hi-Z mip chain (`getHiZMip`, R32I)** — a *new consumer* (the compact pass) of an existing texture; producer (`COMPUTE_DISTANCE_HIZ`) unchanged. Ordering already correct: Hi-Z is built from last frame's distances and read this frame (one-frame lag, by design). Must be bound to the compact dispatch's units.
+- **binding-7 FrameData UBO** — additive field (`occlusionCullActive`/`mipCount`); the CPU `FrameDataVoxelToTrixel` struct and every shader that declares the binding-7 prefix must stay layout-synced (the compact and stage-1 share the block).
+- **binding 0** — fog image (`canvasFogOfWar`, GL image unit) and `hiZLevels[0]` (GL texture unit) coexist in GL; **Metal needs distinct argument-table indices** (the one real parity hazard).
+- **`system_build_light_occlusion_grid`** — **NOT touched** (lighting invariant 1: it iterates the full pool, never the compacted list). Do not wire the cull into it.
+
+### Acceptance criteria
+
+- On `voxel_set` zoom8, per-voxel cull captures a **clear majority** of the 0.97 `occludedExposedFraction` (target: far above the ~3 % per-chunk realizes); realized `voxelStage1` ms reduction recorded in the PR body.
+- **Bit-identical** cull-on vs cull-off (`IRPerfGrid --mode voxel_set --no-overlay --auto-screenshot`, md5 A/B) — a fully-occluded voxel writes nothing anyway, so any diff is a cull bug.
+- **Net-positive across the perf_grid zoom range**, or gated so no view regresses (the per-voxel sample must not cost more than it saves at low zoom, the failure mode the per-chunk cull hit).
+- **Zero added cost** when `getVoxelOcclusionCullEnabled()==false` (default-config profile unchanged; Hi-Z not bound, branch not taken).
+- Both backends build; `render-debug-loop` + `attach-screenshots`; carries both cross-host smoke labels.
+
+### Gotchas
+
+- **Shadow-feeder coverage (the #1 correctness hazard).** The chunk cull's eligibility guard only tests chunks fully inside the VISIBLE viewport, so it never drops an off-screen shadow feeder. The per-voxel test **must preserve the same safety**: it runs only inside the visible-frustum gate (`cullIsoMin/Max`), and a voxel in the shadow-feeder-widened swept region but outside the visible viewport is never per-voxel-culled. Do not sample the Hi-Z (which covers only the visible viewport) for shadow-feeder voxels — dropping a camera-occluded but shadow-relevant caster loses its sun shadow (design § "The one real hazard").
+- **Encoding must match the Hi-Z.** `encoded = rawDepth * 4` (bits [31:2]); use `isoDepthAlongAxis` with the uploaded `voxelDepthAxis`, not a hand-rolled depth, or the compare desyncs from `trixelDistances`.
+- **Cardinal / NONE-mode only.** Gate exactly on the chunk dispatch's conditions (`residualYaw==0`, NONE render mode, not rotating, no re-voxelize buffer); the continuous-yaw and per-axis paths keep every voxel (conservative), matching the shipped chunk cull.
+- **Per-voxel cost in the hottest loop** (design § 1 flags this explicitly). One Hi-Z sample per surviving voxel per frame. Keep it behind the enable flag and on survivors only; the net-positive acceptance gate is the guard against shipping a regression.
+- **One-frame-lag silhouette pop** — acceptable, same class as the chunk cull; note it as intentional drift so reviewers don't read it as a regression.
+- **Backend parity** — the Metal mirror and the shared-include hoist must land in the same PR; a GL-only change would drift the backends (Metal build is the macOS host's — CI cross-host smoke covers it).

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -346,6 +346,16 @@ bool g_occlusionCull = false;
 // scene. The --auto-profile path enables frame timing explicitly, so timing
 // still works under --no-overlay.
 bool g_noOverlay = false;
+// --no-sun-shadows (#1812): disable sun shadows globally so the render cull
+// collapses from the shadow-feeder-widened extent back to the visible viewport
+// (`IRMath::shadowFeederIsoBounds` only widens when `getSunShadowsEnabled()`;
+// render/CLAUDE.md "Lighting culling invariants"). Pairs with --occlusion-cull
+// --auto-profile to measure the per-voxel cull's capture in the regime where the
+// WHOLE frustum is legally cullable — with shadows on, visibleVoxelCount is
+// dominated by off-screen shadow feeders the cull must not drop, so the ratio
+// understates the mechanism. This is the baseline number the widened-domain
+// feeder-occlusion follow-on needs.
+bool g_noSunShadows = false;
 
 PerfGridMode parseMode(const std::string &value) {
     if (value == "voxel_set" || value == "voxel") {
@@ -513,6 +523,10 @@ void registerCliArgs() {
         "Force the voxel-pool chunk-occlusion HZB pre-pass ON (off by default)"
     );
     args.flag("--no-overlay", "Drop PERF_STATS_OVERLAY so a captured frame is deterministic");
+    args.flag(
+        "--no-sun-shadows",
+        "Disable sun shadows so the cull collapses to the visible viewport (occlusion-cull measurement baseline)"
+    );
     args.string("--mode", "Scene mode: voxel_set | sdf | dense_set | hollow_set", "voxel_set");
     args.integer("--grid-size", "Grid edge in cells", 64);
     args.number("--zoom", "Initial camera zoom", 0.5f);
@@ -551,6 +565,7 @@ void readCliArgs() {
     }
     g_occlusionCull = args.getFlag("--occlusion-cull");
     g_noOverlay = args.getFlag("--no-overlay");
+    g_noSunShadows = args.getFlag("--no-sun-shadows");
 
     if (args.wasProvided("--mode")) {
         g_cliOverrides.mode_ = parseMode(args.getString("--mode"));
@@ -831,7 +846,17 @@ void configureLightingAndCanvas() {
     const ivec2 canvasSize = IREntity::getComponent<C_TriangleCanvasTextures>(mainCanvas).size_;
 
     IREntity::setComponent(mainCanvas, C_CanvasAOTexture{canvasSize});
+    // Keep C_CanvasSunShadow attached unconditionally — Metal's LIGHTING_TO_TRIXEL
+    // asserts the main canvas carries it (slot 4 must be bound). --no-sun-shadows
+    // instead flips the global gate below: the bake self-disables
+    // (system_bake_sun_shadow_map reads getSunShadowsEnabled()) and the render
+    // cull collapses from the shadow-feeder-widened extent to the visible viewport
+    // (shadowFeederIsoBounds only widens when enabled), isolating the occlusion
+    // cull's capture in the fully-cullable regime (see g_noSunShadows).
     IREntity::setComponent(mainCanvas, C_CanvasSunShadow{canvasSize});
+    if (g_noSunShadows) {
+        IRRender::setSunShadowsEnabled(false);
+    }
     IREntity::setComponent(mainCanvas, C_CanvasLightVolume{});
     IREntity::setComponent(mainCanvas, C_TrixelCanvasRenderBehavior{});
     IREntity::setComponent(mainCanvas, C_CanvasFogOfWar{});

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -356,6 +356,16 @@ bool g_noOverlay = false;
 // understates the mechanism. This is the baseline number the widened-domain
 // feeder-occlusion follow-on needs.
 bool g_noSunShadows = false;
+// --no-per-voxel-occlusion (#1812): with --occlusion-cull on, disable ONLY the
+// per-voxel Hi-Z refine (keep the #1294 chunk pre-pass). This is the marginal
+// acceptance-gate isolation: --occlusion-cull A/B measures the UNION of the two
+// culls, and the chunk cull owns the pre-existing `max_delta 96` silhouette
+// holes (its own bug, filed separately), so union-vs-no-cull can never be
+// bit-identical. The per-voxel test's real, PR-scoped contribution is the
+// MARGINAL delta — cull-with-per-voxel vs cull-without — which is bit-identical
+// (it drops zero visible voxels; the 2×2 isolation E2==A proved it). No-op
+// without --occlusion-cull.
+bool g_noPerVoxelOcclusion = false;
 
 PerfGridMode parseMode(const std::string &value) {
     if (value == "voxel_set" || value == "voxel") {
@@ -527,6 +537,10 @@ void registerCliArgs() {
         "--no-sun-shadows",
         "Disable sun shadows so the cull collapses to the visible viewport (occlusion-cull measurement baseline)"
     );
+    args.flag(
+        "--no-per-voxel-occlusion",
+        "With --occlusion-cull, disable only the #1812 per-voxel Hi-Z refine (keep the #1294 chunk cull) — the marginal-gate isolation"
+    );
     args.string("--mode", "Scene mode: voxel_set | sdf | dense_set | hollow_set", "voxel_set");
     args.integer("--grid-size", "Grid edge in cells", 64);
     args.number("--zoom", "Initial camera zoom", 0.5f);
@@ -566,6 +580,7 @@ void readCliArgs() {
     g_occlusionCull = args.getFlag("--occlusion-cull");
     g_noOverlay = args.getFlag("--no-overlay");
     g_noSunShadows = args.getFlag("--no-sun-shadows");
+    g_noPerVoxelOcclusion = args.getFlag("--no-per-voxel-occlusion");
 
     if (args.wasProvided("--mode")) {
         g_cliOverrides.mode_ = parseMode(args.getString("--mode"));
@@ -934,6 +949,19 @@ int main(int argc, char **argv) {
             "Voxel chunk-occlusion cull forced ON (--occlusion-cull, #1294 child 3/3). "
             "Output stays bit-identical to cull-off; one-frame silhouette pop on a "
             "discontinuous camera move is intentional drift (stale Hi-Z self-disable)."
+        );
+        if (g_noPerVoxelOcclusion) {
+            IRRender::setVoxelPerVoxelOcclusionEnabled(false);
+            IR_LOG_INFO(
+                "Per-voxel Hi-Z refine DISABLED (--no-per-voxel-occlusion, #1812). Chunk "
+                "cull only; this is the marginal-gate B side (A = per-voxel on). The two "
+                "must render bit-identical — the per-voxel test drops zero visible voxels."
+            );
+        }
+    } else if (g_noPerVoxelOcclusion) {
+        IR_LOG_WARN(
+            "--no-per-voxel-occlusion is a no-op without --occlusion-cull (the whole "
+            "cull is off, so the per-voxel refine never runs)."
         );
     }
 

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -535,11 +535,13 @@ void registerCliArgs() {
     args.flag("--no-overlay", "Drop PERF_STATS_OVERLAY so a captured frame is deterministic");
     args.flag(
         "--no-sun-shadows",
-        "Disable sun shadows so the cull collapses to the visible viewport (occlusion-cull measurement baseline)"
+        "Disable sun shadows so the cull collapses to the visible viewport (occlusion-cull "
+        "measurement baseline)"
     );
     args.flag(
         "--no-per-voxel-occlusion",
-        "With --occlusion-cull, disable only the #1812 per-voxel Hi-Z refine (keep the #1294 chunk cull) — the marginal-gate isolation"
+        "With --occlusion-cull, disable only the #1812 per-voxel Hi-Z refine (keep the #1294 chunk "
+        "cull) — the marginal-gate isolation"
     );
     args.string("--mode", "Scene mode: voxel_set | sdf | dense_set | hollow_set", "voxel_set");
     args.integer("--grid-size", "Grid edge in cells", 64);

--- a/docs/design/voxel-occlusion-culling.md
+++ b/docs/design/voxel-occlusion-culling.md
@@ -315,6 +315,40 @@ labels.
 - **One-frame-lag pop** — acceptable but call it out in the demo's intentional-
   drift note so reviewers don't read it as a regression.
 
+## Acceptance-gate lessons (#1812 per-voxel refine)
+
+The per-voxel refine (#1812) went through six rounds, three of which shipped a
+**vacuous PASS** — a cull that measured as correct while doing nothing. The
+durable lessons:
+
+- **(i) An identity gate requires a paired positive-fire gate.** Byte-identity
+  cull-on vs cull-off (or marginal-on vs marginal-off) only proves the OFF path
+  is a no-op — it can never prove the feature *works*. A cull that never fires
+  passes every byte-identity test. #1812's three vacuous-PASS variants were:
+  mode-gated-off (the enable flag never reached the tested state), union
+  mis-attribution (the byte-identity + "capture" numbers were entirely the
+  #1294 chunk cull; the per-voxel marginal was zero), and zero-fire (the Hi-Z
+  read returned the cleared sentinel — see below). Every default-off cull needs
+  a **positive-fire gate**: a measured, non-zero marginal capture at a pose
+  where the cull is legally active. This is the cull-shaped instance of the
+  "default-off features need a positive enabled-path test" rule in
+  [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md).
+- **(h) Isolate the marginal.** `--occlusion-cull` measures the UNION of the
+  chunk pre-pass and the per-voxel refine; a split gate
+  (`--no-per-voxel-occlusion`) is required so each mechanism's acceptance is
+  measured *marginally*, against the other running. Without it, a zero-fire
+  per-voxel test rides the chunk cull's capture and reads as working.
+- **Metal: a sampler bind at a texture unit is shadowed by a stale IMAGE bind
+  at the same unit.** `bindComputeResources` flushes the (sticky, never-cleared)
+  image-binding table AFTER the sampler table at the same encoder texture index,
+  so binding a Hi-Z read at a unit that a prior dispatch left an image bound to
+  reads that stale image, not the Hi-Z. The compact read `trixelDistances`
+  (freshly cleared to the 65535 sentinel) instead of `getHiZMip(0)`, so the test
+  never fired. Bind Hi-Z reads as **images** (matching the Metal `access::read`
+  declaration) so they win the flush. GL is immune (separate image/texture-unit
+  namespaces) — a Metal-only defect a GL-only smoke will miss. The same
+  mechanism latently corrupts the #1294 chunk cull's fine Hi-Z levels on Metal.
+
 ---
 
 ## See also

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -1058,10 +1058,10 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // then runs the per-voxel Hi-Z test on the survivors (occlusionCullMipCount_
         // uploaded here, Hi-Z bound at the compact dispatch below).
         const int occlusionMipCount = triangleCanvasTextures.hiZMipCount();
-        const bool occlusionCullActive =
-            IRRender::getVoxelOcclusionCullEnabled() && !occlusionLagSourceStale_ &&
-            frameData_.voxelRenderOptions_.x == 0 && !rotating && revoxBuffer == nullptr &&
-            occlusionMipCount > 0;
+        const bool occlusionCullActive = IRRender::getVoxelOcclusionCullEnabled() &&
+                                         !occlusionLagSourceStale_ &&
+                                         frameData_.voxelRenderOptions_.x == 0 && !rotating &&
+                                         revoxBuffer == nullptr && occlusionMipCount > 0;
         // The chunk pre-pass (dispatched below on occlusionCullActive) and the
         // per-voxel Hi-Z refine are separately toggleable so the #1812 marginal
         // acceptance gate can A/B the per-voxel test in isolation while the chunk
@@ -1261,18 +1261,29 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         }
         fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
         // Per-voxel occlusion cull Hi-Z input (#1812). Bind the finest Hi-Z level
-        // at a texture unit distinct from the fog IMAGE at 0 (GL image/texture
-        // unit 0 alias; Metal's shared argument table needs the distinct index).
-        // The compact samples it only when frameData_.occlusionCullMipCount_ > 0;
-        // a canvas with no Hi-Z chain (≤1px) binds the R32I distance texture as a
-        // never-sampled sentinel so Metal's argument table stays satisfied. Bound
-        // every frame (one texture bind) — the shader gate keeps the default
-        // (cull-off) output byte-identical.
+        // as a read-only IMAGE at a unit distinct from the fog image at 0. The
+        // image bind (not a sampler bind) is required on Metal: bindComputeResources
+        // flushes the sticky image-binding table AFTER the sampler table at the
+        // same encoder texture index, so a sampler bind of the Hi-Z at unit 1 was
+        // shadowed by the leftover trixelDistances IMAGE bound there by the prior
+        // frame's stage-1/stage-2 — the compact then read the freshly-cleared
+        // distance sentinel (all 65535) instead of the Hi-Z and the per-voxel test
+        // never fired (#1812 zero-capture). Binding the Hi-Z as an image overwrites
+        // that stale slot so it wins the flush. The compact reads it only when
+        // frameData_.occlusionCullMipCount_ > 0; a canvas with no Hi-Z chain (≤1px)
+        // binds the R32I distance texture as a never-read sentinel so the argument
+        // table stays satisfied. Bound every frame — the shader gate keeps the
+        // default (cull-off) output byte-identical (stage-1 re-binds distances as
+        // the image at this unit right after, so no downstream state leaks).
         constexpr int kHiZLevel0CompactTextureUnit = 1;
         const Texture2D *hiZLevel0 = (triangleCanvasTextures.hiZMipCount() > 0)
                                          ? triangleCanvasTextures.getHiZMip(0)
                                          : triangleCanvasTextures.getTextureDistances();
-        hiZLevel0->bind(kHiZLevel0CompactTextureUnit);
+        hiZLevel0->bindAsImage(
+            kHiZLevel0CompactTextureUnit,
+            TextureAccess::READ_ONLY,
+            TextureFormat::R32I
+        );
         constexpr int kCompactLocalSize = 64;
         // Inverse-resample walks the D dest slots; the source path walks the live
         // source count. frameData_.voxelCount_ (the compact's per-slot guard) was

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -1044,20 +1044,28 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         const IsoBounds2D visibleVp = IRRender::getCullViewport().isoViewport(kGpuMargin);
         frameData_.visibleIsoBounds_ =
             ivec4(ivec2(IRMath::floor(visibleVp.min_)), ivec2(IRMath::ceil(visibleVp.max_)));
+
+        // Occlusion cull gate (#1294 chunk pre-pass + #1812 per-voxel refine, off
+        // by default). Enabled only on the states whose distance encoding +
+        // shadow-feeder semantics are verified: enabled, NOT stale (no
+        // discontinuous camera move this frame — #1294 child 3/3, resolved in
+        // beginTick), NONE render mode (encodeDepthWithFace = rawDepth*4), cardinal
+        // yaw (!rotating → per-axis canvases inactive, so no split-list
+        // interaction), a non-re-voxelize pool (the frustum mask is the real
+        // per-chunk mask, not the all-visible dest-cell scratch), AND a built Hi-Z
+        // chain. Any other state keeps every voxel (conservative). The chunk
+        // pre-pass ANDs occluded chunks out of ChunkVisibility (24); the compact
+        // then runs the per-voxel Hi-Z test on the survivors (occlusionCullMipCount_
+        // uploaded here, Hi-Z bound at the compact dispatch below).
+        const int occlusionMipCount = triangleCanvasTextures.hiZMipCount();
+        const bool occlusionCullActive =
+            IRRender::getVoxelOcclusionCullEnabled() && !occlusionLagSourceStale_ &&
+            frameData_.voxelRenderOptions_.x == 0 && !rotating && revoxBuffer == nullptr &&
+            occlusionMipCount > 0;
+        frameData_.occlusionCullMipCount_ = occlusionCullActive ? occlusionMipCount : 0;
         frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &frameData_);
 
-        // Chunk-occlusion HZB pre-pass (#1294 child 2/3, off by default). Gated to
-        // the configuration whose distance encoding + shadow-feeder semantics are
-        // verified: enabled, NOT stale (no discontinuous camera move this frame —
-        // #1294 child 3/3, resolved in beginTick), NONE render mode
-        // (encodeDepthWithFace = rawDepth*4), cardinal yaw (!rotating → per-axis
-        // canvases are also inactive, so no split-list interaction), and a
-        // non-re-voxelize pool (the frustum mask is the real per-chunk mask, not
-        // the all-visible dest-cell scratch). Any other state keeps every chunk
-        // (conservative). The pass ANDs occluded chunks out of ChunkVisibility
-        // (24) before the compact pass reads it.
-        if (IRRender::getVoxelOcclusionCullEnabled() && !occlusionLagSourceStale_ &&
-            frameData_.voxelRenderOptions_.x == 0 && !rotating && revoxBuffer == nullptr) {
+        if (occlusionCullActive) {
             dispatchChunkOcclusion(voxelPool, triangleCanvasTextures, visibleVp);
         }
 
@@ -1243,6 +1251,19 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             fogObserverBuf_->subData(0, sizeof(FrameDataFogObservers), &cutSectionFog->observers_);
         }
         fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
+        // Per-voxel occlusion cull Hi-Z input (#1812). Bind the finest Hi-Z level
+        // at a texture unit distinct from the fog IMAGE at 0 (GL image/texture
+        // unit 0 alias; Metal's shared argument table needs the distinct index).
+        // The compact samples it only when frameData_.occlusionCullMipCount_ > 0;
+        // a canvas with no Hi-Z chain (≤1px) binds the R32I distance texture as a
+        // never-sampled sentinel so Metal's argument table stays satisfied. Bound
+        // every frame (one texture bind) — the shader gate keeps the default
+        // (cull-off) output byte-identical.
+        constexpr int kHiZLevel0CompactTextureUnit = 1;
+        const Texture2D *hiZLevel0 = (triangleCanvasTextures.hiZMipCount() > 0)
+                                         ? triangleCanvasTextures.getHiZMip(0)
+                                         : triangleCanvasTextures.getTextureDistances();
+        hiZLevel0->bind(kHiZLevel0CompactTextureUnit);
         constexpr int kCompactLocalSize = 64;
         // Inverse-resample walks the D dest slots; the source path walks the live
         // source count. frameData_.voxelCount_ (the compact's per-slot guard) was

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -1049,7 +1049,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // by default). Enabled only on the states whose distance encoding +
         // shadow-feeder semantics are verified: enabled, NOT stale (no
         // discontinuous camera move this frame — #1294 child 3/3, resolved in
-        // beginTick), NONE render mode (encodeDepthWithFace = rawDepth*4), cardinal
+        // beginTick), NONE render mode (encodeDepthWithFace = rawDepth*kDepthEncodeShift), cardinal
         // yaw (!rotating → per-axis canvases inactive, so no split-list
         // interaction), a non-re-voxelize pool (the frustum mask is the real
         // per-chunk mask, not the all-visible dest-cell scratch), AND a built Hi-Z
@@ -1062,7 +1062,16 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             IRRender::getVoxelOcclusionCullEnabled() && !occlusionLagSourceStale_ &&
             frameData_.voxelRenderOptions_.x == 0 && !rotating && revoxBuffer == nullptr &&
             occlusionMipCount > 0;
-        frameData_.occlusionCullMipCount_ = occlusionCullActive ? occlusionMipCount : 0;
+        // The chunk pre-pass (dispatched below on occlusionCullActive) and the
+        // per-voxel Hi-Z refine are separately toggleable so the #1812 marginal
+        // acceptance gate can A/B the per-voxel test in isolation while the chunk
+        // cull stays on: --no-per-voxel-occlusion zeroes the mip count (skips the
+        // compact's per-voxel test) without touching dispatchChunkOcclusion. The
+        // per-voxel toggle defaults on, so --occlusion-cull alone runs both.
+        frameData_.occlusionCullMipCount_ =
+            (occlusionCullActive && IRRender::getVoxelPerVoxelOcclusionEnabled())
+                ? occlusionMipCount
+                : 0;
         frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &frameData_);
 
         if (occlusionCullActive) {

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -852,3 +852,21 @@ parity with voxel-pool primary shapes.
   texture as a bake/compute read input. Invariant: the sun-shadow bake only
   ever reads main-canvas-layout depth sources. The underlying backend gap is
   tracked as #1640; until it lands, resolve-then-bake is mandatory.
+- **A compute kernel's texture read is silently shadowed by a stale IMAGE bind
+  at the same unit on Metal (#1812).** `bindComputeResources`
+  (`metal_render_impl.cpp`) flushes the sticky image-binding table AFTER the
+  sampler table at the *same* encoder texture index, and the image table is
+  never cleared per-frame. So if you bind a texture as a **sampler**
+  (`Texture2D::bind`) at unit N to read it, but a prior dispatch left a
+  **different** texture bound as an **image** (`bindAsImage`) at unit N, your
+  read gets that stale image, not your texture — no error, no warning. The
+  #1812 per-voxel cull read `getHiZMip(0)` at unit 1 via `bind()`, but
+  `VOXEL_TO_TRIXEL_STAGE_1`/`STAGE_2` leave `trixelDistances` imaged at unit 1,
+  so the compact read the (just-cleared, all-65535) distance texture and the
+  cull captured zero. **Fix: bind compute texture reads as IMAGES**
+  (`bindAsImage(unit, READ_ONLY, <fmt>)` + `access::read` on Metal / `imageLoad`
+  on GL) so they occupy — and win — the image slot, rather than a sampler bind
+  that a stale image shadows. GL is immune (separate image/texture-unit
+  namespaces), so a GL-only smoke will not catch it. Any compute kernel that
+  mixes a sampler read with images bound elsewhere in the pipeline is exposed;
+  the #1294 chunk cull's fine Hi-Z levels are the known other victim.

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -370,6 +370,15 @@ bool getSunShadowsEnabled();
 /// closer geometry (last frame's Hi-Z) are dropped before the compact pass.
 void setVoxelOcclusionCullEnabled(bool enabled);
 bool getVoxelOcclusionCullEnabled();
+/// Per-voxel Hi-Z occlusion refine (#1812), layered on the chunk cull above. On
+/// by default, but only active when the chunk cull is enabled (the per-voxel
+/// test shares getVoxelOcclusionCullEnabled()'s gate), so a default scene stays
+/// byte-identical. Set false to isolate the chunk cull's contribution: the
+/// #1812 marginal acceptance gate A/Bs this while --occlusion-cull stays on, so
+/// cull-with-per-voxel vs cull-without-per-voxel must be bit-identical (the
+/// per-voxel test drops zero visible voxels; the chunk cull owns any holes).
+void setVoxelPerVoxelOcclusionEnabled(bool enabled);
+bool getVoxelPerVoxelOcclusionEnabled();
 /// When false, ambient occlusion crease darkening is skipped — the AO compute
 /// shader short-circuits with a constant 1.0 so the lighting pass treats AO
 /// as a no-op. Sun face shading and projected shadows are unaffected.

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -503,7 +503,16 @@ struct FrameDataVoxelToCanvas {
     // offset is unchanged. Trailing pads keep sizeof at the 16-byte std140
     // stride for the full-struct subData uploads.
     int resolveMode_ = 0;
-    int resolveModePad0_ = 0;
+    // Per-voxel Hi-Z occlusion-cull gate (#1812), refining the per-chunk cull
+    // (#1294 child 2/3). 0 = the compact's per-voxel test is skipped, so the
+    // default (occlusion cull off) pipeline is byte-identical. Non-zero = the
+    // Hi-Z chain level count; the compact samples level 0 at each surviving
+    // voxel's canvas pixel and drops it when strictly behind the farthest visible
+    // surface. Set (in VOXEL_TO_TRIXEL_STAGE_1) only on the same states the chunk
+    // pre-pass is verified for: enabled, lag source fresh, NONE render mode,
+    // cardinal (not rotating), non-re-voxelize pool, Hi-Z chain built. Reuses the
+    // first resolveMode tail pad so the std140 layout / sizeof stay unchanged.
+    int occlusionCullMipCount_ = 0;
     int resolveModePad1_ = 0;
     int resolveModePad2_ = 0;
 };

--- a/engine/render/include/irreden/render/render_manager.hpp
+++ b/engine/render/include/irreden/render/render_manager.hpp
@@ -94,6 +94,8 @@ class RenderManager {
     bool getAOEnabled() const;
     void setVoxelOcclusionCullEnabled(bool enabled);
     bool getVoxelOcclusionCullEnabled() const;
+    void setVoxelPerVoxelOcclusionEnabled(bool enabled);
+    bool getVoxelPerVoxelOcclusionEnabled() const;
 
     void setDebugOverlay(DebugOverlayMode mode);
     DebugOverlayMode getDebugOverlay() const;
@@ -185,6 +187,12 @@ class RenderManager {
     // not dispatched unless this is set, so a default scene is byte-identical to
     // master. The gating heuristic + camera-cut disable land in child 3 (#1800).
     bool m_voxelOcclusionCullEnabled = false;
+    // Per-voxel Hi-Z occlusion refine (#1812), layered on the chunk pre-pass
+    // above. On by default, but only active when the chunk cull is enabled (the
+    // per-voxel test shares getVoxelOcclusionCullEnabled()'s gate). Flip it off
+    // (--no-per-voxel-occlusion) to isolate the chunk cull's contribution for the
+    // #1812 marginal acceptance gate.
+    bool m_voxelPerVoxelOcclusionEnabled = true;
     DebugOverlayMode m_debugOverlayMode = DebugOverlayMode::NONE;
     bool m_depthColorDebugOn = false;
     float m_depthColorDebugExtent = 0.0f;

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -330,6 +330,14 @@ bool getVoxelOcclusionCullEnabled() {
     return getRenderManager().getVoxelOcclusionCullEnabled();
 }
 
+void setVoxelPerVoxelOcclusionEnabled(bool enabled) {
+    getRenderManager().setVoxelPerVoxelOcclusionEnabled(enabled);
+}
+
+bool getVoxelPerVoxelOcclusionEnabled() {
+    return getRenderManager().getVoxelPerVoxelOcclusionEnabled();
+}
+
 void setAOEnabled(bool enabled) {
     getRenderManager().setAOEnabled(enabled);
 }

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -53,7 +53,10 @@ vec2 getEffectiveCameraIso() {
         // drift-cancel offset (`IRMath::cameraYawPivotOffset`) keeps the focus at
         // a constant on-screen position across the yaw sweep.
         return IRMath::cameraYawPivotOffset(
-            cameraIso, getRenderManager().getRotationPivotFocus(), visualYaw);
+            cameraIso,
+            getRenderManager().getRotationPivotFocus(),
+            visualYaw
+        );
     }
     // CAMERA_CENTER default — pivot Z-yaw about the EXACT z = 0 world point under
     // screen center, held fixed across the yaw sweep so the scene rotates in
@@ -70,8 +73,8 @@ vec2 getEffectiveCameraIso() {
     // together — see system_entity_canvas_to_framebuffer.hpp. See
     // docs/design/camera-yaw-pivot.md (#1352, #1942, #1944).
     const ivec2 canvasSize = getRenderManager().getMainCanvasSizeTriangles();
-    const vec2 viewCenterIso = vec2(canvasSize) * 0.5f -
-                               vec2(IRMath::trixelOriginOffsetZ1(canvasSize)) - cameraIso;
+    const vec2 viewCenterIso =
+        vec2(canvasSize) * 0.5f - vec2(IRMath::trixelOriginOffsetZ1(canvasSize)) - cameraIso;
     const vec3 cameraFocusWorld = IRMath::isoPixelToPos3D(viewCenterIso, 0.0f);
     return IRMath::cameraYawPivotOffset(cameraIso, cameraFocusWorld, visualYaw);
 }

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -622,6 +622,14 @@ bool RenderManager::getVoxelOcclusionCullEnabled() const {
     return m_voxelOcclusionCullEnabled;
 }
 
+void RenderManager::setVoxelPerVoxelOcclusionEnabled(bool enabled) {
+    m_voxelPerVoxelOcclusionEnabled = enabled;
+}
+
+bool RenderManager::getVoxelPerVoxelOcclusionEnabled() const {
+    return m_voxelPerVoxelOcclusionEnabled;
+}
+
 void RenderManager::setDebugOverlay(DebugOverlayMode mode) {
     m_debugOverlayMode = mode;
 }

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
@@ -191,6 +191,14 @@ void resolveWinnerTap(const ivec2 canvasPixel, const int voxelDistance, const ui
 // column lengths ≤ √3, since |col0|² = 3 - 2(c±s) ≤ 3 for X/Y faces);
 // detached canvases cap at n=6 for full SO(3).
 // At residualYaw==0 on any canvas the identity D collapses n to 1.
+// KEEP IN SYNC with c_voxel_visibility_compact.{glsl,metal} voxelOccludedByHiZ:
+// the per-voxel Hi-Z occlusion cull's sampled window MUST be a conservative
+// superset of this function's write set (`base + roundHalfUp(D * src)` for src
+// across the [0,2)x[0,3) invocation lattice), so a visible voxel's own last-frame
+// depth write always lands in the window it is tested against. Widening this
+// emission hull (a larger super-sample lattice, a new dilation, a bigger D)
+// without widening the compact's window re-introduces the #1812 static-scene
+// silhouette holes (it false-culls voxels whose write escapes the stale window).
 void emitDeformedFace(
     const ivec2 base, const mat2 D, const int voxelDistance, const int faceId,
     const bool reVoxelize

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -23,8 +23,41 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     uniform float visualYaw;
     uniform float rasterYaw;
     uniform float residualYaw;
-    uniform float _yawPadding;
+    // Prefix through residualYaw is the shared binding-7 head. The fields below
+    // (matching FrameDataVoxelToCanvas / the stage-1 UBO offsets) are declared so
+    // the per-voxel occlusion cull (#1812) can read visibleIsoBounds (offset 176)
+    // and occlusionCullMipCount (offset 196); the rest are layout placeholders
+    // this pass does not consume.
+    uniform float isDetachedCanvas;     // offset 76 (was _yawPadding)
+    uniform vec4 faceDeform[3];         // offset 80
+    uniform ivec4 visibleFaceIds;       // offset 128
+    uniform vec4 voxelDepthAxis;        // offset 144
+    uniform vec4 detachedWorldReceive;  // offset 160
+    // Un-widened (no shadow-feeder sweep) visible iso viewport. The per-voxel
+    // occlusion test only culls voxels fully inside this box — a caster in the
+    // shadow-feeder swept ring (inside cullIsoMin/Max but outside here) must keep
+    // its sun shadow (mirrors dispatchChunkOcclusion's fully-visible eligibility).
+    uniform ivec4 visibleIsoBounds;     // offset 176
+    uniform int resolveMode;            // offset 192
+    // Per-voxel Hi-Z occlusion-cull gate (#1812): 0 = off (byte-identical),
+    // non-zero = Hi-Z chain level count → run the per-voxel test.
+    uniform int occlusionCullMipCount;  // offset 196
+    uniform int _occlusionPad0;         // offset 200
+    uniform int _occlusionPad1;         // offset 204
 };
+
+// Finest Hi-Z downsampled level (conceptual mip 1) over last frame's canvas
+// distances (#1798), R32I. Bound at texture unit 1 by VOXEL_TO_TRIXEL_STAGE_1
+// when this compact runs — kept off unit 0 so it never aliases the fog IMAGE at
+// binding 0 on Metal's shared argument table (GL image/texture unit 0 are
+// separate namespaces, but the compact must stay backend-parity-clean). Sampled
+// only when occlusionCullMipCount > 0.
+layout(binding = 1) uniform isampler2D hiZLevel0;
+
+// Strict-behind margin (encoded units) so FMA / round noise on the boundary
+// never culls a voxel only coplanar with the occluder. Must match
+// kOcclusionDepthMargin in c_chunk_occlusion_cull.glsl.
+const int kOcclusionDepthMargin = 4;
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
     vec4 positions[];
@@ -186,6 +219,50 @@ void writeDispatchDims(uint base) {
         uint(kStageMicroSlicesPerGroup);
 }
 
+// Per-voxel Hi-Z occlusion refine (#1812), layered on top of the per-chunk
+// pre-pass (coarse -> fine hierarchical occlusion). Drops a voxel that is
+// locally-exposed + in-frustum but globally occluded by closer geometry —
+// capturing the per-voxel occludedExposedFraction the all-or-nothing 256-voxel
+// chunk test leaves on the table. Conservative + off by default:
+//   * occlusionCullMipCount == 0 (the default; any non-cardinal / rotating /
+//     re-voxelize / no-Hi-Z frame) -> no test, byte-identical to master.
+//   * Only voxels inside the UN-WIDENED visible viewport are tested. A caster in
+//     the shadow-feeder swept ring (inside cullIsoMin/Max but outside
+//     visibleIsoBounds) is never culled — the Hi-Z covers only the visible
+//     viewport, so dropping it would lose its sun shadow. Mirrors
+//     dispatchChunkOcclusion's fully-inside-visible eligibility.
+//   * A footprint that still sees background keeps the voxel (empty texels carry
+//     the 65535 sentinel -> hiZMax stays large -> never occlude). A false
+//     positive is a visible hole; a false negative is only lost savings.
+// Encoding matches the Hi-Z exactly: encoded = pos3DtoDistance(voxelPos) * 4,
+// the same cardinal-rotated iso depth dispatchChunkOcclusion writes as
+// cb.minDepth_ * 4 (encodeDepthWithFace spacing, face slot 0).
+bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
+    if (occlusionCullMipCount <= 0) {
+        return false;
+    }
+    if (isoPos.x < visibleIsoBounds.x || isoPos.y < visibleIsoBounds.y ||
+        isoPos.x > visibleIsoBounds.z || isoPos.y > visibleIsoBounds.w) {
+        return false;
+    }
+    // iso -> canvas pixel, exactly as dispatchChunkOcclusion / stage 1 at NONE
+    // mode (effectiveTrixelSubdivisionScale == 1).
+    ivec2 canvasPixel = trixelCanvasOffsetZ1 + ivec2(floor(frameCanvasOffset)) + isoPos;
+    // A voxel projects to ~1 iso px, so the finest downsampled level (source
+    // px >> 1) always covers the footprint. Expand by one texel and take the max.
+    ivec2 texel = canvasPixel >> 1;
+    ivec2 sz = textureSize(hiZLevel0, 0);
+    int hiZMax = -2147483648;
+    for (int ty = texel.y - 1; ty <= texel.y + 1; ++ty) {
+        for (int tx = texel.x - 1; tx <= texel.x + 1; ++tx) {
+            hiZMax = max(
+                hiZMax, texelFetch(hiZLevel0, clamp(ivec2(tx, ty), ivec2(0), sz - ivec2(1)), 0).x
+            );
+        }
+    }
+    return pos3DtoDistance(voxelPos) * 4 > hiZMax + kOcclusionDepthMargin;
+}
+
 void main() {
     const int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
     uint workGroupIndex = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
@@ -202,6 +279,11 @@ void main() {
                 ivec3 voxelPosRaw = roundHalfUp(positions[idx].xyz);
                 ivec2 isoPos;
                 int cullMargin = 0;
+                // Cardinal-rotated position, hoisted so the per-voxel occlusion
+                // test can reuse it. Only rotated in the residual==0 branch below
+                // (the only path where occlusionCullMipCount can be non-zero);
+                // stays raw on the rotating path, which never runs the test.
+                ivec3 voxelPos = voxelPosRaw;
                 // Smooth camera Z-yaw (T3 / #1310): while the per-axis canvases
                 // are active (residual yaw != 0) the framebuffer scatter
                 // rasterizes each voxel at its CONTINUOUS yawed iso position, so
@@ -216,7 +298,6 @@ void main() {
                     isoPos = roundHalfUp(pos3DtoPos2DIsoYawed(vec3(voxelPosRaw), visualYaw));
                     cullMargin = 2;
                 } else {
-                    ivec3 voxelPos = voxelPosRaw;
                     if (cardinalIndex != 0) {
                         voxelPos = rotateCardinalZ(voxelPos, cardinalIndex);
                         voxelPos += cardinalLowerCornerShift(cardinalIndex);
@@ -241,9 +322,16 @@ void main() {
                         // off while any circle is live. (No early return — the
                         // cross-group completion barrier below must stay
                         // uniformly reached.)
+                        // Per-voxel Hi-Z occlusion refine (#1812): drop a voxel
+                        // globally occluded by closer geometry. Off by default
+                        // (occlusionCullMipCount == 0 -> no-op), and skipped for a
+                        // fully-interior voxel that was already dropped above, so
+                        // it never re-adds one. No early return — the completion
+                        // barrier below must stay uniformly reached.
                         uint flagsByte = (voxels[idx].materialFlagBone >> 8u) & 0xFFu;
-                        if (visionCircleCount != 0 ||
-                            (flagsByte & kFaceOccludedMaskBits) != kFaceOccludedMaskBits) {
+                        if ((visionCircleCount != 0 ||
+                             (flagsByte & kFaceOccludedMaskBits) != kFaceOccludedMaskBits) &&
+                            !voxelOccludedByHiZ(voxelPos, isoPos)) {
                             uint slot = atomicAdd(params[3], 1u);
                             compactedVoxelIndices[slot] = idx;
                         }

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -54,10 +54,12 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
 // only when occlusionCullMipCount > 0.
 layout(binding = 1) uniform isampler2D hiZLevel0;
 
-// Strict-behind margin (encoded units) so FMA / round noise on the boundary
-// never culls a voxel only coplanar with the occluder. Must match
-// kOcclusionDepthMargin in c_chunk_occlusion_cull.glsl.
-const int kOcclusionDepthMargin = 4;
+// Strict-behind margin (one raw-depth unit of encoded slack) so FMA / round
+// noise on the boundary never culls a voxel only coplanar with the occluder,
+// and so the encoded low bits (slot [1:0] + flip [2], #2207) never tip the
+// comparison. Tracks kDepthEncodeShift, matching kOcclusionDepthMargin in
+// c_chunk_occlusion_cull.glsl (both = the encode scale).
+const int kOcclusionDepthMargin = kDepthEncodeShift;
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
     vec4 positions[];
@@ -234,9 +236,15 @@ void writeDispatchDims(uint base) {
 //   * A footprint that still sees background keeps the voxel (empty texels carry
 //     the 65535 sentinel -> hiZMax stays large -> never occlude). A false
 //     positive is a visible hole; a false negative is only lost savings.
-// Encoding matches the Hi-Z exactly: encoded = pos3DtoDistance(voxelPos) * 4,
-// the same cardinal-rotated iso depth dispatchChunkOcclusion writes as
-// cb.minDepth_ * 4 (encodeDepthWithFace spacing, face slot 0).
+// Encoding matches the Hi-Z exactly: encodeDepthWithFace(pos3DtoDistance(voxelPos), 0)
+// — the same cardinal iso depth dispatchChunkOcclusion writes as its
+// encodedNearest_ (cb.minDepth_ * kDepthEncodeShift, face slot 0). Route through
+// the shared encode helper, NOT an open-coded scale: #2207 changed the cardinal
+// layout from *4 to *kDepthEncodeShift (depth [31:3] | flip [2] | slot [1:0]),
+// and a hard-coded *4 here silently compares a half-scale depth against the
+// Hi-Z's *8 values so the test never fires (a vacuous no-op). flip = 0 on the
+// cardinal path this cull runs on (riser-flip is gated to rotated content), so
+// slot 0 / flip 0 is the correct encode; the margin absorbs the Hi-Z's low bits.
 bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
     if (occlusionCullMipCount <= 0) {
         return false;
@@ -288,7 +296,7 @@ bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
             );
         }
     }
-    return pos3DtoDistance(voxelPos) * 4 > hiZMax + kOcclusionDepthMargin;
+    return encodeDepthWithFace(pos3DtoDistance(voxelPos), 0) > hiZMax + kOcclusionDepthMargin;
 }
 
 void main() {

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -246,15 +246,43 @@ bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
         return false;
     }
     // iso -> canvas pixel, exactly as dispatchChunkOcclusion / stage 1 at NONE
-    // mode (effectiveTrixelSubdivisionScale == 1).
-    ivec2 canvasPixel = trixelCanvasOffsetZ1 + ivec2(floor(frameCanvasOffset)) + isoPos;
-    // A voxel projects to ~1 iso px, so the finest downsampled level (source
-    // px >> 1) always covers the footprint. Expand by one texel and take the max.
-    ivec2 texel = canvasPixel >> 1;
+    // mode (effectiveTrixelSubdivisionScale == 1). This is stage 1's emit `base`.
+    ivec2 base = trixelCanvasOffsetZ1 + ivec2(floor(frameCanvasOffset)) + isoPos;
+    // Sample the Hi-Z over the EMISSION HULL — the conservative superset of every
+    // pixel stage 1 can write for this voxel — NOT a fixed ±1 window. stage 1's
+    // emitDeformedFace writes each face at `base + roundHalfUp(D_s * src)` for src
+    // across the [0,2)x[0,3) invocation lattice (local_size 2x3), per visible-
+    // triplet slot s, with D_s = mat2(faceDeform[s].xy, faceDeform[s].zw). The
+    // fixed ±1 window missed the +iso extreme of that hull at silhouette / upper
+    // edges (the near Z face is unexposed so it never writes at `base`, and the
+    // exposed X/Y faces land past the window), false-culling a VISIBLE voxel whose
+    // own last-frame depth write fell outside the sampled window — the #1812
+    // static-scene hole. The window MUST stay a superset of emitDeformedFace's
+    // write set (the self-referential Hi-Z then re-anchors every surviving voxel):
+    // KEEP IN SYNC with c_voxel_to_trixel_stage_1.{glsl,metal} emitDeformedFace.
+    // faceDeform is identity at residualYaw==0 (the only path the cull runs on), so
+    // this reduces to a fixed ~3x4-texel box on the cardinal path; deriving it from
+    // faceDeform keeps it correct by construction if the emit deform ever changes.
+    const vec2 hullCorners[4] =
+        vec2[4](vec2(0.0, 0.0), vec2(2.0, 0.0), vec2(0.0, 3.0), vec2(2.0, 3.0));
+    vec2 loF = vec2(1.0e30);
+    vec2 hiF = vec2(-1.0e30);
+    for (int s = 0; s < 3; ++s) {
+        mat2 D = mat2(faceDeform[s].xy, faceDeform[s].zw);
+        for (int c = 0; c < 4; ++c) {
+            vec2 p = D * hullCorners[c];
+            loF = min(loF, p);
+            hiF = max(hiF, p);
+        }
+    }
+    // ±1 px pad absorbs roundHalfUp of the intra-hull super-sample taps; >>1 maps
+    // canvas px to the finest half-res Hi-Z level.
+    ivec2 loTexel = (base + ivec2(floor(loF)) - ivec2(1)) >> 1;
+    ivec2 hiTexel = (base + ivec2(ceil(hiF)) + ivec2(1)) >> 1;
     ivec2 sz = textureSize(hiZLevel0, 0);
     int hiZMax = -2147483648;
-    for (int ty = texel.y - 1; ty <= texel.y + 1; ++ty) {
-        for (int tx = texel.x - 1; tx <= texel.x + 1; ++tx) {
+    for (int ty = loTexel.y; ty <= hiTexel.y; ++ty) {
+        for (int tx = loTexel.x; tx <= hiTexel.x; ++tx) {
             hiZMax = max(
                 hiZMax, texelFetch(hiZLevel0, clamp(ivec2(tx, ty), ivec2(0), sz - ivec2(1)), 0).x
             );

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -47,12 +47,18 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
 };
 
 // Finest Hi-Z downsampled level (conceptual mip 1) over last frame's canvas
-// distances (#1798), R32I. Bound at texture unit 1 by VOXEL_TO_TRIXEL_STAGE_1
-// when this compact runs — kept off unit 0 so it never aliases the fog IMAGE at
-// binding 0 on Metal's shared argument table (GL image/texture unit 0 are
-// separate namespaces, but the compact must stay backend-parity-clean). Sampled
-// only when occlusionCullMipCount > 0.
-layout(binding = 1) uniform isampler2D hiZLevel0;
+// distances (#1798), R32I. Bound as a read-only IMAGE at unit 1 (not a sampler)
+// by VOXEL_TO_TRIXEL_STAGE_1 when this compact runs. The image bind is load-
+// bearing on Metal: bindComputeResources flushes the image-binding table AFTER
+// the sampler table at the same encoder texture index, and the image table is
+// sticky, so the leftover trixelDistances IMAGE bound at unit 1 by the prior
+// frame's stage-1/stage-2 shadowed a sampler bind of the Hi-Z here — the compact
+// then read freshly-cleared trixelDistances (the all-65535 distance sentinel)
+// instead of the Hi-Z, and the per-voxel test never fired (#1812 zero-capture).
+// Binding the Hi-Z as an image overwrites that stale slot so it wins the flush.
+// Read only when occlusionCullMipCount > 0; off unit 0 so it never aliases the
+// fog image there.
+layout(r32i, binding = 1) readonly uniform iimage2D hiZLevel0;
 
 // Strict-behind margin (one raw-depth unit of encoded slack) so FMA / round
 // noise on the boundary never culls a voxel only coplanar with the occluder,
@@ -287,12 +293,12 @@ bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
     // canvas px to the finest half-res Hi-Z level.
     ivec2 loTexel = (base + ivec2(floor(loF)) - ivec2(1)) >> 1;
     ivec2 hiTexel = (base + ivec2(ceil(hiF)) + ivec2(1)) >> 1;
-    ivec2 sz = textureSize(hiZLevel0, 0);
+    ivec2 sz = imageSize(hiZLevel0);
     int hiZMax = -2147483648;
     for (int ty = loTexel.y; ty <= hiTexel.y; ++ty) {
         for (int tx = loTexel.x; tx <= hiTexel.x; ++tx) {
             hiZMax = max(
-                hiZMax, texelFetch(hiZLevel0, clamp(ivec2(tx, ty), ivec2(0), sz - ivec2(1)), 0).x
+                hiZMax, imageLoad(hiZLevel0, clamp(ivec2(tx, ty), ivec2(0), sz - ivec2(1))).x
             );
         }
     }

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -67,6 +67,12 @@ inline void resolveWinnerTap(
 // World canvas: maxN=2 (Z-yaw residual ≤ π/4, column lengths ≤ √3).
 // Detached canvas: maxN=6 (full SO(3)).
 // See c_voxel_to_trixel_stage_1.glsl for the full contract.
+// KEEP IN SYNC with c_voxel_visibility_compact.{glsl,metal} voxelOccludedByHiZ:
+// the per-voxel Hi-Z occlusion cull's sampled window MUST be a conservative
+// superset of this function's write set (`base + roundHalfUp(D * src)` over the
+// [0,2)x[0,3) invocation lattice) so a visible voxel's own last-frame write always
+// lands in the window it is tested against. Widening this emission hull without
+// widening that window re-introduces the #1812 static-scene silhouette holes.
 inline void emitDeformedFace(
     int2 base,
     float2x2 D,

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -135,6 +135,46 @@ constant float kCullSafetyCells = 9.0f;
 // flags byte matching the full mask marks a fully-interior voxel.
 constant uint kFaceOccludedMaskBits = 0xFCu;
 
+// Strict-behind margin (encoded units) so FMA / round noise on the boundary
+// never culls a voxel only coplanar with the occluder. Must match
+// kOcclusionDepthMargin in c_chunk_occlusion_cull.metal.
+constant int kOcclusionDepthMargin = 4;
+
+// Per-voxel Hi-Z occlusion refine (#1812) — see the GLSL twin
+// (c_voxel_visibility_compact.glsl) for the full rationale: conservative,
+// off by default (occlusionCullMipCount == 0 -> no-op), shadow-feeder-safe
+// (only voxels inside the un-widened visibleIsoBounds are tested), background
+// sentinel keeps a voxel that still sees background, and the encoding
+// (pos3DtoDistance(voxelPos) * 4) matches dispatchChunkOcclusion's cb.minDepth_
+// exactly. hiZLevel0 is the finest downsampled level (source px >> 1); a voxel's
+// ~1 iso px footprint always lands there.
+static bool voxelOccludedByHiZ(
+    texture2d<int, access::read> hiZLevel0,
+    constant FrameDataVoxelToTrixel& fd,
+    int3 voxelPos,
+    int2 isoPos
+) {
+    if (fd.occlusionCullMipCount <= 0) {
+        return false;
+    }
+    if (isoPos.x < fd.visibleIsoBounds.x || isoPos.y < fd.visibleIsoBounds.y ||
+        isoPos.x > fd.visibleIsoBounds.z || isoPos.y > fd.visibleIsoBounds.w) {
+        return false;
+    }
+    const int2 canvasPixel =
+        fd.trixelCanvasOffsetZ1 + int2(floor(fd.frameCanvasOffset)) + isoPos;
+    const int2 texel = canvasPixel >> 1;
+    const int2 sz = int2(int(hiZLevel0.get_width()), int(hiZLevel0.get_height()));
+    int hiZMax = -2147483648;
+    for (int ty = texel.y - 1; ty <= texel.y + 1; ++ty) {
+        for (int tx = texel.x - 1; tx <= texel.x + 1; ++tx) {
+            const int2 c = clamp(int2(tx, ty), int2(0), sz - int2(1));
+            hiZMax = max(hiZMax, hiZLevel0.read(uint2(c)).x);
+        }
+    }
+    return pos3DtoDistance(voxelPos) * 4 > hiZMax + kOcclusionDepthMargin;
+}
+
 // True iff this column lies under any live analytic vision circle, so its voxels
 // survive the grid cull and FOG_TO_TRIXEL can reveal them smoothly per pixel.
 // Uses a cell nearest-point (AABB) test (mirrors the GLSL): the voxel cell at
@@ -176,6 +216,11 @@ kernel void c_voxel_visibility_compact(
     device uint* compactedVoxelIndices [[buffer(25)]],
     device atomic_uint* indirectParams [[buffer(26)]],
     texture2d<float, access::read> canvasFogOfWar [[texture(0)]],
+    // Finest Hi-Z level for the per-voxel occlusion cull (#1812). At texture(1)
+    // so it never aliases the fog image at texture(0) in Metal's shared argument
+    // table. Sampled only when frameData.occlusionCullMipCount > 0; otherwise a
+    // never-sampled sentinel is bound so the argument table stays satisfied.
+    texture2d<int, access::read> hiZLevel0 [[texture(1)]],
     constant FogObserverData& fogObservers [[buffer(27)]],
     uint3 groupId [[threadgroup_position_in_grid]],
     uint3 groupCount [[threadgroups_per_grid]],
@@ -196,6 +241,10 @@ kernel void c_voxel_visibility_compact(
                 const int3 voxelPosRaw = roundHalfUp(positions[idx].xyz);
                 int2 isoPos;
                 int cullMargin = 0;
+                // Cardinal-rotated position, hoisted for the per-voxel occlusion
+                // test (only rotated on the residual==0 path — the only path
+                // where occlusionCullMipCount can be non-zero).
+                int3 voxelPos = voxelPosRaw;
                 // Smooth camera Z-yaw (T3 / #1310) — see the GLSL mirror for the
                 // rationale: while rotating, project the cull with the same
                 // continuous yaw the per-axis scatter raster uses (cardinal snap
@@ -207,7 +256,6 @@ kernel void c_voxel_visibility_compact(
                     );
                     cullMargin = 2;
                 } else {
-                    int3 voxelPos = voxelPosRaw;
                     if (cardinalIndex != 0) {
                         voxelPos = rotateCardinalZ(voxelPos, cardinalIndex);
                         voxelPos += cardinalLowerCornerShift(cardinalIndex);
@@ -231,9 +279,15 @@ kernel void c_voxel_visibility_compact(
                         // occluded vertical face as a cut wall, #2125). No early
                         // return — the completion barrier below must stay
                         // uniformly reached.
+                        // Per-voxel Hi-Z occlusion refine (#1812): drop a voxel
+                        // globally occluded by closer geometry. Off by default;
+                        // never re-adds a fully-interior voxel already dropped
+                        // above. No early return — the completion barrier below
+                        // must stay uniformly reached.
                         const uint flagsByte = (voxels[idx].materialFlagBone >> 8u) & 0xFFu;
-                        if (fogObservers.visionCircleCount != 0 ||
-                            (flagsByte & kFaceOccludedMaskBits) != kFaceOccludedMaskBits) {
+                        if ((fogObservers.visionCircleCount != 0 ||
+                             (flagsByte & kFaceOccludedMaskBits) != kFaceOccludedMaskBits) &&
+                            !voxelOccludedByHiZ(hiZLevel0, frameData, voxelPos, isoPos)) {
                             const uint slot = atomic_fetch_add_explicit(
                                 &indirectParams[kSlotVisibleCount],
                                 1u,

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -252,10 +252,16 @@ kernel void c_voxel_visibility_compact(
     device uint* compactedVoxelIndices [[buffer(25)]],
     device atomic_uint* indirectParams [[buffer(26)]],
     texture2d<float, access::read> canvasFogOfWar [[texture(0)]],
-    // Finest Hi-Z level for the per-voxel occlusion cull (#1812). At texture(1)
-    // so it never aliases the fog image at texture(0) in Metal's shared argument
-    // table. Sampled only when frameData.occlusionCullMipCount > 0; otherwise a
-    // never-sampled sentinel is bound so the argument table stays satisfied.
+    // Finest Hi-Z level for the per-voxel occlusion cull (#1812). access::read
+    // (image); the C++ binds it as an IMAGE at unit 1 (bindAsImage, not bind).
+    // The image bind is load-bearing: bindComputeResources flushes the sticky
+    // image-binding table AFTER the sampler table at the same texture index, so a
+    // sampler bind here was shadowed by the leftover trixelDistances IMAGE at
+    // unit 1 and the compact read the freshly-cleared distance sentinel (#1812
+    // zero-capture). The image bind makes the Hi-Z win that slot. At texture(1)
+    // so it never aliases the fog image at texture(0). Read only when
+    // frameData.occlusionCullMipCount > 0; else a never-read sentinel is bound so
+    // the argument table stays satisfied.
     texture2d<int, access::read> hiZLevel0 [[texture(1)]],
     constant FogObserverData& fogObservers [[buffer(27)]],
     uint3 groupId [[threadgroup_position_in_grid]],

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -135,18 +135,23 @@ constant float kCullSafetyCells = 9.0f;
 // flags byte matching the full mask marks a fully-interior voxel.
 constant uint kFaceOccludedMaskBits = 0xFCu;
 
-// Strict-behind margin (encoded units) so FMA / round noise on the boundary
-// never culls a voxel only coplanar with the occluder. Must match
-// kOcclusionDepthMargin in c_chunk_occlusion_cull.metal.
-constant int kOcclusionDepthMargin = 4;
+// Strict-behind margin (one raw-depth unit of encoded slack) so FMA / round
+// noise on the boundary never culls a voxel only coplanar with the occluder,
+// and so the encoded low bits (slot [1:0] + flip [2], #2207) never tip the
+// comparison. Tracks kDepthEncodeShift, matching kOcclusionDepthMargin in
+// c_chunk_occlusion_cull.metal (both = the encode scale).
+constant int kOcclusionDepthMargin = kDepthEncodeShift;
 
 // Per-voxel Hi-Z occlusion refine (#1812) — see the GLSL twin
 // (c_voxel_visibility_compact.glsl) for the full rationale: conservative,
 // off by default (occlusionCullMipCount == 0 -> no-op), shadow-feeder-safe
 // (only voxels inside the un-widened visibleIsoBounds are tested), background
 // sentinel keeps a voxel that still sees background, and the encoding
-// (pos3DtoDistance(voxelPos) * 4) matches dispatchChunkOcclusion's cb.minDepth_
-// exactly. hiZLevel0 is the finest downsampled level (source px >> 1); the
+// (encodeDepthWithFace(pos3DtoDistance(voxelPos), 0)) matches
+// dispatchChunkOcclusion's cb.minDepth_ * kDepthEncodeShift exactly — routed
+// through the shared encode helper because #2207 changed the cardinal layout
+// from *4 to *kDepthEncodeShift (a hard-coded *4 silently no-ops the test).
+// hiZLevel0 is the finest downsampled level (source px >> 1); the
 // sampled window is derived from stage 1's emission hull (see the window
 // derivation below) so it always contains the voxel's own last-frame write.
 static bool voxelOccludedByHiZ(
@@ -203,7 +208,7 @@ static bool voxelOccludedByHiZ(
             hiZMax = max(hiZMax, hiZLevel0.read(uint2(c)).x);
         }
     }
-    return pos3DtoDistance(voxelPos) * 4 > hiZMax + kOcclusionDepthMargin;
+    return encodeDepthWithFace(pos3DtoDistance(voxelPos), 0) > hiZMax + kOcclusionDepthMargin;
 }
 
 // True iff this column lies under any live analytic vision circle, so its voxels

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -146,8 +146,9 @@ constant int kOcclusionDepthMargin = 4;
 // (only voxels inside the un-widened visibleIsoBounds are tested), background
 // sentinel keeps a voxel that still sees background, and the encoding
 // (pos3DtoDistance(voxelPos) * 4) matches dispatchChunkOcclusion's cb.minDepth_
-// exactly. hiZLevel0 is the finest downsampled level (source px >> 1); a voxel's
-// ~1 iso px footprint always lands there.
+// exactly. hiZLevel0 is the finest downsampled level (source px >> 1); the
+// sampled window is derived from stage 1's emission hull (see the window
+// derivation below) so it always contains the voxel's own last-frame write.
 static bool voxelOccludedByHiZ(
     texture2d<int, access::read> hiZLevel0,
     constant FrameDataVoxelToTrixel& fd,
@@ -161,13 +162,43 @@ static bool voxelOccludedByHiZ(
         isoPos.x > fd.visibleIsoBounds.z || isoPos.y > fd.visibleIsoBounds.w) {
         return false;
     }
-    const int2 canvasPixel =
+    // stage 1's emit `base` at NONE (effectiveTrixelSubdivisionScale == 1).
+    const int2 base =
         fd.trixelCanvasOffsetZ1 + int2(floor(fd.frameCanvasOffset)) + isoPos;
-    const int2 texel = canvasPixel >> 1;
+    // Sample the Hi-Z over the EMISSION HULL — the conservative superset of every
+    // pixel stage 1 can write for this voxel — NOT a fixed ±1 window. stage 1's
+    // emitDeformedFace writes each face at `base + roundHalfUp(D_s * src)` for src
+    // across the [0,2)x[0,3) invocation lattice (threadgroup 2x3), per visible-
+    // triplet slot s, with D_s = float2x2(faceDeform[s].xy, faceDeform[s].zw). A
+    // fixed ±1 window missed the +iso extreme of that hull at silhouette / upper
+    // edges (the near Z face is unexposed so it never writes at `base`, the exposed
+    // X/Y faces land past the window), false-culling a VISIBLE voxel — the #1812
+    // static-scene hole. The window MUST stay a superset of emitDeformedFace's write
+    // set: KEEP IN SYNC with c_voxel_to_trixel_stage_1.{glsl,metal} emitDeformedFace.
+    // faceDeform is identity at residualYaw==0 (the only path the cull runs on), so
+    // this reduces to a fixed ~3x4-texel box; deriving it from faceDeform keeps it
+    // correct by construction if the emit deform ever changes.
+    const float2 hullCorners[4] = {
+        float2(0.0f, 0.0f), float2(2.0f, 0.0f), float2(0.0f, 3.0f), float2(2.0f, 3.0f)
+    };
+    float2 loF = float2(1.0e30f);
+    float2 hiF = float2(-1.0e30f);
+    for (int s = 0; s < 3; ++s) {
+        const float2x2 D = float2x2(fd.faceDeform[s].xy, fd.faceDeform[s].zw);
+        for (int c = 0; c < 4; ++c) {
+            const float2 p = D * hullCorners[c];
+            loF = min(loF, p);
+            hiF = max(hiF, p);
+        }
+    }
+    // ±1 px pad absorbs roundHalfUp of the intra-hull super-sample taps; >>1 maps
+    // canvas px to the finest half-res Hi-Z level.
+    const int2 loTexel = (base + int2(floor(loF)) - int2(1)) >> 1;
+    const int2 hiTexel = (base + int2(ceil(hiF)) + int2(1)) >> 1;
     const int2 sz = int2(int(hiZLevel0.get_width()), int(hiZLevel0.get_height()));
     int hiZMax = -2147483648;
-    for (int ty = texel.y - 1; ty <= texel.y + 1; ++ty) {
-        for (int tx = texel.x - 1; tx <= texel.x + 1; ++tx) {
+    for (int ty = loTexel.y; ty <= hiTexel.y; ++ty) {
+        for (int tx = loTexel.x; tx <= hiTexel.x; ++tx) {
             const int2 c = clamp(int2(tx, ty), int2(0), sz - int2(1));
             hiZMax = max(hiZMax, hiZLevel0.read(uint2(c)).x);
         }

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -986,7 +986,14 @@ struct FrameDataVoxelToTrixel {
     // (offset 192); pads mirror the CPU struct's 16-byte-stride tail. Read
     // only by c_voxel_to_trixel_stage_1.
     int resolveMode;
-    int _resolveModePad0;
+    // Per-voxel Hi-Z occlusion-cull gate (#1812). 0 = the compact's per-voxel
+    // test is skipped (default pipeline byte-identical); non-zero = the Hi-Z
+    // chain level count, so c_voxel_visibility_compact samples level 0 at each
+    // surviving voxel and drops globally-occluded ones. Mirrors
+    // FrameDataVoxelToCanvas::occlusionCullMipCount_ (offset 196); reuses the
+    // first resolveMode pad so the layout stays unchanged. Read only by
+    // c_voxel_visibility_compact.
+    int occlusionCullMipCount;
     int _resolveModePad1;
     int _resolveModePad2;
 };


### PR DESCRIPTION
## Summary

WIP. Follow-on to epic #1294. The shipped per-chunk occlusion cull (#1798 Hi-Z / #1799 chunk pre-pass / #1800 gate) realizes only ~3% of the **0.97 per-voxel `occludedExposedFraction`** ceiling on `voxel_set` zoom8 — a 256-voxel chunk spanning depth is rarely *fully* occluded, and the visible-viewport eligibility guard excludes most chunks at high zoom.

This adds a **per-voxel** Hi-Z occlusion test inside `c_voxel_visibility_compact`, layered on top of the per-chunk pre-pass (coarse→fine hierarchical occlusion), dropping voxels that are locally-exposed + in-frustum but globally occluded by closer geometry.

Plan: `.fleet/plans/issue-1812.md`.

## Invariants
- **Bit-identical** cull-on vs cull-off (a fully-occluded voxel writes nothing anyway).
- **Off by default** (`getVoxelOcclusionCullEnabled()`), zero added cost when disabled.
- **Cardinal / NONE-mode only**; conservative on the shadow-feeder swept region.
- Backend parity (GL + Metal).

## Status
- [ ] Hoist Hi-Z helpers into `ir_iso_common`
- [ ] Per-voxel test in compact GLSL + Metal
- [ ] Bind Hi-Z + gate uniform in `system_voxel_to_trixel`
- [ ] Bit-identity A/B + render-debug-loop + screenshots
- [ ] Perf number (needs Linux/GL cross-host — macOS-Metal-debug is raster-dominated)

Closes #1812