### PR TITLE
lua-ecs: expose C_LocalTransform.rotation_ on the C++-component Lua binding (#2191)

### DIFF
--- a/engine/prefabs/irreden/common/components/component_local_transform_lua.hpp
+++ b/engine/prefabs/irreden/common/components/component_local_transform_lua.hpp
@@ -2,6 +2,7 @@
 #define COMPONENT_LOCAL_TRANSFORM_LUA_H
 
 #include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/script/ir_script_utils.hpp>
 #include <irreden/script/lua_script.hpp>
 
 namespace IRScript {
@@ -9,7 +10,9 @@ template <> inline constexpr bool kHasLuaBinding<IRComponents::C_LocalTransform>
 
 template <> inline void bindLuaType<IRComponents::C_LocalTransform>(LuaScript &luaScript) {
     using IRComponents::C_LocalTransform;
-    luaScript.registerType<
+    // The scalar convenience getters (translation_x/y/z) stay as the zero-alloc
+    // read path and register in the usual key/value list, unchanged.
+    sol::usertype<C_LocalTransform> type = luaScript.registerType<
         C_LocalTransform,
         C_LocalTransform(IRMath::vec3),
         C_LocalTransform(IRMath::vec3, IRMath::vec4),
@@ -21,6 +24,67 @@ template <> inline void bindLuaType<IRComponents::C_LocalTransform>(LuaScript &l
         [](C_LocalTransform &obj) { return obj.translation_.y; },
         "translation_z",
         [](C_LocalTransform &obj) { return obj.translation_.z; }
+    );
+
+    // The math-typed SQT fields bind as read-write `sol::property` pairs: the
+    // getter returns a fresh { x, y, z[, w] } table (matching the Lua-defined
+    // packed-vec read shape in lua_component_data.hpp), and the setter routes a
+    // Lua { x, y, z, w } table (or an IRMath userdata) through the *FromLua
+    // converters. A bare `&C_LocalTransform::rotation_` member pointer can't be
+    // used — IRMath::vec3/vec4 are not registered Lua usertypes, so Lua could
+    // neither construct a value to assign nor read the returned userdata. Writes
+    // land in place because `:at(i)` hands Lua a std::ref to the column row (see
+    // recordComponentLuaName in lua_script.hpp), so the property setter's `self`
+    // is the live row. Convention: engine/script/CLAUDE.md "C++-component
+    // per-field writes from Lua".
+    //
+    // These are added *after* registerType, directly on the returned usertype,
+    // so the property_wrapper is pushed as an rvalue. sol2's const-lvalue
+    // property pusher (function_types.hpp `unqualified_pusher<property_wrapper>`,
+    // the `const property_wrapper<F, G>&` overload) is broken in the vendored
+    // version — it references `pw.read`/`pw.write` without calling them and
+    // fails to compile; only the rvalue overload is correct. Routing the
+    // property in via registerType's by-value key/value pack would hit the
+    // broken const path. `sol::this_state` gives each getter the calling Lua
+    // state without capturing it.
+    type["rotation"] = sol::property(
+        [](C_LocalTransform &obj, sol::this_state ts) {
+            return sol::state_view{ts}.create_table_with(
+                "x",
+                obj.rotation_.x,
+                "y",
+                obj.rotation_.y,
+                "z",
+                obj.rotation_.z,
+                "w",
+                obj.rotation_.w
+            );
+        },
+        [](C_LocalTransform &obj, sol::object value) {
+            obj.rotation_ = IRScript::quatFromLua(value);
+        }
+    );
+    type["translation"] = sol::property(
+        [](C_LocalTransform &obj, sol::this_state ts) {
+            return sol::state_view{ts}.create_table_with(
+                "x",
+                obj.translation_.x,
+                "y",
+                obj.translation_.y,
+                "z",
+                obj.translation_.z
+            );
+        },
+        [](C_LocalTransform &obj, sol::object value) {
+            obj.translation_ = IRScript::vec3FromLua(value);
+        }
+    );
+    type["scale"] = sol::property(
+        [](C_LocalTransform &obj, sol::this_state ts) {
+            return sol::state_view{ts}
+                .create_table_with("x", obj.scale_.x, "y", obj.scale_.y, "z", obj.scale_.z);
+        },
+        [](C_LocalTransform &obj, sol::object value) { obj.scale_ = IRScript::vec3FromLua(value); }
     );
 }
 } // namespace IRScript

--- a/engine/prefabs/irreden/update/components/component_rotation_target_lua.hpp
+++ b/engine/prefabs/irreden/update/components/component_rotation_target_lua.hpp
@@ -14,8 +14,11 @@ template <> inline void bindLuaType<IRComponents::C_RotationTarget>(LuaScript &l
     // — `arch.C_RotationTarget:at(i).input = cc` writes straight through the
     // column (`:at` hands Lua a std::ref to the row). The axis + easing curve
     // are construction-time config, set through the constructors below; `axis_`
-    // (a vec3) follows the C_LocalTransform / C_Velocity3D precedent of staying
-    // constructor-only rather than a directly-mutable usertype member.
+    // (a vec3) stays constructor-only — it's fixed config, not a per-frame Lua
+    // write (the C_Velocity3D precedent). A math-typed field that DOES need
+    // per-frame Lua writes uses the `sol::property` {x,y,z[,w]}-table convention
+    // now on C_LocalTransform (rotation/translation/scale) — see
+    // engine/script/CLAUDE.md "C++-component per-field writes from Lua".
     luaScript.registerType<
         C_RotationTarget,
         C_RotationTarget(),

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -602,6 +602,30 @@ local sysId = IRSystem.registerSystem({
     `setAt` exists because most existing `*_lua.hpp` bindings expose
     fields as getter lambdas rather than `sol::property` pairs, so a
     full-row replacement is the universal write path.
+- **C++-component per-field writes from Lua.** When a `*_lua.hpp`
+  binding wants `:at(i).field = v` to write a single field through the
+  column ref (not a whole-row `setAt`), how the field binds depends on
+  its type:
+  - **Scalar** (`float`/`int`/`bool`) — bind as a read-write **member
+    pointer** (`"input", &C_RotationTarget::input_`); sol2 makes it a
+    directly-mutable property and the write lands in the referenced row.
+  - **Math-typed** (`IRMath::vec3`/`vec4`/`Color`) — bind as
+    `sol::property(getter, setter)` where the setter routes a Lua
+    `{ x, y, z, w }` table (or an IRMath userdata) through the matching
+    `IRScript::*FromLua` converter (`ir_script_utils.hpp`) and the getter
+    returns a fresh `{ x, y, z[, w] }` table. A bare
+    `&C_Foo::vecField_` member pointer compiles but is **unusable** from
+    Lua: `IRMath::vec3`/`vec4` are not registered Lua usertypes, so Lua
+    can neither construct a value to assign nor read the returned
+    userdata. The table convention mirrors the Lua-defined packed-vec
+    read/write shape (see "Packed vec3 / ivec3 / vec4 fields" above), so
+    C++-component and Lua-defined math fields round-trip through Lua
+    identically. `C_LocalTransform` (`rotation`/`translation`/`scale`)
+    is the reference binding. The getter allocates a small table per read
+    — keep any zero-alloc scalar convenience getters (e.g.
+    `translation_x/y/z`) as the hot read path.
+  - **Whole-object `setAt(i, T.new(...))`** remains the fallback for a
+    binding that hasn't exposed per-field properties.
   - `arch.<name>` for a Lua-defined component is a
     `LuaTypedColumnView`: `:getField(i, "name")` /
     `:setField(i, "name", v)` for typed per-field access, or

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(IrredenEngineTest
   script/lua_world_snapshot_test.cpp
   script/lua_pipeline_register_test.cpp
   script/lua_render_bindings_test.cpp
+  script/lua_local_transform_lua_test.cpp
   script/lua_rotation_target_lua_test.cpp
   script/lua_system_codegen_test.cpp
   script/prefab_api_test.cpp

--- a/test/script/lua_local_transform_lua_test.cpp
+++ b/test/script/lua_local_transform_lua_test.cpp
@@ -1,0 +1,249 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/common/components/component_local_transform_lua.hpp>
+#include <irreden/common/components/component_world_transform.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
+
+#include <irreden/script/lua_script.hpp>
+
+namespace {
+
+using IRComponents::C_LocalTransform;
+using IRComponents::C_WorldTransform;
+
+constexpr float kEps = 1e-4f;
+
+// End-to-end coverage for the C_LocalTransform Lua binding (#2191): a
+// Lua-defined system writes the math-typed SQT fields (rotation/translation/
+// scale) in place through the same `:at(i)` column view any creation's EVAL
+// tick would use, and PROPAGATE_TRANSFORM composes them onto C_WorldTransform.
+// Proves the fields are reachable (read + write) from Lua via the standard
+// { x, y, z, w } table convention — no C++ shim, no IRMath::vec* usertype.
+class LocalTransformLuaTest : public testing::Test {
+  protected:
+    LocalTransformLuaTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        // bindLuaDrivenEcs() first so the IRComponent table exists before
+        // registerType records the C_LocalTransform handle under it.
+        m_lua.bindLuaDrivenEcs();
+        m_lua.registerTypeFromTraits<C_LocalTransform>();
+    }
+
+    static void expectVec3Near(IRMath::vec3 actual, IRMath::vec3 expected, float eps = kEps) {
+        EXPECT_NEAR(actual.x, expected.x, eps);
+        EXPECT_NEAR(actual.y, expected.y, eps);
+        EXPECT_NEAR(actual.z, expected.z, eps);
+    }
+
+    // q and -q are the same rotation; compare by action on the basis vectors.
+    static void expectSameRotation(IRMath::vec4 actual, IRMath::vec4 expected) {
+        for (const auto &v :
+             {IRMath::vec3(1, 0, 0), IRMath::vec3(0, 1, 0), IRMath::vec3(0, 0, 1)}) {
+            expectVec3Near(
+                IRMath::rotateVectorByQuat(v, actual),
+                IRMath::rotateVectorByQuat(v, expected)
+            );
+        }
+    }
+
+    // Push a quaternion's components into Lua globals so the EVAL tick can
+    // assemble the { x, y, z, w } table the binding's setter accepts.
+    void setQuatGlobals(IRMath::vec4 q) {
+        auto &lua = m_lua.lua();
+        lua["qx"] = q.x;
+        lua["qy"] = q.y;
+        lua["qz"] = q.z;
+        lua["qw"] = q.w;
+    }
+
+    IRSystem::SystemId registerLuaSystem(const char *src) {
+        auto result = m_lua.lua().safe_script(src, sol::script_pass_on_error);
+        EXPECT_TRUE(result.valid()) << sol::error{result}.what();
+        return result.get<lua_Integer>();
+    }
+
+    // m_lua first so its sol::state outlives any sol::function-bearing columns
+    // held by the EntityManager (matches lua_rotation_target_lua_test.cpp).
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(LocalTransformLuaTest, KeyedRotationTableDrivesWorldTransform) {
+    auto id = IREntity::createEntity(C_LocalTransform{}, C_WorldTransform{});
+
+    // A Lua EVAL lane writing rotation_ in place via the column view —
+    // `:at(i)` hands Lua a std::ref to the row, so `.rotation = {..}` writes
+    // through the referenced C_LocalTransform, exactly like the proven scalar
+    // member-pointer path in lua_rotation_target_lua_test.cpp.
+    const IRSystem::SystemId luaSysId = registerLuaSystem(
+        R"(
+        return IRSystem.registerSystem({
+            name = 'DriveLocalRotation',
+            components = { IRComponent.C_LocalTransform },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    arch.C_LocalTransform:at(i).rotation = { x = qx, y = qy, z = qz, w = qw }
+                end
+            end,
+        })
+    )"
+    );
+
+    m_system_manager.registerPipeline(
+        IRTime::Events::UPDATE,
+        {luaSysId, IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>()}
+    );
+
+    // First tick: yaw 90° about +Z. The Lua write lands in the C++ column and
+    // PROPAGATE_TRANSFORM (root entity → world.rotation = local.rotation)
+    // reflects it.
+    const IRMath::vec4 expected1 = IRMath::quatAxisAngle(IRMath::vec3(0, 0, 1), IRMath::kHalfPi);
+    setQuatGlobals(expected1);
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    expectSameRotation(IREntity::getComponent<C_LocalTransform>(id).rotation_, expected1);
+    expectSameRotation(IREntity::getComponent<C_WorldTransform>(id).rotation_, expected1);
+
+    // Second tick with a different quat — proves the per-frame write path, not
+    // a one-shot construction-time value.
+    const IRMath::vec4 expected2 =
+        IRMath::quatAxisAngle(IRMath::vec3(1, 0, 0), IRMath::kHalfPi * 0.5f);
+    setQuatGlobals(expected2);
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    expectSameRotation(IREntity::getComponent<C_WorldTransform>(id).rotation_, expected2);
+}
+
+TEST_F(LocalTransformLuaTest, IndexedRotationTableIsAccepted) {
+    auto id = IREntity::createEntity(C_LocalTransform{}, C_WorldTransform{});
+
+    // The indexed { qx, qy, qz, qw } spelling must round-trip identically to
+    // the keyed one (quatFromLua accepts both).
+    const IRSystem::SystemId luaSysId = registerLuaSystem(
+        R"(
+        return IRSystem.registerSystem({
+            name = 'DriveLocalRotationIndexed',
+            components = { IRComponent.C_LocalTransform },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    arch.C_LocalTransform:at(i).rotation = { qx, qy, qz, qw }
+                end
+            end,
+        })
+    )"
+    );
+
+    m_system_manager.registerPipeline(
+        IRTime::Events::UPDATE,
+        {luaSysId, IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>()}
+    );
+
+    const IRMath::vec4 expected = IRMath::quatAxisAngle(IRMath::vec3(0, 1, 0), IRMath::kHalfPi);
+    setQuatGlobals(expected);
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    expectSameRotation(IREntity::getComponent<C_WorldTransform>(id).rotation_, expected);
+}
+
+TEST_F(LocalTransformLuaTest, PartialRotationTableDefaultsToIdentity) {
+    // Start from a non-identity rotation so an identity result can't be the
+    // untouched default — the empty-table write must actively reset it.
+    auto id = IREntity::createEntity(
+        C_LocalTransform{
+            IRMath::vec3(0.0f),
+            IRMath::quatAxisAngle(IRMath::vec3(0, 0, 1), IRMath::kHalfPi)
+        },
+        C_WorldTransform{}
+    );
+
+    const IRSystem::SystemId luaSysId = registerLuaSystem(
+        R"(
+        return IRSystem.registerSystem({
+            name = 'ResetLocalRotation',
+            components = { IRComponent.C_LocalTransform },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    arch.C_LocalTransform:at(i).rotation = {}
+                end
+            end,
+        })
+    )"
+    );
+
+    m_system_manager.registerPipeline(
+        IRTime::Events::UPDATE,
+        {luaSysId, IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>()}
+    );
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    // quatFromLua fills missing components with identity (0,0,0,1).
+    const IRMath::vec4 identity(0.0f, 0.0f, 0.0f, 1.0f);
+    expectSameRotation(IREntity::getComponent<C_LocalTransform>(id).rotation_, identity);
+    expectSameRotation(IREntity::getComponent<C_WorldTransform>(id).rotation_, identity);
+}
+
+TEST_F(LocalTransformLuaTest, TranslationAndScaleWriteReadRoundTripAndScalarGettersUnchanged) {
+    auto id = IREntity::createEntity(C_LocalTransform{}, C_WorldTransform{});
+
+    // One tick that writes translation + scale via the table convention, then
+    // reads all three math fields back as tables (proving the property getter),
+    // plus the legacy translation_x/y/z scalar getters (proving no regression).
+    // The scalar getters are bound as bare-lambda member *functions* — Lua
+    // invokes them with call syntax (`h:translation_x()`), unlike the new
+    // `sol::property` fields which use assignment/index syntax.
+    const IRSystem::SystemId luaSysId = registerLuaSystem(
+        R"(
+        readTx, readTy, readTz = nil, nil, nil
+        readSx, readSy, readSz = nil, nil, nil
+        readScalarX, readScalarY, readScalarZ = nil, nil, nil
+        return IRSystem.registerSystem({
+            name = 'WriteReadLocalTransform',
+            components = { IRComponent.C_LocalTransform },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    local h = arch.C_LocalTransform:at(i)
+                    h.translation = { x = 1.5, y = -2.0, z = 3.25 }
+                    h.scale = { x = 2.0, y = 4.0, z = 0.5 }
+                    local t = h.translation
+                    readTx, readTy, readTz = t.x, t.y, t.z
+                    local s = h.scale
+                    readSx, readSy, readSz = s.x, s.y, s.z
+                    readScalarX = h:translation_x()
+                    readScalarY = h:translation_y()
+                    readScalarZ = h:translation_z()
+                end
+            end,
+        })
+    )"
+    );
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {luaSysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    auto &lua = m_lua.lua();
+    // Property-table getter round-trip.
+    EXPECT_FLOAT_EQ(lua["readTx"].get<float>(), 1.5f);
+    EXPECT_FLOAT_EQ(lua["readTy"].get<float>(), -2.0f);
+    EXPECT_FLOAT_EQ(lua["readTz"].get<float>(), 3.25f);
+    EXPECT_FLOAT_EQ(lua["readSx"].get<float>(), 2.0f);
+    EXPECT_FLOAT_EQ(lua["readSy"].get<float>(), 4.0f);
+    EXPECT_FLOAT_EQ(lua["readSz"].get<float>(), 0.5f);
+    // Legacy scalar getters (member functions) read the same freshly-written
+    // translation through the live column ref — unchanged by the new bindings.
+    EXPECT_FLOAT_EQ(lua["readScalarX"].get<float>(), 1.5f);
+    EXPECT_FLOAT_EQ(lua["readScalarY"].get<float>(), -2.0f);
+    EXPECT_FLOAT_EQ(lua["readScalarZ"].get<float>(), 3.25f);
+
+    // The writes landed in the C++ column, not just a Lua-side copy.
+    const auto &local = IREntity::getComponent<C_LocalTransform>(id);
+    expectVec3Near(local.translation_, IRMath::vec3(1.5f, -2.0f, 3.25f));
+    expectVec3Near(local.scale_, IRMath::vec3(2.0f, 4.0f, 0.5f));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add read-write `rotation` / `translation` / `scale` `sol::property` bindings to the `C_LocalTransform` C++-component Lua binding, so an EVAL system can drive an entity's SQT per field (`arch.C_LocalTransform:at(i).rotation = { x, y, z, w }`) without a whole-object `setAt` or a C++ shim.
- Setters route a `{ x, y, z, w }` table (or an `IRMath` userdata) through the existing `IRScript::quatFromLua` / `vec3FromLua` converters; getters return a fresh `{ x, y, z[, w] }` table (the Lua-defined packed-vec shape). Keyed `{x=,y=,z=,w=}` and indexed `{1,2,3,4}` spellings both work; nil/partial → identity for the quat.
- The zero-alloc `translation_x/y/z` scalar getters are **kept unchanged** (still bound as member functions).
- Properties are registered on the returned usertype *after* `registerType()` so the `property_wrapper` is pushed as an **rvalue** — the vendored sol2's const-lvalue property pusher is broken (`unqualified_pusher<property_wrapper>`'s `const&` overload references `pw.read`/`pw.write` without calling them and fails to compile). Comment in the binding explains why.
- Document the C++-component per-field-write convention (scalar member pointer vs math-typed `sol::property` table) in `engine/script/CLAUDE.md`; refresh the now-stale "constructor-only" note in the `C_RotationTarget` binding comment.

## Test plan
- [x] New headless `test/script/lua_local_transform_lua_test.cpp` (mirrors `lua_rotation_target_lua_test.cpp`): keyed + indexed rotation writes drive `C_WorldTransform.rotation_` through `PROPAGATE_TRANSFORM`; per-frame re-write; partial-table → identity; translation + scale table round-trip; legacy `translation_x/y/z` scalar getters unchanged.
- [x] `IrredenEngineTest` green: 1317 passed, 1 skipped (GPU/OpenGL-only, expected on macOS/Metal), 0 failed.
- [x] `format-changed` clean.

Closes #2191
