### PR TITLE
profile: intra-tick GPU sub-stage scopes — wire the reserved voxelStage1 sub-rows (#2280)

### DIFF
--- a/.fleet/plans/issue-2280.md
+++ b/.fleet/plans/issue-2280.md
@@ -1,0 +1,79 @@
+# Plan: profile — intra-tick GPU sub-stage scopes (wire the reserved voxelStage1 sub-rows)
+
+- **Issue:** #2280 (blocks #2258)
+- **Model:** opus (Metal backend timestamp infrastructure + render hot-path system wiring)
+- **Date:** 2026-07-08
+
+## Scope
+
+An intra-tick scoped GPU timing mechanism so a system can bracket individual
+dispatch groups inside one tick, wiring the reserved `voxelStage1` sub-rows
+(`voxelCompact` / `canvasClear` / `voxelStage2`) on **both** backends, then use
+it to attribute the ~140 ms `voxelStage1` cost that #2258 measured but could not
+localize (the per-`SystemId` timer bundles compact + clear + stage-1 + stage-2).
+
+## Confirmed repro
+
+PR #2266's measurement table (2026-07-06 NEEDS-DESIGN comment): `voxelStage1`
+~139–152 ms at zoom 16 on the IRPerfGrid wave scene (Metal, shadows on),
+invariant to a 256× stage-1 body reduction — the cost is inside the bundled
+per-system scope but not in the stage-1 raster body. The bundle is structural:
+one `GpuStageTimingObserver` pair per `SystemId`
+(`gpu_stage_timing.hpp:196-209`), so compact/clear/stage-1/stage-2 are
+indistinguishable today.
+
+## Approach (picked): RAII sub-stage scope + a second sample-buffer attachment on Metal
+
+1. `RenderDevice` gains scoped-timestamp entry points reusing the existing pair
+   machinery (`createTimestampPair` / `writeTimestamp` / `readTimestampPairMs`),
+   plus a Metal path that attaches the sub-scope's `MTL::CounterSampleBuffer` on
+   **attachment index 1** of the compute-pass descriptor, leaving index 0 to the
+   enclosing per-system pair (`createComputeEncoder`, `metal_render_impl.cpp`).
+   Same sticky first-encoder-claims-start / last-encoder-wins-end semantics as
+   #1746, scoped to the sub-window. OpenGL needs no structural change —
+   `glQueryCounter`-style pairs nest freely in the command stream.
+2. A small `IRRender::GpuSubStageScope(name)` RAII (prefab layer, next to
+   `gpu_stage_timing_observer.hpp`) resolves the name against
+   `gpuStageRegistry()` and brackets the enclosed dispatches; used inside
+   `VOXEL_TO_TRIXEL_STAGE_1`'s tick around its four dispatch groups to fill
+   `voxelCompact`, `canvasClear`, `voxelStage1` (now stage-1 only),
+   `voxelStage2`. Async readback keeps the `kSamplesInFlight` pattern per scope;
+   timers-off cost stays one bool check.
+3. **Fallback (only if the second Metal attachment misbehaves on real
+   hardware):** sub-scopes own attachment index 0 while active and the outer
+   per-system row is computed as the **sum** of sub-scope samples for that
+   system. Document whichever shape lands in the registry comment.
+4. Measure: post the zoom 8 / zoom 16 wave-scene attribution table on #2258 (per
+   this issue's acceptance criteria).
+
+## Acceptance criteria
+
+- GPU STAGES overlay shows non-zero `voxelCompact` / `canvasClear` /
+  `voxelStage2` rows when frame timing is enabled, on both backends.
+- Sum of sub-rows ≈ the old bundled `voxelStage1` value (± measurement overhead)
+  at a test pose on at least one backend.
+- Attribution table for the #2258 scenario (IRPerfGrid default wave scene, zoom 8
+  and zoom 16, sun shadows on, `--auto-profile 100`+) posted on #2258, naming
+  which sub-stage carries the ~140 ms.
+- Byte-identical rendering with timing disabled and enabled (screenshot compare
+  on one demo).
+
+## Sibling / in-flight reconciliation
+
+PR #2266 is being narrowed to the byte-identical `sunBakeFrustumUVBounds`
+refactor only (architect direction on the PR) — no overlap with this surface.
+#2256's plan explicitly does NOT need this issue (its stages are separate,
+already-timed systems). #2258 is blocked by this issue and must not be
+re-planned until the attribution table lands on its thread.
+
+## Gotchas
+
+- Wiring the sub-rows changes the meaning of the `voxelStage1` row (from bundle
+  to stage-1-only) — update the registry comment in `gpu_stage_timing.hpp` and
+  any overlay docs in the same PR.
+- Metal is excluded from clang-format; match surrounding hand-formatting in
+  `metal_render_impl.cpp`.
+- Timing-only change: rendering must stay byte-identical with timers on or off;
+  the timers-off path must keep its one-bool-check cost.
+- GL-backend build/verify needs a Linux/Windows host (this pane is macOS/Metal
+  only); if authored on macOS, the GL side rides as owed cross-host smoke.

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -1058,12 +1058,16 @@ void initSystems() {
                             IR_LOG_INFO("Auto-profile CPU-scope — {}: {:.3f}ms", name, ms);
                         }
                     }
+                    // #2280 sub-stage attribution: canvasClear + voxelCompact +
+                    // voxelStage1 (the stage-1 dispatch only now) + voxelStage2
+                    // sum to the old bundled voxelStage1 measurement.
                     IR_LOG_INFO(
-                        "Auto-profile GPU — voxelStage1:{:.3f} voxelStage2:{:.3f} "
-                        "voxelCompact:{:.3f}",
+                        "Auto-profile GPU — canvasClear:{:.3f} voxelCompact:{:.3f} "
+                        "voxelStage1:{:.3f} voxelStage2:{:.3f}",
+                        gpu.canvasClearMs_,
+                        gpu.voxelCompactMs_,
                         gpu.voxelStage1Ms_,
-                        gpu.voxelStage2Ms_,
-                        gpu.voxelCompactMs_
+                        gpu.voxelStage2Ms_
                     );
                     IRWindow::closeWindow();
                 }

--- a/docs/design/gpu-stage-timing-cost-model.md
+++ b/docs/design/gpu-stage-timing-cost-model.md
@@ -32,13 +32,17 @@ changes (occupied-only lists, indirect dispatch, subdivision caps).
   accumulators build the shutdown avg/min/max (#1738). A `finish()`-bracket
   legacy path exists for devices without timestamp support
   (`legacyFinishTiming_`).
-- **Several registry rows have NO writer and always read 0.000:**
-  `canvasClear`, `voxelCompact`, `voxelStage2`, `shapePass0` (folded into
-  their per-system bundles), and `shapeCompact` (reserved). They stay in
-  the registry for overlay/Lua stability. Two rows are **bundles**:
-  `voxelStage1` covers the entire `VOXEL_TO_TRIXEL_STAGE_1` tick —
-  visibility compact + canvas clear + stage-1 + stage-2 dispatches — and
-  `shapePass1` covers all of `SHAPES_TO_TRIXEL`.
+- **Two registry rows have NO writer and always read 0.000:** `shapePass0`
+  (folded into the `SHAPES_TO_TRIXEL` per-system bundle) and `shapeCompact`
+  (reserved). They stay in the registry for overlay/Lua stability.
+- **`canvasClear` / `voxelCompact` / `voxelStage1` / `voxelStage2` are
+  intra-tick sub-rows (#2280).** `VOXEL_TO_TRIXEL_STAGE_1` is no longer tagged
+  for the per-system observer; its per-canvas tick brackets each dispatch group
+  with a `GpuSubStageScope`, so `voxelStage1` now measures the stage-1 dispatch
+  ONLY and the other three rows carry the clear / compact / stage-2 costs. The
+  old whole-tick number = the sum of the four. (CPU `voxelStage1` stays the
+  whole tick — an `IR_PROFILE_SCOPE` replaces the observer's CPU bracket.)
+- **`shapePass1` is still a bundle** — it covers all of `SHAPES_TO_TRIXEL`.
 
 ### Reading rules
 
@@ -48,10 +52,11 @@ changes (occupied-only lists, indirect dispatch, subdivision caps).
    have now been made in opposite directions (#2266 initially read unwired
    rows as measurements; verifying #2271 required confirming
    `resolvePerAxisScreenDepth` was NOT unwired).
-2. A **bundle row** (`voxelStage1`, `shapePass1`) cannot attribute cost to a
-   sub-dispatch. Until #2280 lands intra-tick sub-stage scopes, no
-   conclusion of the form "stage-1's raster is the cost" can be drawn from
-   `voxelStage1` alone.
+2. A **bundle row** (`shapePass1`) cannot attribute cost to a sub-dispatch.
+   The voxel path is no longer a bundle: since #2280, `voxelStage1` /
+   `voxelCompact` / `canvasClear` / `voxelStage2` are per-dispatch GPU rows,
+   so "stage-1's raster is the cost" IS answerable from `voxelStage1` alone
+   (it measured ~65 ms of the ~140 ms at zoom 16 — see §2).
 3. Per-system rows for single-purpose systems (`computeVoxelAO`,
    `computeSunShadow`, `lightingToTrixel`, `resolvePerAxisScreenDepth`,
    `trixelToFb`, …) are trustworthy per-stage measurements on both
@@ -77,13 +82,17 @@ a measurement says otherwise on a specific path:
   grid is fixed CPU-side at `dispatchCompute` time; an invocation that
   returns immediately still launched. PR #2266 capped shadow-feeder
   micro-grids via early-return and measured no change in `voxelStage1`.
-- **The stage-1 raster body is not where `voxelStage1`'s high-zoom cost
-  lives.** Forcing *every* voxel to a single 1×1 micro-tap (a 256×
-  per-invocation body reduction at zoom 16) left `voxelStage1` unchanged
-  within run-to-run noise (~140–150 ms, IRPerfGrid wave scene, shadows on).
-  The true hotspot inside the bundle (compact walk / canvas clear / launch
-  overhead / stage-2) is **unattributed** until #2280's sub-stage scopes
-  produce the table on #2258.
+- **The stage-1 raster body is not where the high-zoom cost lives — but the
+  stage-1 *dispatch* still carries ~half of it.** Forcing *every* voxel to a
+  single 1×1 micro-tap (a 256× per-invocation body reduction at zoom 16) left
+  the whole-tick number unchanged within noise (~140–150 ms, IRPerfGrid wave
+  scene, shadows on) — the raster BODY is not the cost. The #2280 sub-scopes
+  then attributed the bundle (Metal, IRPerfGrid wave, shadows on): at zoom 16
+  `voxelStage1` ~65 ms + `voxelStage2` ~76 ms carry essentially all of it,
+  with `voxelCompact` ~0.06 ms and `canvasClear` ~0.01 ms negligible; at
+  zoom 8, ~24 / ~28 / ~0.7 / ~0.1 ms. So the high-zoom cost is the stage-1 +
+  stage-2 *dispatch-grid* cost (fixed CPU-side, body-independent), split
+  roughly evenly — NOT compact, clear, or launch overhead.
 - The per-axis yaw GPU delta (#2256) is therefore **occupied-cell-bound**,
   not invocation-count-bound. #2256 closed via #2273 with the delta
   unrecovered; its per-stage attribution uses the existing per-system
@@ -109,12 +118,15 @@ a measurement says otherwise on a specific path:
 
 ## 4. Migration status / open items
 
-- **#2280** — intra-tick sub-stage GPU scopes wiring the reserved
-  `voxelCompact` / `canvasClear` / `voxelStage2` rows on both backends.
-  When it lands, `voxelStage1` narrows to stage-1-only; update the registry
-  comment and §1 of this doc in the same PR.
-- **#2258** — parked `fleet:needs-plan`, blocked by #2280; the lever must
-  key on the attribution table posted there.
+- **#2280** — LANDED: intra-tick sub-stage GPU scopes (`GpuSubStageScope`,
+  `gpu_substage_timing.hpp`) wire the `voxelCompact` / `canvasClear` /
+  `voxelStage2` rows and narrow `voxelStage1` to stage-1-only, on both
+  backends. `VOXEL_TO_TRIXEL_STAGE_1` is untagged from the per-system observer
+  (the sub-scopes reuse the freed attachment slot; Metal's clear blit is timed
+  via a timestamp-aware `createBlitEncoder`). Coverage delta: the rotating-only
+  per-axis voxel dispatch is not sub-scoped.
+- **#2258** — unblocked by #2280; the lever keys on the attribution table
+  (stage-1 + stage-2 dispatch-grid cost, ~evenly split) posted there.
 - **#2281** — per-stage cardinal-vs-yaw delta table with existing timers
   (successor to #2256, which closed via the perf-neutral #2273); the lever
   decision is a design gate after the table exists.

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -578,17 +578,32 @@ the NEAREST 1:1-assuming parity reconstruction). Every term is `× cubeSub` /
 scale. Full invariant + verify steps:
 [`docs/design/detached-canvas-density-compensation.md`](../../../../docs/design/detached-canvas-density-compensation.md).
 
-## GPU stage timing (`gpu_stage_timing.hpp` / `gpu_stage_timing_observer.hpp`)
+## GPU stage timing (`gpu_stage_timing.hpp` / `gpu_stage_timing_observer.hpp` / `gpu_substage_timing.hpp`)
 
 One GPU measurement per tagged `SystemId`, bracketing the whole tick via
-device timestamp pairs (encoder-boundary counter samples on Metal). Several
-registry rows are unwired and always read 0.000, and `voxelStage1` /
-`shapePass1` are whole-tick bundles — before quoting the overlay in a perf
-plan or attributing cost to a sub-dispatch, read
+device timestamp pairs (encoder-boundary counter samples on Metal). Some
+registry rows are unwired and always read 0.000, and `shapePass1` is still a
+whole-tick bundle — before quoting the overlay in a perf plan or attributing
+cost to a sub-dispatch, read
 [`docs/design/gpu-stage-timing-cost-model.md`](../../../../docs/design/gpu-stage-timing-cost-model.md)
 (the reading contract + the measured dispatch cost model: empty early-return
 sweeps are effectively free; shader-side early-return cannot reclaim
 CPU-fixed dispatch-grid cost).
+
+**Intra-tick sub-stage rows (#2280).** `VOXEL_TO_TRIXEL_STAGE_1` is NOT tagged
+for the per-system observer. Its per-canvas tick brackets each dispatch group
+with a `GpuSubStageScope` (`gpu_substage_timing.hpp`), so the `canvasClear` /
+`voxelCompact` / `voxelStage1` / `voxelStage2` **GPU** rows are attributed
+individually rather than bundled — `voxelStage1` now measures the stage-1
+dispatch only, and the old whole-tick number is the sum of the four rows. A
+sub-scope reuses the device timestamp machinery at the same attachment slot the
+observer would have used (free because the system is untagged); on Metal the
+distance-clear blit is captured via a timestamp-aware `createBlitEncoder`. The
+**CPU** `voxelStage1` row stays the whole per-canvas tick (an
+`IR_PROFILE_SCOPE` in the tick replaces the observer's CPU bracket) — GPU
+sub-attribution is per-dispatch, CPU stays coarse. Sub-scopes are
+single-canvas-exact (last-sample on multi-canvas) and do not cover the
+rotating-only per-axis voxel dispatch.
 
 ## Gotchas
 

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -188,25 +188,48 @@ inline void resetGpuStageAccumulators() {
     }
 }
 
+// Commit one resolved GPU-timing sample for a registry stage: overwrite the
+// live last-sample field the perf overlay reads, and feed the running
+// accumulator the shutdown profile report drains. Shared by the per-system
+// `GpuStageTimingObserver` and the intra-tick `GpuSubStageScope` so both write
+// samples through one code path. `registryIndex` is the stage's slot in
+// `gpuStageRegistry()` order (== its `gpuStageAccumulators()` index).
+inline void commitGpuStageSample(const GpuStageInfo &info, int registryIndex, float ms) {
+    gpuStageTiming().*(info.field_) = ms;
+    if (registryIndex >= 0 &&
+        static_cast<std::size_t>(registryIndex) < gpuStageAccumulators().size()) {
+        gpuStageAccumulators()[registryIndex].record(ms);
+    }
+}
+
 // Authoritative mapping name → field → budget. `gpu_stage_timing_observer`
 // resolves a system's tag against this table; pass the same name to
 // `IRRender::tagGpuStage(system, "<name>")` and the observer fills the
 // matching `GpuStageTiming::*Ms_` field at end-of-tick.
 //
-// Per-system mapping post-T-066 (one observer fire per `SystemId`):
-//   `voxelStage1`  ← VOXEL_TO_TRIXEL_STAGE_1 (covers former canvasClear +
-//                    voxelCompact + voxelStage1 + voxelStage2 sub-stages —
-//                    the stage-2 dispatch was merged into STAGE_1)
+// Per-system mapping (one `GpuStageTimingObserver` fire per `SystemId`):
 //   `shapePass1`   ← SHAPES_TO_TRIXEL (covers former shapePass0 + shapePass1)
-//   The remaining 8 names map 1:1 to single-stage systems.
+//   Most remaining names map 1:1 to single-stage systems.
 //
-// Four rows have no current writer: `canvasClear`, `voxelCompact`,
-// `voxelStage2`, `shapePass0` (folded into the per-system measurement
-// above — `voxelStage2`'s dispatch now runs inside VOXEL_TO_TRIXEL_STAGE_1),
-// and `shapeCompact` (no system has ever written it; reserved for a
-// future shape-compaction pass). They stay in the registry to keep
-// the Lua API and perf overlay stable — the overlay still shows them at
-// 0.0f; the shutdown profile report omits them (sampleCount_ == 0).
+// Intra-tick sub-stage rows (#2280): VOXEL_TO_TRIXEL_STAGE_1 is NOT tagged for
+// the per-system observer. Instead its per-canvas tick brackets each of its
+// four dispatch groups with a `GpuSubStageScope` (gpu_substage_timing.hpp),
+// so these rows are attributed individually rather than bundled:
+//   `canvasClear`  ← the per-frame distance-texture clear (blit)
+//   `voxelCompact` ← the visibility-compaction dispatch
+//   `voxelStage1`  ← the stage-1 raster dispatch ONLY (was the whole-tick
+//                    bundle before #2280 wired the sub-rows)
+//   `voxelStage2`  ← the stage-2 dispatch (runs inside STAGE_1's tick)
+// The old bundled `voxelStage1` value is reconstructed as the sum of these
+// four rows. Sub-scopes are single-canvas-exact and record the last canvas's
+// sample on multi-canvas scenes (like every `*Ms_` field's last-sample
+// semantics); the rotating-only per-axis voxel dispatch is not sub-scoped.
+//
+// Two rows still have no current writer: `shapePass0` (folded into the
+// SHAPES_TO_TRIXEL per-system measurement) and `shapeCompact` (no system has
+// ever written it; reserved for a future shape-compaction pass). They stay in
+// the registry to keep the Lua API and perf overlay stable — the overlay still
+// shows them at 0.0f; the shutdown profile report omits them (sampleCount_ == 0).
 inline const std::array<GpuStageInfo, kGpuStageCount> &gpuStageRegistry() {
     static const std::array<GpuStageInfo, kGpuStageCount> registry{{
         {"canvasClear", &GpuStageTiming::canvasClearMs_, 0.05f},

--- a/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
@@ -110,8 +110,7 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
         if (useLegacyTiming()) {
             IRRender::device()->finish();
             const float ms = elapsedMs(m_t0, SteadyClock::now());
-            gpuStageTiming().*(it->second.info_->field_) = ms;
-            recordStageSample(it->second.registryIndex_, ms);
+            commitGpuStageSample(*it->second.info_, it->second.registryIndex_, ms);
             return;
         }
 
@@ -154,22 +153,10 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
             if (!state.pending_[i])
                 continue;
             if (IRRender::device()->readTimestampPairMs(state.handles_[i], ms)) {
-                gpuStageTiming().*(state.info_->field_) = ms;
-                recordStageSample(state.registryIndex_, ms);
+                commitGpuStageSample(*state.info_, state.registryIndex_, ms);
                 state.pending_[i] = false;
             }
         }
-    }
-
-    // Feed one resolved per-frame GPU sample into the running accumulator the
-    // profile report drains. The live `GpuStageTiming::*Ms_` field (read by the
-    // perf overlay) keeps only the last frame; this builds the avg/min/max.
-    static void recordStageSample(int registryIndex, float ms) {
-        if (registryIndex < 0 ||
-            static_cast<std::size_t>(registryIndex) >= gpuStageAccumulators().size()) {
-            return;
-        }
-        gpuStageAccumulators()[registryIndex].record(ms);
     }
 
     static int nextAvailableSlot(StageState &state) {

--- a/engine/prefabs/irreden/render/gpu_substage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_substage_timing.hpp
@@ -1,0 +1,182 @@
+#ifndef GPU_SUBSTAGE_TIMING_H
+#define GPU_SUBSTAGE_TIMING_H
+
+#include <irreden/render/render_device.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
+
+#include <array>
+#include <string_view>
+
+namespace IRRender {
+
+// Intra-tick GPU sub-stage timing (#2280).
+//
+// Where the per-system `GpuStageTimingObserver` brackets a whole system tick
+// with one timestamp pair, `GpuSubStageScope` brackets an individual dispatch
+// group *inside* one tick, so a bundled per-system row can be split into its
+// reserved sub-rows. VOXEL_TO_TRIXEL_STAGE_1 uses four of these
+// (`canvasClear` / `voxelCompact` / `voxelStage1` / `voxelStage2`) to attribute
+// what used to be one opaque `voxelStage1` measurement — see #2258.
+//
+// Mechanism: reuses the device timestamp-pair machinery unchanged
+// (`createTimestampPair` / `writeTimestamp` / `readTimestampPairMs`) at the
+// same attachment slot the observer uses. This is safe because a system that
+// owns sub-scopes is NOT tagged for the per-system observer, so its own tick
+// leaves that slot free. On Metal the sub-scope's `writeTimestamp(START)`
+// claims the sticky encoder attachment for the enclosed dispatch group's
+// encoders (compute encoders via `createComputeEncoder`, and the distance-clear
+// blit via `createBlitEncoder`); `END` releases it — exactly the #1746
+// semantics, scoped to the sub-window. On OpenGL the `glQueryCounter` markers
+// bracket the enclosed commands in the stream.
+//
+// The per-scope async readback mirrors the observer's `kSamplesInFlight` ring,
+// so no `finish()` stall is introduced. Timers-off (the default) costs one bool
+// check per scope. A scope produces one sample per close; multi-canvas scenes
+// overwrite the row with the last canvas's sample (the single-canvas #2258
+// target is exact), matching every `GpuStageTiming::*Ms_` field's existing
+// last-sample semantics.
+class GpuSubStageTimer {
+  public:
+    static constexpr int kSamplesInFlight = 3;
+
+    struct SubStageState {
+        const GpuStageInfo *info_ = nullptr;
+        int registryIndex_ = -1;
+        std::array<GpuTimestampHandle, kSamplesInFlight> handles_{};
+        std::array<bool, kSamplesInFlight> pending_{};
+        int nextSlot_ = 0;
+        int activeSlot_ = -1;
+        bool initialized_ = false;
+    };
+
+    // Resolve @p stageName to its persistent per-stage state, lazily allocating
+    // the timestamp-pair ring on first use. Returns nullptr for an unknown name
+    // or when the device cannot allocate any pair (graceful no-op — the caller
+    // just skips timing this scope, like the observer's invalid-handle path).
+    SubStageState *acquire(std::string_view stageName) {
+        const auto &registry = gpuStageRegistry();
+        for (std::size_t i = 0; i < registry.size(); ++i) {
+            if (registry[i].name_ != stageName) {
+                continue;
+            }
+            SubStageState &state = m_states[i];
+            if (!state.initialized_) {
+                state.info_ = &registry[i];
+                state.registryIndex_ = static_cast<int>(i);
+                RenderDevice *device = IRRender::device();
+                if (device != nullptr && device->supportsGpuTimestampPairs()) {
+                    const int pairs = IRMath::clamp(
+                        device->recommendedTimestampPairsInFlight(),
+                        1,
+                        kSamplesInFlight
+                    );
+                    for (int p = 0; p < pairs; ++p) {
+                        state.handles_[p] = device->createTimestampPair();
+                    }
+                }
+                state.initialized_ = true;
+            }
+            return &state;
+        }
+        return nullptr;
+    }
+
+    void begin(SubStageState &state) {
+        resolveReadySamples(state);
+        const int slot = nextAvailableSlot(state);
+        if (slot < 0) {
+            state.activeSlot_ = -1;
+            return;
+        }
+        state.activeSlot_ = slot;
+        IRRender::device()->writeTimestamp(state.handles_[slot], TimestampSlot::START);
+    }
+
+    void end(SubStageState &state) {
+        if (state.activeSlot_ < 0) {
+            return;
+        }
+        IRRender::device()->writeTimestamp(state.handles_[state.activeSlot_], TimestampSlot::END);
+        state.pending_[state.activeSlot_] = true;
+        state.activeSlot_ = -1;
+    }
+
+  private:
+    static void resolveReadySamples(SubStageState &state) {
+        float ms = 0.0f;
+        for (int i = 0; i < kSamplesInFlight; ++i) {
+            if (!state.pending_[i]) {
+                continue;
+            }
+            if (IRRender::device()->readTimestampPairMs(state.handles_[i], ms)) {
+                commitGpuStageSample(*state.info_, state.registryIndex_, ms);
+                state.pending_[i] = false;
+            }
+        }
+    }
+
+    static int nextAvailableSlot(SubStageState &state) {
+        for (int attempt = 0; attempt < kSamplesInFlight; ++attempt) {
+            const int slot = (state.nextSlot_ + attempt) % kSamplesInFlight;
+            if (state.handles_[slot] != kInvalidGpuTimestampHandle && !state.pending_[slot]) {
+                state.nextSlot_ = (slot + 1) % kSamplesInFlight;
+                return slot;
+            }
+        }
+        return -1;
+    }
+
+    // Persistent per-registry-stage state (parallel to `gpuStageRegistry()`).
+    // Only the entries a `GpuSubStageScope` names are ever initialized. The
+    // timer outlives every scope (program-bound singleton) so the pairs and the
+    // in-flight ring survive across frames; the pairs leak at process exit,
+    // which the OpenGL segfault-on-static-destruction lesson (#2031) makes the
+    // deliberate choice over a static destructor that touches a dead GL context.
+    std::array<SubStageState, kGpuStageCount> m_states{};
+};
+
+inline GpuSubStageTimer &gpuSubStageTimer() {
+    static GpuSubStageTimer timer;
+    return timer;
+}
+
+// RAII bracket for one intra-tick dispatch group. Construct just before the
+// group's first dispatch/clear, let it destruct after the group's last barrier.
+// A no-op unless per-frame GPU timing is enabled, the device supports timestamp
+// pairs, and the legacy `finish()`-bracketed path is off (that path can't nest
+// sub-scopes without a stall per group, so sub-rows stay 0.0f under it).
+class GpuSubStageScope {
+  public:
+    explicit GpuSubStageScope(std::string_view stageName) {
+        const GpuStageTiming &timing = gpuStageTiming();
+        if (!timing.enabled_ || timing.legacyFinishTiming_) {
+            return;
+        }
+        RenderDevice *device = IRRender::device();
+        if (device == nullptr || !device->supportsGpuTimestampPairs()) {
+            return;
+        }
+        m_state = gpuSubStageTimer().acquire(stageName);
+        if (m_state != nullptr) {
+            gpuSubStageTimer().begin(*m_state);
+        }
+    }
+
+    ~GpuSubStageScope() {
+        if (m_state != nullptr) {
+            gpuSubStageTimer().end(*m_state);
+        }
+    }
+
+    GpuSubStageScope(const GpuSubStageScope &) = delete;
+    GpuSubStageScope &operator=(const GpuSubStageScope &) = delete;
+    GpuSubStageScope(GpuSubStageScope &&) = delete;
+    GpuSubStageScope &operator=(GpuSubStageScope &&) = delete;
+
+  private:
+    GpuSubStageTimer::SubStageState *m_state = nullptr;
+};
+
+} // namespace IRRender
+
+#endif /* GPU_SUBSTAGE_TIMING_H */

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -31,6 +31,7 @@
 
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
+#include <irreden/render/gpu_substage_timing.hpp>
 
 #include <algorithm>
 #include <array>
@@ -846,6 +847,15 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         C_TriangleCanvasTextures &triangleCanvasTextures,
         const C_CanvasLocalRotation &canvasLocalRotation
     ) {
+        // CPU whole-tick timing (#2280): this system is no longer tagged for the
+        // per-system GpuStageTimingObserver (which used to supply both the CPU
+        // and GPU `voxelStage1` samples), so record the CPU side here to keep
+        // the HUD's / auto-profile's `voxelStage1` CPU number. Note the
+        // intentional asymmetry the sub-attribution introduces: CPU `voxelStage1`
+        // stays the WHOLE per-canvas tick, while GPU `voxelStage1` now measures
+        // only the stage-1 dispatch (the compact / clear / stage-2 GPU costs
+        // moved to their own sub-rows).
+        IR_PROFILE_SCOPE("voxelStage1");
         const int liveVoxelCount = voxelPool.getLiveVoxelCount();
 
         // Per-frame canvas clear runs unconditionally — every downstream
@@ -859,6 +869,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // longer dictates whether the canvas refreshes.
         {
             IR_PROFILE_SCOPE("vs1_clear");
+            IRRender::GpuSubStageScope gpuScope("canvasClear");
             clearCanvasAndDistances(entity, triangleCanvasTextures);
         }
 
@@ -1237,9 +1248,12 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // set to the same effectiveVoxelCount above.
         const int compactGroups = IRMath::divCeil(effectiveVoxelCount, kCompactLocalSize);
         const ivec2 compactGrid = voxelDispatchGridForCount(compactGroups);
-        IRRender::device()->dispatchCompute(compactGrid.x, compactGrid.y, 1);
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-        IRRender::device()->memoryBarrier(BarrierType::COMMAND);
+        {
+            IRRender::GpuSubStageScope gpuScope("voxelCompact");
+            IRRender::device()->dispatchCompute(compactGrid.x, compactGrid.y, 1);
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+            IRRender::device()->memoryBarrier(BarrierType::COMMAND);
+        }
 
         if (perAxisSplit) {
             // Reset perAxisRoute_ for any downstream UBO read; the per-axis pass
@@ -1265,8 +1279,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
             triangleCanvasTextures.getTextureDistances()
                 ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->dispatchComputeIndirect(indirectBuf_, 0);
-            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            {
+                IRRender::GpuSubStageScope gpuScope("voxelStage1");
+                IRRender::device()->dispatchComputeIndirect(indirectBuf_, 0);
+                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            }
 
             // Stage 2 runs in the SAME per-canvas tick rather than as a separate
             // system. The compact + position/color SSBOs (`voxelPosBuf_`,
@@ -1297,8 +1314,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             (cutSectionFog != nullptr ? cutSectionFog->getTexture() : fogCullPlaceholder_)
                 ->bindAsImage(3, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
             fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
-            IRRender::device()->dispatchComputeIndirect(indirectBuf_, 0);
-            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            {
+                IRRender::GpuSubStageScope gpuScope("voxelStage2");
+                IRRender::device()->dispatchComputeIndirect(indirectBuf_, 0);
+                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            }
         }
 
         // Smooth camera Z-yaw (T2 / #1309): once the single-canvas pass above
@@ -1669,11 +1689,15 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             BufferTarget::SHADER_STORAGE,
             kBufferIndex_IndirectDispatchParams
         );
-        // The observer-based timing brackets the entire system tick. The
-        // formerly-separate canvasClear and voxelCompact sub-stages now
-        // collapse into voxelStage1's measurement; their registry slots
-        // remain at 0.0f for API-compatibility.
-        IRRender::tagGpuStage(systemId, "voxelStage1");
+        // Intra-tick sub-stage timing (#2280): this system is deliberately NOT
+        // tagged for the per-system GpuStageTimingObserver. A single per-tick
+        // bracket bundles compact + clear + stage-1 + stage-2 into one opaque
+        // `voxelStage1` value (the ~140 ms #2258 could not attribute). Instead
+        // the per-canvas tick brackets each of its four dispatch groups with a
+        // GpuSubStageScope, filling the `canvasClear` / `voxelCompact` /
+        // `voxelStage1` / `voxelStage2` rows individually. Not tagging here
+        // leaves the device timestamp attachment slot free for the sub-scopes
+        // to reuse during this tick.
         return systemId;
     }
 };

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -144,6 +144,37 @@ MTL::ComputeCommandEncoder *createComputeEncoder(MTL::CommandBuffer *commandBuff
     return encoder;
 }
 
+// Blit twin of createComputeEncoder: when a timestamp attachment is active
+// (a per-system observer pair or an intra-tick GpuSubStageScope), attach the
+// sticky sample buffer to the blit pass so a blit-only stage — the per-frame
+// distance-texture clear that backs the `canvasClear` sub-row (#2280) — still
+// resolves a non-zero pair. Same first-encoder-claims-start / last-encoder-wins-
+// end semantics as the compute path (#1746). Returns a plain blit encoder when
+// no attachment is active.
+MTL::BlitCommandEncoder *createBlitEncoder(MTL::CommandBuffer *commandBuffer) {
+    if (commandBuffer == nullptr) {
+        return nullptr;
+    }
+    if (g_nextComputeTimestampAttachment.sampleBuffer_ == nullptr) {
+        return commandBuffer->blitCommandEncoder();
+    }
+
+    auto *descriptor = MTL::BlitPassDescriptor::alloc()->init();
+    auto *attachment = descriptor->sampleBufferAttachments()->object(kTimestampAttachmentIndex);
+    attachment->setSampleBuffer(g_nextComputeTimestampAttachment.sampleBuffer_);
+    attachment->setStartOfEncoderSampleIndex(
+        g_nextComputeTimestampAttachment.firstEncoder_
+            ? g_nextComputeTimestampAttachment.startSampleIndex_
+            : MTL::CounterDontSample
+    );
+    attachment->setEndOfEncoderSampleIndex(g_nextComputeTimestampAttachment.endSampleIndex_);
+    auto *encoder = commandBuffer->blitCommandEncoder(descriptor);
+    descriptor->release();
+
+    g_nextComputeTimestampAttachment.firstEncoder_ = false;
+    return encoder;
+}
+
 void attachTimestampSamples(MTL::RenderPassDescriptor *descriptor) {
     if (descriptor == nullptr || g_nextComputeTimestampAttachment.sampleBuffer_ == nullptr) {
         return;
@@ -719,7 +750,9 @@ metalCurrentDepthPixelFormat(),
         auto *commandBuffer = metalCommandBuffer();
         if (commandBuffer != nullptr) {
             // GPU-side blit: no per-frame allocation, no replaceRegion stall.
-            auto *blit = commandBuffer->blitCommandEncoder();
+            // Routed through createBlitEncoder so an active GpuSubStageScope
+            // (the `canvasClear` sub-row, #2280) samples this clear.
+            auto *blit = createBlitEncoder(commandBuffer);
             blit->copyFromBuffer(
                 clearBuf,
                 0,
@@ -738,7 +771,7 @@ metalCurrentDepthPixelFormat(),
             if (pixelFormat == MTL::PixelFormatR32Sint) {
                 if (MTL::Buffer *scratch = lookupImageAtomicScratchBuffer(texture);
                     scratch != nullptr) {
-                    auto *blit2 = commandBuffer->blitCommandEncoder();
+                    auto *blit2 = createBlitEncoder(commandBuffer);
                     blit2->copyFromBuffer(clearBuf, 0, scratch, 0, totalBytes);
                     blit2->endEncoding();
                 }


### PR DESCRIPTION
## Summary
Wires intra-tick GPU sub-stage timing so the opaque `voxelStage1` bundle (~140 ms at zoom 16, #2258) is attributed to its dispatch groups.

- **`GpuSubStageScope`** (`gpu_substage_timing.hpp`, new) — RAII bracket timing one dispatch group inside a system tick, reusing the existing device timestamp-pair machinery (async `kSamplesInFlight` readback, no `finish()` stall).
- **`VOXEL_TO_TRIXEL_STAGE_1`** — untagged from the per-system `GpuStageTimingObserver`; its four dispatch groups now each bracket with a sub-scope, wiring the reserved `canvasClear` / `voxelCompact` / `voxelStage2` rows and narrowing GPU `voxelStage1` to the stage-1 dispatch only. The old whole-tick number = the sum of the four. CPU `voxelStage1` stays whole-tick via an `IR_PROFILE_SCOPE` (no HUD/auto-profile regression).
- **Metal** — a timestamp-aware `createBlitEncoder` (twin of `createComputeEncoder`) captures the distance-clear blit so `canvasClear` is non-zero. Sub-scopes reuse the freed attachment slot (index 0) since the system is untagged — no second attachment index / no dual-attachment quota risk.
- Registry comment + `engine/prefabs/irreden/render/CLAUDE.md` + `docs/design/gpu-stage-timing-cost-model.md` updated for the new attribution.

## #2258 attribution (IRPerfGrid wave scene, sun shadows on, Metal/macOS 2x, `--auto-profile 120`)

| zoom | canvasClear | voxelCompact | voxelStage1 (stage-1 only) | voxelStage2 | sum | old bundled |
|---|---|---|---|---|---|---|
| 8 | 0.14 | 0.71 | 23.71 | 28.14 | ~52.7 | ~47.6 |
| 16 | 0.01 | 0.06 | 64.79 | 76.05 | ~140.9 | ~145 |

The ~140 ms is the **stage-1 + stage-2 dispatch grids** (~evenly split); compact + clear are negligible. Full table posted on #2258.

## Test plan
- [x] Builds clean on macOS/Metal (`IRPerfGrid`, `IRShapeDebug`).
- [x] Non-zero `canvasClear` / `voxelCompact` / `voxelStage2` rows (criterion 1).
- [x] Sum of sub-rows ≈ old bundled `voxelStage1` (criterion 2).
- [x] Attribution table posted on #2258 (criterion 3).
- [x] Rendering **byte-identical timing-on vs timing-off** — 28/28 `IRShapeDebug` shots (criterion 4).
- [ ] OpenGL (Linux/Windows) build + smoke — authored on macOS/Metal; GL path needs cross-host verification (`glQueryCounter` markers nest freely, no structural GL change).

## Follow-up (not in this PR)
`GpuSubStageScope`'s timestamp ring (`nextAvailableSlot` / `resolveReadySamples`) mirrors `GpuStageTimingObserver`'s. Extracting a shared `GpuTimestampRing` would dedupe it, but that touches the observer (critical timing infra for 14 systems) and wants its own verification — deliberately deferred to keep this PR's blast radius on the new file.

Closes #2280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
