### PR TITLE
ci: share auto-rereview flow + skip mechanical rebases (game #229)

### DIFF
--- a/.github/workflows/auto-rereview.yml
+++ b/.github/workflows/auto-rereview.yml
@@ -24,15 +24,19 @@ name: Auto re-review on push to approved PR
 #   on a `fleet:stacked-rebase` label guard because the merger applies
 #   that label *after* it pushes — the synchronize event payload
 #   captures labels at push time and races ahead of it. Instead we
-#   compare the PR's net-diff patch-id (git diff base...head, reduced by
-#   `git patch-id --stable`, which is invariant across rebases/SHAs)
-#   before vs after the push. Identical patch-id => mechanical rebase =>
+#   compare the PR's net-diff patch-id (reduced by `git patch-id --stable`,
+#   which is invariant across rebases/SHAs) before vs after the push, each
+#   tip against its *own* base. Identical patch-id => mechanical rebase =>
 #   skip. A rebase where master actually altered the effective diff (a
-#   *semantic* rebase) changes the patch-id and still triggers review.
+#   *semantic* rebase) changes the patch-id and still triggers review. The
+#   classify logic lives in `scripts/fleet/classify-auto-rereview.sh` (with a
+#   test suite at `scripts/fleet/tests/test_classify_auto_rereview.sh`) so it
+#   is unit-testable against a git sandbox rather than buried in a `run:` block.
 #
-# This file is kept byte-identical between the engine repo
-# (jakildev/IrredenEngine) and the game repo (jakildev/irreden) so both
-# repos share one re-review flow. Edit both when changing it.
+# This file and `scripts/fleet/classify-auto-rereview.sh` are kept
+# byte-identical between the engine repo (jakildev/IrredenEngine) and the game
+# repo (jakildev/irreden) so both repos share one re-review flow. Edit both
+# repos (and both files) when changing it.
 
 on:
   pull_request:
@@ -60,41 +64,9 @@ jobs:
           AFTER: ${{ github.event.after }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          set -uo pipefail
-
-          # Make sure the three commits we reason about are present locally.
-          # `after` and the base tip come with the PR checkout; `before` is
-          # orphaned by a force-push and may or may not be fetchable.
-          git fetch --no-tags --quiet origin "$AFTER" "$BASE_SHA" 2>/dev/null || true
-          git cat-file -e "${BEFORE}^{commit}" 2>/dev/null \
-            || git fetch --no-tags --quiet origin "$BEFORE" 2>/dev/null || true
-
-          # Net content of a tip = diff from its merge-base with the current
-          # base branch, hashed by patch-id (stable across rebase/SHA churn).
-          net_patch_id() {
-            local tip="$1" mb
-            mb=$(git merge-base "$BASE_SHA" "$tip" 2>/dev/null) || return 1
-            git diff "$mb" "$tip" | git patch-id --stable | awk '{print $1}'
-          }
-
-          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            echo "before commit $BEFORE unavailable — cannot prove a rebase; re-reviewing."
-            echo "rebase_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          OLD_ID=$(net_patch_id "$BEFORE") || OLD_ID=""
-          NEW_ID=$(net_patch_id "$AFTER") || NEW_ID=""
-          echo "old net patch-id: '${OLD_ID:-<empty>}'"
-          echo "new net patch-id: '${NEW_ID:-<empty>}'"
-
-          if [ -n "$OLD_ID" ] && [ "$OLD_ID" = "$NEW_ID" ]; then
-            echo "Net content diff unchanged — mechanical rebase. Skipping re-review."
-            echo "rebase_only=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Net content diff changed — real update. Re-reviewing."
-            echo "rebase_only=false" >> "$GITHUB_OUTPUT"
-          fi
+          # The script prints exactly `rebase_only=true|false` on stdout (routed
+          # to $GITHUB_OUTPUT); its diagnostics go to stderr (the Actions log).
+          bash scripts/fleet/classify-auto-rereview.sh >> "$GITHUB_OUTPUT"
 
       - name: Swap fleet:approved → human:re-review
         if: steps.classify.outputs.rebase_only != 'true'

--- a/.github/workflows/auto-rereview.yml
+++ b/.github/workflows/auto-rereview.yml
@@ -1,0 +1,110 @@
+name: Auto re-review on push to approved PR
+
+# Fires when commits are pushed to a PR that already has fleet:approved.
+# Swaps the label to human:re-review so the fleet reviewers pick it up
+# again on their next poll. This means the human can edit an approved
+# PR and just `git push` — no skill invocation needed.
+#
+# Why filter on fleet:approved only (not all fleet verdict labels):
+#   - During fleet:needs-fix, the author agent is addressing feedback
+#     and pushing fixes via commit-and-push. Auto-swapping there would
+#     fight the fleet:changes-made label the author sets.
+#   - During fleet:wip, the author is actively working. No verdict yet.
+#   - fleet:approved is the only state where a human-pushed change
+#     unambiguously means "I edited after fleet was done — please look
+#     again."
+#
+# Why the mechanical-rebase guard (the `classify` step below):
+#   A push whose *content* is unchanged does not need re-review. The
+#   fleet merger re-targets a stacked PR onto master and force-pushes
+#   the replayed child commits (see role-merger.md — "verdict labels
+#   survive a mechanical rebase that doesn't change the PR's content
+#   intent"). That force-push fires `synchronize` but introduces no new
+#   content, so stripping fleet:approved there is wrong. We cannot rely
+#   on a `fleet:stacked-rebase` label guard because the merger applies
+#   that label *after* it pushes — the synchronize event payload
+#   captures labels at push time and races ahead of it. Instead we
+#   compare the PR's net-diff patch-id (git diff base...head, reduced by
+#   `git patch-id --stable`, which is invariant across rebases/SHAs)
+#   before vs after the push. Identical patch-id => mechanical rebase =>
+#   skip. A rebase where master actually altered the effective diff (a
+#   *semantic* rebase) changes the patch-id and still triggers review.
+#
+# This file is kept byte-identical between the engine repo
+# (jakildev/IrredenEngine) and the game repo (jakildev/irreden) so both
+# repos share one re-review flow. Edit both when changing it.
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write   # gh pr edit --add-label uses the issues label API
+  contents: read  # checkout / fetch the before + after commits
+
+jobs:
+  swap-approval-label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'fleet:approved')
+    steps:
+      - name: Checkout with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify push (mechanical rebase vs real content change)
+        id: classify
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+
+          # Make sure the three commits we reason about are present locally.
+          # `after` and the base tip come with the PR checkout; `before` is
+          # orphaned by a force-push and may or may not be fetchable.
+          git fetch --no-tags --quiet origin "$AFTER" "$BASE_SHA" 2>/dev/null || true
+          git cat-file -e "${BEFORE}^{commit}" 2>/dev/null \
+            || git fetch --no-tags --quiet origin "$BEFORE" 2>/dev/null || true
+
+          # Net content of a tip = diff from its merge-base with the current
+          # base branch, hashed by patch-id (stable across rebase/SHA churn).
+          net_patch_id() {
+            local tip="$1" mb
+            mb=$(git merge-base "$BASE_SHA" "$tip" 2>/dev/null) || return 1
+            git diff "$mb" "$tip" | git patch-id --stable | awk '{print $1}'
+          }
+
+          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "before commit $BEFORE unavailable — cannot prove a rebase; re-reviewing."
+            echo "rebase_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          OLD_ID=$(net_patch_id "$BEFORE") || OLD_ID=""
+          NEW_ID=$(net_patch_id "$AFTER") || NEW_ID=""
+          echo "old net patch-id: '${OLD_ID:-<empty>}'"
+          echo "new net patch-id: '${NEW_ID:-<empty>}'"
+
+          if [ -n "$OLD_ID" ] && [ "$OLD_ID" = "$NEW_ID" ]; then
+            echo "Net content diff unchanged — mechanical rebase. Skipping re-review."
+            echo "rebase_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Net content diff changed — real update. Re-reviewing."
+            echo "rebase_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Swap fleet:approved → human:re-review
+        if: steps.classify.outputs.rebase_only != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR" --repo "$REPO" \
+            --remove-label "fleet:approved" \
+            --add-label "human:re-review"
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "New commits pushed after fleet approval. Re-tagging \`human:re-review\` so the fleet picks it up again."

--- a/scripts/fleet/classify-auto-rereview.sh
+++ b/scripts/fleet/classify-auto-rereview.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Classify a force-push to a fleet:approved PR as a mechanical rebase (net
+# content unchanged) vs a real content change, so the auto-rereview workflow
+# only strips fleet:approved when the diff actually changed.
+#
+# Reads three commit SHAs from the environment (the synchronize-event payload):
+#   BEFORE   — the PR head before the push (github.event.before). Orphaned by a
+#              force-push, so it may be unfetchable.
+#   AFTER    — the PR head after the push (github.event.after).
+#   BASE_SHA — the PR's *current* base tip (github.event.pull_request.base.sha),
+#              i.e. the base AFTER any retarget performed by the same operation.
+#
+# Prints exactly one line to stdout:  rebase_only=true | rebase_only=false
+# Diagnostics go to stderr (surfaced in the Actions log). The decision is the
+# stdout, not the exit status — exit is 0 on every decided path; a non-zero
+# exit means the environment was malformed.
+#
+# Why we cannot just diff both tips against BASE_SHA (the game #229 / engine
+# #2290 bug):
+#   A stacked child PR retargeted onto master after its parent *squash-merges*
+#   loses the parent's original commits from history. merge-base(BASE_SHA,
+#   BEFORE) then falls back past the parent's fork point, so diff(mb, BEFORE)
+#   wrongly folds the parent's entire diff into the child's net diff and the
+#   before/after patch-ids differ even though the child's own change is
+#   byte-identical — reproducing exactly the "mechanical rebase strips
+#   fleet:approved" bug the guard exists to prevent.
+#
+# We recover the child's pre-retarget base *structurally* instead of persisting
+# cross-event state:
+#   * AFTER is the child replayed directly onto the current base, so the child's
+#     own commit count is N = commits in BASE_SHA..AFTER.
+#   * BEFORE's own base is therefore BEFORE~N — the commit just under BEFORE's
+#     top N commits, which is the old parent tip whatever it was.
+#   Diffing each tip against its *own* base yields the child's net diff on both
+#   sides, which patch-id-compares equal for a mechanical rebase and unequal for
+#   a real edit — with no dependence on the parent's commits still existing, and
+#   no edited-event marker racing the synchronize handler.
+
+set -uo pipefail
+
+: "${BEFORE:?BEFORE (github.event.before) required}"
+: "${AFTER:?AFTER (github.event.after) required}"
+: "${BASE_SHA:?BASE_SHA (github.event.pull_request.base.sha) required}"
+
+emit() { echo "rebase_only=$1"; }  # stdout: the decision, nothing else
+
+# Best-effort: make the commits we reason about present locally. The workflow
+# checkout brings AFTER + the base tip; BEFORE is orphaned by the force-push and
+# may or may not be fetchable. A missing origin (e.g. the hermetic test sandbox)
+# fails closed to the local objects we already have.
+git fetch --no-tags --quiet origin "$AFTER" "$BASE_SHA" 2>/dev/null || true
+git cat-file -e "${BEFORE}^{commit}" 2>/dev/null \
+  || git fetch --no-tags --quiet origin "$BEFORE" 2>/dev/null || true
+
+# Net content of a tip against an explicit base, hashed by patch-id (stable
+# across rebase/SHA churn). Empty stdout => "unknown", handled by the caller.
+net_patch_id() {  # $1 = base  $2 = tip
+  git diff "$1" "$2" | git patch-id --stable | awk '{print $1}'
+}
+
+if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+  echo "before commit $BEFORE unavailable — cannot prove a rebase; re-reviewing." >&2
+  emit false
+  exit 0
+fi
+
+# The child's own commit count, measured on the side that is cleanly based on
+# the current base (AFTER was just replayed onto BASE_SHA).
+N=$(git rev-list --count "$BASE_SHA..$AFTER" 2>/dev/null) || N=""
+if [ -z "$N" ] || [ "$N" -eq 0 ]; then
+  echo "AFTER has no commits above the current base (N='${N:-<empty>}') — re-reviewing." >&2
+  emit false
+  exit 0
+fi
+
+# BEFORE's own base = the commit just under its top N commits (the pre-retarget
+# parent tip, recovered structurally). If BEFORE has fewer than N ancestors,
+# BEFORE~N does not resolve and we conservatively re-review.
+OLD_BASE=$(git rev-parse --verify --quiet "${BEFORE}~${N}^{commit}") || OLD_BASE=""
+if [ -z "$OLD_BASE" ]; then
+  echo "BEFORE has fewer than N=$N commits — cannot recover pre-retarget base; re-reviewing." >&2
+  emit false
+  exit 0
+fi
+
+OLD_ID=$(net_patch_id "$OLD_BASE" "$BEFORE")
+NEW_ID=$(net_patch_id "$BASE_SHA" "$AFTER")
+echo "old net patch-id: '${OLD_ID:-<empty>}' (base ${OLD_BASE})" >&2
+echo "new net patch-id: '${NEW_ID:-<empty>}' (base ${BASE_SHA})" >&2
+
+if [ -n "$OLD_ID" ] && [ "$OLD_ID" = "$NEW_ID" ]; then
+  echo "Net content diff unchanged — mechanical rebase. Skipping re-review." >&2
+  emit true
+else
+  echo "Net content diff changed — real update. Re-reviewing." >&2
+  emit false
+fi

--- a/scripts/fleet/tests/test_classify_auto_rereview.sh
+++ b/scripts/fleet/tests/test_classify_auto_rereview.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests for scripts/fleet/classify-auto-rereview.sh (engine #2290 / game #229).
+#
+# Each case builds a throwaway git repo mirroring a real synchronize-event
+# graph, invokes the classify script with the event's BEFORE/AFTER/BASE_SHA,
+# and asserts the emitted rebase_only decision:
+#
+#   T1  stacked child retargeted onto master after the parent SQUASH-merges
+#       -> mechanical (the headline bug: this must NOT strip fleet:approved)
+#   T2  in-place catch-up rebase onto an advanced master, child diff unchanged
+#       -> mechanical (must stay correct — the case the old logic handled)
+#   T3  real content change (amended tip commit) -> re-review
+#   T4  BEFORE commit unavailable (orphaned, unfetchable) -> re-review (safe)
+#   T5  plain force-push, identical tree, new SHA -> mechanical
+#
+# Hermetic: no live GitHub, no origin remote, no ~/.fleet. The script's
+# best-effort `git fetch origin` fails closed to the local objects we build.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$SCRIPT_DIR/classify-auto-rereview.sh"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "SKIP: script not found at $SCRIPT" >&2
+    exit 0
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "SKIP: git not available" >&2
+    exit 0
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+ok()   { echo "  ok: $1";   PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# Deterministic commit identity + dates so SHAs don't depend on wall-clock.
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=t@t
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=t@t
+export GIT_AUTHOR_DATE="2026-01-01T00:00:00 +0000"
+export GIT_COMMITTER_DATE="2026-01-01T00:00:00 +0000"
+# Never let rebase/commit open an editor.
+export GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true
+
+new_repo() {  # $1 = name -> echoes path
+    local d="$TMPROOT/$1"
+    git -c init.defaultBranch=master init -q "$d"
+    ( cd "$d" && echo base > base.txt && git add base.txt && git commit -qm M0 )
+    echo "$d"
+}
+
+add() {  # $1 = repo  $2 = file  $3 = msg
+    ( cd "$1" && echo "$2" > "$2" && git add "$2" && git commit -qm "$3" )
+}
+
+# Run the classifier in $1 with the given event SHAs; echoes the decision line.
+classify() {  # $1 = repo  BEFORE AFTER BASE_SHA
+    ( cd "$1" && BEFORE="$2" AFTER="$3" BASE_SHA="$4" bash "$SCRIPT" 2>/dev/null )
+}
+
+expect() {  # $1 = label  $2 = got  $3 = want
+    if [[ "$2" == "$3" ]]; then ok "$1 -> $2"; else fail "$1: got '$2' want '$3'"; fi
+}
+
+# --- T1: stacked child retargeted after parent SQUASH-merge ------------------
+echo "T1: retarget-after-squash-merge (the bug) -> rebase_only=true"
+R=$(new_repo t1)
+git -C "$R" checkout -q -b parent
+add "$R" parent1.txt p1
+add "$R" parent2.txt p2
+PARENT_TIP=$(git -C "$R" rev-parse HEAD)
+git -C "$R" checkout -q -b child
+add "$R" child1.txt c1
+add "$R" child2.txt c2
+BEFORE=$(git -C "$R" rev-parse HEAD)                 # child on the parent branch
+git -C "$R" checkout -q master
+git -C "$R" merge --squash -q parent >/dev/null      # squash parent's changes...
+git -C "$R" commit -qm "squash parent (#PR)"         # ...as one commit; p1/p2 gone
+BASE_SHA=$(git -C "$R" rev-parse HEAD)               # new master tip
+git -C "$R" rebase -q --onto master "$PARENT_TIP" child >/dev/null
+AFTER=$(git -C "$R" rev-parse child)                 # child replayed onto master
+expect "T1" "$(classify "$R" "$BEFORE" "$AFTER" "$BASE_SHA")" "rebase_only=true"
+
+# --- T2: in-place catch-up rebase onto advanced master -----------------------
+echo "T2: in-place catch-up rebase, child diff unchanged -> rebase_only=true"
+R=$(new_repo t2)
+git -C "$R" checkout -q -b feature
+add "$R" child1.txt c1
+add "$R" child2.txt c2
+BEFORE=$(git -C "$R" rev-parse HEAD)
+git -C "$R" checkout -q master
+add "$R" master_extra.txt m1                         # master advances (disjoint file)
+BASE_SHA=$(git -C "$R" rev-parse HEAD)
+git -C "$R" checkout -q feature
+git -C "$R" rebase -q master >/dev/null
+AFTER=$(git -C "$R" rev-parse HEAD)
+expect "T2" "$(classify "$R" "$BEFORE" "$AFTER" "$BASE_SHA")" "rebase_only=true"
+
+# --- T3: real content change (amended tip) -----------------------------------
+echo "T3: real content change -> rebase_only=false"
+R=$(new_repo t3)
+BASE_SHA=$(git -C "$R" rev-parse master)
+git -C "$R" checkout -q -b feature
+add "$R" child1.txt c1
+add "$R" child2.txt c2
+BEFORE=$(git -C "$R" rev-parse HEAD)
+( cd "$R" && echo "edited content" > child2.txt && git add child2.txt \
+    && git commit -q --amend -m c2 )                 # genuine edit to the tip
+AFTER=$(git -C "$R" rev-parse HEAD)
+expect "T3" "$(classify "$R" "$BEFORE" "$AFTER" "$BASE_SHA")" "rebase_only=false"
+
+# --- T4: BEFORE unavailable (orphaned, unfetchable) --------------------------
+echo "T4: before commit unavailable -> rebase_only=false (conservative)"
+R=$(new_repo t4)
+BASE_SHA=$(git -C "$R" rev-parse master)
+git -C "$R" checkout -q -b feature
+add "$R" child1.txt c1
+AFTER=$(git -C "$R" rev-parse HEAD)
+BEFORE=0000000000000000000000000000000000000000       # not a real object
+expect "T4" "$(classify "$R" "$BEFORE" "$AFTER" "$BASE_SHA")" "rebase_only=false"
+
+# --- T5: plain force-push, identical tree, new SHA ---------------------------
+echo "T5: no-op force-push (same tree, new SHA) -> rebase_only=true"
+R=$(new_repo t5)
+BASE_SHA=$(git -C "$R" rev-parse master)
+git -C "$R" checkout -q -b feature
+add "$R" child1.txt c1
+add "$R" child2.txt c2
+BEFORE=$(git -C "$R" rev-parse HEAD)
+# Re-commit the identical tip content with a later committer date -> new SHA,
+# same tree (mirrors a bare `git push --force` with no edits).
+GIT_COMMITTER_DATE="2026-02-02T00:00:00 +0000" \
+    git -C "$R" commit -q --amend --no-edit
+AFTER=$(git -C "$R" rev-parse HEAD)
+[[ "$AFTER" != "$BEFORE" ]] || fail "T5 setup: AFTER SHA should differ from BEFORE"
+expect "T5" "$(classify "$R" "$BEFORE" "$AFTER" "$BASE_SHA")" "rebase_only=true"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

Adds `.github/workflows/auto-rereview.yml` to the engine repo and fixes it so a **mechanical rebase no longer triggers a re-review**. Kept byte-identical with the game repo's copy (jakildev/irreden) so both repos share one flow.

## Why

On game [PR #229](https://github.com/jakildev/irreden/pull/229) the fleet merger re-targeted a stacked PR onto master and force-pushed the replayed child commits. `role-merger.md` guarantees verdict labels survive that mechanical rebase, but the game's `auto-rereview.yml` fired on the `synchronize` and stripped `fleet:approved` → `human:re-review` anyway. Timeline:

```
head_ref_force_pushed        (merger rebase)
unlabeled fleet:approved   } auto-rereview (github-actions[bot])
labeled   human:re-review  }
labeled   fleet:stacked-rebase   (merger — 3s TOO LATE)
```

A `fleet:stacked-rebase` label guard can't fix this: the merger applies the label *after* it pushes, and the `synchronize` payload captures labels at push time.

## Fix

The workflow now classifies the push by comparing the PR's **net-diff patch-id** (`git diff base...head` reduced by `git patch-id --stable`, which is invariant across rebase/SHA churn) before vs after:

- identical → mechanical rebase → **skip** (verdict preserved)
- changed → real edit or semantic rebase (master altered the effective diff) → re-review as before

Race-free and needs no coordination with the merger's labeling order. If the pre-push commit is unfetchable (rare orphan case), it conservatively falls back to re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)