### PR TITLE
fleet: best-effort st_mtime-near-state.json freshness lint (#2267)

### DIFF
--- a/.fleet/plans/issue-2267.md
+++ b/.fleet/plans/issue-2267.md
@@ -1,0 +1,69 @@
+# Plan: scripts/fleet: best-effort lint flag for st_mtime reads near state.json consumers
+
+- **Issue:** #2267
+- **Model:** sonnet — every design decision (co-occurrence heuristic, inline-suppression ratchet, exit policy, CI placement) is pinned below; implementation is bounded mechanical work (one ~70-line stdlib script + one test + one CI step + two one-line comment seeds).
+- **Date:** 2026-07-08
+
+### Scope
+
+Add a best-effort, standalone Python lint that flags a `.st_mtime` **freshness** read in any `scripts/fleet/` file that *also* consumes the scout cache (`state.json` / `STATE_JSON` / `STATE_FILE`), wired into the same CI lint job as `ruff check scripts/`. Cache freshness must derive from the in-file `generated_at` (canonical helper `fleet_poll_topology.state_age_seconds`, contract in `docs/agents/FLEET-RUNTIME.md`); mtime lies when a #1394-Q2 follower rewrites `state.json` every tick while preserving a dead leader's `generated_at`. The mtime shape was introduced twice independently (`fleet-dispatcher:_state_age_seconds`, `fleet-epic-status:load_state_cache`, PR #2231) with no gate to catch the third. This adds that gate. Migrating the two existing readers to `generated_at` is **out of scope** (separate work); this task only lands the lint and grandfathers them.
+
+### Verified current state
+
+- CI lint lives in `.github/workflows/quality.yml` → step **"Python lint (ruff)"** (`astral-sh/ruff-action@v3`, `check scripts/`) in the `quality-checks` job, which runs on **`windows-latest`**. `ruff.toml` pins the rule set; ruff has no native cross-line rule for "`.st_mtime` read AND `state.json` reference in the same file", which is why a separate grep-style check is needed (confirmed against the issue's own note).
+- The canonical helper already exists: `scripts/fleet/fleet_poll_topology.py:222` `state_age_seconds(generated_at, mtime, now=None)` — prefers `generated_at`, falls back to `mtime` only when `generated_at` is missing/unparseable. It receives `mtime` as a **parameter**; it does **not** itself read `.st_mtime`, and `grep -n st_mtime scripts/fleet/fleet_poll_topology.py` is empty — so the helper is correctly NOT a target.
+- `grep -rn "\.st_mtime" scripts/fleet/` returns exactly five reads. Classifying each against the "file also references `state.json`" discriminator:
+  - `fleet-dispatcher:1685` (`_state_age_seconds`, `STATE_FILE.stat().st_mtime`) — **offender** (file defines `STATE_FILE = STATE/"state.json"`).
+  - `fleet-epic-status:108` (`load_state_cache`, `p.stat().st_mtime` on `STATE_JSON`) — **offender** (file defines `STATE_JSON = .../state.json`).
+  - `fleet-debug:105` (strftime display of a trigger file's mtime) — legitimate; verified `fleet-debug` does **not** reference `state.json` → not flagged.
+  - `fleet-pr:124` (sort key by mtime) — legitimate; verified `fleet-pr` does **not** reference `state.json` → not flagged.
+  - `tests/test_fleet_debug_triggers.py` (`st_mtime_ns` snapshot) — under `tests/`, excluded from scan scope.
+- So the file-level co-occurrence heuristic is precise on the current tree: it flags exactly the two real offenders and nothing else.
+
+### Approach (one approach, picked)
+
+1. **New lint script `scripts/fleet/lint_state_mtime.py`** — stdlib-only, pure-Python (no `grep`/shell, so it runs unchanged on the Windows CI runner). Behavior:
+   - Accept one-or-more root paths on argv (default `scripts/fleet/`). Walk `*.py` **and** the extension-less Python executables; skip `tests/`, `__pycache__/`, and the lint script itself.
+   - For each file, read text once. Flag the file iff it contains **both** (a) a `.st_mtime` attribute read — regex `\.st_mtime(_ns)?\b` (dot-anchored, so the helper's bare `mtime` parameter never matches) — **and** (b) a state-cache token — `state.json` / `STATE_JSON` / `STATE_FILE`.
+   - For each flagged `.st_mtime` line **not carrying the inline suppression**, print `path:line: state.json freshness must use fleet_poll_topology.state_age_seconds / generated_at (FLEET-RUNTIME.md); mtime lies under Q2 follower rewrite. Suppress with '# lint: state-mtime-ok <reason>' if this read is genuinely non-staleness.`
+   - **Inline suppression escape hatch (the "not a hard ban" mechanism):** a `# lint: state-mtime-ok <reason>` trailing comment on (or immediately above) the `.st_mtime` line suppresses that line. Diff-local and self-documenting, so it doesn't drift like a central line-number allowlist would.
+   - **Exit policy (the one interpretive call I'm making for the human):** exit **non-zero** when any *unsuppressed* finding remains; exit 0 otherwise. Rationale: a warn-only exit-0 step is green-CI-ignorable, and the whole motivation (#2231 introduced the shape twice *unnoticed*) is that silent surfacing already failed. The suppression-with-reason hatch keeps it from being a "hard ban" on `st_mtime` — a legit use is one justified comment away, which a reviewer sees in the diff. If plan-review prefers pure warn-only, it is a one-line change (drop the non-zero exit, keep the prints) — but I recommend the ratchet.
+2. **Seed the two known offenders** with `# lint: state-mtime-ok pending generated_at migration (#2231/#2267)` so the tree is green on landing and both are documented as known-pending: `scripts/fleet/fleet-dispatcher:1685` and `scripts/fleet/fleet-epic-status:108`.
+3. **Wire CI:** add a step to `.github/workflows/quality.yml` in the `quality-checks` job, immediately after "Python lint (ruff)":
+   ```yaml
+   - name: State-mtime freshness lint (best-effort ratchet)
+     run: python scripts/fleet/lint_state_mtime.py scripts/fleet/
+   ```
+4. **Test `scripts/fleet/tests/test_lint_state_mtime.py`** (pytest-style, matching `test_blocked_by.py`): write tmp fixtures and assert the exit code + findings — (a) positive: `.st_mtime` + `state.json`, no suppression → flagged, non-zero; (b) negative-display: `.st_mtime` for strftime, no state token → clean; (c) negative-suppressed: offender + `# lint: state-mtime-ok …` → clean; (d) no-state-token file with mtime sort → clean. Register it the same way the sibling `.py` tests are picked up by the ctest/pytest harness (mirror `test_blocked_by.py`'s CMake/ctest registration).
+5. **Author-side pointer (minor):** add one line to the ruff pre-commit note (`scripts/bootstrap_linux.sh` / `scripts/bootstrap_macos.sh`, wherever the `ruff check scripts/fleet/` local reminder is) pointing at `python scripts/fleet/lint_state_mtime.py scripts/fleet/` so it runs locally too. The doc/review-checklist half of this already landed via #2235; this is just the runnable pointer.
+
+### Affected files
+
+- `scripts/fleet/lint_state_mtime.py` — **new**, the lint (~70 lines).
+- `scripts/fleet/tests/test_lint_state_mtime.py` — **new**, fixtures + assertions.
+- `.github/workflows/quality.yml` — **+1 step** after the ruff step.
+- `scripts/fleet/fleet-dispatcher` — **+comment** at the `_state_age_seconds` mtime read (line ~1685).
+- `scripts/fleet/fleet-epic-status` — **+comment** at the `load_state_cache` mtime read (line ~108).
+- `scripts/bootstrap_linux.sh` / `scripts/bootstrap_macos.sh` — **+1 line** pointer (optional, low-priority).
+- Test registration file (CMake/ctest list) — mirror `test_blocked_by.py`'s entry.
+
+### Acceptance criteria
+
+- `python scripts/fleet/lint_state_mtime.py scripts/fleet/` exits **0** on the current tree (both offenders suppressed) and **non-zero** when a new unsuppressed `.st_mtime`+state.json file is added.
+- The new test passes under the existing test harness (`ctest`/pytest), covering positive, display-negative, suppressed-negative, and mtime-sort-negative cases.
+- The new CI step runs in `quality-checks` and is green; the ruff step still passes over the new `.py` (it auto-enters `ruff check scripts/` scope because it has a `.py` extension — keep it ruff-clean; **no `ruff.toml` edit needed**).
+- Both existing instances carry the justification comment.
+
+### Gotchas
+
+- **Windows CI runner** — keep the lint pure-Python (`pathlib`, no `grep`/shell); emit `file:line` via `Path.as_posix()` for stable, OS-independent refs.
+- **Don't broaden the regex to bare `mtime`** — it would false-positive `fleet_poll_topology.state_age_seconds`'s legitimate `mtime` *parameter*. Anchor on `.st_mtime`.
+- **Scope stays `scripts/fleet/`** (per the issue), not all of `scripts/` — the render/perf/gui harnesses sort/format by mtime and don't touch `state.json`; narrowing avoids even considering them.
+- **New `.py` auto-lints under ruff** — line-length 100, import order, or the ruff step fails. No `ruff.toml` change (it's a `.py`, not an extension-less executable that would need explicit enumeration).
+- **Wire the real CI file** — `.github/workflows/quality.yml`, not the stray `.githooks/quality.yml`.
+- **Not gated** — `scripts/fleet/` and `.github/workflows/` are outside the `.claude/**` self-config commit gate, so a worker can implement and push this normally (no `fleet:gated` risk).
+
+### One task or subtasks
+
+**One task** — ~5 small files, single PR. No stack, no shared-resource migration (additive: a lint + two documenting comments), so no cross-system audit section is required.
+

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,6 +43,13 @@ jobs:
           version: "0.15.20"
           args: "check scripts/"
 
+      # Cross-line pattern ruff has no native rule for: an st_mtime freshness
+      # read on the scout cache (must derive from generated_at instead; #2231/
+      # #2267). Best-effort ratchet — legit reads opt out with an inline
+      # `# lint: state-mtime-ok` comment. Pure-Python, runs on the Windows runner.
+      - name: State-mtime freshness lint (best-effort ratchet)
+        run: python scripts/fleet/lint_state_mtime.py scripts/fleet/
+
       - name: Build tests
         run: cmake --build --preset windows-tests
 

--- a/scripts/bootstrap_linux.sh
+++ b/scripts/bootstrap_linux.sh
@@ -87,6 +87,10 @@ else
          "--user ruff') to enable 'ruff check scripts/fleet/' before commit."
 fi
 
+# stdlib-only, ruff-independent: the state.json st_mtime-freshness ratchet (#2267).
+echo "[note] Author-side: 'python scripts/fleet/lint_state_mtime.py scripts/fleet/'" \
+     "flags st_mtime freshness reads on the scout cache."
+
 verify_tool() {
     local label="$1"
     shift

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -23,7 +23,10 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
 - **`state.json` staleness comes from the in-file `generated_at`, never file
   mtime.** Canonical rule + rationale: `docs/agents/FLEET-RUNTIME.md`.
   Shared helper: `fleet_poll_topology.state_age_seconds` (a heredoc consumer
-  that can't import mirrors it inline, commented as such).
+  that can't import mirrors it inline, commented as such). A best-effort CI
+  ratchet (`lint_state_mtime.py`) flags a new `.st_mtime` read that co-occurs
+  with a `state.json` reference; opt a justified read out with an inline
+  `# lint: state-mtime-ok <reason>` comment.
 - **A new executable ships with a `tests/test_<name>.{sh,py}`** in the same
   PR — the fleet-tooling form of the review checklist's "new feature with no
   new test"; the `simplify` pre-commit pass flags the omission.

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1682,6 +1682,7 @@ def _state_age_seconds():
             return time.time() - epoch
         except (ValueError, TypeError):
             pass
+    # lint: state-mtime-ok generated_at-first; mtime is the malformed-snapshot fallback (#2267)
     return time.time() - STATE_FILE.stat().st_mtime
 
 

--- a/scripts/fleet/fleet-epic-status
+++ b/scripts/fleet/fleet-epic-status
@@ -105,6 +105,7 @@ def load_state_cache():
     """
     try:
         p = pathlib.Path(STATE_JSON)
+        # lint: state-mtime-ok generated_at-first; mtime is the fallback (#2267)
         mtime = p.stat().st_mtime
         data = read_json_retry(STATE_JSON)
         gen = (data or {}).get("generated_at")

--- a/scripts/fleet/lint_state_mtime.py
+++ b/scripts/fleet/lint_state_mtime.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Best-effort ratchet: flag new `st_mtime` freshness reads on the scout cache.
+
+Scout-cache freshness must derive from the in-file `generated_at` (canonical
+helper `fleet_poll_topology.state_age_seconds`; contract in
+`docs/agents/FLEET-RUNTIME.md`), never from the file's `st_mtime`. Under Q2
+centralized polling (#1394) a follower rewrites `state.json` every tick while
+preserving a *dead* leader's `generated_at`, so the file mtime stays fresh while
+the snapshot is stale — mtime lies. The mtime shape was introduced twice
+independently (`fleet-dispatcher`, `fleet-epic-status`; PR #2231) with no gate
+to catch the third, so this is that gate.
+
+It is a best-effort co-occurrence heuristic, NOT a hard ban — `st_mtime` has
+legitimate non-staleness uses (display, sort keys). A file is flagged only when
+it both reads `.st_mtime` AND references the scout cache (`state.json` /
+`STATE_JSON` / `STATE_FILE`). A genuine non-staleness read opts out with a
+`# lint: state-mtime-ok <reason>` comment on, or immediately above, the line —
+self-documenting and diff-local, so a reviewer sees the justification and no
+central line-number allowlist drifts.
+
+File selection is by co-occurrence over both `.py` files and extension-less
+executables — deliberately NOT shebang-gated, because `fleet-dispatcher` is a
+bash script with an embedded-Python heredoc (the scout-dead watchdog) and its
+mtime read must still be caught. Pure-bash files can't false-positive: `.st_mtime`
+is Python attribute syntax that never appears in shell.
+
+Exit non-zero when any unsuppressed finding remains (a warn-only exit-0 step is
+green-CI-ignorable, and the whole motivation is that silent surfacing already
+failed to catch #2231); exit 0 otherwise. Wired into the same CI lint job as
+`ruff check scripts/`, which runs on the Windows runner — so this is pure
+`pathlib` with no shell/grep dependency and emits POSIX `file:line` refs.
+"""
+import re
+import sys
+from pathlib import Path
+
+# Dot-anchored so the bare `mtime` PARAMETER of state_age_seconds never matches;
+# the optional `_ns` covers `st_mtime_ns`.
+_MTIME_RE = re.compile(r"\.st_mtime(_ns)?\b")
+
+# Any reference to the scout cache marks a file as a state-freshness consumer.
+_STATE_TOKENS = ("state.json", "STATE_JSON", "STATE_FILE")
+
+# Per-line opt-out marker; the free-text `<reason>` after it is for humans.
+_SUPPRESS = "# lint: state-mtime-ok"
+
+# Directory names pruned from the walk: tests use st_mtime as a fixture
+# primitive, __pycache__ is build output, completions are shell.
+_SKIP_DIRS = {"tests", "__pycache__", "completions"}
+
+_SELF = Path(__file__).resolve()
+
+_MESSAGE = (
+    "state.json freshness must use fleet_poll_topology.state_age_seconds / "
+    "generated_at (FLEET-RUNTIME.md); mtime lies under a Q2 follower rewrite. "
+    "Suppress with '# lint: state-mtime-ok <reason>' if this read is genuinely "
+    "non-staleness."
+)
+
+
+def _is_scannable(path):
+    # `.py`/`.pyi` plus extension-less executables (Python, or bash-with-embedded
+    # -Python like fleet-dispatcher). Everything else — .sh/.md/.json — cannot
+    # carry a `.st_mtime` attribute read, so skipping it costs no coverage.
+    return path.suffix in (".py", ".pyi") or path.suffix == ""
+
+
+def _suppressed(lines, idx):
+    # Opt-out marker on the flagged line or the line immediately above it.
+    if _SUPPRESS in lines[idx]:
+        return True
+    return idx > 0 and _SUPPRESS in lines[idx - 1]
+
+
+def scan_file(path):
+    """Return the 1-based line numbers of unsuppressed offending reads in `path`."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []  # unreadable or binary extension-less file — nothing to scan
+    if not _MTIME_RE.search(text) or not any(tok in text for tok in _STATE_TOKENS):
+        return []
+    lines = text.splitlines()
+    return [
+        idx + 1
+        for idx, line in enumerate(lines)
+        if _MTIME_RE.search(line) and not _suppressed(lines, idx)
+    ]
+
+
+def iter_files(roots):
+    """Yield scannable files under each root, pruning tests/build/completions."""
+    for root in roots:
+        root = Path(root)
+        if root.is_file():
+            if _is_scannable(root):
+                yield root
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            if any(part in _SKIP_DIRS for part in path.parts):
+                continue
+            if _is_scannable(path):
+                yield path
+
+
+def main(argv):
+    roots = argv[1:] or ["scripts/fleet/"]
+    total = 0
+    for path in iter_files(roots):
+        if path.resolve() == _SELF:
+            continue  # this lint carries the pattern + tokens by construction
+        for lineno in scan_file(path):
+            print(f"{path.as_posix()}:{lineno}: {_MESSAGE}")
+            total += 1
+    if total:
+        print(f"\n{total} unsuppressed state.json st_mtime read(s) found.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/fleet/tests/test_lint_state_mtime.py
+++ b/scripts/fleet/tests/test_lint_state_mtime.py
@@ -1,0 +1,140 @@
+"""Unit + integration tests for lint_state_mtime.py (#2267).
+
+The lint is a best-effort co-occurrence ratchet: it flags a file that both reads
+`.st_mtime` AND references the scout cache (`state.json` / `STATE_JSON` /
+`STATE_FILE`), unless the line carries an inline `# lint: state-mtime-ok`
+opt-out. These cases lock the contract:
+
+  - positive: `.st_mtime` + a state token, unsuppressed          -> flagged
+  - display-negative: `.st_mtime`, no state token                -> clean
+  - sort-negative: `.st_mtime` sort key, no state token          -> clean
+  - bare `mtime` parameter (state_age_seconds arg)               -> clean
+  - suppressed trailing and suppressed line-above                -> clean
+  - `st_mtime_ns` variant                                        -> flagged
+  - extension-less bash-with-embedded-Python (fleet-dispatcher)  -> flagged
+  - tests/ and __pycache__/ subtrees are pruned from the walk
+  - non-Python extensions (.md/.sh) are skipped
+  - the committed scripts/fleet/ tree is green (both offenders suppressed)
+
+stdlib-only; every fixture is written under a TemporaryDirectory (no network,
+no repo mutation).
+"""
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import lint_state_mtime as lint
+
+_FLEET_DIR = Path(__file__).resolve().parent.parent
+
+
+def _run_main(root):
+    # Exercise the CLI entry point, swallowing its report; return the exit code.
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        return lint.main(["lint_state_mtime.py", str(root)])
+
+
+class TmpTreeTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, rel, body):
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        return path
+
+
+class ScanFile(TmpTreeTest):
+    def test_positive_state_token_and_mtime_is_flagged(self):
+        path = self.write("consumer.py",
+                          "STATE_FILE = STATE / 'state.json'\n"
+                          "age = time.time() - STATE_FILE.stat().st_mtime\n")
+        self.assertEqual(lint.scan_file(path), [2])
+
+    def test_display_mtime_without_state_token_is_clean(self):
+        path = self.write("show.py",
+                          "def fmt(path):\n"
+                          "    return time.localtime(path.stat().st_mtime)\n")
+        self.assertEqual(lint.scan_file(path), [])
+
+    def test_sort_mtime_without_state_token_is_clean(self):
+        path = self.write("sorter.py", "prs.sort(key=lambda p: p.stat().st_mtime)\n")
+        self.assertEqual(lint.scan_file(path), [])
+
+    def test_bare_mtime_parameter_is_not_matched(self):
+        # state_age_seconds(gen, mtime) takes mtime as a plain parameter — the
+        # dot-anchored regex must not flag it even beside a state token.
+        path = self.write("helper.py",
+                          "STATE_JSON = 'state.json'\n"
+                          "def age(gen, mtime):\n"
+                          "    return state_age_seconds(gen, mtime)\n")
+        self.assertEqual(lint.scan_file(path), [])
+
+    def test_trailing_suppression_is_clean(self):
+        path = self.write("ok_trailing.py",
+                          "STATE_JSON = 'state.json'\n"
+                          "m = p.stat().st_mtime  # lint: state-mtime-ok legit (#2267)\n")
+        self.assertEqual(lint.scan_file(path), [])
+
+    def test_line_above_suppression_is_clean(self):
+        path = self.write("ok_above.py",
+                          "STATE_FILE = 'state.json'\n"
+                          "# lint: state-mtime-ok legit (#2267)\n"
+                          "m = STATE_FILE.stat().st_mtime\n")
+        self.assertEqual(lint.scan_file(path), [])
+
+    def test_st_mtime_ns_variant_is_flagged(self):
+        path = self.write("ns.py",
+                          "STATE_FILE = 'state.json'\n"
+                          "snap = STATE_FILE.stat().st_mtime_ns\n")
+        self.assertEqual(lint.scan_file(path), [2])
+
+
+class IterFilesAndMain(TmpTreeTest):
+    def test_extensionless_bash_with_embedded_python_is_caught(self):
+        # Mirrors fleet-dispatcher: a bash shebang wrapping an embedded-Python
+        # heredoc. Selection must NOT be shebang-gated or this offender escapes.
+        self.write("fleet-dispatcher-like",
+                   "#!/usr/bin/env bash\n"
+                   "python3 - <<'PY'\n"
+                   "STATE_FILE = STATE / 'state.json'\n"
+                   "age = time.time() - STATE_FILE.stat().st_mtime\n"
+                   "PY\n")
+        self.assertEqual(_run_main(self.root), 1)
+
+    def test_tests_and_pycache_dirs_are_pruned(self):
+        self.write("tests/test_fixture.py",
+                   "STATE_FILE = 'state.json'\n"
+                   "m = STATE_FILE.stat().st_mtime\n")
+        self.write("__pycache__/cached.py",
+                   "STATE_FILE = 'state.json'\n"
+                   "m = STATE_FILE.stat().st_mtime\n")
+        self.assertEqual([p.name for p in lint.iter_files([self.root])], [])
+        self.assertEqual(_run_main(self.root), 0)
+
+    def test_non_python_extension_is_skipped(self):
+        # A .md carrying both tokens as prose must not be scanned.
+        self.write("notes.md", "reads state.json via p.stat().st_mtime\n")
+        self.assertEqual([p.name for p in lint.iter_files([self.root])], [])
+
+    def test_clean_tree_exits_zero(self):
+        self.write("fine.py", "m = p.stat().st_mtime  # display only, no state token\n")
+        self.assertEqual(_run_main(self.root), 0)
+
+
+class CommittedTree(unittest.TestCase):
+    def test_committed_fleet_tree_is_green(self):
+        # Acceptance: both real offenders (fleet-dispatcher, fleet-epic-status)
+        # carry the opt-out, so the ratchet passes on the committed tree.
+        self.assertEqual(_run_main(_FLEET_DIR), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `scripts/fleet/lint_state_mtime.py`: stdlib-only, pure-`pathlib` co-occurrence ratchet flagging a file that reads `.st_mtime` **and** references the scout cache (`state.json` / `STATE_JSON` / `STATE_FILE`) — the cross-line pattern ruff has no native rule for. Exits non-zero on any unsuppressed hit.
- Best-effort, not a hard ban: a justified read opts out with an inline `# lint: state-mtime-ok <reason>` comment (on, or immediately above, the line).
- Wired into `.github/workflows/quality.yml` right after `ruff check scripts/` (runs on the Windows runner).
- Seeded the two current readers (`fleet-dispatcher:1685`, `fleet-epic-status:108`) with the opt-out so the tree is green on landing.
- Test `scripts/fleet/tests/test_lint_state_mtime.py` (12 cases); `scripts/fleet/CLAUDE.md` + `scripts/bootstrap_linux.sh` note the ratchet.

## Test plan
- [x] `python scripts/fleet/lint_state_mtime.py scripts/fleet/` exits 0 on the committed tree (both offenders suppressed)
- [x] Negative control: an unsuppressed `.st_mtime`+`state.json` file exits 1 with the finding
- [x] `python scripts/fleet/tests/test_lint_state_mtime.py` — 12/12 pass (positive, display-negative, sort-negative, bare-mtime-param, suppressed trailing + line-above, `st_mtime_ns`, extension-less bash+embedded-python, tests//pycache pruning, .md skip, committed-tree-green)
- [x] `ruff check scripts/` clean (new `.py` auto-discovered; no `ruff.toml` edit)

## Notes for reviewer
Two deliberate departures from the `## Plan`, both to match reality:

1. **File selection is by extension (`.py` + extension-less), NOT shebang-gated.** `fleet-dispatcher` is a *bash* script whose embedded-Python heredoc carries the offending `.st_mtime` read — a shebang-based "Python file" filter would silently miss it. The co-occurrence heuristic is safe over bash because `.st_mtime` is Python attribute syntax that never appears in shell.
2. **Test registration.** Plan item 4 called for "ctest/pytest registration", but the sibling `scripts/fleet/tests/*.py` are standalone `unittest` files run directly (`python test_x.py`) — they are **not** CMake/ctest-registered and are not gated in CI today. I mirrored that actual pattern rather than inventing a registration that doesn't exist.
3. **Suppression reason wording.** The seed comment says `generated_at-first; mtime is the fallback` rather than the plan's "pending migration": both readers already prefer `generated_at` (mtime is only the documented malformed-snapshot fallback), so they are grandfathered-correct, not pending a migration.

Closes #2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)