### PR TITLE
fleet: dispatcher-assigned planning — retire the planning-claim contention machinery (#2197)

### DIFF
--- a/.fleet/plans/issue-2197.md
+++ b/.fleet/plans/issue-2197.md
@@ -1,0 +1,106 @@
+## Plan: fleet: dispatcher-assigned planning (retire the planning-claim contention machinery)
+
+- **Issue:** #2197
+- **Model:** opus — the design below is committed (no open judgment calls); implementation is bounded bash+python across the dispatcher fan-out loop with an existing test harness. Not sonnet: the dispatch loop's failure paths (claim-then-launch, error-path release, mode gating) are subtle enough to warrant opus.
+- **Date:** 2026-07-07
+
+### Scope
+
+Make the dispatcher hand a **specific, already-claimed** needs-plan issue to the planning dispatch, so no two concurrent planning dispatches can target the same issue — by construction, because a planning dispatch only exists after a successful sole-holder claim. Workers stop self-selecting planning work entirely. The `fleet:planning-*` label lock survives as a primitive (cross-host arbiter, TTL orphan reaper, architect path), but the *contention protocol* — N worker panes racing per tick and arbitrating after the fact — is retired.
+
+### Verified current state
+
+Confirmed by code read on `origin/master` (256d24f9):
+
+- **No per-item assignment exists anywhere in the dispatcher.** `build_dispatch_command` (`scripts/fleet/fleet-dispatcher:1182-1215`) emits exactly six args — `pane_key model effort role fallback mode` — and the wrap launches the generic `/role-worker live` prompt (`fleet-dispatch-wrap:178-183, 204`). The dispatcher header states the model outright: same command to every idle pane, `fleet-claim` arbitrates (`fleet-dispatcher:20-23, 1329-1335`).
+- **Same-tick planning fan-out is already capped at ~1 pane per class.** `_candidates` de-dups needs_plan to one yield per planning class (`fleet_task_class.py:263-269`), `count` caps the pane fan-out (`fleet-dispatcher:1379-1414`). So the issue body's "every idle pane" framing is slightly stale: the *residual* contention is (a) **every dispatched opus+ iteration runs role step 2 before pickup** — a tick that fires 3 opus panes for 3 opus *tasks* still produces 3 contenders for the same oldest needs-plan issue; (b) **cross-tick** races beyond the 90s `CLAIM_SETTLE_SECONDS` window; (c) **cross-host** — each host runs its own dispatcher (mac + windows claims both live in the queue today) and nothing partitions issues between them.
+- **The lock is a GitHub label, not a file.** `cmd_planning_claim` (`fleet-claim:1498-1547`) takes `fleet:planning-<host>-<agent>` via the shared lex-min `_acquire_label_on`/`_claim_decision` primitive; exit 0 = sole holder, 1 = lost, 2 = misuse (incl. `--replan` without `fleet:needs-plan` live), 3 = `## Plan` comment already exists. No heartbeat; orphans reaped only by the `cleanup --gh` fourth pass at `FLEET_CLAIM_STALE_SECS_PLANNING` = 3600s (`fleet-claim:1956-2003`), invoked from the scout on projection change (`fleet-state-scout:2701-2705`). Release removes only the caller's own host+agent label (`fleet-claim:1425-1449`) — re-claim by the same host+agent is idempotent (POST + sole-holder re-read → win).
+- **The scout is planning-lock-blind.** `needs_plan[]` is the raw `fleet:needs-plan` set, number-sorted (`fleet-state-scout:406-435`); the worker projection/slice filter only `human:owned/wip/no-plan` (`_HUMAN_GATE_LABELS`, `fleet-state-scout:394, 1622-1623, 2104-2106`). Trigger is edge-fired on set-membership hash (`update_role_trigger`, `fleet-state-scout:2330-2373`) with a periodic safety re-arm (`fleet-dispatcher:1266-1269, 1709-1748`).
+- **Sonnet light-plan routing is dispatch-side and label-authoritative**: `_plan_class` (`fleet_task_class.py:197-216`) → sonnet for `fleet:sonnet`-tagged issues, else fable degrading to opus when `count_active_for_class fable >= FLEET_CONCURRENCY_MODEL_FABLE` (default 1, **per host** — `fleet-dispatcher:166-169, 749-759`).
+- Races the machinery exists for: #1810 (3 duplicate plans, same tick) → lex-min lock (#1978/#2035); #1999 (3 panes re-derived a stale plan) → `--replan`.
+
+### Approach
+
+**Assignment IS the claim.** The dispatcher takes the existing planning claim itself — under the **target pane's worktree basename** — *before* dispatching, then passes the assignment into the iteration. Contenders drop from N panes × M hosts to M dispatchers (plus the interactive architect), and a dispatcher that loses a cross-host race simply assigns the *next* issue — a lost race becomes parallel planning of distinct issues instead of a burned worker iteration.
+
+Steps, in one PR:
+
+1. **`fleet_task_class.py`: add a `--plan-pick` mode and a 5th output field.**
+   - `python3 fleet_task_class.py --plan-pick <slice.json> <class> <fable-blocked 0|1>` prints ordered `repo:number` lines: the slice's `needs_plan[]` entries (already human-gate-filtered, engine-first/oldest-first) whose `_plan_class` == `<class>`.
+   - `resolve()`'s output line gains a 5th token: `<class> <effort> <more> <count> <plan 0|1>` — 1 when the elected class's candidate set includes its (single, per-class-deduped) needs_plan yield. The per-class de-dup **stays**: one planning assignment per class per tick is a deliberate serialization (planning is not the throughput bottleneck — issue body, candidate 1); parallelism across classes (sonnet light-plan alongside a fable heavy plan) is preserved. Multi-issue fan-out within a class is an explicit non-goal.
+   - Update the now-stale contention comment at `fleet_task_class.py:229-244`.
+2. **`fleet-dispatcher`: claim-then-assign in `dispatch_role`.** When the elected class has `plan == 1`, `DISPATCH_MODE == live`, and a pane is about to be dispatched for that class, iterate `--plan-pick` lines for the **first** pane only:
+   - `fleet-claim [--repo game] planning-claim <N> <pane-worktree-basename>` (basename via the existing `pane_current_path` helper; game namespace when the line's repo is `game`).
+   - **exit 0** → assigned; stop.
+   - **exit 3** (`## Plan` comment exists) → this is either already-planned-with-stale-slice or the re-plan state (plan-review bounce / stale-queued flip). Retry with `--replan`: **exit 0** → assigned as a re-plan; **exit 2** (no live `fleet:needs-plan`) → genuinely done, next line.
+   - **exit 1** (cross-host dispatcher or architect holds it) → next line.
+   - All lines exhausted → no assignment; subtract the planning candidate from the effective count, and if that leaves 0 claimable items of the elected class, skip the dispatch entirely (no no-op iteration).
+   - Append a 7th arg `plan=<repo>:<N>` in `build_dispatch_command` for the assigned pane; stamp `plan_issue` into the pane's dispatch record (`write_dispatch_record`) for `fleet-debug` observability.
+   - **Error-path release:** if the launch fails after a successful claim (tmux send error, occupied-pane skip), `planning-release` with the same basename before moving on.
+3. **`fleet-dispatch-wrap`: accept the optional 7th arg**, export `FLEET_PLAN_ISSUE=<repo>:<N>` (unset when absent). No prompt change — the role doc reads the env var.
+4. **Worker protocol (docs now, role docs when the human applies the gated edit):**
+   - `FLEET_PLAN_ISSUE` set → verify the issue still carries `fleet:needs-plan` live (if not: `planning-release`, skip); read the thread; post `## Plan`; swap `fleet:needs-plan` → `fleet:plan-review` (+ `human:review-plan` when high-stakes); `planning-release`. **No `planning-claim` call** — the dispatch arrives pre-claimed under this pane's own agent name, so release Just Works.
+   - `FLEET_PLAN_ISSUE` unset → **skip planning entirely.** This also deletes today's hidden tax where every task-elected opus+ iteration burns a claim attempt at step 2.
+   - Sonnet class: identical mechanics; the light-plan flow (`fleet-plan-lint`, self-queue on pass) is unchanged past the claim step.
+   - **Stale-queued-plan discovery simplifies:** the discoverer flips `fleet:queued` → `fleet:needs-plan`, comments why, and moves on — no lock, no inline re-derivation. The flip re-enters the issue into `needs_plan[]`, and the dispatcher's exit-3→`--replan` path routes the re-plan like any first plan. Workers never invoke `--replan` again.
+5. **Docs in the same PR** (non-gated): rewrite PLANNING-PROTOCOL.md step 0 (claim → assignment), the light-plan step 1, and §"Re-planning a stale queued plan" (flip-and-move-on contract); update the planning-lock prose in `fleet-labels-reference.md` and the `fleet-state-machine.json` transition note. No label is added or removed, so no catalog change.
+6. **File the gated follow-up** per TASK-FILING.md (no labels, `[no-plan]` token, noting it is gated self-config for the human to apply directly): rewrite `role-worker.md` step 2 / startup echo of `FLEET_PLAN_ISSUE`, and the `role-opus-reviewer.md:172` exit-3 note.
+
+**Retire / keep inventory** (the migration analysis the issue asks for):
+
+| Surface | Verdict |
+|---|---|
+| Worker-side `planning-claim` acquisition + exit-code protocol (role step 2, PLANNING-PROTOCOL step 0) | **Retired** — replaced by pre-claimed assignment |
+| Worker-side `--replan` flow (flip + lock + inline re-derive) | **Retired** — flip-and-move-on; dispatcher routes the re-plan |
+| `cmd_planning_claim` / `planning-release` / lex-min primitive (`fleet-claim`) | **Kept** — now called by the dispatcher (M contenders) + architect; unchanged code |
+| Exit-3 `## Plan` dedup early-out | **Kept** — the dispatcher's stale-slice guard |
+| `--replan` gating on live `fleet:needs-plan` | **Kept** — the dispatcher's re-plan-state discriminator |
+| TTL sweep (3600s, `cleanup --gh` pass 4) | **Kept** — orphan reaper for died iterations, unchanged |
+| `test_fleet_claim_planning.sh` | **Kept green** — primitive untouched |
+
+Deleting `cmd_planning_claim` outright is out of scope: the architect's interactive planning path (`role-opus-architect`, human-cued) legitimately races the dispatcher and needs the same mutex.
+
+### Interaction analysis
+
+- **Sonnet light-plan lane (#2192, merged):** `_plan_class` is reused verbatim by `--plan-pick`, so a `fleet:sonnet`-tagged issue is assigned to a sonnet dispatch and every other issue to fable/opus. Cross-class fan-out (`exclude` re-resolve) still serves a sonnet light-plan concurrently with a heavy plan — each carries its own assignment.
+- **Fable cap:** unchanged. `_plan_class`'s opus degrade on `fable_blocked` happens before assignment; the cap remains per-host (`count_active_for_class` reads local dispatch records) — a pre-existing property this design neither fixes nor worsens.
+- **Cross-repo:** `--plan-pick` lines carry the repo namespace; the dispatcher adds `--repo game` to `fleet-claim` for game issues. Slice ordering (engine-first, oldest-first within repo) is inherited, preserving today's priority.
+- **Cross-host:** the label claim is the shared coordination point (GitHub is the only cross-host state). Two dispatchers colliding on the oldest issue resolve by lex-min in one round; the loser assigns the next issue. No deterministic host partition is attempted — host liveness is dynamic and a down host would strand its partition.
+- **Architect:** keeps calling `planning-claim` directly; mutual exclusion with dispatcher assignments via the same primitive.
+- **API quota (Q1–Q4, #2219–#2222 in flight):** adds ≤3 REST calls per planning dispatch (claim, maybe `--replan` retry, rare release). At most one assignment per class per tick — negligible against the polling budget those tickets address; no overlap with their file surfaces (`fleet_gh_poll.py` / `fleet_poll_topology.py` contain no planning logic).
+- **Sibling PRs:** #2284 (open, approved) touches `fleet-up`/`fleet-babysit`/`install.sh` — disjoint from this PR's `fleet-dispatcher`/`fleet-dispatch-wrap`/`fleet_task_class.py` surface. #2192/#2195 are merged and reflected above. In-flight ingest work (#2110, #2196) touches `fleet-queue-ingest` only — no overlap.
+
+### One task or subtasks
+
+**One implementation task (this issue, one PR)** — scripts + tests + non-gated docs land together so code and protocol can't drift. Plus the **gated follow-up issue** from step 6 (human-applied; not fleet-queueable — every worker class hits the self-config gate deterministically). Ordering constraint between them is a hard rule, see Gotchas.
+
+### Affected files
+
+- `scripts/fleet/fleet_task_class.py` — `--plan-pick` mode; 5th output token; stale comment refresh
+- `scripts/fleet/fleet-dispatcher` — claim-then-assign loop in `dispatch_role`; 7th dispatch arg; `plan_issue` in dispatch records; error-path release; effective-count reduction on assignment failure
+- `scripts/fleet/fleet-dispatch-wrap` — optional 7th arg → `FLEET_PLAN_ISSUE` export
+- `scripts/fleet/tests/test_fleet_task_class.py` — `--plan-pick` cases (class routing, fable-degrade, repo ordering, human-gate filtering); 5-token output cases
+- `scripts/fleet/tests/test_dispatcher_class_dispatch.sh` — extend: assignment attached to first pane of elected class; claim-fail fallthrough; plan-only-tick skip; live-mode gating
+- `scripts/fleet/tests/test_dispatch_wrap_session.sh` — extend: `FLEET_PLAN_ISSUE` export present/absent
+- `docs/agents/PLANNING-PROTOCOL.md` — step 0 → assignment; light-plan step 1; re-plan section rewrite
+- `docs/agents/fleet-labels-reference.md`, `docs/agents/fleet-state-machine.json` — planning-lock prose/transition notes
+- *(gated follow-up, human-applied)* `.claude/commands/role-worker.md`, `.claude/commands/role-opus-reviewer.md`
+
+### Acceptance criteria
+
+- Given a slice with ≥1 needs-plan issue routed to class C, idle-pane headroom, and live mode: exactly one class-C dispatch carries `FLEET_PLAN_ISSUE` naming a specific issue, and the `fleet:planning-<host>-<basename>` label is on that issue **before** the claude process launches.
+- Claim-fail fallthrough works: a held oldest issue → the next issue is assigned; all held/planned → no assignment, and when planning was the elected class's only candidate, no dispatch fires.
+- Exit-3 + live `fleet:needs-plan` → assigned via `--replan`; exit-3 + exit-2 on retry → skipped (already done).
+- `dry-run` / `review-only` dispatches never pre-claim.
+- A launch failure after a successful claim releases the label in the same tick.
+- All existing dispatcher/task-class/claim tests stay green; `test_fleet_claim_planning.sh` unmodified.
+- After the gated role-doc edit is applied: worker iterations make zero `planning-claim` calls; iterations without `FLEET_PLAN_ISSUE` do no planning work.
+
+### Gotchas
+
+- **Deployment order is load-bearing.** Scripts-first is safe: an old-protocol worker that self-selects the assigned issue re-claims idempotently (same host+agent → exit 0) and plans it — correct, one redundant call. Role-docs-first is a **planning outage**: workers skip step 2 waiting for an env var no dispatcher sets. Land + deploy the scripts PR (dispatcher changes need a fleet bounce — in-process scout/dispatcher code doesn't hot-reload) before the human applies the gated edit.
+- **Claim under the pane's worktree basename, exactly.** `planning-release` recomputes `<host>-<agent>` from the caller; any other claim name (e.g. "dispatcher") makes the worker's release a no-op and every assignment leaks a 1-hour orphan.
+- **TTL reap doesn't flip the trigger hash** (label changes don't change needs-plan set membership). Re-dispatch after an orphan reap rides the periodic worker re-arm — existing behavior, but worth a test note so nobody "fixes" it into a hash input.
+- **The assigned issue can go stale between claim and read** (human closes it, architect plans it out-of-band). The worker's live `fleet:needs-plan` re-verify + release covers this; don't skip it.
+- **Engine-public wording** applies to the protocol docs — no game-side jargon in examples.
+

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -38,18 +38,41 @@ reviewed artifact.
 
 For each `fleet:needs-plan` issue:
 
-0. **Claim the issue before planning.** Take the planning lock —
-   `fleet-claim planning-claim <N> <your-agent-name>` — and **skip the issue if
-   it exits non-zero**: exit 3 means a `## Plan` comment already exists (someone
-   planned it on a prior tick), and exit 1 means another pane holds the lock.
-   Without an atomic claim, two opus panes that select the same oldest
-   needs-plan issue on one scout tick both see no plan yet and both plan it
-   (#1810 produced **three** duplicate plans for one issue — three wasted plan
-   rounds). A comment cross-check alone doesn't close the same-tick race (both
-   planners pass it before either posts a comment); the atomic claim does. (The
-   claim/dedup lock shipped in #1978/#2035 — the re-scope of #1889; use it, do
-   not hand-roll the check.) **Re-planning an already-planned task** that went
-   stale has its own guarded flow — see [§ Re-planning a stale queued plan](#re-planning-a-stale-queued-plan).
+0. **The claim arrives with the dispatch — do not take it yourself.**
+   Planning dispatches are **assignment-based** (#2197): the dispatcher
+   pre-claims one specific needs-plan issue (`fleet-claim planning-claim`,
+   under the target pane's worktree basename) *before* launching the
+   iteration, and hands it over as `FLEET_PLAN_ISSUE=<repo>:<N>` in the
+   environment.
+   - **`FLEET_PLAN_ISSUE` set** — that issue is yours, already locked. It can
+     have gone stale between claim and read (the human closed it, the
+     architect planned it out-of-band), so first verify `fleet:needs-plan` is
+     still live on the issue; if it is gone, release
+     (`fleet-claim planning-release <N> <your-agent-name>`, `--repo game`
+     for a `game:` assignment) and skip planning. Otherwise plan exactly that
+     issue (steps 1–3 below). Do **not** call `planning-claim` — the lock is
+     already held under your own worktree basename, so the step-3 release
+     Just Works.
+   - **`FLEET_PLAN_ISSUE` unset** — skip planning entirely and move on to
+     task pickup. Do not self-select a needs-plan issue from the cache; an
+     unassigned iteration has no claim and would only re-create the
+     contention this design retires.
+
+   The `fleet:planning-<host>-<agent>` label lock itself is unchanged — the
+   dispatcher and the interactive architect still take it through
+   `fleet-claim planning-claim`, and the same lex-min mutex arbitrates
+   dispatcher-vs-architect collisions (plus the 1-hour TTL reaper for
+   orphans). What #2197 retires is the *worker-side contention protocol*:
+   N panes racing per tick for the same oldest issue and arbitrating after
+   the fact (#1810's three duplicate plans; #1999's triple re-derive). A
+   planning dispatch now exists only after a successful sole-holder claim,
+   so two dispatches can never target the same issue by construction.
+   (Transition note: an old-protocol worker that still self-selects and calls
+   `planning-claim` under its own name re-claims its assignment idempotently
+   — same host+agent exits 0 — so the window between the scripts landing and
+   the gated role-doc edit is safe, just one redundant call.)
+   **Re-planning an already-planned task** that went stale is now
+   flip-and-move-on — see [§ Re-planning a stale queued plan](#re-planning-a-stale-queued-plan).
 
 1. **Read the full issue thread** — title, body, and every comment.
    The plan is often seeded in a comment, and the human may have left
@@ -266,59 +289,49 @@ the human only ever *adds* a label — the fleet manages every other transition.
 (The scout pulls a `human:revise-plan` issue back into the ingest set even though
 its stage labels would otherwise exclude it; see `_ingest_skipped`.) This affords
 the **pre-queue** stages only; an already-queued plan that has gone stale uses
-the race-guarded flow below.
+the flip-and-move-on flow below.
 
 ---
 
 ## Re-planning a stale queued plan
 
-A first plan and its claim are guarded by step 0. **A re-plan is not** — and that
-gap is its own race. A `fleet:queued` task whose already-committed plan goes
-**stale post-approval** (its blocker shipped a *different* design during review,
-so the committed `.fleet/plans/issue-<N>.md` / `## Plan` comment now cites a
-renamed/removed symbol or a superseded decision) needs a fresh plan. The trigger
-to re-plan lives **outside** the first-plan lock, so without a guard two opus
-panes can both judge the same queued task stale and both deep-investigate the
-refresh — #1999: #1960 was re-derived by three panes after #1958/PR #1974 shipped
-a different encoding (no clobber, ~1 opus iteration wasted each).
+A `fleet:queued` task whose already-committed plan goes **stale post-approval**
+(its blocker shipped a *different* design during review, so the committed
+`.fleet/plans/issue-<N>.md` / `## Plan` comment now cites a renamed/removed
+symbol or a superseded decision) needs a fresh plan. Historically the re-plan
+trigger lived outside the first-plan lock, so multiple panes could judge the
+same queued task stale and each deep-investigate the refresh (#1999: #1960
+re-derived by three panes). Under assignment-based planning (#2197) the
+contract is simpler:
 
-**The contract — re-flag and lock BEFORE any deep re-investigation.** The moment
-you judge a queued task's committed plan stale, and *before* spending an
-iteration re-deriving it:
+**Flip and move on.** The moment you judge a queued task's committed plan
+stale, and *without* spending the iteration re-deriving it:
 
-1. Flip the labels `fleet:queued → fleet:needs-plan`:
+1. Flip the labels `fleet:queued → fleet:needs-plan` and say why:
    ```
    gh issue edit <N> --repo <owner/repo> \
      --remove-label "fleet:queued" --add-label "fleet:needs-plan"
+   gh issue comment <N> --repo <owner/repo> \
+     --body "Plan stale: <what shipped differently and where> — flagging for re-plan."
    ```
-2. Take the re-plan lock with the trailing `--replan` flag:
-   ```
-   fleet-claim planning-claim <N> <your-agent-name> --replan
-   ```
-   - **Exit 0** — you own the re-plan. Re-investigate, then post a **fresh**
-     `## Plan` comment that notes it supersedes the prior plan (the prior comment
-     stays as audit trail; the implementer reads the most-recent `## Plan`
-     comment as authoritative). Then proceed as a normal plan: swap
-     `fleet:needs-plan → fleet:plan-review` and `planning-release`.
-   - **Exit 1** — another pane already owns the re-plan. Back off immediately, do
-     **not** investigate, pick a different task (the losing label self-removes;
-     nothing to clean up).
-   - **Exit 2** — misuse: `fleet:needs-plan` isn't currently on the issue.
-     `--replan` requires it (step 1 sets it) so a re-plan can't grab a
-     freshly-planned or never-re-flagged issue. Re-check the label state.
+2. **Move on to other work.** No lock, no inline re-derivation. The flip
+   re-enters the issue into `needs_plan[]`; the dispatcher routes the re-plan
+   like any first plan — its claim walk hits the `## Plan`-comment dedup
+   (exit 3), retries with `--replan` (which gates on the live
+   `fleet:needs-plan` you just set), and hands the assignment to a fresh
+   planning dispatch. Workers never invoke `--replan` themselves.
 
-`--replan` exists because plain `planning-claim` would refuse a re-plan: a stale
-queued plan *has* a `## Plan` comment by definition, so the step-0 dedup early-out
-returns exit 3 to *every* planner — leaving the re-plan both unguarded **and**
-stranded until someone hand-deletes the old comment. `--replan` skips that
-comment-presence early-out (a re-plan expects a prior plan) and instead gates on
-the `fleet:needs-plan` label you set in step 1, so the lex-min lock arms for
-re-plans and guarantees a sole holder — exactly like a first plan.
+The re-planner (the assigned dispatch) posts a **fresh** `## Plan` comment that
+notes it supersedes the prior plan (the prior comment stays as audit trail; the
+implementer reads the most-recent `## Plan` comment as authoritative), then
+proceeds as a normal plan: swap `fleet:needs-plan → fleet:plan-review` and
+`planning-release`.
 
-> The `role-worker.md` echo of this contract ("judge a queued plan stale → flip
-> `fleet:queued → fleet:needs-plan` + `planning-claim --replan` before
-> investigating") is **gated self-config** and is a human follow-up — this doc is
-> the worker-applicable half.
+`--replan` survives as a **dispatcher/architect primitive** because plain
+`planning-claim` refuses an issue with an existing `## Plan` comment (the dedup
+early-out, exit 3) — a re-plan *expects* a prior plan, so the flag skips that
+early-out and instead gates on the live `fleet:needs-plan` label, keeping the
+lex-min lock armed for re-plans exactly like first plans.
 
 ---
 
@@ -365,11 +378,14 @@ take this path; if it isn't already tagged, it plans on the default (opus+)
 flow. The dispatcher routes a `fleet:sonnet`-tagged needs-plan issue to the
 sonnet lane automatically (`fleet_task_class._plan_class`).
 
-**[worker, sonnet class]** For the oldest `fleet:sonnet`-tagged needs-plan
-issue:
+**[worker, sonnet class]** For the `fleet:sonnet`-tagged needs-plan issue the
+dispatch names:
 
-1. **Claim it** — `fleet-claim planning-claim <N> <your-agent-name>` (same lock
-   as the opus path; skip if a `## Plan` comment already exists or exit 3).
+1. **The claim arrives with the dispatch** (`FLEET_PLAN_ISSUE=<repo>:<N>` —
+   step 0 of "The flow", same assignment mechanics as the opus path; the
+   dispatcher routes a `fleet:sonnet`-tagged issue to a sonnet dispatch). No
+   `planning-claim` call: verify `fleet:needs-plan` is still live, release and
+   skip if not; with `FLEET_PLAN_ISSUE` unset, do no planning at all.
 2. **Read the thread** (`fleet-issue view <N>`). A mechanical task needs the
    issue read, not a deep code investigation — if you find yourself needing a
    cross-system audit or a repro spike to write the plan, it is **not**
@@ -414,12 +430,11 @@ tag is a starting hypothesis, not a one-way door.
 
 ## Role-specific notes
 
-**[worker, opus+ classes]** The cached `repos.engine.needs_plan[]` and
-`repos.game.needs_plan[]` arrays hold the open needs-plan issues; pick
-the oldest unprocessed entry (smallest `number`) across both repos.
-This runs as a scout-triggered loop step — see the worker role file
-for where it sits in the iteration. Cross-repo: add `--repo game` to
-`fleet-issue` / `gh issue edit` for game-side issues. You post the
+**[worker, opus+ classes]** The dispatch names your issue:
+`FLEET_PLAN_ISSUE=<repo>:<N>`, pre-claimed by the dispatcher (step 0). You do
+not pick from the cached `needs_plan[]` arrays — an iteration without an
+assignment does no planning. Cross-repo: a `game:` assignment takes
+`--repo game` on `fleet-issue` / `gh issue edit` / `fleet-claim`. You post the
 `## Plan` comment and swap to `fleet:plan-review`; for **high-stakes** issues
 (step 3 checklist) also add `human:review-plan` in the same edit. The
 implementation step (later, possibly a cheaper-class worker on another host)

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -90,10 +90,13 @@ Specifically, **never pass these via `--label` when filing**:
 - `fleet:needs-plan` — owned by **`fleet-queue-ingest`** as a triage state.
   Set (in place of `fleet:queued`) when an `human:approved` issue has no
   `## Plan` comment and is not opted out — the issue must be planned before it
-  can queue. An opus+ planner (worker or opus-architect, via
-  [`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) / the `file-epic` skill) posts
-  the `## Plan` comment and swaps this label for `fleet:plan-review`. Workers
-  skip issues carrying this label. Don't add manually.
+  can queue. A planner — a **dispatcher-assigned** worker iteration
+  (`FLEET_PLAN_ISSUE`, pre-claimed via `fleet:planning-*`, #2197) or the
+  opus-architect on request, via
+  [`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) / the `file-epic` skill —
+  posts the `## Plan` comment and swaps this label for `fleet:plan-review`.
+  Workers skip issues carrying this label and never self-select one to plan.
+  Don't add manually.
 - `fleet:plan-review` — owned by the **planner** (sets it, swapping out
   `fleet:needs-plan`, once the `## Plan` comment is posted) and the **plan
   reviewer** (the architect, or the opus-reviewer loop — clears it). While
@@ -136,8 +139,8 @@ Specifically, **never pass these via `--label` when filing**:
   into the ingest set via `_ingest_skipped` even though its stage labels would
   otherwise exclude it, so adding the label both fires ingest and surfaces it in
   `pending_issues`. Pre-queue stages only — an already-queued stale plan uses the
-  race-guarded re-plan flow (PLANNING-PROTOCOL.md §"Re-planning a stale queued
-  plan"). A fleet agent never applies it (`human:*` by convention).
+  flip-and-move-on re-plan flow (PLANNING-PROTOCOL.md §"Re-planning a stale
+  queued plan"). A fleet agent never applies it (`human:*` by convention).
 - `human:no-plan` — owned by the **human**, applied at filing to a simple,
   self-contained issue to skip planning entirely. `fleet-queue-ingest` then
   stamps `fleet:queued` directly — no `## Plan` comment required — and the
@@ -356,6 +359,22 @@ Specifically, **never pass these via `--label` when filing**:
   reviewer touches an in-flight diff. The scout's `fleet-claim cleanup
   --gh` pass sweeps labels older than 30 min and replays orphan
   sentinels. Don't add manually; don't add to issues.
+- `fleet:planning-<host>-<agent>` — owned by the **`fleet-claim`
+  script** (atomic planning-claim primitive; same sole-holder lex-min
+  claim as `fleet:reviewing-`), applied to the **issue** being planned.
+  Under assignment-based planning (#2197) it is taken by the
+  **dispatcher** *before* a planning dispatch launches — under the
+  target pane's worktree basename — and handed to the iteration as
+  `FLEET_PLAN_ISSUE=<repo>:<N>`; the worker never calls
+  `fleet-claim planning-claim` itself and releases with
+  `fleet-claim planning-release` after the `fleet:plan-review` swap.
+  The interactive **architect** is the other legitimate taker (it plans
+  on human request and calls `planning-claim` directly); the shared
+  mutex arbitrates dispatcher-vs-architect collisions. Orphans (a died
+  iteration, a hard-killed pane) are swept by `fleet-claim cleanup
+  --gh` on a 1-hour TTL (`FLEET_CLAIM_STALE_SECS_PLANNING`), and
+  fleet-dispatch-wrap releases the label itself when a session-resume
+  discards the fresh assignment. Don't add manually.
 - `fleet:human-amending` / `fleet:human-deferred` — owned by the
   **author worker** (any class) when picking up
   `human:needs-fix`. The two labels express which disposition the

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -481,7 +481,7 @@
       "add": [
         "fleet:plan-review"
       ],
-      "note": "Planner posted the ## Plan comment and hands it to review. PLANNING-PROTOCOL.md step 3. Release the planning-claim lock after."
+      "note": "Planner posted the ## Plan comment and hands it to review. PLANNING-PROTOCOL.md step 3. Release the planning-claim lock after — the lock was pre-taken by the dispatcher under this pane's worktree basename (assignment-based planning, #2197), so the planner only ever releases, never claims."
     },
     {
       "name": "plan-propose-high-stakes",

--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -426,9 +426,9 @@ child for them (adds `fleet:needs-plan`, strips stale stage labels, keeps
 
 > **Stale child before it's worked?** If a filed child's plan goes stale
 > (a predecessor shipped a different design than its `## Plan` assumed) before
-> the child is claimed, it re-plans through the guarded re-plan flow — flip
-> `fleet:queued → fleet:needs-plan` and take `planning-claim --replan` before
-> re-investigating. See
+> the child is claimed, it re-plans through the flip-and-move-on flow — flip
+> `fleet:queued → fleet:needs-plan`, comment why, and move on; the dispatcher
+> assigns the re-plan to a fresh planning dispatch (#2197). See
 > [`PLANNING-PROTOCOL.md § Re-planning a stale queued plan`](../PLANNING-PROTOCOL.md#re-planning-a-stale-queued-plan)
 > (#1999). `file-epic` does not re-file the child.
 

--- a/scripts/fleet/fleet-common.sh
+++ b/scripts/fleet/fleet-common.sh
@@ -147,6 +147,23 @@ fleet_install_refresh() {
     touch "$stamp" 2>/dev/null || true
 }
 
+# fleet_planning_release_assignment "<repo>:<N>" <agent> — release a
+# planning-claim label taken under <agent> for a dispatcher planning
+# assignment (#2197). Shared by fleet-dispatcher (launch failed after a
+# successful pre-claim) and fleet-dispatch-wrap (a session-resume discards
+# the fresh assignment). Best-effort by design: both callers sit on discard
+# paths where a failed release only means the claim waits for the 1-hour
+# TTL reaper instead.
+fleet_planning_release_assignment() {
+    local line="$1" agent="$2"
+    local repo="${line%%:*}" num="${line##*:}"
+    if [[ "$repo" == "game" ]]; then
+        fleet-claim --repo game planning-release "$num" "$agent" >/dev/null 2>&1 || true
+    else
+        fleet-claim planning-release "$num" "$agent" >/dev/null 2>&1 || true
+    fi
+}
+
 # fleet_install_maybe_refresh [main-clone-root] — the guarded entry point both
 # hooks call. Stale-check first (sub-ms common path); if stale, take an atomic
 # mkdir-lock (same primitive fleet-claim uses; NOT flock, absent on macOS) so

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -14,6 +14,12 @@
 #                 runs the standby path, not a live task-pickup iteration
 #                 (#2022). Absent/unrecognized → live (an older dispatcher
 #                 that passes only 5 args keeps today's behavior).
+#   $7  plan      optional pre-claimed planning assignment from the
+#                 dispatcher, `plan=<repo>:<N>` (#2197). Exported as
+#                 FLEET_PLAN_ISSUE so the role iteration plans exactly that
+#                 issue (already claimed under this pane's worktree basename)
+#                 and releases the claim when done. Absent → unset — the
+#                 iteration does no planning work.
 #
 # On usage-limit exit (exit code 2), writes a Unix-epoch timestamp to
 # ~/.fleet/state/rate-limit/<pane_key>.ts. fleet-dispatcher checks that
@@ -41,6 +47,16 @@ case "$_mode_arg" in
     *) ROLE_MODE="live" ;;
 esac
 unset _mode_arg
+# Optional 7th arg (#2197): the dispatcher's pre-claimed planning assignment,
+# `plan=<repo>:<N>`. Require the full `plan=`-prefixed non-empty form — a bare
+# `plan=` (or garbage) must NOT export an empty FLEET_PLAN_ISSUE that
+# downstream `[[ -n ]]` guards would misread (the dual-spelling lesson,
+# scripts/fleet/CLAUDE.md).
+_plan_arg="${7:-}"
+if [[ "$_plan_arg" == plan=?* ]]; then
+    export FLEET_PLAN_ISSUE="${_plan_arg#plan=}"
+fi
+unset _plan_arg
 # Track fleet-dispatcher's STATE_DIR via the same env-var override so a
 # config change in one place propagates to both scripts.
 STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
@@ -57,7 +73,10 @@ if [[ -f "$_FLEET_COMMON_SH" ]]; then
     # shellcheck source=/dev/null
     source "$_FLEET_COMMON_SH"
 else
-    fleet_install_maybe_refresh() { :; }  # helper not installed yet — no-op
+    fleet_install_maybe_refresh() { :; }  # helpers not installed yet — no-op
+    # No-op release degrades a discarded planning assignment (#2197) to the
+    # 1-hour TTL reaper — the same failure budget as the dispatcher's copy.
+    fleet_planning_release_assignment() { :; }
 fi
 unset _FLEET_COMMON_SH
 
@@ -165,6 +184,17 @@ if (( _resume_role )) && [[ -f "$SIDECAR" ]]; then
     fi
 fi
 
+# A resume reloads the prior session and discards this dispatch's fresh config
+# — including any planning assignment (#2197). Release the pre-claim now,
+# under the same worktree basename the dispatcher claimed with, rather than
+# stranding the label for the 1-hour TTL reaper; the issue re-enters
+# assignment on a later tick once this resumed iteration finishes.
+if (( RESUMED )) && [[ -n "${FLEET_PLAN_ISSUE:-}" ]]; then
+    fleet_planning_release_assignment "$FLEET_PLAN_ISSUE" "$worktree_name"
+    echo "fleet-dispatch-wrap: resume discards planning assignment $FLEET_PLAN_ISSUE — released" >&2
+    unset FLEET_PLAN_ISSUE
+fi
+
 # --fallback-model only exists in print mode, which is exactly this path. When
 # the dispatcher hands us a chain (fresh fable dispatch), claude retries on the
 # fallback model(s) if $MODEL is overloaded. Resume targets one specific session,
@@ -189,9 +219,11 @@ else
 fi
 
 # Test hook: print the resolved launch decision + argv and exit before spawning
-# claude (mirrors fleet-babysit's FLEET_BABYSIT_PRINT_LAUNCH).
+# claude (mirrors fleet-babysit's FLEET_BABYSIT_PRINT_LAUNCH). `plan=` mirrors
+# the FLEET_PLAN_ISSUE export (empty when no assignment / discarded by resume).
 if [[ -n "${FLEET_DISPATCH_PRINT_LAUNCH:-}" ]]; then
-    printf 'resumed=%s prompt=%s argv=claude %s\n' "$RESUMED" "$PROMPT" "${CLAUDE_ARGS[*]}"
+    printf 'resumed=%s plan=%s prompt=%s argv=claude %s\n' \
+        "$RESUMED" "${FLEET_PLAN_ISSUE:-}" "$PROMPT" "${CLAUDE_ARGS[*]}"
     exit 0
 fi
 

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -100,6 +100,15 @@ if [[ -f "$FLEET_LIB_DIR/fleet-clone-freshness.sh" ]]; then
 else
     advance_main_clone() { :; }  # helper not installed yet — no-op
 fi
+# Shared fleet-claim helpers (fleet_planning_release_assignment). A missing
+# file degrades the error-path release to a no-op — the 1-hour planning TTL
+# reaper covers the leaked claim, same failure budget as the wrap's copy.
+if [[ -f "$FLEET_LIB_DIR/fleet-common.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$FLEET_LIB_DIR/fleet-common.sh"
+else
+    fleet_planning_release_assignment() { :; }
+fi
 
 # --- Per-role concurrency cap config ---------------------------------------
 #
@@ -714,6 +723,19 @@ pane_id_to_key() {
     printf 'pane-%s\n' "${1#%}"
 }
 
+# Basename of a pane's current working directory — the worktree name
+# (`worker-1` … `worker-4`) fleet panes sit in, which is also the agent
+# name fleet-claim locks are held under. The planning pre-claim (#2197)
+# must claim under EXACTLY this name: the dispatched worker releases
+# with its own worktree basename, so any other claim name would make
+# that release a no-op and leak a 1-hour orphan to the TTL reaper.
+pane_worktree_basename() {
+    local wt_path
+    wt_path=$(tmux display-message -t "$1" -p '#{pane_current_path}' 2>/dev/null || true)
+    [[ -n "$wt_path" ]] || return 1
+    basename "$wt_path"
+}
+
 dispatch_record() {
     # $1 = pane_id (e.g. `%3`)
     printf '%s\n' "$DISPATCH_DIR/$(pane_id_to_key "$1").json"
@@ -722,13 +744,16 @@ dispatch_record() {
 write_dispatch_record() {
     # $3 = model class of the dispatch (fable|opus|sonnet) — counted by
     # count_active_for_class for the fable concurrency cap.
-    local role="$1" pane_id="$2" class="${3:-}"
-    local ts epoch
+    # $4 = optional pre-claimed planning assignment ("<repo>:<N>", #2197),
+    # stamped as `plan_issue` for fleet-debug observability.
+    local role="$1" pane_id="$2" class="${3:-}" plan_issue="${4:-}"
+    local ts epoch extra=""
     ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     epoch=$(date +%s)   # read back by cleanup_stale_dispatches for the empty-exit streak
+    [[ -n "$plan_issue" ]] && extra=$(printf ',"plan_issue":"%s"' "$plan_issue")
     mkdir -p "$DISPATCH_DIR"
-    printf '{"role":"%s","pane":"%s","class":"%s","dispatched_at":"%s","dispatched_epoch":%s}\n' \
-        "$role" "$pane_id" "$class" "$ts" "$epoch" >"$(dispatch_record "$pane_id")"
+    printf '{"role":"%s","pane":"%s","class":"%s","dispatched_at":"%s","dispatched_epoch":%s%s}\n' \
+        "$role" "$pane_id" "$class" "$ts" "$epoch" "$extra" >"$(dispatch_record "$pane_id")"
 }
 
 # Map a concrete model string back to its class name, for stamping
@@ -1195,9 +1220,13 @@ build_dispatch_command() {
     # on command lines, so the eaten space is harmless.
     # $3/$4 = optional model/effort overrides from per-task class
     # resolution (resolve_worker_class); empty -> the role defaults.
+    # $5 = optional pre-claimed planning assignment ("<repo>:<N>", #2197);
+    # non-empty appends a 7th `plan=<repo>:<N>` arg that fleet-dispatch-wrap
+    # exports as FLEET_PLAN_ISSUE.
     local role="$1" pane_key="$2"
     local model="${3:-${ROLE_MODEL[$role]:-sonnet}}"
     local effort="${4:-${ROLE_EFFORT[$role]:-high}}"
+    local plan="${5:-}"
     # Fable-class dispatches carry the fallback chain so claude degrades
     # per-iteration (--fallback-model, print-mode only) if Fable stops
     # being available mid-session. Other classes get no fallback:
@@ -1210,8 +1239,14 @@ build_dispatch_command() {
     # which role mode to run — `/role-<role> <mode>` — so a dry-run boot runs the
     # standby path, not a live task-pickup iteration. Live → "live", identical to
     # the prior hard-coded behavior.
-    printf ' fleet-dispatch-wrap %q %q %q %q %q %q\n' \
-        "$pane_key" "$model" "$effort" "$role" "$fallback" "${DISPATCH_MODE:-live}"
+    if [[ -n "$plan" ]]; then
+        printf ' fleet-dispatch-wrap %q %q %q %q %q %q %q\n' \
+            "$pane_key" "$model" "$effort" "$role" "$fallback" \
+            "${DISPATCH_MODE:-live}" "plan=$plan"
+    else
+        printf ' fleet-dispatch-wrap %q %q %q %q %q %q\n' \
+            "$pane_key" "$model" "$effort" "$role" "$fallback" "${DISPATCH_MODE:-live}"
+    fi
 }
 
 # Resolve the model class for a worker-lane dispatch from the lane's
@@ -1227,7 +1262,7 @@ resolve_worker_class() {
     # re-resolve in dispatch_role, after a class is found cap-saturated).
     local exclude="${2:-}"
     DISPATCH_CLASS="" DISPATCH_MODEL="" DISPATCH_EFFORT=""
-    DISPATCH_MORE=0 DISPATCH_DEFER=0 DISPATCH_COUNT=""
+    DISPATCH_MORE=0 DISPATCH_DEFER=0 DISPATCH_COUNT="" DISPATCH_PLAN=0
     local lane_default="${WORKER_LANE_DEFAULT_CLASS[$role]:-}"
     [[ -n "$lane_default" ]] || return 0
     local slice="$STATE_DIR/projections/$role.json"
@@ -1244,8 +1279,8 @@ resolve_worker_class() {
         return 0
     fi
     [[ -n "$out" ]] || return 0
-    local cls effort more count
-    read -r cls effort more count <<< "$out"
+    local cls effort more count plan
+    read -r cls effort more count plan <<< "$out"
     DISPATCH_CLASS="$cls"
     DISPATCH_MODEL="${CLASS_MODEL[$cls]:-}"
     DISPATCH_EFFORT="$effort"
@@ -1254,6 +1289,90 @@ resolve_worker_class() {
     # Older slices / the '' fallthrough leave it empty (uncapped). Validate so a
     # malformed value can't corrupt the cap arithmetic under `set -u`.
     [[ "$count" =~ ^[0-9]+$ ]] && DISPATCH_COUNT="$count"
+    # The elected class's count includes its needs-plan yield: dispatch_role
+    # pre-claims a specific issue (plan_assign_for_pane) and hands the
+    # assignment to the dispatch (#2197). Validated like `count`. Explicit
+    # `if` — a `[[ ]] &&` here would fail the function on plan=0 and, as its
+    # last command, abort the whole daemon under `set -e`.
+    if [[ "$plan" == "1" ]]; then
+        DISPATCH_PLAN=1
+    fi
+}
+
+# --- Planning pre-claim (#2197) --------------------------------------------
+#
+# Assignment IS the claim: when the elected class's claimable count includes a
+# needs-plan yield (DISPATCH_PLAN=1), the dispatcher takes the existing
+# planning-claim label lock itself — under the target pane's worktree
+# basename — BEFORE dispatching, and hands the assignment into the iteration
+# as `plan=<repo>:<N>` (FLEET_PLAN_ISSUE). A planning dispatch therefore only
+# exists after a successful sole-holder claim, so two concurrent planning
+# dispatches can never target the same issue; contenders drop from N panes x
+# M hosts to the M dispatchers plus the interactive architect, and a lost
+# cross-host race just assigns the NEXT candidate line instead of burning a
+# worker iteration on post-hoc arbitration.
+
+# Result of the most recent plan_assign_for_pane call: "<repo>:<N>" when a
+# claim was granted, empty otherwise.
+PLAN_ASSIGNMENT=""
+
+# Attempt to pre-claim one needs-plan issue of the elected class for the pane
+# about to be dispatched. $1 = role, $2 = the pane's worktree basename (the
+# claim agent name — see pane_worktree_basename). Never pre-claims outside
+# live mode: dry-run/review-only iterations skip planning, so a claim there
+# would only strand a label for the TTL reaper.
+plan_assign_for_pane() {
+    local role="$1" agent="$2"
+    PLAN_ASSIGNMENT=""
+    [[ "$DISPATCH_MODE" == "live" ]] || return 0
+    [[ -n "$DISPATCH_CLASS" ]] || return 0
+    local slice="$STATE_DIR/projections/$role.json"
+    [[ -f "$slice" ]] || return 0
+    local fable_blocked=0
+    if (( $(count_active_for_class fable) >= FABLE_CONCURRENCY_CAP )); then
+        fable_blocked=1
+    fi
+    local picks
+    picks=$(python3 "$FLEET_LIB_DIR/fleet_task_class.py" --plan-pick \
+        "$slice" "$DISPATCH_CLASS" "$fable_blocked" 2>/dev/null) || picks=""
+    [[ -n "$picks" ]] || return 0
+    local line repo num rc
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        repo="${line%%:*}"
+        num="${line##*:}"
+        [[ "$num" =~ ^[0-9]+$ ]] || continue
+        # exit 0 = sole holder (assigned); 1 = a cross-host dispatcher or the
+        # architect holds it (next line); 3 = a `## Plan` comment already
+        # exists — either a stale slice (already planned + queued) or the
+        # re-plan state (plan-review bounce / stale-queued flip re-entered it
+        # into needs_plan). Disambiguate with --replan, which gates on a LIVE
+        # fleet:needs-plan label: exit 0 = assigned as a re-plan, exit 2 = the
+        # label is gone, genuinely done — next line.
+        rc=0
+        if [[ "$repo" == "game" ]]; then
+            fleet-claim --repo game planning-claim "$num" "$agent" >/dev/null 2>&1 || rc=$?
+        else
+            fleet-claim planning-claim "$num" "$agent" >/dev/null 2>&1 || rc=$?
+        fi
+        if (( rc == 0 )); then
+            PLAN_ASSIGNMENT="$line"
+            return 0
+        fi
+        if (( rc == 3 )); then
+            rc=0
+            if [[ "$repo" == "game" ]]; then
+                fleet-claim --repo game planning-claim "$num" "$agent" --replan >/dev/null 2>&1 || rc=$?
+            else
+                fleet-claim planning-claim "$num" "$agent" --replan >/dev/null 2>&1 || rc=$?
+            fi
+            if (( rc == 0 )); then
+                PLAN_ASSIGNMENT="$line"
+                return 0
+            fi
+        fi
+    done <<< "$picks"
+    return 0
 }
 
 # Returns 0 (should re-arm) iff the resolver would dispatch a CONCRETE class for
@@ -1327,12 +1446,15 @@ dispatch_role() {
     # single-flighted the role because the dispatch record was keyed
     # by role name and only the first idle pane was ever picked.
     #
-    # No coordination needed at dispatch time: each iteration runs the
-    # same role command, and the role-doc logic uses fleet-claim to
+    # TASK coordination stays claim-side: each iteration runs the same
+    # role command, and the role-doc logic uses fleet-claim to
     # atomically claim work — only one pane can claim a given task,
     # the others find nothing actionable and exit. If there are fewer
     # actionable items than idle panes, the surplus panes simply
-    # iterate-and-exit cheaply.
+    # iterate-and-exit cheaply. PLANNING is the exception: the
+    # dispatcher pre-claims a specific needs-plan issue and hands the
+    # assignment to exactly one pane (#2197, see plan_assign_for_pane),
+    # so planning dispatches never contend for the same issue.
     local idle_panes
     idle_panes=$(find_idle_panes_for_role "$role")
     if [[ -z "$idle_panes" ]]; then
@@ -1404,6 +1526,7 @@ dispatch_role() {
 
     local dispatched=0
     local gap_blocked=""
+    local plan_attempted=""
     while IFS= read -r pane_id; do
         [[ -n "$pane_id" ]] || continue
         # Claimable-count cap: stop once this tick's launches have filled the
@@ -1445,10 +1568,46 @@ dispatch_role() {
             gap_blocked=1
             break
         fi
+        # Planning pre-claim (#2197): the first pane launched on a live-mode
+        # planning tick carries a pre-claimed needs-plan assignment. Attempted
+        # here — after every skip/stagger gate above — so a claim is never
+        # taken for a pane that then doesn't launch this tick.
+        local plan_arg=""
+        if (( DISPATCH_PLAN )) && [[ -z "$plan_attempted" && "$DISPATCH_MODE" == "live" ]]; then
+            local pane_basename
+            if pane_basename=$(pane_worktree_basename "$pane_id"); then
+                plan_attempted=1
+                plan_assign_for_pane "$role" "$pane_basename"
+                if [[ -n "$PLAN_ASSIGNMENT" ]]; then
+                    plan_arg="$PLAN_ASSIGNMENT"
+                    unset "CAP_DEFER_LOGGED[$role-planheld]"
+                else
+                    # Every candidate is held by another dispatcher/architect
+                    # or already planned: the planning slot in DISPATCH_COUNT
+                    # is not claimable this tick. Shrink the headroom by that
+                    # slot; when planning was the only remaining claimable
+                    # item, skip the dispatch entirely — a worker without an
+                    # assignment does no planning, so it would only
+                    # iterate-and-exit. The trigger stays: a posted plan or a
+                    # released claim re-fires the projection.
+                    (( claim_headroom > 0 )) && claim_headroom=$((claim_headroom - 1))
+                    if (( claim_headroom >= 0 && dispatched >= claim_headroom )); then
+                        if (( dispatched == 0 )); then
+                            if [[ -z "${CAP_DEFER_LOGGED[$role-planheld]+x}" ]]; then
+                                log "$role: class=$DISPATCH_CLASS planning candidates all held elsewhere or already planned; nothing else claimable — trigger kept"
+                                CAP_DEFER_LOGGED["$role-planheld"]=1
+                            fi
+                            return
+                        fi
+                        break
+                    fi
+                fi
+            fi
+        fi
         local cmd
-        cmd=$(build_dispatch_command "$role" "$pane_key" "$DISPATCH_MODEL" "$DISPATCH_EFFORT")
+        cmd=$(build_dispatch_command "$role" "$pane_key" "$DISPATCH_MODEL" "$DISPATCH_EFFORT" "$plan_arg")
         if [[ -n "$DISPATCH_CLASS" ]]; then
-            log "dispatching $role -> $pane_id [class=$DISPATCH_CLASS effort=$DISPATCH_EFFORT]"
+            log "dispatching $role -> $pane_id [class=$DISPATCH_CLASS effort=$DISPATCH_EFFORT${plan_arg:+ plan=$plan_arg}]"
         else
             log "dispatching $role -> $pane_id"
         fi
@@ -1479,10 +1638,17 @@ dispatch_role() {
         # remains as defense-in-depth.
         if ! dispatch_send_keys -t "$pane_id" C-u "$cmd" C-m; then
             log "send-keys timeout/failed for $role -> $pane_id; trying next idle pane"
+            # Error-path release: the launch failed AFTER a successful
+            # planning pre-claim. Release under the same basename (any other
+            # name would no-op) and let the next pane re-attempt the claim.
+            if [[ -n "$plan_arg" ]]; then
+                fleet_planning_release_assignment "$plan_arg" "$pane_basename"
+                plan_attempted=""
+            fi
             continue
         fi
         write_dispatch_record "$role" "$pane_id" \
-            "${DISPATCH_CLASS:-$(class_of_model "${ROLE_MODEL[$role]:-sonnet}")}"
+            "${DISPATCH_CLASS:-$(class_of_model "${ROLE_MODEL[$role]:-sonnet}")}" "$plan_arg"
         LAST_DISPATCH_EPOCH=$now_epoch
         dispatched=$((dispatched + 1))
     done <<< "$idle_panes"
@@ -1916,9 +2082,11 @@ case "${1:-}" in
     --resolve-class)
         # Test/debug: run the per-task class resolution for a worker lane
         # against the current projection slice and print the verdict:
-        #   "class=<c> model=<m> effort=<e> more=<0|1> defer=<0|1> count=<n>"
+        #   "class=<c> model=<m> effort=<e> more=<0|1> defer=<0|1> count=<n> plan=<0|1>"
         # Empty class means the lane-default fallthrough; count is the number of
-        # claimable items of the elected class (empty when class is empty).
+        # claimable items of the elected class (empty when class is empty);
+        # plan=1 means that count includes the class's needs-plan yield (the
+        # dispatch would carry a pre-claimed assignment, #2197).
         # Optional $3 = comma-separated classes to exclude (the cross-class
         # fan-out re-resolve — serve another class when the elected one is
         # cap-saturated).
@@ -1927,7 +2095,27 @@ case "${1:-}" in
             exit 2
         fi
         resolve_worker_class "$2" "${3:-}"
-        echo "class=$DISPATCH_CLASS model=$DISPATCH_MODEL effort=$DISPATCH_EFFORT more=$DISPATCH_MORE defer=$DISPATCH_DEFER count=$DISPATCH_COUNT"
+        echo "class=$DISPATCH_CLASS model=$DISPATCH_MODEL effort=$DISPATCH_EFFORT more=$DISPATCH_MORE defer=$DISPATCH_DEFER count=$DISPATCH_COUNT plan=$DISPATCH_PLAN"
+        exit 0
+        ;;
+    --plan-assign)
+        # Test/debug: run the class resolution + planning pre-claim exactly as
+        # a live dispatch tick would for <role>, claiming under <agent>.
+        # Resolves DISPATCH_MODE from the boot sentinel first (the same gate
+        # dispatch_role applies — dry-run/review-only never pre-claim). Prints
+        # "plan=<repo>:<N>" when a claim was granted, "plan=" otherwise.
+        # Invokes `fleet-claim` from PATH — tests stub it (hermetic, per
+        # scripts/fleet/CLAUDE.md).
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --plan-assign <role> <agent>" >&2
+            exit 2
+        fi
+        DISPATCH_MODE="$(read_dispatch_mode)"
+        resolve_worker_class "$2"
+        if (( DISPATCH_PLAN )); then
+            plan_assign_for_pane "$2" "$3"
+        fi
+        echo "plan=$PLAN_ASSIGNMENT"
         exit 0
         ;;
     --rearm-check)

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -45,7 +45,7 @@ worker would refuse.
 
 Output protocol (one line on stdout, consumed by fleet-dispatcher):
 
-  ``<class> <effort> <more> <count>``
+  ``<class> <effort> <more> <count> <plan>``
                                   — dispatch this class; ``more`` is 1 when
                                   claimable items of a *different* class
                                   remain (keep the trigger so the next tick
@@ -53,7 +53,13 @@ Output protocol (one line on stdout, consumed by fleet-dispatcher):
                                   of claimable items OF THIS CLASS right now, so
                                   the dispatcher can cap its fan-out at one
                                   worker per claimable item instead of one per
-                                  idle pane.
+                                  idle pane; ``plan`` is 1 when that count
+                                  includes the class's needs-plan yield — the
+                                  dispatcher then pre-claims a specific issue
+                                  (via ``--plan-pick`` + ``fleet-claim
+                                  planning-claim``) and hands the assignment to
+                                  the dispatch, so planning dispatches never
+                                  contend for the same issue (#2197).
   ``defer``                     — queue isn't empty but nothing is claimable
                                   right now (only cap-blocked fable, tasks with
                                   an open implementation PR, a `blocked` task
@@ -64,6 +70,13 @@ Output protocol (one line on stdout, consumed by fleet-dispatcher):
                                   dispatcher falls back to the lane default
                                   (this path covers reservation resumes and
                                   a missing/stale slice).
+
+A second CLI mode, ``--plan-pick <slice.json> <class> <fable-blocked 0|1>``,
+prints ordered ``repo:number`` lines — the slice's ``needs_plan[]`` entries
+(already human-gate-filtered by the scout, engine-first / oldest-first) whose
+`_plan_class` matches ``<class>``. The dispatcher walks these attempting
+``fleet-claim planning-claim`` until one is granted; that issue becomes the
+dispatch's pre-claimed planning assignment (#2197).
 """
 
 import json
@@ -217,32 +230,34 @@ def _plan_class(issue, fable_blocked):
 
 
 def _candidates(slice_data, lane_default, host, fable_blocked=False):
-    """Yield (class, effort) for each actionable item, pickup-priority order.
+    """Yield (class, effort, kind) per actionable item, pickup-priority order.
 
     Feedback PRs come first (the worker fixes review feedback before new work),
     then unblocked open tasks, then stackable `blocked` tasks (a fallback tier,
     claimable only as a stack on the blocker's PR), then needs_plan. This
     mirrors the worker role docs so the *elected* class matches what the worker
     actually picks up, and one yield per item lets the caller count claimable
-    work per class for the dispatcher's fan-out cap.
+    work per class for the dispatcher's fan-out cap. ``kind`` is "plan" for a
+    needs_plan yield and "work" for everything else — `resolve` uses it to flag
+    the elected class's planning candidate so the dispatcher pre-claims a
+    specific issue for the dispatch (#2197).
 
-    needs_plan yields once PER PLANNING CLASS, not once per issue: the lane
-    plans one at a time — the next planner fires after the first posts its
-    `## Plan` comment (the planning-claim label lock plus the comment-presence
-    early-out make a same-tick sibling a cheap no-op, not a duplicate plan) —
-    but a `fleet:sonnet`-tagged (mechanical) needs-plan issue is a light plan
-    the sonnet lane authors, while everything else is architect-tier design
-    planning (fable, or opus when the fable cap is saturated). Yielding one
-    per class lets the dispatcher's cross-class fan-out serve a mechanical
-    light-plan on the sonnet lane at the same time the fable/opus lane plans
-    the heavy ones, without ever fanning out colliding planners of the same
-    class. Iteration order is oldest-within-each-repo, engine-repo-first —
-    not a true global sort by issue number — because `slice_worker()` in
-    `fleet-state-scout` appends all of `repos.engine.needs_plan[]` before any
-    of `repos.game.needs_plan[]` (same pre-existing composition order
-    `tasks_open`/`feedback_prs` already inherit above). See `_plan_class` and
-    PLANNING-PROTOCOL.md §"Lightweight plan for mechanical (fleet:sonnet)
-    tasks".
+    needs_plan yields once PER PLANNING CLASS, not once per issue: one planning
+    assignment per class per tick is a deliberate serialization — planning is
+    not the throughput bottleneck — while parallelism across classes (a sonnet
+    light-plan alongside a fable/opus heavy plan) is preserved. A
+    `fleet:sonnet`-tagged (mechanical) needs-plan issue is a light plan the
+    sonnet lane authors; everything else is architect-tier design planning
+    (fable, or opus when the fable cap is saturated). The dispatcher turns the
+    per-class yield into a single pre-claimed assignment (`--plan-pick` +
+    `fleet-claim planning-claim` before launch), so same-class planning
+    dispatches never contend for one issue. Iteration order is
+    oldest-within-each-repo, engine-repo-first — not a true global sort by
+    issue number — because `slice_worker()` in `fleet-state-scout` appends all
+    of `repos.engine.needs_plan[]` before any of `repos.game.needs_plan[]`
+    (same pre-existing composition order `tasks_open`/`feedback_prs` already
+    inherit above). See `_plan_class` and PLANNING-PROTOCOL.md §"Lightweight
+    plan for mechanical (fleet:sonnet) tasks".
     """
     def _class_effort(task):
         cls = (task.get("model") or lane_default).lower()
@@ -252,25 +267,47 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
 
     for pr in slice_data.get("feedback_prs", []) or []:
         cls = feedback_pr_class(pr.get("labels", []))
-        yield cls, CLASS_DEFAULT_EFFORT[cls]
+        yield cls, CLASS_DEFAULT_EFFORT[cls], "work"
     tasks = slice_data.get("tasks_open", []) or []
     for task in tasks:
         if _task_claimable(task, host) and not task.get("blocked"):
-            yield _class_effort(task)
+            yield (*_class_effort(task), "work")
     for task in tasks:
         if _task_claimable(task, host) and task.get("blocked"):
-            yield _class_effort(task)
+            yield (*_class_effort(task), "work")
     seen_plan_classes = set()
     for issue in slice_data.get("needs_plan") or []:
         pcls = _plan_class(issue, fable_blocked)
         if pcls in seen_plan_classes:
             continue
         seen_plan_classes.add(pcls)
-        yield pcls, CLASS_DEFAULT_EFFORT[pcls]
+        yield pcls, CLASS_DEFAULT_EFFORT[pcls], "plan"
+
+
+def plan_pick(slice_data, cls, fable_blocked):
+    """Ordered ``repo:number`` planning candidates for one class.
+
+    The slice's ``needs_plan[]`` entries whose `_plan_class` routes to ``cls``,
+    in slice order (engine-first, oldest-first within repo — the priority the
+    per-class yield in `_candidates` elects from). The dispatcher iterates
+    these attempting ``fleet-claim planning-claim`` until one is granted; a
+    line held by a cross-host dispatcher or the architect just falls through
+    to the next, so a lost race assigns the *next* issue instead of burning
+    the dispatch (#2197).
+    """
+    picks = []
+    for issue in slice_data.get("needs_plan") or []:
+        if _plan_class(issue, fable_blocked) != cls:
+            continue
+        number = issue.get("number")
+        if number is None:
+            continue
+        picks.append(f"{issue.get('repo') or 'engine'}:{number}")
+    return picks
 
 
 def resolve(slice_data, lane_default, fable_blocked, exclude=()):
-    """Return 'cls effort more count', 'defer', or '' per the output protocol.
+    """Return 'cls effort more count plan', 'defer', or '' per the protocol.
 
     `exclude` is a set of classes the caller has already served-and-saturated
     this tick (the dispatcher's cross-class fan-out: when the elected class is
@@ -291,7 +328,9 @@ def resolve(slice_data, lane_default, fable_blocked, exclude=()):
     excluded_any = False
     servable_classes = set()
     class_counts = {}
-    for cls, effort in _candidates(slice_data, lane_default, host, fable_blocked):
+    plan_classes = set()
+    for cls, effort, kind in _candidates(slice_data, lane_default, host,
+                                         fable_blocked):
         if cls in exclude:
             excluded_any = True
             continue
@@ -306,6 +345,8 @@ def resolve(slice_data, lane_default, fable_blocked, exclude=()):
             continue
         servable_classes.add(cls)
         class_counts[cls] = class_counts.get(cls, 0) + 1
+        if kind == "plan":
+            plan_classes.add(cls)
         if chosen is None:
             chosen = (cls, effort)
     if chosen is not None:
@@ -315,8 +356,11 @@ def resolve(slice_data, lane_default, fable_blocked, exclude=()):
         # more workers of a class than there is work for them to claim (the
         # surplus would only iterate-and-exit, a no-op opus iteration is not
         # free). `more` still drives the *other-class* follow-up dispatch.
+        # `plan` = that count includes the class's (single, per-class-deduped)
+        # needs-plan yield — the dispatcher's cue to pre-claim an assignment.
         count = class_counts[chosen[0]]
-        return f"{chosen[0]} {chosen[1]} {more} {count}"
+        plan = 1 if chosen[0] in plan_classes else 0
+        return f"{chosen[0]} {chosen[1]} {more} {count} {plan}"
     if skipped_fable or excluded_any:
         return "defer"
     # Nothing servable AND no cap-blocked fable. If the queue's only content is
@@ -333,7 +377,28 @@ def resolve(slice_data, lane_default, fable_blocked, exclude=()):
     return ""
 
 
+def _load_slice(slice_path):
+    try:
+        with open(slice_path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def main(argv):
+    if argv[1:2] == ["--plan-pick"]:
+        # --plan-pick <slice.json> <class> <fable-blocked 0|1>: print the
+        # ordered repo:number planning candidates for <class> (see plan_pick).
+        if len(argv) != 5:
+            print("usage: fleet_task_class.py --plan-pick <slice.json> "
+                  "<class> <fable-blocked 0|1>", file=sys.stderr)
+            return 2
+        slice_data = _load_slice(argv[2])
+        if slice_data is None:
+            return 0  # empty output -> nothing to assign
+        for line in plan_pick(slice_data, argv[3], argv[4] == "1"):
+            print(line)
+        return 0
     # Optional 4th arg: comma-separated classes to exclude (the dispatcher's
     # cross-class fan-out re-resolve). Absent -> exclude nothing.
     if len(argv) not in (4, 5):
@@ -342,10 +407,8 @@ def main(argv):
         return 2
     slice_path, lane_default, fable_blocked = argv[1], argv[2], argv[3] == "1"
     exclude = [c for c in (argv[4].split(",") if len(argv) == 5 else []) if c]
-    try:
-        with open(slice_path) as f:
-            slice_data = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    slice_data = _load_slice(slice_path)
+    if slice_data is None:
         return 0  # empty output -> lane default
     out = resolve(slice_data, lane_default, fable_blocked, exclude)
     if out:

--- a/scripts/fleet/tests/test_dispatch_wrap_session.sh
+++ b/scripts/fleet/tests/test_dispatch_wrap_session.sh
@@ -17,6 +17,8 @@
 #   - cleanup: in-flight work (reservation present, branch otherwise clean) keeps the sidecar
 #   - cleanup: in-flight work (claude/* branch, clean but ahead of master) keeps the sidecar
 #   - cleanup: finished/no-op (clean master) clears the sidecar
+#   - planning assignment (#2197): 7th plan= arg -> FLEET_PLAN_ISSUE export;
+#     absent/bare arg stays unset; a resume releases the pre-claim instead
 
 set -uo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
@@ -48,6 +50,7 @@ cat >/dev/null 2>&1 || true
 EOF
 cat > "$BIN/fleet-claim" <<'EOF'
 #!/usr/bin/env bash
+[[ -n "${FLEET_CLAIM_LOG:-}" ]] && printf '%s\n' "$*" >> "$FLEET_CLAIM_LOG"
 [[ "$1" == "reservation-of" ]] && { [[ -n "${STUB_RESERVATION:-}" ]] && echo "$STUB_RESERVATION"; }
 exit 0
 EOF
@@ -134,6 +137,33 @@ echo "T7: cleanup — finished/no-op (clean master) clears the sidecar"
 rm -f "$SIDECAR"
 STUB_BRANCH="master" STUB_DIRTY="" STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
 [[ ! -f "$SIDECAR" ]] && ok "done/no-op worker cleared the sidecar (fresh next)" || bad "done: sidecar wrongly kept"
+
+# --- planning assignment (#2197): 7th arg -> FLEET_PLAN_ISSUE ---------------
+echo "T8: plan=<repo>:<N> 7th arg exports FLEET_PLAN_ISSUE on a fresh dispatch"
+rm -f "$SIDECAR"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 "claude-fable-5[1m]" xhigh worker "" live "plan=engine:2197" 2>/dev/null)
+[[ "$out" == *" plan=engine:2197 "* ]] && ok "fresh: FLEET_PLAN_ISSUE=engine:2197" || bad "fresh plan export: $out"
+rm -f "$SIDECAR"
+
+echo "T9: absent or bare 'plan=' 7th arg -> FLEET_PLAN_ISSUE stays unset"
+rm -f "$SIDECAR"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high worker "" live 2>/dev/null)
+[[ "$out" == *" plan= prompt="* ]] && ok "absent arg: no FLEET_PLAN_ISSUE" || bad "absent-arg plan leak: $out"
+rm -f "$SIDECAR"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high worker "" live "plan=" 2>/dev/null)
+[[ "$out" == *" plan= prompt="* ]] && ok "bare plan=: not exported (dual-spelling guard)" || bad "bare plan= leaked: $out"
+rm -f "$SIDECAR"
+
+echo "T10: resume discards the assignment — released, not exported"
+printf '{"session_id":"SID-77","role":"worker","model":"sonnet","effort":"high","created_epoch":1}\n' > "$SIDECAR"
+export FLEET_CLAIM_LOG="$TMPROOT/wrap-claim.log"; : > "$FLEET_CLAIM_LOG"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high worker "" live "plan=game:7" 2>/dev/null)
+[[ "$out" == resumed=1* && "$out" == *" plan= prompt="* ]] && ok "resume: assignment dropped from env" || bad "resume plan handling: $out"
+grep -q -- '^--repo game planning-release 7 worker-1$' "$FLEET_CLAIM_LOG" \
+  && ok "resume: pre-claim released under the worktree basename (--repo game form)" \
+  || bad "resume: no planning-release call: $(cat "$FLEET_CLAIM_LOG")"
+unset FLEET_CLAIM_LOG
+rm -f "$SIDECAR"
 
 echo
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -10,6 +10,9 @@
 #   - feedback severity routing (nits-only -> sonnet beats queued tasks)
 #   - empty slice -> lane-default fallthrough (class empty)
 #   - non-worker role is a no-op (class empty)
+#   - planning pre-claim (#2197): plan=1 election, --plan-assign claim walk
+#     (grant / held-fallthrough / exit-3 --replan / all-held / game --repo
+#     namespacing / dry-run+review-only gating) against a stubbed fleet-claim
 #
 # The fable in-flight count comes from dispatch records under
 # $FLEET_STATE_DIR/dispatch, same records --count-active reads.
@@ -71,7 +74,7 @@ resolve() {
 echo "T1: fable task resolves to fable model"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 assert_eq "$(resolve worker)" \
-    "class=fable model=claude-fable-5[1m] effort=xhigh more=0 defer=0 count=1" \
+    "class=fable model=claude-fable-5[1m] effort=xhigh more=0 defer=0 count=1 plan=0" \
     "uncapped fable task dispatches on fable at xhigh"
 
 # --- T2: fable cap reached -> next non-fable task ---------------------------
@@ -80,14 +83,14 @@ write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,
 printf '{"role":"worker","pane":"%%9","class":"fable","dispatched_at":"x"}\n' \
     > "$FLEET_STATE_DIR/dispatch/pane-9.json"
 assert_eq "$(resolve worker)" \
-    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0 count=1" \
+    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0 count=1 plan=0" \
     "capped fable skipped; opus task served; cap-blocked fable does NOT hold the trigger (more=0)"
 
 # --- T3: only capped fable work -> defer -------------------------------------
 echo "T3: only cap-blocked fable work defers"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 out=$(resolve worker)
-assert_eq "$out" "class= model= effort= more=0 defer=1 count=" \
+assert_eq "$out" "class= model= effort= more=0 defer=1 count= plan=0" \
     "cap-blocked fable-only slice -> defer (no lane-default burn)"
 rm -f "$FLEET_STATE_DIR/dispatch/pane-9.json"
 
@@ -95,25 +98,25 @@ rm -f "$FLEET_STATE_DIR/dispatch/pane-9.json"
 echo "T4: Effort: override threads through"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":"medium","owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 assert_eq "$(resolve worker)" \
-    "class=opus model=claude-opus-4-8[1m] effort=medium more=0 defer=0 count=1" \
+    "class=opus model=claude-opus-4-8[1m] effort=medium more=0 defer=0 count=1 plan=0" \
     "task-level Effort: medium beats the class default"
 
 # --- T5: feedback severity routing -------------------------------------------
 echo "T5: nits-only feedback routes sonnet ahead of queued tasks"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false}],"feedback_prs":[{"number":50,"labels":["fleet:approved","fleet:has-nits"]}],"needs_plan":[]}'
 assert_eq "$(resolve worker)" \
-    "class=sonnet model=sonnet effort=high more=1 defer=0 count=1" \
+    "class=sonnet model=sonnet effort=high more=1 defer=0 count=1 plan=0" \
     "has-nits feedback dispatches sonnet; opus task keeps the trigger"
 
 # --- T6: empty slice -> lane default fallthrough ------------------------------
 echo "T6: empty slice falls through to lane default"
 write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[]}'
-assert_eq "$(resolve worker)" "class= model= effort= more=0 defer=0 count=" \
+assert_eq "$(resolve worker)" "class= model= effort= more=0 defer=0 count= plan=0" \
     "empty slice -> lane-default dispatch (reservation-resume path)"
 
 # --- T7: non-worker role is a no-op ------------------------------------------
 echo "T7: non-worker roles skip class resolution"
-assert_eq "$(resolve merger)" "class= model= effort= more=0 defer=0 count=" \
+assert_eq "$(resolve merger)" "class= model= effort= more=0 defer=0 count= plan=0" \
     "merger has no lane class; resolution is a no-op"
 
 # --- T8: cross-class exclude threads through resolve_worker_class -------------
@@ -121,14 +124,111 @@ assert_eq "$(resolve merger)" "class= model= effort= more=0 defer=0 count=" \
 echo "T8: --resolve-class <role> <exclude> serves the next class"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false},{"issue":"#11","model":"sonnet","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 assert_eq "$("$DISPATCHER" --resolve-class worker)" \
-    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=1 defer=0 count=1" \
+    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=1 defer=0 count=1 plan=0" \
     "no exclude -> opus elected, sonnet is 'more'"
 assert_eq "$("$DISPATCHER" --resolve-class worker opus)" \
-    "class=sonnet model=sonnet effort=high more=0 defer=0 count=1" \
+    "class=sonnet model=sonnet effort=high more=0 defer=0 count=1 plan=0" \
     "exclude opus -> sonnet served (the cross-class fan-out)"
 assert_eq "$("$DISPATCHER" --resolve-class worker opus,sonnet)" \
-    "class= model= effort= more=0 defer=1 count=" \
+    "class= model= effort= more=0 defer=1 count= plan=0" \
     "exclude both claimable classes -> defer (not lane-default)"
+
+# --- T9+: planning pre-claim (#2197) ------------------------------------------
+# The dispatcher takes the planning-claim label lock itself (under the target
+# pane's worktree basename) BEFORE dispatching, and hands the assignment to the
+# dispatch. Exercised via the --plan-assign hook, which runs the same
+# resolve + plan_assign_for_pane path a live tick does. fleet-claim is stubbed
+# (hermetic — scripts/fleet/CLAUDE.md): grant/held/planned sets come from env,
+# every invocation is logged for argv assertions.
+export FLEET_CLAIM_LOG="$TMPROOT/fleet-claim.log"
+STUB_BIN="$TMPROOT/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/fleet-claim" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FLEET_CLAIM_LOG"
+repo="engine"
+if [[ "${1:-}" == "--repo" ]]; then repo="$2"; shift 2; fi
+sub="${1:-}"; num="${2:-}"
+replan=""
+[[ "${4:-}" == "--replan" ]] && replan=1
+key="$repo:$num"
+[[ "$sub" == "planning-release" ]] && exit 0
+if [[ -n "$replan" ]]; then
+    [[ " ${STUB_REPLAN_GRANT:-} " == *" $key "* ]] && exit 0
+    exit 2
+fi
+[[ " ${STUB_GRANT:-} " == *" $key "* ]] && exit 0
+[[ " ${STUB_PLANNED:-} " == *" $key "* ]] && exit 3
+exit 1
+EOF
+chmod +x "$STUB_BIN/fleet-claim"
+export PATH="$STUB_BIN:$PATH"
+
+plan_assign() {
+    : > "$FLEET_CLAIM_LOG"
+    "$DISPATCHER" --plan-assign worker worker-9
+}
+
+echo "T9: needs-plan slice resolves plan=1 on the elected class"
+write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[{"number":99,"repo":"engine","labels":[]},{"number":120,"repo":"engine","labels":[]},{"number":7,"repo":"game","labels":[]}]}'
+assert_eq "$(resolve worker)" \
+    "class=fable model=claude-fable-5[1m] effort=xhigh more=0 defer=0 count=1 plan=1" \
+    "untagged needs-plan elects fable with plan=1"
+
+echo "T10: assignment granted on the first candidate, claimed under the agent"
+assert_eq "$(STUB_GRANT='engine:99' plan_assign)" "plan=engine:99" \
+    "first candidate claim granted -> assigned"
+grep -q '^planning-claim 99 worker-9$' "$FLEET_CLAIM_LOG" \
+    && { PASS=$((PASS+1)); echo "  ok: claim ran under the pane worktree basename"; } \
+    || { FAIL=$((FAIL+1)); echo "  FAIL: claim argv wrong: $(cat "$FLEET_CLAIM_LOG")"; }
+
+echo "T11: held candidate falls through to the next line (lost race != burned dispatch)"
+assert_eq "$(STUB_GRANT='engine:120' plan_assign)" "plan=engine:120" \
+    "engine:99 held elsewhere (exit 1) -> engine:120 assigned"
+
+echo "T12: exit-3 + live needs-plan retries with --replan and assigns"
+assert_eq "$(STUB_PLANNED='engine:99' STUB_REPLAN_GRANT='engine:99' plan_assign)" "plan=engine:99" \
+    "stale-slice/plan-review re-plan state -> assigned via --replan"
+grep -q '^planning-claim 99 worker-9 --replan$' "$FLEET_CLAIM_LOG" \
+    && { PASS=$((PASS+1)); echo "  ok: --replan retry issued"; } \
+    || { FAIL=$((FAIL+1)); echo "  FAIL: no --replan retry: $(cat "$FLEET_CLAIM_LOG")"; }
+
+echo "T13: exit-3 then replan exit-2 (genuinely done) -> next line"
+assert_eq "$(STUB_PLANNED='engine:99' STUB_GRANT='engine:120' plan_assign)" "plan=engine:120" \
+    "already-planned candidate skipped; next line assigned"
+
+echo "T14: all candidates held/planned -> no assignment"
+assert_eq "$(plan_assign)" "plan=" \
+    "every claim refused -> plan= (dispatch_role shrinks the headroom)"
+
+echo "T15: game-repo candidate claims with --repo game before the subcommand"
+assert_eq "$(STUB_GRANT='game:7' plan_assign)" "plan=game:7" \
+    "engine lines held -> game line assigned"
+grep -q -- '^--repo game planning-claim 7 worker-9$' "$FLEET_CLAIM_LOG" \
+    && { PASS=$((PASS+1)); echo "  ok: game claim namespaced with --repo game"; } \
+    || { FAIL=$((FAIL+1)); echo "  FAIL: game claim argv wrong: $(cat "$FLEET_CLAIM_LOG")"; }
+
+echo "T16: dry-run / review-only never pre-claim"
+printf 'dry-run\n' > "$FLEET_STATE_DIR/dispatch-mode"
+assert_eq "$(STUB_GRANT='engine:99' plan_assign)" "plan=" \
+    "dry-run mode -> no assignment"
+[[ ! -s "$FLEET_CLAIM_LOG" ]] \
+    && { PASS=$((PASS+1)); echo "  ok: no fleet-claim call in dry-run"; } \
+    || { FAIL=$((FAIL+1)); echo "  FAIL: dry-run still called fleet-claim: $(cat "$FLEET_CLAIM_LOG")"; }
+printf 'review-only\n' > "$FLEET_STATE_DIR/dispatch-mode"
+assert_eq "$(STUB_GRANT='engine:99' plan_assign)" "plan=" \
+    "review-only mode -> no assignment"
+rm -f "$FLEET_STATE_DIR/dispatch-mode"
+
+echo "T17: a plan-carrying dispatch command appends the 7th plan= arg"
+# build_dispatch_command is exercised via --print-dispatch-command for the
+# 6-arg (no assignment) shape; the 7-arg shape is asserted through the log of
+# a live-shaped assignment (T10) + the wrap-side export test
+# (test_dispatch_wrap_session.sh). Here: no assignment -> 6 args, no plan=.
+out=$("$DISPATCHER" --print-dispatch-command worker pane-3)
+case "$out" in
+    *" plan="*) FAIL=$((FAIL+1)); echo "  FAIL: unassigned dispatch carries plan=: $out" ;;
+    *) PASS=$((PASS+1)); echo "  ok: unassigned dispatch has no plan= arg" ;;
+esac
 
 echo
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -23,8 +23,12 @@ that matter:
     terminal like `inflight_pr`, and the lane defers when it's the only
     work (#1998, the GL-vs-Metal host-capability gate);
   - per-task **Effort:** overrides beat class defaults;
-  - the output carries a trailing ``count`` = claimable items of the elected
-    class, which the dispatcher uses to cap its idle-pane fan-out;
+  - the output carries ``count`` = claimable items of the elected class,
+    which the dispatcher uses to cap its idle-pane fan-out, and ``plan`` = 1
+    when that count includes the class's needs-plan yield (the dispatcher's
+    cue to pre-claim a specific issue via ``--plan-pick``, #2197);
+  - ``plan_pick`` lists the class's planning candidates as ordered
+    ``repo:number`` lines in slice order (engine-first, oldest-first);
   - an empty/unroutable slice falls through to the lane default (covers
     reservation resumes and missing slices).
 """
@@ -34,7 +38,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from fleet_task_class import feedback_pr_class, resolve  # noqa: E402
+from fleet_task_class import feedback_pr_class, plan_pick, resolve  # noqa: E402
 
 
 def _task(issue, model=None, effort=None, owner="free", blocked=False,
@@ -79,17 +83,17 @@ class TaskResolution(unittest.TestCase):
                                       _task("#11", "fable")]},
                       "opus", fable_blocked=False)
         # fable still queued -> more=1; one claimable sonnet item -> count=1.
-        self.assertEqual(out, "sonnet high 1 1")
+        self.assertEqual(out, "sonnet high 1 1 0")
 
     def test_effort_override_beats_class_default(self):
         out = resolve({"tasks_open": [_task("#10", "opus", effort="medium")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus medium 0 1")
+        self.assertEqual(out, "opus medium 0 1 0")
 
     def test_untagged_task_uses_lane_default(self):
         out = resolve({"tasks_open": [_task("#10", None)]},
                       "sonnet", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 0 1")
+        self.assertEqual(out, "sonnet high 0 1 0")
 
     def test_count_reflects_claimable_items_of_class(self):
         # Three unblocked opus tasks + one sonnet: the elected opus class
@@ -98,7 +102,7 @@ class TaskResolution(unittest.TestCase):
         out = resolve({"tasks_open": [_task("#10", "opus"), _task("#11", "opus"),
                                       _task("#12", "opus"), _task("#13", "sonnet")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 1 3")
+        self.assertEqual(out, "opus xhigh 1 3 0")
 
     def test_owned_and_blocked_tasks_skipped(self):
         # Owned/blocked tasks are invisible: they don't dispatch AND they
@@ -108,7 +112,7 @@ class TaskResolution(unittest.TestCase):
                                       _task("#11", "opus", blocked=True),
                                       _task("#12", "opus")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_inflight_pr_task_skipped_fable_behind_dispatches(self):
         # #1726 / the #1640 incident: a head-of-queue opus task whose own issue
@@ -120,7 +124,7 @@ class TaskResolution(unittest.TestCase):
             _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
             _task("#1695", "fable"),
         ]}, "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0 1")
+        self.assertEqual(out, "fable xhigh 0 1 0")
 
     def test_inflight_pr_only_candidate_defers(self):
         # The parked task is the ONLY queue item: nothing a fresh worker can
@@ -153,7 +157,7 @@ class TaskResolution(unittest.TestCase):
             _task("#1641", "opus", blocked=True,
                   stackable_blocker_pr={"number": 1638}),
         ]}, "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_unblocked_elected_before_stackable(self):
         # Pickup priority: an unblocked task outranks a stackable `blocked` one
@@ -163,7 +167,7 @@ class TaskResolution(unittest.TestCase):
             _task("#10", "opus", blocked=True, stackable_blocker_pr={"number": 9}),
             _task("#11", "opus"),
         ]}, "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0 2")
+        self.assertEqual(out, "opus xhigh 0 2 0")
 
     def test_inflight_pr_head_with_capped_fable_defers(self):
         # Head parked (skipped), only remaining work is cap-blocked fable ->
@@ -179,7 +183,7 @@ class TaskResolution(unittest.TestCase):
         out = resolve({"feedback_prs": [{"labels": ["fleet:has-nits"]}],
                        "tasks_open": [_task("#10", "opus")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 1 1")
+        self.assertEqual(out, "sonnet high 1 1 0")
 
     def test_needs_plan_prefers_fable(self):
         # Planning is architect-tier design work: it elects fable while the
@@ -187,7 +191,7 @@ class TaskResolution(unittest.TestCase):
         # panes on the fable class).
         out = resolve({"needs_plan": [{"number": 99}]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0 1")
+        self.assertEqual(out, "fable xhigh 0 1 1")
 
     def test_needs_plan_falls_back_to_opus_when_fable_capped(self):
         # A saturated fable cap must DOWNGRADE planning to opus, not defer it —
@@ -195,7 +199,7 @@ class TaskResolution(unittest.TestCase):
         # behind a long fable implementation iteration.
         out = resolve({"needs_plan": [{"number": 99}]},
                       "opus", fable_blocked=True)
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 1")
 
     def test_needs_plan_counts_once_regardless_of_backlog(self):
         # The lane plans one issue at a time (planning-claim lock + the
@@ -205,7 +209,7 @@ class TaskResolution(unittest.TestCase):
         out = resolve({"needs_plan": [{"number": 99}, {"number": 100},
                                       {"number": 101}]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0 1")
+        self.assertEqual(out, "fable xhigh 0 1 1")
 
     def test_needs_plan_sonnet_tagged_routes_sonnet(self):
         # A `fleet:sonnet`-tagged needs-plan issue is MECHANICAL: the sonnet
@@ -213,13 +217,13 @@ class TaskResolution(unittest.TestCase):
         # of burning fable/opus. Sonnet default effort (high), count=1.
         out = resolve({"needs_plan": [{"number": 99, "labels": ["fleet:sonnet"]}]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 0 1")
+        self.assertEqual(out, "sonnet high 0 1 1")
 
     def test_needs_plan_untagged_still_prefers_fable(self):
         # No fleet:sonnet tag -> architect-tier design planning, unchanged.
         out = resolve({"needs_plan": [{"number": 99, "labels": ["render"]}]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0 1")
+        self.assertEqual(out, "fable xhigh 0 1 1")
 
     def test_needs_plan_mixed_classes_elects_oldest_and_flags_more(self):
         # Oldest plannable issue is the sonnet-tagged mechanical one, so the
@@ -230,14 +234,14 @@ class TaskResolution(unittest.TestCase):
             {"number": 99, "labels": ["fleet:sonnet"]},
             {"number": 100, "labels": ["render"]},
         ]}, "opus", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 1 1")
+        self.assertEqual(out, "sonnet high 1 1 1")
 
     def test_needs_plan_sonnet_tagged_unaffected_by_fable_cap(self):
         # A saturated fable cap downgrades DESIGN-tier planning to opus, but a
         # mechanical sonnet light-plan is a sonnet-lane job regardless.
         out = resolve({"needs_plan": [{"number": 99, "labels": ["fleet:sonnet"]}]},
                       "opus", fable_blocked=True)
-        self.assertEqual(out, "sonnet high 0 1")
+        self.assertEqual(out, "sonnet high 0 1 1")
 
     def test_design_unblocked_feedback_resolves_opus(self):
         # The engine #1885 shape: a design-unblocked PR is the top feedback
@@ -254,7 +258,7 @@ class TaskResolution(unittest.TestCase):
                                  inflight_pr={"number": 1885, "parked": True})],
             "needs_plan": [{"number": 1887}],
         }, "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 1 1")
+        self.assertEqual(out, "opus xhigh 1 1 0")
 
 
 class FableCap(unittest.TestCase):
@@ -265,7 +269,7 @@ class FableCap(unittest.TestCase):
         out = resolve({"tasks_open": [_task("#10", "fable"),
                                       _task("#11", "opus")]},
                       "opus", fable_blocked=True)
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_only_capped_fable_defers(self):
         out = resolve({"tasks_open": [_task("#10", "fable")]},
@@ -275,7 +279,7 @@ class FableCap(unittest.TestCase):
     def test_uncapped_fable_dispatches_xhigh(self):
         out = resolve({"tasks_open": [_task("#10", "fable")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0 1")
+        self.assertEqual(out, "fable xhigh 0 1 0")
 
 
 class EmptySlice(unittest.TestCase):
@@ -324,12 +328,12 @@ class GlHostGate(unittest.TestCase):
     def test_gl_only_task_claimable_on_linux(self):
         out = self._resolve_on(
             "linux", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_gl_only_task_claimable_on_windows(self):
         out = self._resolve_on(
             "windows", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_mixed_mac_slice_dispatches_claimable_no_churn(self):
         # GL-only #1937-shaped head + a claimable opus task: the mac pane skips
@@ -339,7 +343,7 @@ class GlHostGate(unittest.TestCase):
             _task("#1937", "opus", needs_gl_host=True),
             _task("#1998", "opus"),
         ]})
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_gl_only_plus_inflight_only_on_mac_defers(self):
         # All-terminal mix on a mac pane: one GL-only (host-terminal) + one
@@ -368,7 +372,7 @@ class GlHostGate(unittest.TestCase):
             _task("#1941", "opus", blocked=True,
                   stackable_blocker_pr={"number": 1900}),
         ]})
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
     def test_unknown_host_is_fail_closed(self):
         # Fail-closed: an unrecognized host is treated as not GL-capable, so a
@@ -386,10 +390,10 @@ class ExcludeClasses(unittest.TestCase):
     def test_exclude_elects_the_next_class(self):
         slice_data = {"tasks_open": [_task("#10", "opus"), _task("#11", "sonnet")]}
         # No exclude: opus is the elected (oldest) class, sonnet is `more`.
-        self.assertEqual(resolve(slice_data, "opus", False), "opus xhigh 1 1")
+        self.assertEqual(resolve(slice_data, "opus", False), "opus xhigh 1 1 0")
         # Exclude opus -> sonnet is elected, nothing else servable -> more=0.
         self.assertEqual(resolve(slice_data, "opus", False, exclude=["opus"]),
-                         "sonnet high 0 1")
+                         "sonnet high 0 1 0")
 
     def test_exclude_all_claimable_defers_not_empty(self):
         # Excluding every claimable class must DEFER (there is real work, just
@@ -403,13 +407,71 @@ class ExcludeClasses(unittest.TestCase):
         # Excluding a class with no claimable work changes nothing.
         slice_data = {"tasks_open": [_task("#10", "opus")]}
         self.assertEqual(resolve(slice_data, "opus", False, exclude=["fable"]),
-                         "opus xhigh 0 1")
+                         "opus xhigh 0 1 0")
 
     def test_exclude_on_empty_slice_stays_empty(self):
         # No claimable work at all + an exclude -> '' (lane-default), not defer:
         # nothing was excluded, so the reservation-resume fallthrough stands.
         self.assertEqual(resolve({"tasks_open": []}, "opus", False,
                                  exclude=["opus"]), "")
+
+
+class PlanFlag(unittest.TestCase):
+    """The trailing ``plan`` token: 1 iff the ELECTED class's claimable count
+    includes its needs-plan yield — the dispatcher then pre-claims a specific
+    issue and hands the assignment to the dispatch (#2197)."""
+
+    def test_task_plus_same_class_plan_sets_flag_and_counts_both(self):
+        # An opus task + an opus-degraded plan (fable capped): opus elected,
+        # count=2 (task + the planning slot), plan=1.
+        out = resolve({"tasks_open": [_task("#10", "opus")],
+                       "needs_plan": [{"number": 99}]},
+                      "opus", fable_blocked=True)
+        self.assertEqual(out, "opus xhigh 0 2 1")
+
+    def test_other_class_plan_does_not_set_flag(self):
+        # The plan candidate routes to fable; the elected class is opus (the
+        # task) -> plan=0, fable plan rides `more` for a later tick.
+        out = resolve({"tasks_open": [_task("#10", "opus")],
+                       "needs_plan": [{"number": 99}]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 1 1 0")
+
+
+class PlanPick(unittest.TestCase):
+    """`plan_pick` — the ordered repo:number candidate lines the dispatcher
+    walks with `fleet-claim planning-claim` until one is granted (#2197)."""
+
+    SLICE = {"needs_plan": [
+        {"number": 90, "repo": "engine", "labels": ["fleet:sonnet"]},
+        {"number": 99, "repo": "engine", "labels": []},
+        {"number": 120, "repo": "engine", "labels": ["render"]},
+        {"number": 7, "repo": "game", "labels": []},
+    ]}
+
+    def test_fable_class_picks_design_tier_in_slice_order(self):
+        # Engine-first / oldest-first is the slice composition order —
+        # plan_pick preserves it; the sonnet-tagged mechanical issue is not a
+        # fable candidate.
+        self.assertEqual(plan_pick(self.SLICE, "fable", False),
+                         ["engine:99", "engine:120", "game:7"])
+
+    def test_sonnet_class_picks_only_mechanical(self):
+        self.assertEqual(plan_pick(self.SLICE, "sonnet", False), ["engine:90"])
+
+    def test_fable_cap_degrades_design_tier_to_opus(self):
+        # fable_blocked routes design-tier planning to opus (same `_plan_class`
+        # degrade `resolve` applies), so the opus pick set is the fable set.
+        self.assertEqual(plan_pick(self.SLICE, "opus", True),
+                         ["engine:99", "engine:120", "game:7"])
+        self.assertEqual(plan_pick(self.SLICE, "opus", False), [])
+
+    def test_missing_repo_defaults_engine_and_missing_number_skipped(self):
+        s = {"needs_plan": [{"number": 5}, {"labels": []}]}
+        self.assertEqual(plan_pick(s, "fable", False), ["engine:5"])
+
+    def test_empty_slice_yields_no_picks(self):
+        self.assertEqual(plan_pick({}, "fable", False), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Assignment IS the claim (#2197):** the dispatcher pre-claims one specific `fleet:needs-plan` issue via `fleet-claim planning-claim` — under the target pane's worktree basename — *before* launching the iteration, and hands it over as `FLEET_PLAN_ISSUE=<repo>:<N>`. Planning dispatches can no longer contend for the same issue; a lost cross-host race assigns the next candidate instead of burning a worker iteration (#1810, #1999 retire as worker-side protocols).
- `fleet_task_class.py`: new `--plan-pick` mode (ordered `repo:number` planning candidates per class, reusing `_plan_class` routing + fable-cap degrade) and a 5th `plan 0|1` output token on `resolve()`.
- `fleet-dispatcher`: claim-then-assign walk in the pane loop (exit 3 → `--replan` retry gated on live `fleet:needs-plan`; exit 1/2 → next line), 7th `plan=` dispatch arg for the assigned pane only, `plan_issue` stamped into dispatch records, error-path release on send-keys failure, headroom shrink + dispatch skip when planning was the only claimable item and all candidates are held, dry-run/review-only never pre-claim.
- `fleet-dispatch-wrap`: exports `FLEET_PLAN_ISSUE` (rejects a bare `plan=`), and releases the pre-claim when a session-resume discards the fresh dispatch config. Shared release helper in `fleet-common.sh` (single copy, both callers).
- Docs: PLANNING-PROTOCOL step 0 + light-plan step 1 rewritten to the assignment contract; stale-queued-plan re-plan becomes **flip-and-move-on** (workers never invoke `--replan`; the dispatcher routes re-plans); `fleet:planning-*` lock entry added to the labels reference; state-machine `plan-propose` note updated; file-epic re-plan pointer refreshed.
- **Retire/keep inventory** per the plan: worker-side claim + `--replan` flows retired; `cmd_planning_claim`/`planning-release`/lex-min primitive, exit-3 dedup, `--replan` gating, and the 1-hour TTL sweep all kept unchanged (`fleet-claim` untouched; `test_fleet_claim_planning.sh` green, unmodified).

## Test plan
- [x] `test_fleet_task_class.py` — 49/49 (5-token protocol, `PlanFlag`, `PlanPick` class routing / fable degrade / repo ordering)
- [x] `test_dispatcher_class_dispatch.sh` — 24/24 (T9–T17: plan=1 election, grant / held-fallthrough / exit-3 `--replan` / all-held / `--repo game` namespacing / dry-run + review-only gating via the new `--plan-assign` hook against a stubbed `fleet-claim`)
- [x] `test_dispatch_wrap_session.sh` — 23/23 (T8–T10: `FLEET_PLAN_ISSUE` export, bare-`plan=` guard, resume release under the worktree basename)
- [x] `test_fleet_claim_planning.sh` 19/19 (unmodified), `test_dispatcher_dry_run_mode.sh` 13/13, `test_dispatcher_stagger.sh` 24/24, `test_worker_projection.py` 51/51, `ruff check scripts/` clean
- [ ] Reviewer note: `test_dispatcher_concurrency_cap.sh` T4c fails pre-existing on macOS hosts (known flake, #1707 lineage) — unrelated to this diff

## Notes for reviewer
- **Deployment order is load-bearing:** this PR must merge and the fleet must bounce *before* the gated role-doc edit (#2300) is applied. Scripts-first is safe — an old-protocol worker re-claims its assignment idempotently (same host+agent → exit 0). Role-docs-first would be a planning outage.
- The full `dispatch_role` pane loop (headroom shrink, send-keys-failure release) isn't drivable hermetically — no existing test spins the tmux loop; coverage there is via the `--plan-assign` hook, which runs the identical resolve + claim-walk path, plus the mode-gate check inside `plan_assign_for_pane` itself.

Closes #2197

🤖 Generated with [Claude Code](https://claude.com/claude-code)