### PR TITLE
fleet: gate needs-plan Blocked-by parking out of planner dispatch (#2287)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -432,7 +432,10 @@ def fetch_issues_by_label(repo, filter_label, exclude_labels=None,
 
 
 def fetch_needs_plan(repo):
-    return fetch_issues_by_label(repo, "fleet:needs-plan")
+    # with_body=True: resolve_needs_plan_blocked_by (#2287) needs the body to
+    # parse a standalone `**Blocked by:**` line; it pops the field after
+    # parsing so state.json never carries it.
+    return fetch_issues_by_label(repo, "fleet:needs-plan", with_body=True)
 
 
 def fetch_plan_review(repo):
@@ -1391,6 +1394,51 @@ def resolve_human_approved_blockers(state):
                 break
 
 
+def resolve_needs_plan_blocked_by(state):
+    """Annotate each fleet:needs-plan issue with `blocked` — True when its
+    `**Blocked by:**` predecessor is still open (#2287).
+
+    Mirrors resolve_human_approved_blockers(): in-memory only
+    (closed_fleet_queued + merged `claude/<N>-*` heads), no live gh, so the
+    per-tick projection stays fast. `body` is popped after parsing so it
+    never bloats state.json or the per-role slices. Without this, a
+    needs-plan issue explicitly parked behind an open blocker (e.g. #2258
+    held for #2280) kept projecting as plannable, firing a planner dispatch
+    every tick that found nothing to do on arrival.
+    """
+    for repo_key, repo_state in state["repos"].items():
+        closed_nums = _closed_issue_numbers(repo_state)
+        merged_heads = [
+            pr.get("headRefName", "") or ""
+            for pr in repo_state.get("recent_merged_prs", [])
+        ]
+
+        for issue in repo_state.get("needs_plan", []):
+            body = issue.pop("body", "") or ""
+            issue["blocked"] = False
+            raw = _parse_blocked_by(body)
+            if not raw:
+                continue
+            refs = _parse_blocker_refs(raw, repo_key)
+            if not refs:
+                # Blocker named only as prose with no resolvable #N — hold
+                # the issue out of the plannable set, matching
+                # resolve_human_approved_blockers.
+                issue["blocked"] = True
+                continue
+            for ref_key, ref in refs:
+                if ref_key != repo_key:
+                    # Cross-repo blocker — unresolvable from this repo's
+                    # window; don't hold the issue back on it.
+                    continue
+                if ref in closed_nums:
+                    continue
+                if any(branch_matches_issue(h, ref, repo_key) for h in merged_heads):
+                    continue
+                issue["blocked"] = True
+                break
+
+
 def resolve_epic_children(state):
     """Annotate each epic for the steward projection (#1664). Mutates state
     in place before the state write, mirroring resolve_blocked_by, so both
@@ -1618,8 +1666,14 @@ def project_worker(state):
             # from *claiming* the issue but not the wake itself, since the dispatcher
             # diffs *this* projection to decide whether to fire. A merely fleet:blocked
             # needs-plan issue is still plannable (planning is independent of the
-            # blocker), so it is NOT gated.
+            # blocker), so it is NOT gated on that label.
             if set(issue.get("labels", [])) & _HUMAN_GATE_LABELS:
+                continue
+            # #2287: an issue whose body declares a still-open `**Blocked by:**`
+            # predecessor (resolve_needs_plan_blocked_by) is explicitly parked —
+            # e.g. "do not plan until #N posts" — and must not wake a planner
+            # dispatch either, mirroring the human-gate skip just above.
+            if issue.get("blocked"):
                 continue
             items.append({"kind": "needs_plan", "repo": repo,
                           "issue": issue["number"]})
@@ -2100,8 +2154,13 @@ def slice_worker(state):
             # count them as plannable and spin a no-op opus worker that finds
             # nothing — the idle-fleet churn behind the needs-plan/no-plan limbo.
             # A merely fleet:blocked needs-plan issue is still plannable, so it
-            # is NOT gated here.
+            # is NOT gated here on that label.
             if set(issue.get("labels", [])) & _HUMAN_GATE_LABELS:
+                continue
+            # #2287: mirror project_worker's Blocked-by gate so a woken worker
+            # never even surfaces an explicitly-parked needs-plan issue as a
+            # planning candidate.
+            if issue.get("blocked"):
                 continue
             out["needs_plan"].append(_slice_issue_with_repo(repo_key, issue))
         for pr in repo_state.get("prs", []):
@@ -2644,6 +2703,7 @@ def tick_once():
         _populate_review_plan(state)
         resolve_blocked_by(state)
         resolve_human_approved_blockers(state)
+        resolve_needs_plan_blocked_by(state)
         resolve_epic_children(state)
         enrich_stackable_blocker_prs(state)
         # Drop PR bodies now the only consumer (the Closes-#N stack-base match

--- a/scripts/fleet/tests/test_needs_plan_blocked_by.py
+++ b/scripts/fleet/tests/test_needs_plan_blocked_by.py
@@ -1,0 +1,156 @@
+"""Tests for resolve_needs_plan_blocked_by() in fleet-state-scout (#2287).
+
+Covers the fix for: a fleet:needs-plan issue whose body declares a
+standalone `**Blocked by:**` line to an open issue kept projecting as
+plannable (the projection never parsed the field), firing a planner
+dispatch every tick that found nothing to do on arrival.
+
+Mirrors test_queue_manager_projection.py's IngestHonorsBlockedBy, which
+covers the analogous resolve_human_approved_blockers() — in-memory only
+(closed_fleet_queued + merged claude/<N>-* heads), no live gh.
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+resolve_needs_plan_blocked_by = _mod.resolve_needs_plan_blocked_by
+project_worker = _mod.project_worker
+slice_worker = _mod.slice_worker
+
+
+def _state(*, needs_plan=None, closed=None, merged=None):
+    return {
+        "repos": {
+            "engine": {
+                "needs_plan": needs_plan or [],
+                "prs": [],
+                "tasks": {"open": [], "in_progress": [], "done": []},
+                "closed_fleet_queued": closed or [],
+                "recent_merged_prs": merged or [],
+            },
+        },
+    }
+
+
+class ResolveNeedsPlanBlockedBy(unittest.TestCase):
+
+    def _resolved(self, *, needs_plan, closed=None, merged=None):
+        st = _state(needs_plan=needs_plan, closed=closed, merged=merged)
+        resolve_needs_plan_blocked_by(st)
+        return st
+
+    def test_open_blocker_marks_issue_blocked(self):
+        st = self._resolved(needs_plan=[
+            {"number": 2258, "labels": ["fleet:needs-plan"],
+             "body": "**Blocked by:** #2280"},
+        ])
+        issue = st["repos"]["engine"]["needs_plan"][0]
+        self.assertTrue(issue["blocked"], "open predecessor must mark issue blocked")
+        self.assertNotIn("body", issue, "body must be stripped after resolution")
+
+    def test_closed_blocker_clears_blocked(self):
+        st = self._resolved(
+            needs_plan=[
+                {"number": 2258, "labels": ["fleet:needs-plan"],
+                 "body": "**Blocked by:** #2280"},
+            ],
+            closed=[{"number": 2280, "title": "head"}],
+        )
+        self.assertFalse(st["repos"]["engine"]["needs_plan"][0]["blocked"],
+                         "predecessor in closed_fleet_queued must clear blocked")
+
+    def test_merged_head_pr_clears_blocked(self):
+        st = self._resolved(
+            needs_plan=[
+                {"number": 2258, "labels": ["fleet:needs-plan"],
+                 "body": "**Blocked by:** #2280"},
+            ],
+            merged=[{"number": 999, "headRefName": "claude/2280-attribution",
+                     "baseRefName": "master"}],
+        )
+        self.assertFalse(st["repos"]["engine"]["needs_plan"][0]["blocked"],
+                         "a merged claude/2280-* head must clear the blocker")
+
+    def test_no_blocker_field_is_not_blocked(self):
+        st = self._resolved(needs_plan=[
+            {"number": 2092, "labels": ["fleet:needs-plan"],
+             "body": "**Model:** opus\nno blocker line here"},
+        ])
+        self.assertFalse(st["repos"]["engine"]["needs_plan"][0]["blocked"])
+
+    def test_none_sentinel_is_not_blocked(self):
+        st = self._resolved(needs_plan=[
+            {"number": 2092, "labels": ["fleet:needs-plan"],
+             "body": "**Blocked by:** (none)"},
+        ])
+        self.assertFalse(st["repos"]["engine"]["needs_plan"][0]["blocked"])
+
+    def test_missing_body_is_not_blocked(self):
+        # No body key at all (defensive — fetch_needs_plan always sets one
+        # with with_body=True, but the resolver must not crash without it).
+        st = self._resolved(needs_plan=[
+            {"number": 2092, "labels": ["fleet:needs-plan"]},
+        ])
+        self.assertFalse(st["repos"]["engine"]["needs_plan"][0]["blocked"])
+
+    def test_prose_only_blocker_holds_issue(self):
+        # A `Blocked on …` header naming a PR but no resolvable #N (the
+        # `_BLOCKED_ON_RE` fallback) parses to a non-empty raw value with no
+        # extractable ref — matches resolve_human_approved_blockers' analogous
+        # "prose blocker with no #N" case, which also holds the issue back.
+        st = self._resolved(needs_plan=[
+            {"number": 2258, "labels": ["fleet:needs-plan"],
+             "body": "## Blocked on the lighting redesign PR\n\n**Model:** opus"},
+        ])
+        self.assertTrue(st["repos"]["engine"]["needs_plan"][0]["blocked"])
+
+    def test_cross_repo_blocker_does_not_block(self):
+        st = self._resolved(needs_plan=[
+            {"number": 2258, "labels": ["fleet:needs-plan"],
+             "body": "**Blocked by:** jakildev/irreden#125"},
+        ])
+        self.assertFalse(st["repos"]["engine"]["needs_plan"][0]["blocked"],
+                         "cross-repo blocker is unresolvable from this window")
+
+
+class ProjectAndSliceWorkerHonorNeedsPlanBlocked(unittest.TestCase):
+    """The dispatch consequence: a needs-plan issue already annotated
+    `blocked: True` by resolve_needs_plan_blocked_by must not surface in
+    either the wake projection or the dispatch slice."""
+
+    def test_blocked_dropped_from_project_worker(self):
+        items = project_worker(_state(needs_plan=[
+            {"number": 2258, "labels": ["fleet:needs-plan"], "blocked": True},
+        ]))
+        self.assertEqual(
+            [i for i in items if i.get("kind") == "needs_plan"], [])
+
+    def test_unblocked_still_surfaces_in_project_worker(self):
+        items = project_worker(_state(needs_plan=[
+            {"number": 2092, "labels": ["fleet:needs-plan"], "blocked": False},
+        ]))
+        self.assertEqual(
+            [i["issue"] for i in items if i.get("kind") == "needs_plan"], [2092])
+
+    def test_blocked_dropped_from_slice_worker(self):
+        out = slice_worker(_state(needs_plan=[
+            {"number": 2258, "labels": ["fleet:needs-plan"], "blocked": True},
+        ]))
+        self.assertEqual(out["needs_plan"], [])
+
+    def test_unblocked_still_surfaces_in_slice_worker(self):
+        out = slice_worker(_state(needs_plan=[
+            {"number": 2092, "labels": ["fleet:needs-plan"], "blocked": False},
+        ]))
+        self.assertEqual([i["number"] for i in out["needs_plan"]], [2092])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `fetch_needs_plan` never fetched issue bodies, so the scout's `needs_plan[]` projection couldn't see a standalone `**Blocked by:**` line — a `fleet:needs-plan` issue explicitly parked behind an open blocker (e.g. #2258 held for #2280's attribution table) kept projecting as plannable, firing a no-op planner dispatch every tick (five consecutive fable-class no-ops observed on 2026-07-07).
- Added `resolve_needs_plan_blocked_by`, mirroring `resolve_human_approved_blockers`: in-memory-only resolution (`closed_fleet_queued` + merged `claude/<N>-*` heads), body popped after parsing so `state.json` stays lean.
- Gated both `project_worker` (the wake-decision hash) and `slice_worker` (the dispatch slice a woken worker reads) on the new `blocked` flag — gating only one leaves the dispatcher waking a phantom iteration or still surfacing the parked issue as a claimable candidate (the same "gate both lanes" pattern #2110/#2114 established for the `human:no-plan` gate).
- `project_queue_manager` / `slice_queue_manager` deliberately stay ungated — that lane wakes `fleet-queue-ingest`'s reconcile pass, which must still see parked issues to act on them later.

## Test plan
- [x] `python3 -m unittest discover -s scripts/fleet/tests -p "test_*.py"` — 605 tests, all green.
- [x] New `scripts/fleet/tests/test_needs_plan_blocked_by.py` covers `resolve_needs_plan_blocked_by` (open blocker, closed blocker, merged-head satisfaction, `(none)` sentinel, missing body, prose-only blocker, cross-repo blocker) and the `project_worker`/`slice_worker` gating consequence.
- [x] `ruff check scripts/` — clean.

Closes #2287