### PR TITLE
render: micro-slice packing — cut launched workgroups for high-zoom stage-1/2 dispatch (#2258 Step A)

### DIFF
--- a/engine/render/src/metal/metal_pipeline.cpp
+++ b/engine/render/src/metal/metal_pipeline.cpp
@@ -29,10 +29,19 @@ std::string metalFunctionNameForStage(const ShaderStage &stage) {
     return std::filesystem::path(stage.getFilepath()).stem().string();
 }
 
+// #2258 micro-slice packing: each stage threadgroup runs
+// kStageMicroSlicesPerGroup z-slices (its local_size_z). MUST match the shader
+// constant kStageMicroSlicesPerGroup (shaders/ir_constants.glsl +
+// metal/ir_constants.metal) and the compact's divCeil(zTotal, N) numGroupsZ — a
+// stale entry here silently reverts the stage kernels to 1×1×1 threadgroups
+// (Metal defaults unmapped functions to 1×1×1), dropping every micro-slice past
+// the first.
+constexpr int kStageMicroSlicesPerGroup = 8;
+
 MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
     if (functionName == "c_voxel_to_trixel_stage_1" ||
         functionName == "c_voxel_to_trixel_stage_2") {
-        return MTL::Size(2, 3, 1);
+        return MTL::Size(2, 3, kStageMicroSlicesPerGroup);
     }
     if (functionName == "c_text_to_trixel") {
         return MTL::Size(7, 11, 1);

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
@@ -9,9 +9,14 @@
 
 #version 450 core
 
-layout(local_size_x = 2, local_size_y = 3, local_size_z = 1) in;
+// local_size_z packs kStageMicroSlicesPerGroup (#2258) micro-slices per
+// workgroup — keep this literal in lockstep with kStageMicroSlicesPerGroup in
+// ir_constants.glsl (the layout qualifier must be a literal; the include lands
+// below it, so it can't reference the constant here).
+layout(local_size_x = 2, local_size_y = 3, local_size_z = 8) in;
 
 #include "ir_iso_common.glsl"
+#include "ir_constants.glsl"
 
 // Coordinate chain: World 3D -> Iso 2D -> Canvas pixel
 //   canvasPixel = trixelCanvasOffsetZ1 + floor(cameraIso) + pos3DtoPos2DIso(world)
@@ -325,6 +330,18 @@ void main() {
     uint compactedIdx = gl_WorkGroupID.x + gl_WorkGroupID.y * numGroupsX;
     if (compactedIdx >= visibleCount) return;
 
+    // #2258 micro-slice packing: the compact now dispatches
+    // divCeil(zTotal, kStageMicroSlicesPerGroup) z-workgroups instead of one per
+    // micro-slice. Re-derive this invocation's absolute micro-slice index and
+    // early-return the trailing slices of the last workgroup. zTotal is sub² for
+    // the subdivided/per-axis routes and 1 for the base-resolution routes, so a
+    // base-res voxel still does exactly one store (zIdx 0) rather than 8.
+    const int subdivisions = max(voxelRenderOptions.y, 1);
+    const int zIdx =
+        int(gl_WorkGroupID.z) * kStageMicroSlicesPerGroup + int(gl_LocalInvocationID.z);
+    const int zTotal = (voxelRenderOptions.x != 0) ? (subdivisions * subdivisions) : 1;
+    if (zIdx >= zTotal) return;
+
     uint voxelIndex = compactedVoxelIndices[compactedIdx];
     const vec4 voxelPosition = positions[voxelIndex];
 
@@ -583,7 +600,7 @@ void main() {
         // Only the z=0 invocation writes; higher z-slices return early.
         // The voxel's continuous sub-cell offset is packed into the lower bits
         // of the encoding so scatter can sub-pixel-shift the face quad.
-        if (gl_WorkGroupID.z != 0) return;
+        if (zIdx != 0) return;
         const vec3 worldAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
         const ivec3 worldPos_sub = roundHalfUp(worldAligned);
         const ivec3 facePos_sub = faceMicroPositionFixed6(faceId, worldPos_sub, 0, 0, 1);
@@ -632,9 +649,10 @@ void main() {
         return;
     }
 
-    const int subdivisions = max(voxelRenderOptions.y, 1);
-    int u = int(gl_WorkGroupID.z) / subdivisions;
-    int v = int(gl_WorkGroupID.z) % subdivisions;
+    // subdivisions hoisted to top-of-main (#2258); u/v index the micro-grid via
+    // the packed zIdx (== gl_WorkGroupID.z at the old local_size_z == 1).
+    int u = zIdx / subdivisions;
+    int v = zIdx % subdivisions;
 
     const vec3 voxelPositionAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
     const ivec3 voxelPositionFixed = roundHalfUp(voxelPositionAligned * float(subdivisions));

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -1,8 +1,13 @@
 #version 450 core
 
-layout(local_size_x = 2, local_size_y = 3, local_size_z = 1) in;
+// local_size_z packs kStageMicroSlicesPerGroup (#2258) micro-slices per
+// workgroup — keep this literal in lockstep with kStageMicroSlicesPerGroup in
+// ir_constants.glsl (the layout qualifier must be a literal; the include lands
+// below it, so it can't reference the constant here).
+layout(local_size_x = 2, local_size_y = 3, local_size_z = 8) in;
 
 #include "ir_iso_common.glsl"
+#include "ir_constants.glsl"
 
 layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     uniform vec2 frameCanvasOffset;
@@ -220,6 +225,16 @@ void main() {
     uint compactedIdx = gl_WorkGroupID.x + gl_WorkGroupID.y * numGroupsX;
     if (compactedIdx >= visibleCount) return;
 
+    // #2258 micro-slice packing (mirrors stage 1): re-derive the absolute
+    // micro-slice index from the packed z-workgroup + local z, and early-return
+    // the trailing slices of the last workgroup. zTotal is sub² for the
+    // subdivided/per-axis routes and 1 for the base-resolution routes.
+    const int subdivisions = max(voxelRenderOptions.y, 1);
+    const int zIdx =
+        int(gl_WorkGroupID.z) * kStageMicroSlicesPerGroup + int(gl_LocalInvocationID.z);
+    const int zTotal = (voxelRenderOptions.x != 0) ? (subdivisions * subdivisions) : 1;
+    if (zIdx >= zTotal) return;
+
     uint voxelIndex = compactedVoxelIndices[compactedIdx];
     const vec4 voxelPosition = positions[voxelIndex];
     vec4 voxelColor = unpackColor(voxels[voxelIndex].colorPacked);
@@ -332,7 +347,7 @@ void main() {
             return;
         }
         // #1458: mirror stage 1's base-resolution store (z=0 only).
-        if (gl_WorkGroupID.z != 0) return;
+        if (zIdx != 0) return;
         const vec3 worldAligned_s2 = snapNearIntegerVoxelPosition(voxelPosition.xyz);
         const ivec3 worldPos_s2 = roundHalfUp(worldAligned_s2);
         const ivec3 facePos_s2 = faceMicroPositionFixed6(faceId, worldPos_s2, 0, 0, 1);
@@ -397,9 +412,10 @@ void main() {
         return;
     }
 
-    const int subdivisions = max(voxelRenderOptions.y, 1);
-    int u = int(gl_WorkGroupID.z) / subdivisions;
-    int v = int(gl_WorkGroupID.z) % subdivisions;
+    // subdivisions hoisted to top-of-main (#2258); u/v index the micro-grid via
+    // the packed zIdx (== gl_WorkGroupID.z at the old local_size_z == 1).
+    int u = zIdx / subdivisions;
+    int v = zIdx % subdivisions;
 
     const vec3 voxelPositionAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
     const ivec3 voxelPositionFixed = roundHalfUp(voxelPositionAligned * float(subdivisions));

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -175,7 +175,14 @@ void writeDispatchDims(uint base) {
     params[base + 0u] = gx;
     params[base + 1u] = max((count + gx - 1u) / gx, 1u);
     int subdivisions = max(voxelRenderOptions.y, 1);
-    params[base + 2u] = (voxelRenderOptions.x != 0) ? uint(subdivisions * subdivisions) : 1u;
+    // #2258 micro-slice packing: dispatch divCeil(zTotal, kStageMicroSlicesPerGroup)
+    // z-workgroups; each stage workgroup covers kStageMicroSlicesPerGroup micro-slices
+    // (its local_size_z). The stage kernels re-derive zIdx and early-return the
+    // trailing zIdx >= zTotal slices, so the launch count drops ~Nx with identical
+    // output.
+    uint zTotal = (voxelRenderOptions.x != 0) ? uint(subdivisions * subdivisions) : 1u;
+    uint microSlices = uint(kStageMicroSlicesPerGroup);
+    params[base + 2u] = (zTotal + microSlices - 1u) / microSlices;
 }
 
 void main() {

--- a/engine/render/src/shaders/ir_constants.glsl
+++ b/engine/render/src/shaders/ir_constants.glsl
@@ -4,3 +4,13 @@
 
 const int VOXEL_CHUNK_SIZE = 256;
 const int kInvalidDepth = 0x7FFFFFFF;
+
+// Voxel stage-1/stage-2 micro-slice packing (#2258). Each stage workgroup runs
+// this many z-slices (`local_size_z`), so the compact dispatches
+// divCeil(zTotal, kStageMicroSlicesPerGroup) workgroups instead of one per
+// micro-slice. Byte-identical output (the z-slices are independent atomic
+// writers); it only cuts the launched-workgroup count. Must stay in lockstep
+// with the `local_size_z` literal in c_voxel_to_trixel_stage_{1,2}.glsl, the
+// compact's writeDispatchDims numGroupsZ, and the Metal twins (ir_constants.metal
+// + the (2,3,N) threadgroup-size map in metal_pipeline.cpp).
+const int kStageMicroSlicesPerGroup = 8;

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -238,6 +238,19 @@ kernel void c_voxel_to_trixel_stage_1(
         return;
     }
 
+    // #2258 micro-slice packing (mirrors the GLSL): the compact dispatches
+    // divCeil(zTotal, kStageMicroSlicesPerGroup) z-threadgroups; re-derive the
+    // absolute micro-slice index and early-return the trailing slices of the last
+    // threadgroup. zTotal is sub² for the subdivided/per-axis routes and 1 for
+    // the base-resolution routes.
+    const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
+    const int zIdx =
+        int(groupId.z) * kStageMicroSlicesPerGroup + int(localId3.z);
+    const int zTotal = (frameData.voxelRenderOptions.x != 0) ? (subdivisions * subdivisions) : 1;
+    if (zIdx >= zTotal) {
+        return;
+    }
+
     const uint voxelIndex = compactedVoxelIndices[compactedIdx];
     const float4 voxelPosition = positions[voxelIndex];
     const uint2 localId = localId3.xy;
@@ -420,7 +433,7 @@ kernel void c_voxel_to_trixel_stage_1(
         }
         // #1458: store at BASE (world-unit) resolution regardless of effSub.
         // Only the z=0 invocation writes; higher z-slices return early.
-        if (groupId.z != 0) return;
+        if (zIdx != 0) return;
         const float3 worldAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
         const int3 worldPos_sub = roundHalfUp(worldAligned);
         const int3 facePos_sub = faceMicroPositionFixed6(faceId, worldPos_sub, 0, 0, 1);
@@ -472,9 +485,10 @@ kernel void c_voxel_to_trixel_stage_1(
         return;
     }
 
-    const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
-    const int u = int(groupId.z) / subdivisions;
-    const int v = int(groupId.z) % subdivisions;
+    // subdivisions hoisted to top-of-kernel (#2258); u/v index the micro-grid via
+    // the packed zIdx (== groupId.z at the old threadgroup local_size_z == 1).
+    const int u = zIdx / subdivisions;
+    const int v = zIdx % subdivisions;
 
     const float3 voxelPositionAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
     const int3 voxelPositionFixed = roundHalfUp(voxelPositionAligned * float(subdivisions));

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
@@ -222,6 +222,17 @@ kernel void c_voxel_to_trixel_stage_2(
         return;
     }
 
+    // #2258 micro-slice packing (mirrors stage 1): re-derive the absolute
+    // micro-slice index from the packed z-threadgroup + local z, early-returning
+    // the trailing slices of the last threadgroup.
+    const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
+    const int zIdx =
+        int(groupId.z) * kStageMicroSlicesPerGroup + int(localId3.z);
+    const int zTotal = (frameData.voxelRenderOptions.x != 0) ? (subdivisions * subdivisions) : 1;
+    if (zIdx >= zTotal) {
+        return;
+    }
+
     const uint voxelIndex = compactedVoxelIndices[compactedIdx];
     const float4 voxelPosition = positions[voxelIndex];
     float4 voxelColor = unpackColor(voxels[voxelIndex].colorPacked);
@@ -343,7 +354,7 @@ kernel void c_voxel_to_trixel_stage_2(
             return;
         }
         // #1458: mirror stage 1's base-resolution store (z=0 only).
-        if (groupId.z != 0) return;
+        if (zIdx != 0) return;
         const float3 worldAligned_s2 = snapNearIntegerVoxelPosition(voxelPosition.xyz);
         const int3 worldPos_s2 = roundHalfUp(worldAligned_s2);
         const int3 facePos_s2 = faceMicroPositionFixed6(faceId, worldPos_s2, 0, 0, 1);
@@ -426,9 +437,10 @@ kernel void c_voxel_to_trixel_stage_2(
         return;
     }
 
-    const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
-    const int u = int(groupId.z) / subdivisions;
-    const int v = int(groupId.z) % subdivisions;
+    // subdivisions hoisted to top-of-kernel (#2258); u/v index the micro-grid via
+    // the packed zIdx (== groupId.z at the old threadgroup local_size_z == 1).
+    const int u = zIdx / subdivisions;
+    const int v = zIdx % subdivisions;
 
     const float3 voxelPositionAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
     const int3 voxelPositionFixed = roundHalfUp(voxelPositionAligned * float(subdivisions));

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -68,7 +68,12 @@ static void writeDispatchDims(
         memory_order_relaxed
     );
     const int subdivisions = max(subdivisionsY, 1);
-    const uint gz = (renderModeX != 0) ? uint(subdivisions * subdivisions) : 1u;
+    // #2258 micro-slice packing: dispatch divCeil(zTotal, kStageMicroSlicesPerGroup)
+    // z-threadgroups; each stage threadgroup covers kStageMicroSlicesPerGroup
+    // micro-slices (its local_size_z). Mirrors the GLSL writeDispatchDims.
+    const uint zTotal = (renderModeX != 0) ? uint(subdivisions * subdivisions) : 1u;
+    const uint microSlices = uint(kStageMicroSlicesPerGroup);
+    const uint gz = (zTotal + microSlices - 1u) / microSlices;
     atomic_store_explicit(&indirectParams[base + kSlotNumGroupsZ], gz, memory_order_relaxed);
 }
 

--- a/engine/render/src/shaders/metal/ir_constants.metal
+++ b/engine/render/src/shaders/metal/ir_constants.metal
@@ -3,3 +3,11 @@
 
 constant int VOXEL_CHUNK_SIZE = 256;
 constant int kInvalidDepth = 0x7FFFFFFF;
+
+// Voxel stage-1/stage-2 micro-slice packing (#2258). Mirror of
+// shaders/ir_constants.glsl kStageMicroSlicesPerGroup — each stage threadgroup
+// runs this many z-slices, so the compact dispatches
+// divCeil(zTotal, kStageMicroSlicesPerGroup) threadgroups. Must stay in lockstep
+// with the (2,3,N) threadgroup-size map entry in metal_pipeline.cpp and the GLSL
+// side's local_size_z.
+constant int kStageMicroSlicesPerGroup = 8;


### PR DESCRIPTION
## Summary

**Step A of the #2258 plan: micro-slice packing — cut launched workgroups.**

The zoom-16 `voxelStage1`+`voxelStage2` cost (~140 ms) is a **dispatch-grid**
cost, not a per-invocation-body cost (attribution table on #2258 via #2280's
sub-stage scopes; a 256× body reduction changed nothing, #2266). Both stages
dispatch `compactedCount × effSub²` workgroups of 6 threads each — O(10⁷)
six-thread launches per stage per frame at zoom 16.

This PR packs `kStageMicroSlicesPerGroup` (**8**) z micro-slices into each
stage workgroup:
- `local_size_z` 1 → 8 in `c_voxel_to_trixel_stage_{1,2}` (GLSL + Metal).
- The compact's `writeDispatchDims` writes `numGroupsZ = divCeil(zTotal, 8)`
  instead of `zTotal`.
- Each stage kernel re-derives its absolute micro-slice index
  `zIdx = gl_WorkGroupID.z*8 + gl_LocalInvocationID.z` and early-returns the
  trailing `zIdx >= zTotal` slices of the last workgroup.
- The Metal threadgroup-size map (`metal_pipeline.cpp`) goes `(2,3,1) → (2,3,8)`
  — an unmapped/stale entry silently reverts to 1×1×1 launches.

All five sites (2 GLSL `local_size_z`, 2 Metal shader derivations via
`ir_constants.metal`, the compact `writeDispatchDims`) key off the single
shared `kStageMicroSlicesPerGroup` constant.

## Byte-identity

The z-slices are **independent, order-independent `atomicMin` writers with no
workgroup-shared state** (no `shared`/`barrier` in either stage kernel), so
packing them into fatter workgroups changes the *launch count* only, never the
output. Verified empirically:

- `shape_debug --auto-screenshot` (the canonical determinism target): **28/28
  shots byte-identical** (`cmp`) branch-vs-master, cardinal **and** the yaw45
  per-axis poses.
- (`perf_grid` byte-compare is invalid here — it is non-deterministic
  run-to-run: master-vs-master is also 7/7 mismatch, from idle-wave + unsettled
  iterative lighting at the capture frame. #2255 covers the per-axis case.)

Because the change is provably byte-identical, `attach-screenshots` /
`render-debug-loop` are skipped (they would produce identical before/after);
the `cmp` result above is the stronger evidence.

## Perf (same-session master A/B, macOS/Metal 2560×1440 2x, `IRPerfGrid --auto-profile 120`)

| zoom | stage | master (ms) | Step A (ms) | drop |
|---|---|---|---|---|
| 8 | voxelStage1 | 25.379 | 6.109 | **4.15×** |
| 8 | voxelStage2 | 32.084 | 5.692 | **5.64×** |
| 16 | voxelStage1 | 63.029 | 15.534 | **4.06×** |
| 16 | voxelStage2 | 75.155 | 10.083 | **7.45×** |

Drops are 4–7.5× — comfortably above the plan's ×2 STOP threshold, so the
per-launch cost model is validated (a per-invocation cost would show ~1×). Not
a clean ×8 (a residual per-invocation floor remains); the remaining gap to the
occupancy-armed band (6.1 / 12.6 ms) is what **Step B** (feeder dispatch
partition) targets.

## Step B follow-up

This PR is **Step A only**; it intentionally does **not** close #2258. Step B
(the feeder dispatch partition — classify visible vs shadow-feeder voxels in
the compact and dispatch feeders coarsely at bake-texel density) is a larger,
shadow-quality-sensitive change (std140 UBO-lane repurposing, a new stage-1
feeder pass, a bake-coupled cap derivation, and a hole-avoidance
render-debug-loop gate) and lands as a separate PR against the same issue. See
the #2258 comment for the hand-off.

## Test plan

- [x] Metal build clean; runtime shader compile OK (ran shape_debug across 21
      poses + perf_grid, exit 0, no crashes)
- [x] Byte-identity: shape_debug 28/28 `cmp` branch-vs-master
- [x] Perf gate: same-session A/B, 4–7.5× on voxelStage1/voxelStage2
- [ ] Linux/OpenGL cross-host smoke (`fleet:needs-linux-smoke`)

Part of #2258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
