### PR TITLE
script: deferred entity create/destroy binding for Lua EVAL systems (#2286)

### DIFF
--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -83,6 +83,12 @@ deferred API:
 
 - `removeComponentDeferred(id, C)` — queue a removal.
 - `setComponentDeferred(id, C{...})` — queue an add/set.
+- `createEntityDeferred()` — reserve an id now, queue a bare-entity insert;
+  the id is returned immediately (like the worker-thread `createEntity`),
+  usable to attach components / destroy the entity before the insert runs.
+- `stageStructuralChange(fn)` — queue an arbitrary `void()` mutation (the
+  non-templated staging entry point the Lua `IREntity.deferredCreate` binding
+  uses to marshal runtime-typed component attachment).
 - `flushStructuralChanges()` — apply queued changes at a safe point (the
   frame boundary in most pipelines).
 

--- a/engine/entity/include/irreden/entity/entity_manager.hpp
+++ b/engine/entity/include/irreden/entity/entity_manager.hpp
@@ -211,6 +211,22 @@ class EntityManager {
         updateRecord(entity, archetypeNode, index);
     }
 
+    // #2286: deferred dynamic entity create for the Lua EVAL binding. Reserve
+    // an id now (so a tick can reference / attach to the entity immediately)
+    // and stage the bare-entity insert for the next `flushStructuralChanges`,
+    // mirroring the worker-thread `createEntity` path. The archetype starts
+    // empty; components are attached by follow-up `addComponentDynamic` calls
+    // staged via `stageStructuralChange` — those drain after this insert
+    // because a slot's structural changes replay in push order. Runtime
+    // (Lua-registered) ComponentIds are the intended payload, so the create
+    // stays out of the templated `createEntity<...>` path.
+    EntityId createEntityDeferred() {
+        IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
+        EntityId entity = allocateEntityIdAtomic();
+        stageStructuralChange([this, entity]() { insertReservedEntity(entity); });
+        return entity;
+    }
+
     template <typename Component, typename... Args> ComponentId registerComponent(Args &&...args) {
         IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
         std::string typeName = typeid(Component).name();
@@ -384,6 +400,17 @@ class EntityManager {
                 setComponent<Component>(entity, component);
             }
         });
+    }
+
+    // #2286: stage an arbitrary structural mutation to run at the next
+    // `flushStructuralChanges`, in the current thread's staging slot (slot 0
+    // == main thread). The templated `setComponentDeferred` /
+    // `removeComponentDeferred` cover C++-typed ops; this generic entry point
+    // exists for the Lua deferred-create binding, which must marshal
+    // `sol::table` override values in a lambda the entity module cannot depend
+    // on the type of. Ops replay in push order within a slot.
+    void stageStructuralChange(std::function<void()> op) {
+        m_workerStaging[workerSlotForCurrentThread()].structuralChanges_.push_back(std::move(op));
     }
 
     void flushStructuralChanges();

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -138,6 +138,27 @@ local rules = IREntity.singleton(C_Hp)                    -- LuaEntity
 IREntity.setLuaField(rules, C_Hp, C_Hp.fields.current.index, 100)
 ```
 
+**Deferred entity create/destroy (mid-tick, #2286).** A structural change
+issued from inside a system tick must be deferred, exactly like a C++ system
+(archetype iteration is live). `IREntity.deferredCreate` / `deferredDestroy`
+queue the op through the engine's deferred machinery — the create's insert
+drains at the next `flushStructuralChanges` (group boundary), the destroy at
+`destroyMarkedEntities` (pipeline end):
+
+```lua
+-- Optional component list: { componentDef, overridesTableOrNil } entries.
+-- componentDef is any IRComponent.register / codegen'd handle (carries
+-- componentId); overrides apply exactly like addLuaComponent.
+local eid = IREntity.deferredCreate({ { C_Hp, { current = 30 } } })  -- → EntityId
+IREntity.deferredDestroy(eid)   -- eid is a raw EntityId (e.g. arch.entityAt(i))
+```
+
+The returned EntityId is reserved immediately (usable to destroy or stash the
+entity), but the entity does not materialize until the flush. Attaches any
+component addressable from Lua by `componentId`; a native C++-only component
+(no Lua-typed default-row support) still uses the templated C++
+`createEntity`. See `docs/design/lua-driven-ecs.md` §G4.
+
 - **Type inference:** integer literal → `int32`; float literal → `float`;
   string → `std::string`; bool → `bool`; function → `sol::function`. The
   short form fails registration with a Lua error if a default value isn't

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -168,6 +168,26 @@ LuaFieldSchema buildFieldSchema(
     return s;
 }
 
+// Add a dynamic (Lua-registered / codegen'd) component to `entity` by
+// ComponentId and, when `overrides` is present, write its fields from the
+// table. Shared by the eager `IREntity.addLuaComponent` binding and the
+// deferred `IREntity.deferredCreate` attach path.
+void attachDynamicComponent(
+    IREntity::EntityManager &em,
+    IREntity::EntityId entity,
+    IREntity::ComponentId componentId,
+    const sol::optional<sol::table> &overrides
+) {
+    em.addComponentDynamic(entity, componentId);
+    if (!overrides) {
+        return;
+    }
+    auto [data, row] = em.getComponentDataAndRow(entity, componentId);
+    IR_ASSERT(data != nullptr, "attachDynamicComponent: post-add lookup failed");
+    auto *typed = static_cast<IComponentDataLuaTyped *>(data);
+    typed->writeRowFromTable(row, *overrides);
+}
+
 } // namespace
 
 // lua_dofile runs a lua script. Global functions and variables
@@ -525,14 +545,7 @@ void LuaScript::bindLuaDrivenEcs() {
                                                sol::optional<sol::table> overrides
                                            ) {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
-        auto &em = IREntity::getEntityManager();
-        em.addComponentDynamic(entity.entity, componentId);
-        if (overrides) {
-            auto [data, row] = em.getComponentDataAndRow(entity.entity, componentId);
-            IR_ASSERT(data != nullptr, "addLuaComponent: post-add lookup failed");
-            auto *typed = static_cast<IComponentDataLuaTyped *>(data);
-            typed->writeRowFromTable(row, *overrides);
-        }
+        attachDynamicComponent(IREntity::getEntityManager(), entity.entity, componentId, overrides);
     };
 
     m_lua["IREntity"]["getLuaComponent"] =
@@ -555,6 +568,58 @@ void LuaScript::bindLuaDrivenEcs() {
     m_lua["IREntity"]["hasLuaComponent"] = [](IRScript::LuaEntity entity, sol::table componentDef) {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
         return IREntity::getEntityManager().hasComponent(entity.entity, componentId);
+    };
+
+    // #2286: deferred entity create/destroy for EVAL Lua systems. A structural
+    // change (create, destroy) issued from inside a per-entity tick would
+    // invalidate the archetype iteration in progress, so these route through
+    // the same deferred machinery C++ systems use: the create's archetype
+    // insert drains at the next `flushStructuralChanges` (a group boundary),
+    // the destroy at `destroyMarkedEntities` (pipeline end) — never mid-tick.
+    // See `docs/design/lua-driven-ecs.md` §G4.
+    //
+    // `deferredCreate` returns the reserved EntityId immediately so a tick can
+    // hold it (e.g. to `deferredDestroy` it later, or stash it in a component)
+    // before the entity actually materializes at flush. `componentList` is an
+    // optional array of `{ componentDef, overridesTableOrNil }` entries:
+    // `componentDef` is the table from `IRComponent.register` / a codegen'd
+    // component binding (it carries `componentId`), and the optional overrides
+    // are applied exactly like `addLuaComponent`. Both Lua-registered and
+    // codegen'd components share the ComponentId space, so either attaches.
+    m_lua["IREntity"]["deferredCreate"] =
+        [this](sol::optional<sol::table> componentList) -> IREntity::EntityId {
+        auto &em = IREntity::getEntityManager();
+        // Marshal the sol values on the calling (tick) thread; the deferred
+        // lambda then attaches without re-entering Lua at flush time. Each
+        // pending entry is (componentId, optional field-overrides table).
+        using PendingComponent = std::pair<IREntity::ComponentId, sol::optional<sol::table>>;
+        std::vector<PendingComponent> pending;
+        if (componentList) {
+            const std::size_t count = componentList->size();
+            pending.reserve(count);
+            for (std::size_t i = 1; i <= count; ++i) {
+                sol::table entry = componentList->get<sol::table>(i);
+                sol::table componentDef = entry.get<sol::table>(1);
+                pending.emplace_back(
+                    componentDef.get<lua_Integer>("componentId"),
+                    entry.get<sol::optional<sol::table>>(2)
+                );
+            }
+        }
+        const IREntity::EntityId entity = em.createEntityDeferred();
+        em.stageStructuralChange([entity, pending = std::move(pending)]() {
+            auto &mgr = IREntity::getEntityManager();
+            for (const auto &[componentId, overrides] : pending) {
+                attachDynamicComponent(mgr, entity, componentId, overrides);
+            }
+        });
+        return entity;
+    };
+
+    m_lua["IREntity"]["deferredDestroy"] = [](IREntity::EntityId entity) {
+        // markEntityForDeletion mutates the flag bit on its arg ref; the local
+        // copy absorbs it. Drained by destroyMarkedEntities at pipeline end.
+        IREntity::getEntityManager().markEntityForDeletion(entity);
     };
 
     m_lua["IREntity"]["bindPoint"] = [](IRScript::LuaEntity self,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(IrredenEngineTest
   script/lua_input_bindings_test.cpp
   script/lua_component_codegen_test.cpp
   script/lua_component_register_test.cpp
+  script/lua_deferred_entity_test.cpp
   script/lua_enum_register_test.cpp
   script/lua_persistence_test.cpp
   script/lua_world_snapshot_test.cpp

--- a/test/script/lua_deferred_entity_test.cpp
+++ b/test/script/lua_deferred_entity_test.cpp
@@ -1,0 +1,208 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+#include <irreden/script/lua_component_data.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <variant>
+#include <vector>
+
+// #2286: EVAL-mode coverage for IREntity.deferredCreate / deferredDestroy —
+// the Lua binding for structural entity changes queued from inside a system
+// tick. The create's archetype insert drains at flushStructuralChanges (a
+// group boundary, exercised here via executePipeline); the destroy drains at
+// destroyMarkedEntities (pipeline end, called manually since these tests do
+// not spin a full World). See docs/design/lua-driven-ecs.md §G4.
+
+namespace {
+
+class LuaDeferredEntityTest : public testing::Test {
+  protected:
+    LuaDeferredEntityTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        m_lua.bindLuaDrivenEcs();
+        // LuaEntity is bound per-creation in production; tests bind a minimal
+        // version so the addLuaComponent / setLuaField setup path resolves.
+        m_lua.lua().new_usertype<IRScript::LuaEntity>(
+            "LuaEntity",
+            sol::constructors<IRScript::LuaEntity(IREntity::EntityId)>(),
+            "entity",
+            &IRScript::LuaEntity::entity
+        );
+    }
+
+    // Count live entities carrying `componentId` across all archetype nodes.
+    int countWith(IREntity::ComponentId componentId) {
+        int total = 0;
+        for (auto *node : IREntity::queryArchetypeNodesSimple({componentId})) {
+            total += node->length_;
+        }
+        return total;
+    }
+
+    // Read an int32 field of the single row of the sole entity carrying
+    // `componentId` (helper for the single-spawn assertions).
+    std::vector<std::int32_t>
+    readInt32Column(IREntity::ComponentId componentId, const std::string &fieldName) {
+        std::vector<std::int32_t> values;
+        for (auto *node : IREntity::queryArchetypeNodesSimple({componentId})) {
+            auto *typed = static_cast<IRScript::IComponentDataLuaTyped *>(
+                node->components_.at(componentId).get()
+            );
+            const int idx = typed->findFieldIndex(fieldName);
+            const auto *col = std::get_if<std::vector<std::int32_t>>(&typed->columnAt(idx));
+            if (col) {
+                values.insert(values.end(), col->begin(), col->end());
+            }
+        }
+        return values;
+    }
+
+    // m_lua first so its sol::state outlives sol::function-bearing columns
+    // held by the EntityManager (matches lua_system_register_test.cpp).
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+// A deferredCreate reserves the id immediately but does not materialize the
+// entity until flushStructuralChanges — matching the C++ deferred-create
+// contract (no mid-tick archetype mutation).
+TEST_F(LuaDeferredEntityTest, DeferredCreateMaterializesOnFlush) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script("Widget = IRComponent.register('Widget', { hp = 5 })").valid());
+    const IREntity::ComponentId widgetId = m_entity_manager.getComponentTypeByName("Widget");
+    ASSERT_GT(widgetId, 0u);
+
+    auto result = lua.safe_script(
+        "return IREntity.deferredCreate({ { Widget, { hp = 42 } } })",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    const auto eid = result.get<IREntity::EntityId>();
+
+    // Reserved but not yet inserted — the archetype insert is queued.
+    EXPECT_FALSE(m_entity_manager.entityExists(eid));
+    EXPECT_EQ(countWith(widgetId), 0);
+
+    m_entity_manager.flushStructuralChanges();
+
+    EXPECT_TRUE(m_entity_manager.entityExists(eid));
+    ASSERT_EQ(countWith(widgetId), 1);
+    const auto hps = readInt32Column(widgetId, "hp");
+    ASSERT_EQ(hps.size(), 1u);
+    EXPECT_EQ(hps[0], 42);
+}
+
+// deferredCreate with no component list yields a bare (empty-archetype)
+// entity — still reserved-then-flushed.
+TEST_F(LuaDeferredEntityTest, DeferredCreateWithoutComponentsIsBareEntity) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script("return IREntity.deferredCreate()", sol::script_pass_on_error);
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    const auto eid = result.get<IREntity::EntityId>();
+
+    EXPECT_FALSE(m_entity_manager.entityExists(eid));
+    m_entity_manager.flushStructuralChanges();
+    EXPECT_TRUE(m_entity_manager.entityExists(eid));
+}
+
+// deferredDestroy queues a deletion drained by destroyMarkedEntities, not by
+// flushStructuralChanges — so the entity survives a flush and dies on drain.
+TEST_F(LuaDeferredEntityTest, DeferredDestroyRemovesOnDrain) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script("Widget = IRComponent.register('Widget', { hp = 5 })").valid());
+    const IREntity::ComponentId widgetId = m_entity_manager.getComponentTypeByName("Widget");
+
+    const IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, widgetId);
+    lua["target"] = static_cast<lua_Integer>(e);
+
+    ASSERT_TRUE(lua.safe_script("IREntity.deferredDestroy(target)").valid());
+
+    // Still present after a structural-change flush (destroy is a separate
+    // drain step).
+    m_entity_manager.flushStructuralChanges();
+    EXPECT_TRUE(m_entity_manager.entityExists(e));
+    EXPECT_EQ(countWith(widgetId), 1);
+
+    m_entity_manager.destroyMarkedEntities();
+    EXPECT_FALSE(m_entity_manager.entityExists(e));
+    EXPECT_EQ(countWith(widgetId), 0);
+}
+
+// The core acceptance: a Lua system tick that spawns a child per iterated
+// entity AND destroys the iterated entity does not corrupt the archetype
+// iteration in progress — because both ops are deferred. After the pipeline
+// flush + deletion drain, the drivers are gone and the spawns exist with the
+// per-entity payload the tick queued.
+TEST_F(LuaDeferredEntityTest, CreateAndDestroyMidTickDoNotCorruptIteration) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script("Cell = IRComponent.register('Cell', { n = 0 })").valid());
+    ASSERT_TRUE(
+        lua.safe_script("Spawned = IRComponent.register('Spawned', { origin = 0 })").valid()
+    );
+    const IREntity::ComponentId cellId = m_entity_manager.getComponentTypeByName("Cell");
+    const IREntity::ComponentId spawnedId = m_entity_manager.getComponentTypeByName("Spawned");
+    ASSERT_GT(cellId, 0u);
+    ASSERT_GT(spawnedId, 0u);
+
+    // Three driver entities, each Cell.n set to a distinct value the tick
+    // copies into the spawned child so we can verify payloads survive.
+    const std::vector<std::int32_t> origins{100, 200, 300};
+    for (std::int32_t n : origins) {
+        const IREntity::EntityId e = IREntity::createEntity();
+        lua["_e"] = static_cast<lua_Integer>(e);
+        lua["_n"] = static_cast<lua_Integer>(n);
+        ASSERT_TRUE(
+            lua.safe_script("IREntity.addLuaComponent(LuaEntity.new(_e), Cell, { n = _n })").valid()
+        );
+    }
+
+    lua["visited"] = 0;
+    auto reg = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'SpawnAndReap',
+            components = { 'Cell' },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    visited = visited + 1
+                    IREntity.deferredCreate({
+                        { Spawned, { origin = arch.Cell:getField(i, 'n') } }
+                    })
+                    IREntity.deferredDestroy(arch.entityAt(i))
+                end
+            end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(reg.valid()) << sol::error{reg}.what();
+    const IRSystem::SystemId sysId = reg.get<lua_Integer>();
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // flushes the spawns
+    m_entity_manager.destroyMarkedEntities();                 // drains the reaps
+
+    // The tick saw exactly the three drivers — iteration was not corrupted by
+    // the queued structural changes.
+    EXPECT_EQ(lua["visited"].get<int>(), 3);
+
+    // Drivers reaped, spawns materialized with their copied payloads.
+    EXPECT_EQ(countWith(cellId), 0);
+    ASSERT_EQ(countWith(spawnedId), 3);
+    auto spawnedOrigins = readInt32Column(spawnedId, "origin");
+    std::sort(spawnedOrigins.begin(), spawnedOrigins.end());
+    EXPECT_EQ(spawnedOrigins, origins);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds `IREntity.deferredCreate` / `IREntity.deferredDestroy` Lua bindings so an EVAL Lua system tick can spawn/destroy entities without corrupting the live archetype iteration (the G4 gap in `docs/design/lua-driven-ecs.md` — deferred machinery existed, Lua binding was missing).
- `deferredCreate(componentList?)` reserves an `EntityId` immediately (returned to the tick) and stages the archetype insert + component attach for the next `flushStructuralChanges` (group boundary). `deferredDestroy(eid)` is `markEntityForDeletion`, drained by `destroyMarkedEntities` (pipeline end) — matching the C++ system convention.
- New `EntityManager::createEntityDeferred()` (main-thread analog of the worker-thread reserve-then-stage `createEntity` path) and `EntityManager::stageStructuralChange(fn)` (generic staging entry point so the script layer can marshal `sol::table` overrides in a lambda the entity module can't depend on the type of).
- Component attach reuses a shared `attachDynamicComponent` helper (now also backing `addLuaComponent`).
- Attaches any component addressable from Lua by `componentId` (Lua-registered / codegen'd, shared ComponentId space). Native C++-only components with no Lua default-row support keep using the templated `createEntity` — same boundary as the existing `addLuaComponent`.

## Test plan
- [x] `test/script/lua_deferred_entity_test.cpp` (4 EVAL cases): reserve-then-flush create, bare-entity create, destroy-on-drain, and the acceptance case — a tick spawns a child per iterated entity and reaps the iterated entity; asserts iteration uncorrupted (3 visited, 3 spawns with copied payloads, 0 drivers) after flush + `destroyMarkedEntities`.
- [x] Full suite green on macOS/Metal (`IrredenEngineTest`: 1321 passed, 1 skipped GL-only); `addLuaComponent` coverage (`LuaComponentTest`, `LuaSystemRegisterTest`) still passes through the shared helper.

Notes for reviewer:
- Deferred create flushes at a group boundary; deferred destroy flushes at pipeline end (`destroyMarkedEntities`) — the "flush via existing pipeline step" from the issue spans both existing drains, not `flushStructuralChanges` alone.
- CODEGEN lowering of these calls (also named in §G4) is a separate follow-up; this PR is the EVAL binding the acceptance asks for.

Closes #2286
