### PR TITLE
render: Metal headless GPU vehicle-A harness + R32I cross-encoder regression guard (closes #1640)

### DIFF
--- a/.fleet/plans/issue-1640.md
+++ b/.fleet/plans/issue-1640.md
@@ -1,0 +1,69 @@
+# Plan: Metal headless GPU vehicle-A harness + R32I cross-encoder regression guard (closes #1640)
+
+- **Issue:** #1640 (unblocks #2091 once merged)
+- **Model:** opus (Metal backend headless GPU bring-up + render-invariant investigation)
+- **Date:** 2026-07-08 (architect ruling folded in; supersedes the C3-vs-C1 investigation framing)
+
+## Ruling — investigated, no defect
+
+#1640 was framed as a Metal backend gap: a foreign-canvas R32I distance texture
+read back the clear sentinel (65535) from a **second** in-tick compute dispatch,
+suspected to be a cross-encoder **visibility** bug (candidate **C3**) or a
+pipeline-ordering starvation (candidate **C1**). Both are now ruled out:
+
+- **C3 is refuted by repro.** The headless vehicle-A harness this PR adds
+  (`test/render/gpu_compute_dispatch_test.cpp`, Metal half) proves a texture
+  written by one compute dispatch is correctly read by a second dispatch sharing
+  the same command buffer across separate compute encoders — the exact structure
+  C3 blamed — and the oracle control proves a genuinely missed write *would* have
+  surfaced as the 65535 clear. Metal cross-encoder R32I write→read visibility is
+  **sound**.
+- **C1 dissolves on two static facts (no GPU frame capture needed).** (1) The
+  consolidated per-canvas raster (compact / stage-1 / stage-2, now one per-canvas
+  tick inside `VOXEL_TO_TRIXEL_STAGE_1`) encodes strictly before
+  `RESOLVE_PER_AXIS_SCREEN_DEPTH` and `BAKE_SUN_SHADOW_MAP`, so even a direct
+  foreign read at bake time is encoded after every canvas's writes. (2) The
+  per-axis screen-depth resolve already does a second-in-tick R32I `READ_ONLY`
+  image bind on three non-main canvases every non-cardinal frame on Metal in
+  production, and works.
+
+**Actual cause of the #1626-era symptom:** multi-canvas shared-state, not the
+backend — stage-2 was a separate system clobbering shared voxel SSBOs across
+multi-canvas scenes, and foreign FrameData leaked into the bake, so it sampled
+the wrong texels (uniform clear sentinel). That is the exact class the per-axis
+resolve now defensively patches. `resolve-then-bake` is therefore the permanent
+design independent of any backend bug — already ratified as the Q2-REVISED
+invariant (2026-06-09).
+
+## Deliverable (this PR)
+
+1. **Standing regression guard + reusable vehicle-A Metal harness.**
+   `bootstrapHeadlessRenderDevice` (windowless `MTLDevice` + queue, no swapchain)
+   plus two gtests in the `#elif IR_GRAPHICS_METAL` half of
+   `gpu_compute_dispatch_test.cpp` and two R32I test kernels under
+   `test/render/shaders/metal/`. Guards the Metal cross-encoder R32I contract and
+   is the tool future headless Metal GPU tests build on.
+2. **Design-doc resolution** (`docs/design/detached-revoxelize-world-light.md`,
+   Q2-REVISED block + the P4b-3 note): the "Metal scratch-delivery gap tracked as
+   its own backend issue" caveat is replaced with the no-backend-bug resolution.
+3. **PR metadata:** `Closes #1640`; title drops WIP.
+4. **Deliberately out of scope:** the `attachMetalRenderDevice` dedup (shares
+   ~60% of bring-up with `MetalRenderImpl::init()`) — production init-path churn
+   isn't justified by a test-only harness (architect agreed with the simplify
+   call).
+
+## Downstream
+
+#2091's `Blocked by: #1640` clears automatically on merge. Its investigation
+starts from "visibility is sound — look at frame-data / coordinate / binding
+state in the world-placed resolve path, with the per-axis resolve as the working
+reference" (architect is separately correcting #2091's falsified root-cause
+paragraph).
+
+## Acceptance criteria
+
+- `IrredenEngineTest --gtest_filter='*GpuComputeDispatch*'` → Metal gtests green
+  on macOS; full suite green (no regressions).
+- Design doc no longer references a Metal backend bug / scratch-delivery gap for
+  #1640; the resolution is recorded in the source-of-truth Q2-REVISED block.
+- PR closes #1640.

--- a/docs/design/detached-revoxelize-world-light.md
+++ b/docs/design/detached-revoxelize-world-light.md
@@ -140,8 +140,16 @@ How do model-frame detached voxels enter the world sun-shadow bake?
 > that; otherwise ONE shared resolve accumulating all opt-in casters
 > (min-depth) + ONE extra bake — N casters must not mean N bakes. This also
 > moots backend divergence (even if GL tolerates the foreign read, split
-> cast paths are rejected). The Metal scratch-delivery gap is tracked as its
-> own backend issue; the feature does not block on it. The screen-space
+> cast paths are rejected). **There is no Metal backend bug to track** (#1640,
+> investigated-no-defect): the headless vehicle-A harness
+> (`test/render/gpu_compute_dispatch_test.cpp`) proves cross-encoder R32I texture
+> write→read visibility is sound, and the per-axis screen-depth resolve exercises
+> the exact second-in-tick foreign-canvas R32I read every non-cardinal frame on
+> Metal in production. The #1626-era "scratch-delivery gap" symptom was
+> multi-canvas shared-state (stage-2 clobbering shared voxel SSBOs + foreign
+> frame-data leaking into the bake), not backend visibility — which is why
+> resolve-then-bake is the permanent design independent of any backend concern.
+> The screen-space
 > caveat (casts only from camera-visible surfaces) is the engine's existing
 > sun-bake model, inherited consistently.
 
@@ -248,7 +256,8 @@ Each phase is its own PR, stacks on the previous, and is independently verifiabl
    ONE extra bake dispatch through the unchanged cardinal recovery. The resolve texture is
    imageStore-written (real texture memory), which is exactly why the bake's read works on
    Metal where the rejected foreign-texture read (image-atomic-scratch-resident) returned
-   empty (backend gap tracked as #1640). Reuse check: P4b-1's depth composite
+   empty (a #1626-era multi-canvas shared-state artifact, not a Metal backend gap —
+   #1640 investigated-no-defect). Reuse check: P4b-1's depth composite
    (`ENTITY_CANVAS_TO_FRAMEBUFFER`) writes framebuffer `gl_FragDepth` AFTER the bake stage,
    so no main-layout detached depth texture exists at BAKE time — the dedicated resolve is
    required. Cast keys on the cardinal raster (like the main bake); the cast and the P4b-2

--- a/engine/render/include/irreden/render/metal/metal_runtime.hpp
+++ b/engine/render/include/irreden/render/metal/metal_runtime.hpp
@@ -8,6 +8,15 @@
 
 namespace IRRender {
 
+class RenderDevice;
+
+// Headless render-device bring-up for GPU unit tests (vehicle A, #1640).
+// Creates a windowless Metal device, initializes the runtime with a null layer,
+// wires IRRender::device(), and opens an initial command buffer — everything a
+// compute test needs to drive dispatchCompute + readback without a swapchain.
+// Returns nullptr when no Metal device is available so the caller can skip.
+RenderDevice *bootstrapHeadlessRenderDevice();
+
 class MetalPipelineStateProvider {
   public:
     virtual ~MetalPipelineStateProvider() = default;

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -1012,6 +1012,27 @@ std::unique_ptr<RenderImpl> createRenderer() {
     return std::make_unique<MetalRenderImpl>();
 }
 
+// Headless render-device bring-up for GPU unit tests (vehicle A, #1640). Wires
+// IRRender::device() to a windowless Metal device + command buffer so a test can
+// drive the real ShaderProgram / Texture2D / dispatchCompute path without a
+// swapchain. Mirrors MetalRenderImpl::init() minus the CAMetalLayer, which is
+// only needed for presentation: initializeMetalRuntime stores the layer but
+// never dereferences it (only beginFrame's nextDrawable does, and a headless
+// test never calls beginFrame). Returns nullptr when no Metal device is
+// available (headless CI with no GPU) so the caller can GTEST_SKIP cleanly. Not
+// for production frame rendering — there is no drawable and nothing to present.
+RenderDevice *bootstrapHeadlessRenderDevice() {
+    MTL::Device *device = MTL::CreateSystemDefaultDevice();
+    if (device == nullptr) {
+        return nullptr;
+    }
+    setMetalBootstrapDevice(device);
+    metalRenderDevice().init(device, nullptr);
+    setDevice(&metalRenderDevice());
+    setMetalCommandBuffer(metalCommandQueue()->commandBuffer());
+    return &metalRenderDevice();
+}
+
 MetalRenderImpl::MetalRenderImpl()
     : m_device{MTL::CreateSystemDefaultDevice()} {
     IRE_LOG_INFO("Initializing Metal render implementation.");

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -1026,7 +1026,6 @@ RenderDevice *bootstrapHeadlessRenderDevice() {
     if (device == nullptr) {
         return nullptr;
     }
-    setMetalBootstrapDevice(device);
     metalRenderDevice().init(device, nullptr);
     setDevice(&metalRenderDevice());
     setMetalCommandBuffer(metalCommandQueue()->commandBuffer());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,8 +119,15 @@ target_link_libraries(IrredenEngineTest PUBLIC
 # real engine compute shader by absolute path so it resolves regardless of cwd
 # (the engine itself chdir's to the exe dir at boot; the test never does). The
 # shader source tree is engine/render/src/shaders/.
+#
+# IR_TEST_GPU_SHADER_DIR points at the test-local shader tree
+# (test/render/shaders/) holding the tiny purpose-built repro kernels the Metal
+# half of that test dispatches — the Metal pipeline resolves the `metal/`
+# subdir + `.metal` sibling from a `.glsl`-shaped path, exactly like the engine
+# shader dir, so no `.glsl` twin is needed for a Metal-only kernel.
 target_compile_definitions(IrredenEngineTest PRIVATE
     IR_TEST_RENDER_SHADER_DIR="${CMAKE_SOURCE_DIR}/engine/render/src/shaders"
+    IR_TEST_GPU_SHADER_DIR="${CMAKE_SOURCE_DIR}/test/render/shaders"
 )
 
 # Build lua_component_codegen_fixtures.hpp from the sibling .lua

--- a/test/render/gpu_compute_dispatch_test.cpp
+++ b/test/render/gpu_compute_dispatch_test.cpp
@@ -182,6 +182,23 @@ class MetalGpuComputeDispatchTest : public ::testing::Test {
         }
     }
 
+    // Mirrors the GL fixture's per-test cleanup: without this, each SetUp's
+    // initializeMetalRuntime reassigns the command queue + depth-stencil
+    // states without releasing the previous test's, leaking them (and the
+    // raw MTL::Device, which shutdownMetalRuntime does not own) every test
+    // after the first.
+    void TearDown() override {
+        if (device_ == nullptr) {
+            return;
+        }
+        MTL::Device *rawDevice = IRRender::metalDevice();
+        IRRender::shutdownMetalRuntime();
+        if (rawDevice != nullptr) {
+            rawDevice->release();
+        }
+        device_ = nullptr;
+    }
+
     IRRender::RenderDevice *device_ = nullptr;
 };
 

--- a/test/render/gpu_compute_dispatch_test.cpp
+++ b/test/render/gpu_compute_dispatch_test.cpp
@@ -137,13 +137,169 @@ TEST_F(GpuComputeDispatchTest, ClearSunShadowKernelFillsBufferWithLitSentinel) {
 
 } // namespace
 
-#else // !IR_GRAPHICS_OPENGL
+#elif defined(IR_GRAPHICS_METAL)
 
-// On Metal / Vulkan builds the GL dispatch + readback harness does not apply.
-// Keep a registered placeholder so the suite still appears (as skipped) rather
-// than silently vanishing from the cross-backend test inventory.
-TEST(GpuComputeDispatchTest, SkippedOnNonOpenGLBackend) {
-    GTEST_SKIP() << "Headless GPU compute test targets the OpenGL backend only.";
+// The Metal half of vehicle A (#1640). The OpenGL twin above has no analogous
+// bug — GL writes real image atomics straight to the texture — so this fixture
+// exists to reproduce the *Metal-only* gap headlessly: a non-main canvas's R32I
+// distance texture, written by one in-tick compute dispatch, reads back as the
+// clear value from a SECOND in-tick dispatch (engine/render/CLAUDE.md
+// "Foreign-canvas R32I image reads in a second in-tick compute dispatch return
+// empty on Metal (#1640)"). Metal has no windowless RenderDevice bring-up in the
+// normal engine boot (the CAMetalLayer is window-bound), so the fixture uses
+// bootstrapHeadlessRenderDevice() — device + command queue, no swapchain — then
+// drives the real ShaderProgram / Texture2D / dispatchCompute path.
+
+#include <irreden/render/buffer.hpp>
+#include <irreden/render/ir_render_enums.hpp>
+#include <irreden/render/metal/metal_runtime.hpp>
+#include <irreden/render/render_device.hpp>
+#include <irreden/render/shader.hpp>
+#include <irreden/render/texture.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+// 1024 texels: every linear index stays below the clear sentinel 65535, so a
+// missed write is unambiguously distinguishable from a correct one.
+constexpr int kTexDim = 32;
+constexpr int kTexelCount = kTexDim * kTexDim;
+constexpr std::int32_t kEmptyDistanceEncoded = 65535; // kTrixelDistanceMaxDistance.
+constexpr std::uint32_t kOutputBinding = 0;           // matches [[buffer(0)]] in c_r32i_read.
+
+// Brings up a windowless Metal device for one test and skips cleanly when none
+// is available (headless host without a GPU), mirroring the GL fixture's skip.
+class MetalGpuComputeDispatchTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        device_ = IRRender::bootstrapHeadlessRenderDevice();
+        if (device_ == nullptr) {
+            GTEST_SKIP() << "No Metal device available — headless host without a GPU.";
+        }
+    }
+
+    IRRender::RenderDevice *device_ = nullptr;
+};
+
+// Positive control / oracle validation: with NO write dispatch, a read of the
+// cleared texture must report exactly the clear sentinel. This proves the
+// harness can distinguish a missed write from a correct one — i.e. a real
+// second-dispatch read gap (#1640) would surface here as a failed EXPECT — and
+// that clearTexImage lands on the command buffer before the read encoder.
+TEST_F(MetalGpuComputeDispatchTest, ClearedTextureReadsBackAsClearSentinel) {
+    using namespace IRRender;
+
+    Texture2D distances{TextureKind::TEXTURE_2D, kTexDim, kTexDim, TextureFormat::R32I};
+    const std::int32_t clearValue = kEmptyDistanceEncoded;
+    device_->clearTexImage(&distances, 0, &clearValue);
+
+    const std::vector<std::int32_t> outSeed(kTexelCount, -1);
+    Buffer output{
+        outSeed.data(),
+        outSeed.size() * sizeof(std::int32_t),
+        BUFFER_STORAGE_NONE,
+        BufferTarget::SHADER_STORAGE,
+        kOutputBinding
+    };
+
+    const std::string readPath = std::string(IR_TEST_GPU_SHADER_DIR) + "/c_r32i_read.glsl";
+    ShaderProgram readProgram{std::vector{ShaderStage{readPath.c_str(), ShaderType::COMPUTE}}};
+
+    readProgram.use();
+    distances.bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+    output.bindBase(BufferTarget::SHADER_STORAGE, kOutputBinding);
+    device_->dispatchCompute(kTexDim, kTexDim, 1);
+    device_->finish();
+
+    std::vector<std::int32_t> readback(kTexelCount, -2);
+    output.getSubData(0, readback.size() * sizeof(std::int32_t), readback.data());
+
+    std::size_t nonSentinel = 0;
+    for (int i = 0; i < kTexelCount; ++i) {
+        if (readback[i] != kEmptyDistanceEncoded) {
+            ++nonSentinel;
+        }
+    }
+    EXPECT_EQ(nonSentinel, 0u)
+        << nonSentinel << " / " << kTexelCount
+        << " texels did not read back the clear sentinel — clearTexImage or the "
+           "access::read path is not behaving as the oracle assumes.";
 }
 
-#endif // IR_GRAPHICS_OPENGL
+TEST_F(MetalGpuComputeDispatchTest, SecondDispatchSeesFirstDispatchDistanceWrites) {
+    using namespace IRRender;
+
+    Texture2D distances{TextureKind::TEXTURE_2D, kTexDim, kTexDim, TextureFormat::R32I};
+
+    // Clear to the empty sentinel first, so a read that misses the write reports
+    // exactly 65535 (the documented #1640 symptom) rather than undefined memory.
+    const std::int32_t clearValue = kEmptyDistanceEncoded;
+    device_->clearTexImage(&distances, 0, &clearValue);
+
+    // Seed with -1 (never a valid texel value) so a read dispatch that fails to
+    // run at all is distinguishable from one that reads the clear sentinel.
+    const std::vector<std::int32_t> outSeed(kTexelCount, -1);
+    Buffer output{
+        outSeed.data(),
+        outSeed.size() * sizeof(std::int32_t),
+        BUFFER_STORAGE_NONE,
+        BufferTarget::SHADER_STORAGE,
+        kOutputBinding
+    };
+
+    const std::string writePath = std::string(IR_TEST_GPU_SHADER_DIR) + "/c_r32i_write.glsl";
+    const std::string readPath = std::string(IR_TEST_GPU_SHADER_DIR) + "/c_r32i_read.glsl";
+    ShaderProgram writeProgram{std::vector{ShaderStage{writePath.c_str(), ShaderType::COMPUTE}}};
+    ShaderProgram readProgram{std::vector{ShaderStage{readPath.c_str(), ShaderType::COMPUTE}}};
+
+    // Dispatch 1 — populate the distance texture (mirrors c_voxel_to_trixel_stage_2's
+    // access::write store, the step at which a canvas's distances become canonical).
+    writeProgram.use();
+    distances.bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
+    device_->dispatchCompute(kTexDim, kTexDim, 1);
+
+    // Dispatch 2 — a fresh compute encoder on the SAME command buffer reads the
+    // texture back through the exact access::read path c_bake_sun_shadow_map uses.
+    readProgram.use();
+    distances.bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+    output.bindBase(BufferTarget::SHADER_STORAGE, kOutputBinding);
+    device_->dispatchCompute(kTexDim, kTexDim, 1);
+
+    device_->finish(); // commit + wait so the SSBO readback observes GPU results.
+
+    std::vector<std::int32_t> readback(kTexelCount, -2);
+    output.getSubData(0, readback.size() * sizeof(std::int32_t), readback.data());
+
+    std::size_t emptyReads = 0; // read back the clear sentinel — the #1640 gap.
+    std::size_t wrongReads = 0; // neither the written index nor the sentinel.
+    for (int i = 0; i < kTexelCount; ++i) {
+        if (readback[i] == kEmptyDistanceEncoded) {
+            ++emptyReads;
+        } else if (readback[i] != i) {
+            ++wrongReads;
+        }
+    }
+    EXPECT_EQ(emptyReads, 0u)
+        << emptyReads << " / " << kTexelCount
+        << " texels read back the clear sentinel (65535): the second in-tick "
+           "dispatch did not see the first dispatch's distance writes (#1640).";
+    EXPECT_EQ(wrongReads, 0u) << wrongReads
+                              << " texels read back neither their written linear index "
+                                 "nor the clear sentinel.";
+}
+
+} // namespace
+
+#else // other backend (e.g. Vulkan)
+
+// Keep a registered placeholder so the suite still appears (as skipped) rather
+// than silently vanishing from the cross-backend test inventory.
+TEST(GpuComputeDispatchTest, SkippedOnUnsupportedBackend) {
+    GTEST_SKIP() << "Headless GPU compute test targets the OpenGL and Metal backends.";
+}
+
+#endif // IR_GRAPHICS_OPENGL / IR_GRAPHICS_METAL

--- a/test/render/shaders/metal/c_r32i_read.metal
+++ b/test/render/shaders/metal/c_r32i_read.metal
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Vehicle A (#1640) repro — read half. Reads an R32I distance texture via
+// access::read — the exact path c_bake_sun_shadow_map uses
+// (trixelDistances.read(px).x) — in a SECOND in-tick compute dispatch, and
+// copies each texel into an output SSBO for CPU readback. If this second-
+// dispatch read of a texture a prior same-command-buffer dispatch wrote returns
+// the clear sentinel instead of the written value, that is the #1640 gap.
+//
+// One thread per texel (see c_r32i_write.metal for the 1x1x1-threadgroup note).
+kernel void c_r32i_read(
+    texture2d<int, access::read> dist [[texture(0)]],
+    device int *out [[buffer(0)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    uint width = dist.get_width();
+    uint2 px = gid.xy;
+    if (px.x >= width || px.y >= dist.get_height()) {
+        return;
+    }
+    out[px.y * width + px.x] = dist.read(px).x;
+}

--- a/test/render/shaders/metal/c_r32i_write.metal
+++ b/test/render/shaders/metal/c_r32i_write.metal
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Vehicle A (#1640) repro — populate half. Writes a per-texel distinct value
+// (its linear index) into an R32I distance texture via a plain access::write
+// store, mirroring c_voxel_to_trixel_stage_2's texture write (the step at which
+// a canvas's distance texture becomes canonical). A distinct-per-texel value
+// (not a constant) makes a partial or missing write detectable in readback.
+//
+// One thread per texel: this kernel is intentionally absent from
+// threadgroupSizeForFunctionName, so threadsPerThreadgroup defaults to 1x1x1
+// and dispatchCompute's threadgroup counts (W,H,1) make the grid W*H — so
+// thread_position_in_grid IS the texel coordinate.
+kernel void c_r32i_write(
+    texture2d<int, access::write> dist [[texture(0)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    uint width = dist.get_width();
+    uint2 px = gid.xy;
+    if (px.x >= width || px.y >= dist.get_height()) {
+        return;
+    }
+    dist.write(int4(int(px.y * width + px.x), 0, 0, 0), px);
+}


### PR DESCRIPTION
## Summary

Adds the **Metal half of vehicle A** (#1640) — the engine's first headless Metal
GPU compute-dispatch + readback unit test (mirroring the OpenGL fixture from
#1771) — and resolves #1640 as **investigated, no defect**. The architect ruling
is folded into `docs/design/detached-revoxelize-world-light.md` (Q2-REVISED block
+ P4b-3 note) and `.fleet/plans/issue-1640.md`.

- `bootstrapHeadlessRenderDevice()` (`engine/render/src/metal/metal_render_impl.cpp`,
  decl in `metal_runtime.hpp`) brings up a **windowless** `MTLDevice` + command
  queue and wires `IRRender::device()` — compute needs no swapchain, so the test
  drives the real `ShaderProgram` / `Texture2D` / `dispatchCompute` path.
- Two gtests in the `#elif IR_GRAPHICS_METAL` half of
  `gpu_compute_dispatch_test.cpp` + two R32I test kernels under
  `test/render/shaders/metal/`. These stand as the **regression guard** on the
  Metal cross-encoder R32I contract and the reusable vehicle-A harness for future
  headless Metal GPU tests.

## Resolution — #1640 investigated, no backend bug

The symptom (a foreign-canvas R32I distance texture reading back the clear
sentinel 65535 from a **second** in-tick dispatch) was suspected to be a Metal
cross-encoder **visibility** gap (**C3**) or pipeline-ordering starvation
(**C1**). Both are ruled out:

- **C3 refuted by repro.** `SecondDispatchSeesFirstDispatchDistanceWrites`
  (clear→write→read, both dispatches on the same command buffer in separate
  compute encoders — the exact structure C3 blamed) is **GREEN**; the oracle
  control `ClearedTextureReadsBackAsClearSentinel` proves a genuinely missed write
  *would* surface as 65535. Metal cross-encoder R32I write→read visibility is
  **sound**.
- **C1 dissolves on two static facts** (no GPU frame capture needed): the
  consolidated per-canvas raster (compact / stage-1 / stage-2) encodes strictly
  before `BAKE_SUN_SHADOW_MAP`, and the per-axis screen-depth resolve already does
  the exact second-in-tick foreign-canvas R32I `READ_ONLY` image bind every
  non-cardinal frame on Metal in production.
- **Actual cause:** the #1626-era multi-canvas shared-state (stage-2 clobbering
  shared voxel SSBOs + foreign FrameData leaking into the bake), not the backend.
  `resolve-then-bake` is therefore the permanent design independent of any backend
  bug (already the Q2-REVISED invariant, 2026-06-09).

Unblocks #2091 — its `Blocked by: #1640` clears on merge, and its investigation
now starts from "visibility is sound; look at frame-data / coordinate / binding
state in the world-placed resolve path, with the per-axis resolve as the working
reference."

## Notes for reviewers

- **No render-path change.** `bootstrapHeadlessRenderDevice` is never called by
  the frame loop; the two `.metal` kernels are never dispatched by the pipeline —
  test-only. Render output is byte-identical → no screenshots (render `CLAUDE.md`
  "provably no runtime effect" exception). GL backend untouched (the Metal branch
  is `#elif IR_GRAPHICS_METAL`).
- The `attachMetalRenderDevice` dedup (the harness shares ~60% of its bring-up
  with `MetalRenderImpl::init()`) is deliberately left out — production init-path
  churn isn't justified by a test-only harness (architect agreed with the simplify
  call).

## Test plan

- [x] `IrredenEngineTest --gtest_filter='*GpuComputeDispatch*'` → 2 passed (Metal, macOS).
- [x] Full suite: 1319 tests passed, no regressions.
- [x] `format-changed` clean; build green.
- [x] Design-doc + plan-file resolution is markdown-only; no code changed since the harness commit above (its suite run stands).

Closes #1640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
