### PR TITLE
fleet: deep role-doc slim — relocate war-story rationale to referenced docs (#2226)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -298,30 +298,8 @@ exit cleanly:
         back to a known starting state for the next candidate:
         `git switch claude/merger-scratch`
       - Run `rm -f .merger-body.md`, then write `.merger-body.md`
-        with the **Write** tool:
-        ```
-        Merger: cannot cascade-rebase onto updated base PR
-        #<base-pr-number>. Its head ref `<baseRefName>` was force-
-        pushed and the new tip conflicts with this PR's own
-        commits.
-
-        Resolution: the author of this PR (or the upstream author)
-        rebases manually onto the new upstream tip:
-
-          git fetch origin
-          git rebase origin/<baseRefName>
-          # resolve conflicts, then:
-          git push --force-with-lease
-
-        Labeled `fleet:needs-base-update` — the merger and the
-        cascade-rebase pass skip this PR until the label clears.
-        It clears automatically when the upstream merges (step
-        2.5 re-targets to master and removes the label) or
-        closes; otherwise the human or an opus+-class worker clears it
-        after a manual rebase.
-
-        — fleet merger
-        ```
+        with the **Write** tool using the **§ cascade-rebase-conflict**
+        template from [merger-templates.md](../../docs/agents/merger-templates.md).
       - `gh pr comment <N> --body-file .merger-body.md`
       - `gh pr edit <N> --add-label "fleet:needs-base-update" --add-label "fleet:merger-cooldown"`
       - Log: `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: cascade-rebase conflict onto #<base-pr-number>, labeled fleet:needs-base-update`
@@ -589,29 +567,11 @@ exit cleanly:
       Each fetch + check is a separate Bash call (single-command rule).
 
       If any check exits 0 for an "upstream PR" (`<upstream-N>`):
-      - Resolve the upstream tip SHA (needed for the rebase recipe below):
-        `git rev-parse origin/<upstream-headRefName>`
+      - Resolve the upstream tip SHA (needed for the template's rebase
+        recipe): `git rev-parse origin/<upstream-headRefName>`
         Store this output as `<upstream-tip-sha>`.
-      - Write `.merger-body.md` with:
-        ```
-        Merger: this PR's branch was forked from open PR #<upstream-N>
-        (`<upstream-headRefName>`). Its diff carries inherited commits
-        from that PR and cannot be cleanly rebased onto master until
-        #<upstream-N> merges.
-
-        Resolution after #<upstream-N> merges:
-          git fetch origin
-          git rebase --onto origin/master <upstream-tip-sha> <this-headRefName>
-          git push --force-with-lease
-
-        This drops #<upstream-N>'s inherited commits and leaves only
-        this PR's own changes on top of master.
-
-        Labeled `fleet:fork-of-other-pr` — the merger and worker
-        skip this PR in their conflict-resolution sweeps.
-
-        — fleet merger
-        ```
+      - Write `.merger-body.md` using the **§ fork-of-other-pr** template
+        from [merger-templates.md](../../docs/agents/merger-templates.md).
       - `gh pr comment <N> --body-file .merger-body.md`
       - `gh pr edit <N> --add-label "fleet:fork-of-other-pr"`
       - `gh pr edit <N> --add-label "fleet:merger-cooldown"`
@@ -735,8 +695,8 @@ exit cleanly:
               (ref already fetched in step a)
            3. Fetch the most recent merger comment body (single command):
               `gh pr view <N> --json comments --jq '[.comments[] | select(.body | test("— fleet merger"))] | last | .body'`
-           4. Scan the returned body for a `SHA pair:` line (added to
-              the comment template below). Extract the two SHAs. (If the
+           4. Scan the returned body for a `SHA pair:` line (part of the
+              semantic-conflict template). Extract the two SHAs. (If the
               returned body is null or empty — jq `| last` on an empty
               array — treat as "no prior merger comment found" and
               proceed to step 6.)
@@ -747,13 +707,12 @@ exit cleanly:
               - Log: `[<timestamp>] PR #<N> <headRefName>: recurring semantic-conflict — sha pair unchanged, comment skipped`
               - Jump to step f.
            6. If the sha pair differs, or no prior merger comment is
-              found: proceed with the full comment below, embedding
-              the current sha pair in the `SHA pair:` line.
+              found: proceed with the full comment, embedding the
+              current sha pair in the `SHA pair:` line.
            If `fleet:semantic-conflict` is NOT in the cached labels,
            skip this check and proceed with the full comment.
-         - Build a description of the conflict. Cap the file list at
-           5; if more files conflict, append `… and N more` so the
-           comment stays readable. For each listed file, run
+         - Build a description of the conflict. For each conflicted
+           file, run
            `git log -1 --format="%h %s" origin/master -- <file>` to
            identify what touched it on master, and
            `git log -1 --format="%h %s" origin/<headRefName> -- <file>`
@@ -761,29 +720,10 @@ exit cleanly:
            because `git switch claude/merger-scratch` left HEAD on
            master (and the prior detached HEAD is gone) — a bare
            `git log -- <file>` would log master twice.
-           Write to `.merger-body.md`:
-           ```
-           Merger: cannot auto-resolve mechanically. The PR has
-           semantic conflicts with current master that need
-           judgement-level resolution.
-
-           Conflicted files:
-           - `<file1>` — master: `<sha> <subj>`; PR: `<sha> <subj>`
-           - `<file2>` — ...
-
-           Labeled `fleet:semantic-conflict` — a worker will
-           attempt resolution on its next iteration (rebase,
-           manually resolve, build, push). If the worker also
-           can't resolve (truly ambiguous, design decision needed),
-           it will escalate to `human:needs-fix`.
-
-           The `fleet:approved` label has been removed if it was set
-           — the PR no longer represents a reviewed state.
-
-           SHA pair: master=<master-tip-sha> × PR=<pr-head-sha>
-
-           — fleet merger
-           ```
+           Write `.merger-body.md` using the **§ semantic-conflict**
+           template from [merger-templates.md](../../docs/agents/merger-templates.md)
+           — it carries the file-list cap and the `SHA pair:` line the
+           dedup check above parses.
          - `gh pr comment <N> --body-file .merger-body.md`
          - Remove stale verdict labels (not fleet:has-nits — nits remain valid
            regardless of merge conflicts and should be addressed once the

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -138,7 +138,9 @@ exit cleanly:
    `fleet:awaiting-base` and `fleet:needs-base-update` are NOT in
    the skip set — those PRs are exactly the labeled-population
    case from (1). `fleet:stacked` is also fine here for the same
-   reason. For each such PR, look up its base PR's state:
+   reason. For each such PR, look up its base PR's state with the
+   **base-lookup query** (steps 2.6 and 5a.5 reference this same
+   command):
 
    `gh pr list --search "head:<baseRefName>" --state all --json number,state --jq '.[] | "#\(.number) \(.state)"'`
 
@@ -203,12 +205,8 @@ exit cleanly:
    want to keep tracking. (`fleet:stacked` is also fine here; it
    marks the same population from a different angle.)
 
-   For each candidate, look up the base PR's state — same query as
-   step 2.5 and step 5a.5:
-
-   `gh pr list --search "head:<baseRefName>" --state all --json number,state --jq '.[] | "#\(.number) \(.state)"'`
-
-   If state is not OPEN, skip — step 2.5 owns the merged/closed
+   For each candidate, look up the base PR's state with the step-2.5
+   base-lookup query. If state is not OPEN, skip — step 2.5 owns the merged/closed
    transitions. If OPEN, fetch both refs (separate Bash calls,
    single-command rule):
 
@@ -363,9 +361,8 @@ exit cleanly:
       value is `master`, proceed to step b (normal flow).
 
       Otherwise (stacked PR — base is a feature branch), look up the
-      base PR by its head ref. The base might be OPEN, MERGED, or
-      CLOSED without merging:
-      `gh pr list --search "head:<baseRefName>" --state all --json number,state --jq '.[] | "#\(.number) \(.state)"'`
+      base PR by its head ref with the step-2.5 base-lookup query. The
+      base might be OPEN, MERGED, or CLOSED without merging.
 
       Three sub-cases. Sub-cases i and iii skip the normal rebase
       (step b–d) and jump directly to step f (reset to scratch). Sub-

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -313,13 +313,11 @@ exit cleanly:
      Durable human-handoff signal; only the human clears it by
      re-targeting or closing.
    - `fleet:gated` — the PR's conflict surface is a gated self-config file
-     (`role-*.md` / `.claude/agents/*` / `SKILL.md`) no agent can push. A
-     worker hit the gate and parked it human-only. **Do not re-flag it
-     `fleet:semantic-conflict`** — that is the exact loop fleet:gated
-     exists to break (a worker would re-claim, re-hit the gate, re-park;
-     #1990 thrashed 11× before this label existed). Only the human (or the
-     architect, who can push gated edits with a human in the loop) clears it
-     by resolving the conflict and dropping the label.
+     no agent class can push; a worker parked it human-only. **Do not
+     re-flag it `fleet:semantic-conflict`** — that restarts the exact
+     thrash the label exists to break (#1990; full semantics:
+     [fleet-labels-reference.md § `fleet:gated`](../../docs/agents/fleet-labels-reference.md)).
+     Only the human (or the architect, human-in-loop) clears it.
    - `fleet:fork-of-other-pr` — PR's branch forked from another open PR; skip until the human clears this label after the upstream PR merges
    - `fleet:needs-base-update` — set in step 2.6 when a stacked child's
      upstream tip moved and the cascade-rebase conflicted. Durable
@@ -644,10 +642,9 @@ exit cleanly:
            If **every** conflicted file is a gated self-config file —
            `.claude/commands/role-*.md`, `.claude/agents/*`, or
            `.claude/skills/**/SKILL.md` — then **no worker class can push a
-           resolution**, so labeling `fleet:semantic-conflict` only starts the
-           worker↔merger thrash (the worker re-claims, re-hits the commit
-           gate, re-parks — #1990 looped 11× this way). Skip the
-           semantic-conflict path entirely:
+           resolution**, so labeling `fleet:semantic-conflict` only starts
+           the worker↔merger thrash (#1990 — see the `fleet:gated` skip
+           entry in step 3). Skip the semantic-conflict path entirely:
              - `git switch claude/merger-scratch`
              - `gh pr edit <N> --add-label "fleet:gated"`
              - `gh pr edit <N> --remove-label "fleet:approved"` (best-effort;

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -448,29 +448,11 @@ exit cleanly:
          The detached HEAD at `origin/<headRefName>` from step a is
          already set up — `git rebase` operates on it directly.
 
-         **Order rationale (re-target + label cleanup BEFORE rebase).**
-         On the rebase-conflict branch below, the re-target and label
-         cleanup are intentionally NOT rolled back — and they intentionally
-         run FIRST, before the rebase attempt. Two coupled reasons:
-         (1) worker's `fleet:semantic-conflict` filter at step 1c
-         excludes `fleet:awaiting-base` / `fleet:awaiting-upstream-review`
-         / `fleet:fork-of-other-pr` (PRs not yet rebaseable against
-         master), so those labels MUST be cleared for worker to
-         pick the PR up.
-         (2) worker's step 1c rebases against the PR's current
-         `baseRefName` (`git rebase origin/<baseRefName>`), so
-         `baseRefName` MUST point at master for worker to rebase
-         against the master tip rather than the merged-but-still-extant
-         base branch — which would replay the stacked-merge conflict
-         against the pre-merge base tip without actually resolving it
-         (master may have moved further).
-         Inverting (rebase first, re-target + label cleanup only on
-         clean exit) would silently strand conflict-path PRs: either
-         the labels survive and worker skips the PR indefinitely,
-         or the labels are cleared but `baseRefName` still points at
-         the stale base and worker's rebase target is wrong. The
-         current order keeps the merger ↔ worker contract
-         coherent. See issue #1149 for the full trade-off analysis.
+         The re-target + label cleanup below run FIRST, before the
+         rebase attempt, and are intentionally NOT rolled back on the
+         rebase-conflict branch — the worker ↔ merger contract depends
+         on that order (see
+         [fleet-queue-stacking.md § Re-target + label cleanup BEFORE the rebase (#1149)](../../docs/design/fleet-queue-stacking.md#re-target--label-cleanup-before-the-rebase-1149)).
 
          - `gh pr edit <N> --base master`
          - `gh pr edit <N> --remove-label "fleet:awaiting-base"`

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -116,29 +116,18 @@ exit cleanly:
    `gh pr list --state open --json number,title,mergeable,labels,headRefName,baseRefName,updatedAt`.)
 
 2.5. **Reconcile stacked PRs whose base has merged or closed —
-   retarget proactively, label-independent.** Two failure modes
-   this step has to cover:
+   retarget proactively, label-independent.** Two failure modes this
+   step covers: (1) **labeled stacked PRs** — `fleet:awaiting-base`
+   (step 5a.5 i) or `fleet:needs-base-update` (step 2.6) are in step
+   3's skip set, so those PRs never advance after their base
+   transitions without this pass; (2) **unlabeled stacked PRs whose
+   base just merged** — a still-`MERGEABLE` child keeps its stale
+   `baseRefName`, gets no label, and a human merge would land on the
+   stale base instead of master (the PR-#558 incident:
+   [fleet-queue-stacking.md § Label-independent stacked reconcile](../../docs/design/fleet-queue-stacking.md#label-independent-stacked-reconcile-pr-558)).
 
-   1. **Labeled stacked PRs.** The merger sometimes sets
-      `fleet:awaiting-base` (step 5a.5 sub-case i — child
-      CONFLICTING because base merged) or `fleet:needs-base-update`
-      (step 2.6 — child stale vs upstream tip and cascade-rebase
-      failed). Step 3's filter skips PRs carrying either label, so
-      without this pass they never advance after their base
-      transitions.
-   2. **Unlabeled stacked PRs whose base just merged
-      (PR-#558 case).** A child that stays `MERGEABLE` against its
-      OLD base after the base merges keeps `baseRefName` pointing
-      at the stale `claude/<parent>` branch. If a human clicks
-      merge, GitHub merges to the stale base, NOT master — content
-      ends up on a branch that's unreachable from `origin/master`.
-      The merger normally sets `fleet:awaiting-base` only when the
-      child becomes CONFLICTING; a still-mergeable child gets no
-      label and slips past every guard.
-
-   This step covers both: scan every stacked PR (any
-   `baseRefName != "master"`) regardless of label state, and
-   retarget the moment the base lands.
+   So: scan every stacked PR (any `baseRefName != "master"`)
+   regardless of label state, and retarget the moment the base lands.
 
    From `repos.engine.prs[]`, collect every PR where:
    - `baseRefName != "master"` (stacked PR), AND
@@ -195,14 +184,11 @@ exit cleanly:
    and we don't want to flood the API or the reviewer queue.
 
 2.6. **Cascade rebase stacked children whose upstream tip moved.**
-   Step 2.5 reconciles stacked PRs when their base merges or closes
-   (re-target + rebase in the MERGED case); this step handles the
-   orthogonal case where the base PR is still OPEN but its head ref
-   was force-pushed (typically because the upstream author addressed
-   reviewer feedback). Without this pass, the child PR's branch
-   stays anchored to the upstream's old tip until the base actually
-   merges — and any intervening reviews would see a stale diff that
-   doesn't reflect the upstream's latest fixes.
+   The orthogonal case to step 2.5: the base PR is still OPEN but its
+   head ref was force-pushed (upstream author addressed feedback).
+   Without this pass the child stays anchored to the upstream's old
+   tip until the base merges, and intervening reviews see a stale
+   diff missing the upstream's latest fixes.
 
    From `repos.engine.prs[]`, collect every PR where:
    - `baseRefName != "master"` (stacked PR), AND

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -302,14 +302,11 @@ Do the work, then exit cleanly:
 
     **Atomic claim before checkout.** Before starting the checkout,
     take a `fleet:resolving-<host>-<agent>` label on the PR (step b'
-    below). The lex-min tie-break — the same pattern used by
-    `fleet:reviewing-*` and `fleet:claim-*` — lets one winner proceed
-    while the other backs off immediately, before either has spent time
-    on the rebase + build. This eliminates the expensive
-    `--force-with-lease` loser path that previously wasted a full
-    iteration when two workers raced. The detached HEAD checkout
-    (step c) and `--force-with-lease` push (step h) remain in place as
-    safety nets; the resolving label is the first-line prevention.
+    below) — the same lex-min tie-break pattern as `fleet:reviewing-*`
+    / `fleet:claim-*`. The detached HEAD checkout (step c) and
+    `--force-with-lease` push (step h) remain the safety nets; the
+    resolving label is first-line prevention against two workers each
+    spending a full rebase + build on the same PR.
 
     **Repo routing.** Each candidate carries its source repo (the
     `repo` field on the cached PR record: `engine` or `game`). Resolve

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -776,19 +776,17 @@ Do the work, then exit cleanly:
    re-queues it — or the human closes the issue.
 
    **(c) Design escalation via `fleet:design-blocked`.** When the
-   blocker is specifically architectural — the assigned task can't
-   proceed without a design call you don't have authority to make —
-   escalate via the label-driven flow ([`docs/agents/FLEET.md`](../../docs/agents/FLEET.md)
-   "Design-escalation flow") so the architect can pick it up from
-   the trigger surface and any worker can resume cleanly. (At sonnet
-   class, weigh (a) first: if the task needs design input, it usually
-   needs the heavier class for execution too.)
+   blocker is specifically architectural — a design call you don't have
+   authority to make — escalate via the label-driven flow. (At sonnet
+   class, weigh (a) first: a task that needs design input usually needs
+   the heavier class for execution too.) Full cycle + the
+   handoff-is-the-PR / #1310 claim-release rationale:
+   [FLEET.md § Design-escalation flow](../../docs/agents/FLEET.md#design-escalation-flow).
 
-   a. **Commit and push whatever in-progress work you have on the
-      branch.** Even if half-done — the next worker iteration will
-      need it as the starting point when `fleet:design-unblocked`
-      appears. Use `commit-and-push` (the WIP PR already exists).
-   b. Post a `## NEEDS-DESIGN` escalation comment on the PR:
+   a. **Commit and push your in-progress work** — even half-done; the
+      resuming worker starts from it. Use `commit-and-push` (the WIP
+      PR already exists).
+   b. Post the escalation comment on the PR:
       `gh pr comment <N> --body "## NEEDS-DESIGN
 
       <what you've learned about the existing code / framework that
@@ -799,36 +797,24 @@ Do the work, then exit cleanly:
 
       <suggested options if you have a view; the architect picks,
       you don't have to know the right answer>"`
-   c. Move the PR into the `fleet:design-blocked` state. If you reached
-      this PR via the `fleet:design-unblocked` feedback tier — i.e.
-      you're **re-escalating** after the architect already responded
-      once — the PR still carries `fleet:design-unblocked`. Clear it in
-      the same step, otherwise the PR keeps both labels and gets
-      re-picked as unblocked next iteration (step 1 priority 4). The
-      helper only removes labels that are present, so it's a safe no-op
-      on a first-time escalation straight from the queue:
+   c. Swap into the `fleet:design-blocked` state. If you're
+      **re-escalating** after an architect reply, the PR still carries
+      `fleet:design-unblocked` — clear it in the same step, otherwise
+      the PR keeps both labels and gets re-picked as unblocked next
+      iteration (step 1 priority 4). The helper only removes labels
+      that are present, so it's a safe no-op on a first-time escalation:
       `fleet-pr-clear-feedback-labels <N> --labels "fleet:design-unblocked"`
       `gh pr edit <N> --add-label "fleet:design-blocked"`
-      Keep `fleet:wip` — design-blocked is a state qualifier on top
-      of WIP. But **release your `fleet-claim` and worktree
-      reservation** — a design-blocked task is NOT yours to hold.
-      Resolution can take the architect a while, and when it returns as
-      `fleet:design-unblocked` ANY worker should resume it cleanly
-      (step d frees the branch; step 1 priority 4 re-picks it). The
-      handoff is the PR, not your claim: the pushed WIP commit (a), the
-      `## NEEDS-DESIGN` comment + the architect's reply, the plan file
-      (`~/.fleet/plans/issue-<N>.md`), and the `fleet:design-blocked`
-      label carry everything the next worker needs. Holding the claim
-      through the block is what let two workers race the #1310 resume
-      and force-push over each other — release it:
+      Keep `fleet:wip` — design-blocked is a state qualifier on top of
+      WIP. But **release your `fleet-claim` and worktree reservation** —
+      a design-blocked task is NOT yours to hold (see the FLEET.md
+      rationale linked above):
       `fleet-claim release <N>` (add `--repo game` for game tasks)
    d. Reset the worktree via `start-next-task` so the branch is free
-      for the architect (or anyone else) to `gh pr checkout`. Then
-      pick a different unblocked task from the issue queue as your
-      next iteration's work — do NOT re-claim the same task. Once
-      the architect responds, the PR will be re-armed via
-      `fleet:design-unblocked` and any worker can pick it up via
-      step 1 priority 4 above.
+      for anyone to `gh pr checkout`, then pick a **different** task —
+      do NOT re-claim this one. The architect's reply re-arms it as
+      `fleet:design-unblocked`; any worker resumes it via step 1
+      priority 4.
 
    For non-architectural escalations (scope grew beyond one PR's worth
    of work, build break is structural, public-API surface spans

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -760,20 +760,18 @@ Do the work, then exit cleanly:
    dispatched `--print` one-shot; no human is attached to your pane, so
    `AskUserQuestion` (or "let me confirm with you first…") has nowhere to
    land — it stalls or burns the iteration. Resolve from the plan/issue,
-   or escalate **asynchronously** on the issue/PR (the artifact a human
-   reviews on their own schedule), then move to a different task:
-   comment on the issue naming exactly what a human must apply, then
-   park it out of autonomous pickup so you stop re-claiming it —
+   or escalate **asynchronously**, then move to a different task:
+   comment on the issue naming exactly what a human must apply, park it
+   out of autonomous pickup —
    `gh issue edit <N> --remove-label fleet:queued --add-label fleet:needs-human` —
    and release your `fleet-claim`. **Keep `human:approved`** — it's the
-   human's durable approval signal, not yours to strip; removing it was
-   the old workaround for the ingest re-stamping `fleet:queued` (it
-   re-queues any `human:approved` issue lacking it), which is exactly
-   what `fleet:needs-human` now suppresses (it's in the ingest skip set,
-   like `fleet:scope-shipped`). Do NOT re-claim it next iteration: the
-   gate is deterministic, so retrying only burns iterations on a wall.
-   The label clears when the human applies the change — then the ingest
-   re-queues it — or the human closes the issue.
+   human's durable approval signal, not yours to strip (why the park
+   suppresses ingest re-queue while keeping it:
+   [fleet-labels-reference.md § `fleet:needs-human`](../../docs/agents/fleet-labels-reference.md)).
+   Do NOT re-claim it next iteration — the gate is deterministic, so
+   retrying only burns iterations on a wall. The label clears when the
+   human applies the change (the ingest then re-queues) or closes the
+   issue.
 
    **(c) Design escalation via `fleet:design-blocked`.** When the
    blocker is specifically architectural — a design call you don't have

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -423,25 +423,10 @@ Do the work, then exit cleanly:
 
        **Engine PR:** `fleet-build --target IRShapeDebug`.
 
-       **Game PR:** the game can't build standalone — it compiles via
-       the engine with your game worktree added as a user project. Use a
-       **dedicated** game build dir (so it doesn't clobber your engine
-       worktree's preset build) and point `ir-build` at it with the
-       `IRREDEN_BUILD_DIR` env var (that's the override knob — there is
-       no `--build-dir` flag). `ir-build` only auto-configures with the
-       bare preset, which omits `IRREDEN_USER_PROJECTS`, so you must
-       configure this dir yourself **once** (idempotent; reuse across
-       iterations) with the game worktree as the user project, then
-       build the **affected project's** target:
-       ```
-       ENG=<your-engine-worktree-abs-path>
-       GAME_WT=~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>
-       # one-time configure (skip if $ENG/build-game/CMakeCache.txt exists):
-       cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"
-       # build the affected project target via ir-build, pointed at that dir:
-       IRREDEN_BUILD_DIR="$ENG/build-game" fleet-build --target IRIrredenAll
-       ```
-       `<host>-debug` is your host preset (`macos-debug` / `linux-debug`).
+       **Game PR:** the game can't build standalone — build it in a
+       **dedicated** `build-game` dir pointed at YOUR engine worktree
+       via `IRREDEN_BUILD_DIR`. One-time-configure recipe + rationale:
+       [BUILD.md § Dedicated game build dir](../../docs/agents/BUILD.md#dedicated-game-build-dir-against-a-specific-engine-worktree-build-game).
        Pick the target that matches what the PR touches — `IRIrredenAll`
        (or `IRGame` for the demo) for `irreden/`, the corresponding
        `IR<Project>All` otherwise. **Never build `IRGameAll`** — it

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -635,21 +635,11 @@ Do the work, then exit cleanly:
    (e.g. `cd ~/src/IrredenEngine/creations/game/.claude/worktrees/worker-1`).
    For an engine task, stay in your engine worktree (no cd needed).
 
-   Then acquire the local filesystem lock. **Always pass the issue
+   Then acquire the local filesystem lock — exact per-repo command
+   forms: see § Cross-repo model above. **Always pass the issue
    number**, and pass your worktree basename (`worker-1` … `worker-4`)
-   as the agent name so it's visible in `fleet-claim list`:
-
-   ```
-   # engine task (issue #1234)
-   fleet-claim claim 1234 <your-worktree-name>
-
-   # game task (issue #45) — note --repo game BEFORE the subcommand
-   fleet-claim --repo game claim 45 <your-worktree-name>
-   ```
-
-   The `--repo game` namespace prefixes the slug with `game-` so it
-   doesn't collide with engine issue numbers. Mirror it in
-   `release` / `release-stack` calls later.
+   as the agent name so it's visible in `fleet-claim list`. Mirror
+   `--repo game` in `release` / `release-stack` calls later.
 
    - **Exit 0** — you own it. Proceed.
    - **Exit 1 (already taken)** — go back to step 3, pick another.

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -394,11 +394,11 @@ Do the work, then exit cleanly:
        conflicted files (`git diff --name-only --diff-filter=U`). If **every**
        one is a gated self-config file (`.claude/commands/role-*.md`,
        `.claude/agents/*`, `.claude/skills/**/SKILL.md`), you physically
-       cannot push the resolution — the commit gate blocks the role-doc/agent/
-       SKILL edit regardless of how cleanly you resolve it. Do **not** resolve
-       and do **not** escalate to `human:needs-fix` (that re-triggers step-1
-       worker pickup, and the next worker re-hits the same wall — this is the
-       #1990 thrash). Park it `fleet:gated`, which every picker skips:
+       cannot push the resolution — the commit gate blocks the edit regardless
+       of how cleanly you resolve it. Do **not** resolve and do **not**
+       escalate to `human:needs-fix` — park it `fleet:gated` instead
+       (rationale + the #1990 thrash this prevents:
+       [fleet-labels-reference.md § `fleet:gated`](../../docs/agents/fleet-labels-reference.md)):
        - `git rebase --abort`
        - `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:semantic-conflict" --add-label "fleet:gated"`
        - `gh pr comment <N> --repo jakildev/IrredenEngine --body "Conflict surface is entirely gated self-config; no worker class can push the resolution. Parking \`fleet:gated\` for human-only resolution (or the architect, who can push gated edits with a human in the loop). Conflicted: <file list>. — worker"`

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -378,12 +378,10 @@ Do the work, then exit cleanly:
        copy), do NOT resolve file-by-file — drop the inherited prefix:
        `git rebase --onto origin/master <child-fork-point>`
        where `<child-fork-point>` = `git merge-base HEAD origin/<parent-branch>`
-       (the parent's *pre-merge* head). That replays only your genuine commits;
-       inherited files resolve to master and the diff shrinks to your own
-       changes. `fleet-rebase` auto-drops this normally; do it by hand when it
-       silently doesn't fire — e.g. the parent was amended during review after
-       you forked, so its recorded `headRefOid` is no longer an ancestor of
-       your head (#1791).
+       (the parent's *pre-merge* head). That replays only your genuine
+       commits. `fleet-rebase` auto-drops this normally; do it by hand when it
+       silently doesn't fire (parent amended during review — why + mechanism:
+       [fleet-queue-stacking.md § Inherited-prefix drop (#1791)](../../docs/design/fleet-queue-stacking.md#inherited-prefix-drop-after-the-parent-merges-1791)).
        After the drop lands the branch on master, check the PR body: a
        leftover `Stacked on:` line is now stale (review-pr's stacked
        detection reads it; base==master + `Stacked on:` is a contradiction,

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -98,6 +98,40 @@ Two things to know:
   worktree) builds through `<engine>/build/` via the engine root's
   nested-checkout include.
 
+### Dedicated game build dir against a specific engine worktree (`build-game`)
+
+Fleet workers building a game PR (e.g. resolving a game-side semantic
+conflict, role-worker step 1c g) build against **their own engine
+worktree**, not the enclosing main clone the auto-configure above would
+pick — a stale or concurrently-edited main clone must not decide whether
+the resolution compiles. That is the `IRREDEN_BUILD_DIR` escape hatch
+with a one-time manual configure of a **dedicated** dir (dedicated so the
+game configure can't clobber the engine worktree's own preset build;
+idempotent — reuse it across iterations):
+
+```bash
+ENG=<your-engine-worktree-abs-path>
+GAME_WT=~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>
+# one-time configure (skip if $ENG/build-game/CMakeCache.txt exists):
+cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"
+# build the affected project's target via ir-build, pointed at that dir:
+IRREDEN_BUILD_DIR="$ENG/build-game" fleet-build --target IRIrredenAll
+```
+
+`<host>-debug` is your host preset (`macos-debug` / `linux-debug` /
+`windows-debug`). You own this configure: `ir-build` only auto-configures
+when it can derive the layout itself (bare preset, or the
+creation-worktree detection above, which targets the *enclosing* clone),
+so a dir bound to a specific engine worktree must be configured by hand
+once as shown. There is no `--build-dir` flag — the `IRREDEN_BUILD_DIR`
+env var is the override knob. If the cache in `$ENG/build-game` goes
+stale (worktree renamed/migrated, preset change), reconfigure in place:
+`cmake -S "$ENG" -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+
+Target selection stays with the caller (pick the `IR<Project>All` target
+matching what the PR touches), as does the **never build `IRGameAll`**
+rule (its midi dependency is broken — game #88).
+
 ### `ir-build` / `ir-run` (canonical) vs `fleet-build` / `fleet-run` (aliases)
 
 The canonical build/run wrappers live at `engine/tools/bin/ir-build`

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -328,6 +328,17 @@ the question to the architect and resume cleanly:
    file, addresses the direction, removes the label, pushes via
    `commit-and-push`. PR re-enters normal review flow.
 
+**The handoff is the PR, not the worker's claim.** The escalating worker
+releases its `fleet-claim` (and any worktree reservation) when it parks
+the PR design-blocked: resolution can take the architect a while, and
+when the PR returns as `fleet:design-unblocked` ANY worker — not
+necessarily the original one — must be able to resume it cleanly.
+Everything the resumer needs rides on the PR: the pushed WIP commit, the
+`## NEEDS-DESIGN` comment plus the architect's reply, the plan file on
+the branch, and the label itself. Holding the claim through the block is
+what let two workers race the #1310 resume and force-push over each
+other.
+
 **Epic children route steward-first.** When the blocked PR's backing
 issue is part of an epic (`**Part of epic:** #U`), the **epic-steward**
 — not the architect — does step 2's triage: questions derivable from

--- a/docs/agents/merger-templates.md
+++ b/docs/agents/merger-templates.md
@@ -1,0 +1,92 @@
+# Merger comment templates
+
+Verbatim `.merger-body.md` bodies for [`role-merger.md`](../../.claude/commands/role-merger.md).
+The role doc keeps each trigger and the `Write` → `gh pr comment
+--body-file .merger-body.md` step inline; the template text lives here so
+it isn't reloaded into every merger dispatch. Substitute the
+`<angle-bracket>` fields; always keep the `— fleet merger` sign-off (the
+human-visible audit trail identifies merger comments by it). Short
+one-or-two-sentence bodies (awaiting-base, clean rebase, orphaned base)
+stay inline in the role doc — only the long templates live here.
+
+## § cascade-rebase-conflict (role-merger step 2.6 c, conflict branch)
+
+```
+Merger: cannot cascade-rebase onto updated base PR
+#<base-pr-number>. Its head ref `<baseRefName>` was force-
+pushed and the new tip conflicts with this PR's own
+commits.
+
+Resolution: the author of this PR (or the upstream author)
+rebases manually onto the new upstream tip:
+
+  git fetch origin
+  git rebase origin/<baseRefName>
+  # resolve conflicts, then:
+  git push --force-with-lease
+
+Labeled `fleet:needs-base-update` — the merger and the
+cascade-rebase pass skip this PR until the label clears.
+It clears automatically when the upstream merges (step
+2.5 re-targets to master and removes the label) or
+closes; otherwise the human or an opus+-class worker clears it
+after a manual rebase.
+
+— fleet merger
+```
+
+## § fork-of-other-pr (role-merger step 5a.6)
+
+`<upstream-tip-sha>` is the output of
+`git rev-parse origin/<upstream-headRefName>` captured at detection time.
+
+```
+Merger: this PR's branch was forked from open PR #<upstream-N>
+(`<upstream-headRefName>`). Its diff carries inherited commits
+from that PR and cannot be cleanly rebased onto master until
+#<upstream-N> merges.
+
+Resolution after #<upstream-N> merges:
+  git fetch origin
+  git rebase --onto origin/master <upstream-tip-sha> <this-headRefName>
+  git push --force-with-lease
+
+This drops #<upstream-N>'s inherited commits and leaves only
+this PR's own changes on top of master.
+
+Labeled `fleet:fork-of-other-pr` — the merger and worker
+skip this PR in their conflict-resolution sweeps.
+
+— fleet merger
+```
+
+## § semantic-conflict (role-merger step 5d case ii)
+
+The `SHA pair:` line is load-bearing: the step 5d dedup check parses it
+from the most recent merger comment to decide whether the conflict
+recurred on the same master-tip × PR-head pair (comment skipped) or on a
+new pair (full comment re-posted). Cap the file list at 5; if more files
+conflict, append `… and N more`.
+
+```
+Merger: cannot auto-resolve mechanically. The PR has
+semantic conflicts with current master that need
+judgement-level resolution.
+
+Conflicted files:
+- `<file1>` — master: `<sha> <subj>`; PR: `<sha> <subj>`
+- `<file2>` — ...
+
+Labeled `fleet:semantic-conflict` — a worker will
+attempt resolution on its next iteration (rebase,
+manually resolve, build, push). If the worker also
+can't resolve (truly ambiguous, design decision needed),
+it will escalate to `human:needs-fix`.
+
+The `fleet:approved` label has been removed if it was set
+— the PR no longer represents a reviewed state.
+
+SHA pair: master=<master-tip-sha> × PR=<pr-head-sha>
+
+— fleet merger
+```

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -153,6 +153,18 @@ to a plain rebase that replays the whole inherited prefix as conflicts
 (#1791). That is why role-worker step 1c d' instructs the manual `--onto`
 drop whenever every conflicted file is inherited.
 
+### Label-independent stacked reconcile (PR #558)
+
+A stacked child that stays `MERGEABLE` against its OLD base after that
+base merges keeps `baseRefName` pointing at the stale `claude/<parent>`
+branch. If a human clicks merge, GitHub merges into the stale base, NOT
+master — the content lands on a branch unreachable from `origin/master`.
+The merger normally sets `fleet:awaiting-base` only when the child turns
+CONFLICTING, so a still-mergeable child gets no label and slips past
+every label-keyed guard. That is why role-merger step 2.5 scans every
+`baseRefName != master` PR **regardless of label state** and re-targets
+the moment the base lands.
+
 ### Re-target + label cleanup BEFORE the rebase (#1149)
 
 When a stacked child's base PR merges, the merger (step 5a.5 sub-case ii)

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -153,6 +153,32 @@ to a plain rebase that replays the whole inherited prefix as conflicts
 (#1791). That is why role-worker step 1c d' instructs the manual `--onto`
 drop whenever every conflicted file is inherited.
 
+### Re-target + label cleanup BEFORE the rebase (#1149)
+
+When a stacked child's base PR merges, the merger (step 5a.5 sub-case ii)
+re-targets the child to `master` and clears `fleet:awaiting-base` /
+`fleet:stacked` / `fleet:needs-base-update` **before** attempting the
+rebase — and on the rebase-conflict branch those actions are deliberately
+NOT rolled back. Two coupled reasons:
+
+1. The worker's `fleet:semantic-conflict` filter (role-worker step 1c)
+   excludes `fleet:awaiting-base` / `fleet:awaiting-upstream-review` /
+   `fleet:fork-of-other-pr` — PRs not yet rebaseable against master — so
+   those labels MUST already be cleared for a worker to pick the
+   conflicted child up.
+2. The worker's step 1c rebases against the PR's current `baseRefName`
+   (`git rebase origin/<baseRefName>`), so `baseRefName` MUST point at
+   master — otherwise the worker replays the stacked-merge conflict
+   against the merged-but-still-extant base tip without actually
+   resolving it (master may have moved further).
+
+Inverting the order (rebase first, re-target + cleanup only on clean
+exit) would silently strand conflict-path PRs: either the labels survive
+and the worker skips the PR indefinitely, or the labels are cleared but
+`baseRefName` still points at the stale base and the worker's rebase
+target is wrong. The current order keeps the merger ↔ worker contract
+coherent. Full trade-off analysis: #1149.
+
 ## References
 
 - #1527 (this mechanism), #1526 (umbrella epic), #1476 (the queue-one-at-a-time

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -128,6 +128,31 @@ marker.
 - Reconcile/cleanup never sweeps a `fleet:queued` + `fleet:blocked` no-claim
   issue.
 
+## Maintenance gotchas (worker ↔ merger contract)
+
+Incident rationale behind the stacked-PR maintenance steps in
+`role-worker.md` (step 1c) and `role-merger.md` (step 5a.5). The role docs
+keep the commands; this section keeps the *why*.
+
+### Inherited-prefix drop after the parent merges (#1791)
+
+When a stacked child conflicts against master purely because it still
+carries a stale *inherited* copy of files from a parent PR that has since
+merged, the resolution is topological, not textual: replay only the
+child's own commits with `git rebase --onto origin/master
+<child-fork-point>`, where the fork point is `git merge-base HEAD
+origin/<parent-branch>` (the parent's *pre-merge* head). Inherited files
+then resolve to master and the diff shrinks to the child's own changes.
+
+`fleet-rebase` normally performs this drop automatically by checking the
+parent PR's recorded `headRefOid` against the child's ancestry. It
+silently doesn't fire when the parent was **amended during review after
+the child forked** — the recorded `headRefOid` is no longer an ancestor
+of the child's head, so the ancestor check fails and the tool falls back
+to a plain rebase that replays the whole inherited prefix as conflicts
+(#1791). That is why role-worker step 1c d' instructs the manual `--onto`
+drop whenever every conflicted file is inherited.
+
 ## References
 
 - #1527 (this mechanism), #1526 (umbrella epic), #1476 (the queue-one-at-a-time


### PR DESCRIPTION
## Summary

Implements the #2226 plan (fable-class, human-in-loop — gated role-doc edits pushed from an interactive session per the plan's routing note): relocates self-contained incident rationale, comment templates, and setup recipes out of the two always-loaded role docs into referenced docs, leaving the actionable command + a pointer. Every cut is a **move** — each block lands in its target doc in the same PR (or already existed there verbatim, cited below).

**Always-loaded surface: `role-worker.md` 969 → 923, `role-merger.md` 993 → 895 (−144 lines combined).**

One commit per move, per the plan:

| Move | What moved | Target |
|---|---|---|
| 1 | Step 1c g game-PR `build-game` configure recipe | `docs/agents/BUILD.md` § Dedicated game build dir (new) |
| 2 | Step 1c d'' #1990 gated-thrash narrative | already in `fleet-labels-reference.md` § `fleet:gated` — cited, not duplicated |
| 3 | Step 1c d' #1791 inherited-prefix narrative | `docs/design/fleet-queue-stacking.md` § Maintenance gotchas (new) |
| 4 | Step 8c design-escalation claim-release rationale | `docs/agents/FLEET.md` § Design-escalation flow (added the missing #1310 / handoff-is-the-PR paragraph) |
| 5 | Step 8b `fleet:needs-human` ingest explanation | already in `fleet-labels-reference.md` § `fleet:needs-human` — cited |
| 6 | Step 4 duplicated `fleet-claim` command forms | canonical § Cross-repo model in the same doc |
| 7 | Merger 5a.5 ii #1149 order-rationale | `fleet-queue-stacking.md` § Re-target + label cleanup BEFORE the rebase |
| 8 | Merger's three long comment templates (2.6 c, 5a.6, 5d ii) | `docs/agents/merger-templates.md` (new) |
| 9 | Merger 2.5/2.6 preamble narratives (PR-#558 incident) | `fleet-queue-stacking.md` § Label-independent stacked reconcile |
| 10 | Base-lookup query stated 3× | defined once at step 2.5, referenced twice |
| + | Residual #1990 restatements (merger step 3 skip list, 5d short-circuit) + worker resolving-claim rationale | cites |

## Deviations from the plan

- **Move 2 and move 5 targets**: the plan proposed FLEET.md / CLAUDE-BASELINE.md, but the exact content already lives verbatim in `docs/agents/fleet-labels-reference.md` (`fleet:gated` entry incl. the #1990 11× story; `fleet:needs-human` entry incl. the old label-stripping workaround). Citing the existing canonical home avoids a duplicate that would drift.
- **Line target**: −144 vs the plan's ≈300 estimate. The gap is deliberate under the plan's hard constraint ("when unsure whether a block is load-bearing, leave it"): the NEEDS-DESIGN comment skeleton, the step-1c repo-routing table, all per-step `--repo game` variants, and every command/label transition/exit-code path stay inline.

## Verification

- Diffed every deleted line containing a command or label operation: each survives inline (canonical in-file copy) or is present in its target doc in this PR.
- All 8 new `(see …)` pointers resolve to real headings (GitHub anchor slugs checked).
- Merger's SHA-pair dedup contract: the `SHA pair:` line note moved with the semantic-conflict template and the step-5d dedup text now references the template doc — no dangling "template below".
- #2200 (step-1c overlap gotcha) merged before this branch was cut from current master.

Closes #2226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
