### PR TITLE
render: light/shadow domain instrumentation — freeze pins the light anchor + DOMAIN-STATE log (V1)

### DIFF
--- a/creations/demos/lighting/common/lighting_demo_scene.hpp
+++ b/creations/demos/lighting/common/lighting_demo_scene.hpp
@@ -23,7 +23,9 @@
 #include <irreden/render/components/component_light_source.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
+#include <irreden/render/cull_viewport_state.hpp>
 #include <irreden/render/fog_of_war.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/systems/system_build_light_occlusion_grid.hpp>
 #include <irreden/render/systems/system_compute_light_volume.hpp>
 #include <irreden/render/systems/system_bake_sun_shadow_map.hpp>
@@ -144,6 +146,86 @@ inline IRRender::DebugOverlayMode g_cliOverlay = IRRender::DebugOverlayMode::NON
 // DemoConfig.aoEnabled_ so the flag wins. Lets validation runs flip AO
 // off without rebuilding.
 inline bool g_cliDisableAO = false;
+
+// DOMAIN-STATE instrumentation (#2315, V1). The COMPUTE_LIGHT_VOLUME
+// SystemId, captured at pipeline registration, so the DOMAIN-STATE
+// emission hook can read back its per-light gather records
+// (`IRSystem::lightGatherRecords`) — the system stores that state on
+// itself (`engine/system/CLAUDE.md` "System-owned state"), not in a
+// globally-queryable component.
+inline IRSystem::SystemId g_computeLightVolumeSystemId{};
+// The shot table actually wired into AutoScreenshotConfig this run
+// (kShots or the --light-boundary-sweep series) — the DOMAIN-STATE hook
+// only receives a shot index, so it needs this to recover the shot's
+// label.
+inline const IRVideo::AutoScreenshotShot *g_activeShots = nullptr;
+
+// DOMAIN-STATE emission hook (#2315, V1): `AutoScreenshotConfig::onCaptureFrame_`
+// callback wired below. Fires once per shot, on the settled capture frame,
+// after the frame's render systems (including COMPUTE_LIGHT_VOLUME) have
+// already run — so every value read here reflects what was actually
+// rendered. Emits one machine-readable log line per shot (the same
+// `IR_LOG_INFO` precedent as the `GUI-ASSERT` lines in
+// `gui_test_assertions.hpp`) for the V3 light-verify harness (#2317) to
+// parse; format is the contract — see issue #2315's plan "Sibling
+// reconciliation" note before changing it.
+//
+// Main canvas only for V1 (matches the minimap's V2 scope, #2314 plan
+// "Per-canvas gather scope" gotcha) — `lightGatherRecords` already reads
+// back COMPUTE_LIGHT_VOLUME's own per-canvas gather, so a multi-canvas demo
+// would need one call per canvas; none of the lighting demos have more than
+// the main canvas today.
+inline void logDomainState(int shotIndex) {
+    const char *label = (g_activeShots != nullptr) ? g_activeShots[shotIndex].label_ : "unknown";
+
+    const ivec3 anchor = IRRender::getLightAnchorFreeze().anchor_;
+    const ivec3 windowLo = anchor - ivec3(kLightVolumeHalfExtent);
+    const ivec3 windowHi = anchor + ivec3(kLightVolumeHalfExtent - 1);
+
+    std::string lights = "[";
+    const auto &records = IRSystem::lightGatherRecords(g_computeLightVolumeSystemId);
+    for (std::size_t i = 0; i < records.size(); ++i) {
+        const auto &r = records[i];
+        const char *state = r.state_ == IRSystem::LightGatherState::SEEDED_FULL ? "SEEDED_FULL"
+                            : r.state_ == IRSystem::LightGatherState::BOUNDARY_DISCOUNTED
+                                ? "BOUNDARY_DISCOUNTED"
+                                : "SKIPPED";
+        char entry[64];
+        std::snprintf(
+            entry,
+            sizeof(entry),
+            "%s%llu:%s:%.3f",
+            i == 0 ? "" : ",",
+            static_cast<unsigned long long>(r.entity_),
+            state,
+            r.residual_
+        );
+        lights += entry;
+    }
+    lights += "]";
+
+    const auto &gpu = IRRender::gpuStageTiming();
+    IR_LOG_INFO(
+        "DOMAIN-STATE shot={} anchor={},{},{} window={},{},{}..{},{},{} lights={} "
+        "feeder={:.1f},{:.1f}..{:.1f},{:.1f} casters={}",
+        label,
+        anchor.x,
+        anchor.y,
+        anchor.z,
+        windowLo.x,
+        windowLo.y,
+        windowLo.z,
+        windowHi.x,
+        windowHi.y,
+        windowHi.z,
+        lights,
+        gpu.shadowFeederMin_.x,
+        gpu.shadowFeederMin_.y,
+        gpu.shadowFeederMax_.x,
+        gpu.shadowFeederMax_.y,
+        gpu.worldPlacedCasterCount_
+    );
+}
 
 inline void registerArgs() {
     IREngine::args().optionalInt("--auto-profile", "Run for N frames then exit (default 300)", 300);
@@ -390,13 +472,20 @@ inline void initSystems(const DemoConfig &config) {
         renderPipeline.end(),
         {
             IRSystem::createSystem<IRSystem::RENDERING_VELOCITY_2D_ISO>(),
+            // BUILD_LIGHT_OCCLUSION_GRID must create() before COMPUTE_LIGHT_VOLUME —
+            // the latter looks up "LightOcclusionGridBuffer" (a named resource the
+            // former creates) at init time.
             IRSystem::createSystem<IRSystem::BUILD_LIGHT_OCCLUSION_GRID>(),
             IRSystem::createSystem<IRSystem::VOXEL_TO_TRIXEL_STAGE_1>(),
             IRSystem::createSystem<IRSystem::SHAPES_TO_TRIXEL>(),
             IRSystem::createSystem<IRSystem::COMPUTE_VOXEL_AO>(),
             IRSystem::createSystem<IRSystem::BAKE_SUN_SHADOW_MAP>(),
             IRSystem::createSystem<IRSystem::COMPUTE_SUN_SHADOW>(),
-            IRSystem::createSystem<IRSystem::COMPUTE_LIGHT_VOLUME>(),
+            // Captured for the DOMAIN-STATE emission hook (#2315, V1) — the hook
+            // reads this system's per-light gather records back via
+            // `IRSystem::lightGatherRecords(g_computeLightVolumeSystemId)`.
+            (g_computeLightVolumeSystemId =
+                 IRSystem::createSystem<IRSystem::COMPUTE_LIGHT_VOLUME>()),
             IRSystem::createSystem<IRSystem::LIGHTING_TO_TRIXEL>(),
         }
     );
@@ -482,6 +571,8 @@ inline void initSystems(const DemoConfig &config) {
             screenshotConfig.shots_ = kShots;
             screenshotConfig.numShots_ = sizeof(kShots) / sizeof(kShots[0]);
         }
+        g_activeShots = screenshotConfig.shots_;
+        screenshotConfig.onCaptureFrame_ = &logDomainState;
         renderPipeline.push_back(IRVideo::createAutoScreenshotSystem(screenshotConfig));
     }
 

--- a/engine/prefabs/irreden/render/cull_viewport_state.hpp
+++ b/engine/prefabs/irreden/render/cull_viewport_state.hpp
@@ -66,6 +66,35 @@ struct CullViewportState {
     }
 };
 
+// Pinned light/occlusion anchor storage (#2315, V1). `cameraAnchorVoxel()`
+// (camera_anchor.hpp) re-derives the world voxel the light volume and
+// occlusion grid center on every frame from the LIVE camera pan — it
+// deliberately never consulted the cull freeze. Freezing the cull viewport
+// (above) without also pinning this anchor left the light window still
+// tracking the camera during a freeze, which defeats the freeze's purpose
+// for light/shadow domain inspection. `IRRender::detail::frozenAwareCameraAnchorVoxel()`
+// (camera_anchor.hpp) is the only writer — it owns the capture-on-transition
+// logic; `BUILD_LIGHT_OCCLUSION_GRID` / `COMPUTE_LIGHT_VOLUME` call that
+// helper, never this state directly. `getLightAnchorFreeze()` below is the
+// read-only diagnostic accessor (mirrors `getCullViewport()`) for consumers
+// that only need the pinned value, not the write-path — e.g. a lighting
+// demo's DOMAIN-STATE emission hook reporting the light window bounds.
+struct LightAnchorFreezeState {
+    ivec3 anchor_ = ivec3(0);
+    bool frozen_ = false;
+};
+
+namespace detail {
+inline LightAnchorFreezeState &lightAnchorFreezeState() {
+    static LightAnchorFreezeState s;
+    return s;
+}
+} // namespace detail
+
+inline const LightAnchorFreezeState &getLightAnchorFreeze() {
+    return detail::lightAnchorFreezeState();
+}
+
 namespace detail {
 inline CullViewportState &cullViewportState() {
     static CullViewportState s;

--- a/engine/prefabs/irreden/render/detail/camera_anchor.hpp
+++ b/engine/prefabs/irreden/render/detail/camera_anchor.hpp
@@ -17,6 +17,7 @@
 
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_render.hpp>
+#include <irreden/render/cull_viewport_state.hpp>
 
 namespace IRRender::detail {
 
@@ -46,6 +47,28 @@ inline IRMath::ivec3 cameraAnchorVoxel() {
     const float worldX = (pan.x + pan.y) * 0.5f;
     const float worldY = (pan.y - pan.x) * 0.5f;
     return IRMath::ivec3(IRMath::round(worldX), IRMath::round(worldY), 0);
+}
+
+/// Freeze-aware variant of `cameraAnchorVoxel()` (#2315, V1). While the cull
+/// is live, behaves identically to `cameraAnchorVoxel()`. On the freeze
+/// transition it captures the live anchor once and pins it in
+/// `IRRender::LightAnchorFreezeState`; every subsequent call while still
+/// frozen returns that pinned value instead of re-deriving from the (now
+/// free-flying) camera pan. `BUILD_LIGHT_OCCLUSION_GRID` and
+/// `COMPUTE_LIGHT_VOLUME` both call this once per frame in the same
+/// pipeline order `cameraAnchorVoxel()` was called in before, so the two
+/// consumers stay coherent (same contract as `cameraAnchorVoxel()`'s own
+/// doc comment above). The occlusion-grid origin must stay pinned in lockstep
+/// with the light-volume origin — this single call site is what keeps them
+/// agreeing without a separate per-frame driver.
+inline IRMath::ivec3 frozenAwareCameraAnchorVoxel() {
+    auto &s = IRRender::detail::lightAnchorFreezeState();
+    const bool nowFrozen = IRRender::isCullingFrozen();
+    if (!nowFrozen || !s.frozen_) {
+        s.anchor_ = cameraAnchorVoxel();
+    }
+    s.frozen_ = nowFrozen;
+    return s.anchor_;
 }
 
 } // namespace IRRender::detail

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -54,6 +54,16 @@ struct GpuStageTiming {
     // influence cannot reach the camera-anchored volume window.
     std::uint32_t lightsSeeded_ = 0;
     std::uint32_t lightsEligible_ = 0;
+    // Shadow-feeder diagnostic (#2315, V1). Populated by BAKE_SUN_SHADOW_MAP
+    // each frame: `worldPlacedCasterCount_` = world-placed detached
+    // re-voxelize canvases gathered for the cast resolve
+    // (`gatherWorldPlacedCasters()`, P4b-3); `shadowFeederMin_`/`Max_` = the
+    // iso-space AABB (shared cull viewport widened toward the sun by
+    // `kSunShadowMaxDistance`, gated off when shadows are disabled) that
+    // determines which off-screen casters still feed the bake.
+    std::uint32_t worldPlacedCasterCount_ = 0;
+    IRMath::vec2 shadowFeederMin_ = IRMath::vec2(0.0f);
+    IRMath::vec2 shadowFeederMax_ = IRMath::vec2(0.0f);
     // Only flipped between frames by Lua on the main thread (Lua runs in
     // INPUT/UPDATE, never RENDER). Stable across the RENDER pipeline, so
     // probes can read `enabled_` twice and rely on both values matching.

--- a/engine/prefabs/irreden/render/systems/system_bake_sun_shadow_map.hpp
+++ b/engine/prefabs/irreden/render/systems/system_bake_sun_shadow_map.hpp
@@ -558,6 +558,23 @@ template <> struct System<BAKE_SUN_SHADOW_MAP> {
         // once-per-frame canvas iteration (few canvases), not the per-voxel ECS
         // footgun — same pattern as resolveSun() above.
         gatherWorldPlacedCasters();
+        {
+            // #2315 V1: surface the caster count + the widened shadow-feeder
+            // AABB on the perf HUD's CULL block (same GpuStageTiming counter
+            // pattern as COMPUTE_LIGHT_VOLUME's lightsSeeded_/lightsEligible_).
+            // Uses the canonical gated helper (frameShadowFeederParams()) so
+            // the reported extent collapses to the plain (no-widen) cull
+            // viewport when shadows are off, matching every other feeder
+            // consumer's convention.
+            auto &timing = IRRender::gpuStageTiming();
+            timing.worldPlacedCasterCount_ = static_cast<std::uint32_t>(worldPlacedCasters_.size());
+            const IsoBounds2D feederVp = IRPrefab::SunShadow::shadowFeederCullViewport(
+                0,
+                IRPrefab::SunShadow::frameShadowFeederParams()
+            );
+            timing.shadowFeederMin_ = feederVp.min_;
+            timing.shadowFeederMax_ = feederVp.max_;
+        }
         resolveMainCanvasVoxelFrameInputs(
             perAxisCanvasEntity_,
             &mainTextures_,

--- a/engine/prefabs/irreden/render/systems/system_build_light_occlusion_grid.hpp
+++ b/engine/prefabs/irreden/render/systems/system_build_light_occlusion_grid.hpp
@@ -244,12 +244,14 @@ template <> struct System<BUILD_LIGHT_OCCLUSION_GRID> {
         if (!behavior.useCameraPositionIso_)
             return;
 
-        // Phase 1c (#360): re-center on the iso camera each
-        // frame. The CPU bitfield producer and the GPU consumer
-        // both translate world→local against `origin_` /
-        // `worldOriginVoxel` so the populate path stays origin-
-        // agnostic.
-        origin_ = IRRender::detail::cameraAnchorVoxel();
+        // Phase 1c (#360): re-center on the iso camera each frame. The CPU
+        // bitfield producer and the GPU consumer both translate world→local
+        // against `origin_` / `worldOriginVoxel` so the populate path stays
+        // origin-agnostic. #2315 V1: freeze-aware — pins with the light
+        // volume's anchor while frozen (engine/render/CLAUDE.md invariant
+        // 1: this system reads the pinned ANCHOR only, never the cull
+        // viewport).
+        origin_ = IRRender::detail::frozenAwareCameraAnchorVoxel();
 
         {
             IR_PROFILE_BLOCK("BuildLightOcclusionGrid::Clear", IR_PROFILER_COLOR_RENDER);

--- a/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
@@ -277,6 +277,15 @@ inline std::uint32_t gatherLightSources(
                 continue;
             }
             if (out.size() >= kLightVolumeMaxSources) {
+                // Cap reached: lights past kLightVolumeMaxSources are neither
+                // seeded nor recorded in `outStates`, so the DOMAIN-STATE log
+                // under-reports the true non-directional light count in an
+                // overflow scene. Intentional — `lightGatherRecords_` is
+                // reserved to exactly kLightVolumeMaxSources at create(), so
+                // recording the tail would force a per-frame reallocation; this
+                // mirrors the GPU-staging cap the seed buffer already enforces.
+                // A future #2317 verify harness asserting total light counts
+                // against the log must account for this ceiling.
                 return static_cast<std::uint32_t>(out.size());
             }
             const ivec3 origin = roundedLightOrigin(transforms[i]);

--- a/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
@@ -83,6 +83,26 @@ using namespace IRRender;
 
 namespace IRSystem {
 
+// Per-light gather outcome (#2315, V1 DOMAIN-STATE instrumentation).
+// `SEEDED_FULL` — origin fell inside the camera-anchored window, no
+// boundary clamp. `BOUNDARY_DISCOUNTED` — origin clamped to the window
+// edge; `residual_` is the seed alpha the clamp survived at. `SKIPPED` —
+// the discounted residual was ≤ 0 (light cannot reach the window);
+// `residual_` is 0. Public (not `detail`) — the DOMAIN-STATE emission hook
+// in a lighting demo's `main.cpp` reads these back via `lightGatherRecords()`
+// below.
+enum class LightGatherState : std::uint8_t {
+    SEEDED_FULL,
+    BOUNDARY_DISCOUNTED,
+    SKIPPED,
+};
+
+struct LightGatherRecord {
+    IREntity::EntityId entity_;
+    LightGatherState state_;
+    float residual_;
+};
+
 namespace detail {
 
 class ScopedCpuPhaseTimer {
@@ -196,12 +216,16 @@ inline std::uint32_t gatherLightSources(
     const ivec3 &volumeOriginVoxel,
     int &outMaxRadius,
     std::uint32_t &outEligible,
-    bool &outHasSpot
+    bool &outHasSpot,
+    std::vector<LightGatherRecord> *outStates = nullptr
 ) {
     out.clear();
     outMaxRadius = 0;
     outEligible = 0;
     outHasSpot = false;
+    if (outStates != nullptr) {
+        outStates->clear();
+    }
     const auto include = IREntity::getArchetype<C_LightSource, C_WorldTransform>();
     const auto nodes = IREntity::queryArchetypeNodesSimple(include);
     auto &entityManager = IREntity::getEntityManager();
@@ -269,6 +293,9 @@ inline std::uint32_t gatherLightSources(
             }
             const float seedAlpha = 1.0f - static_cast<float>(boundaryDist) * stepFalloff;
             if (seedAlpha <= 0.0f) {
+                if (outStates != nullptr) {
+                    outStates->push_back({node->entities_[i], LightGatherState::SKIPPED, 0.0f});
+                }
                 continue;
             }
             // This light is actually seeded — flag SPOTs so the consumer only
@@ -287,6 +314,12 @@ inline std::uint32_t gatherLightSources(
             // (queryable against the CPU mirror BUILD_LIGHT_OCCLUSION_GRID
             // already maintains, which runs before this system) is deferred
             // to #2330 rather than shipped silently.
+            if (outStates != nullptr) {
+                const LightGatherState state = boundaryDist == 0
+                                                   ? LightGatherState::SEEDED_FULL
+                                                   : LightGatherState::BOUNDARY_DISCOUNTED;
+                outStates->push_back({node->entities_[i], state, seedAlpha});
+            }
             out.push_back(toGpuLight(lights[i], volumeOriginVoxel + clamped, origin, seedAlpha));
         }
     }
@@ -317,6 +350,11 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
     Buffer *paramsBuf_ = nullptr;
     Buffer *occlusionBuf_ = nullptr;
     std::vector<GPULightSource> lightStaging_{};
+    // Per-light gather outcome (#2315, V1) — reused every frame, read back
+    // via `lightGatherRecords()` below by a lighting demo's DOMAIN-STATE
+    // emission hook (`AutoScreenshotConfig::onCaptureFrame_`) for the
+    // per-shot machine-readable log line.
+    std::vector<LightGatherRecord> lightGatherRecords_{};
     LightVolumeParams params_{};
     // Adaptive iteration count for the per-frame propagate dilation
     // chain. Recomputed at upload time from the eligible lights' max
@@ -350,8 +388,12 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
             // iso camera each frame; the seed/propagate/
             // lighting shaders subtract this origin before
             // indexing, so a panned camera keeps lights in
-            // range without resizing the texture.
-            const ivec3 volumeOrigin = IRRender::detail::cameraAnchorVoxel();
+            // range without resizing the texture. #2315 V1:
+            // freeze-aware — pins at the cull-freeze transition
+            // so F10 / shot-table FREEZE keeps lighting from the
+            // pinned window instead of tracking a free-flying
+            // camera.
+            const ivec3 volumeOrigin = IRRender::detail::frozenAwareCameraAnchorVoxel();
             volume.setWorldOriginVoxel(volumeOrigin);
             int maxRadius = 0;
             std::uint32_t eligible = 0;
@@ -362,7 +404,8 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
                 volumeOrigin,
                 maxRadius,
                 eligible,
-                hasSpot
+                hasSpot,
+                &lightGatherRecords_
             );
             // worldOriginVoxel_.w carries the has-SPOT flag (#2318): the
             // consumer skips the winning-light-ID read entirely when 0, so
@@ -533,10 +576,22 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
         // origin from the same binding.
         p->occlusionBuf_ = IRRender::getNamedResource<Buffer>("LightOcclusionGridBuffer");
         p->lightStaging_.reserve(kLightVolumeMaxSources);
+        p->lightGatherRecords_.reserve(kLightVolumeMaxSources);
         IRRender::tagGpuStage(systemId, "computeLightVolume");
         return systemId;
     }
 };
+
+// Read-back accessor for the DOMAIN-STATE emission hook (#2315, V1) — a
+// lighting demo holds the `SystemId` returned by
+// `createSystem<COMPUTE_LIGHT_VOLUME>()` and calls this from its
+// `AutoScreenshotConfig::onCaptureFrame_` callback to format the per-shot
+// per-light state list. Mirrors the sanctioned `getSystemParams<System<N>>`
+// diagnostics read-back pattern (engine/system/CLAUDE.md).
+inline const std::vector<LightGatherRecord> &lightGatherRecords(SystemId computeLightVolumeSystem) {
+    return getSystemParams<System<COMPUTE_LIGHT_VOLUME>>(computeLightVolumeSystem)
+        ->lightGatherRecords_;
+}
 
 } // namespace IRSystem
 

--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -233,7 +233,7 @@ template <> struct System<PERF_STATS_OVERLAY> {
         std::string out;
         out.reserve(1536);
 
-        char line[160];
+        char line[224];
 
         // The font is uppercase-only (`getGlyph` in `trixel_font.hpp` folds
         // lowercase to uppercase glyphs). Spell every label uppercase so the
@@ -324,13 +324,20 @@ template <> struct System<PERF_STATS_OVERLAY> {
             "CULL\n"
             "  SHAPES V/Z %5u/%u\n"
             "  VOX  %7u/%7u\n"
-            "  LIGHTS %5u/%u",
+            "  LIGHTS %5u/%u\n"
+            "  CASTERS %5u\n"
+            "  FEEDER %5.0f,%5.0f/%5.0f,%5.0f",
             gpu.visibleShapeCount_,
             gpu.shapeGroupsZ_,
             gpu.visibleVoxelCount_,
             gpu.totalVoxelCount_,
             gpu.lightsSeeded_,
-            gpu.lightsEligible_
+            gpu.lightsEligible_,
+            gpu.worldPlacedCasterCount_,
+            gpu.shadowFeederMin_.x,
+            gpu.shadowFeederMin_.y,
+            gpu.shadowFeederMax_.x,
+            gpu.shadowFeederMax_.y
         );
         out.append(line);
 

--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -326,7 +326,8 @@ template <> struct System<PERF_STATS_OVERLAY> {
             "  VOX  %7u/%7u\n"
             "  LIGHTS %5u/%u\n"
             "  CASTERS %5u\n"
-            "  FEEDER %5.0f,%5.0f/%5.0f,%5.0f",
+            "  FEED MIN %5.0f,%5.0f\n"
+            "  FEED MAX %5.0f,%5.0f",
             gpu.visibleShapeCount_,
             gpu.shapeGroupsZ_,
             gpu.visibleVoxelCount_,

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -522,10 +522,15 @@ its own iteration path and must **not** consult that mask. The failure
 mode is sharing a helper that accidentally applies the render cull to
 the grid build.
 
-**Check:** `system_build_light_occlusion_grid.hpp` does not include
-`cull_viewport_state.hpp` and does not call `visibleIsoViewport`.
+**Check:** `System<BUILD_LIGHT_OCCLUSION_GRID>` does not call
+`visibleIsoViewport` and applies no viewport filter to the grid build.
+The invariant is **behavioral**, not "the header is absent":
+`system_build_light_occlusion_grid.hpp` now transitively includes
+`cull_viewport_state.hpp` (via `camera_anchor.hpp`, added in #2315 for
+`isCullingFrozen()` freeze-state gating) — the freeze check is fine; only a
+`visibleIsoViewport`-based cull on the grid path would break the invariant.
 
-**Status (T-010, PR #188; renamed in T-126):** compliant —
+**Status (T-010, PR #188; renamed in T-126; include note #2315):** compliant —
 `System<BUILD_LIGHT_OCCLUSION_GRID>` iterates `pool.getLiveVoxelCount()`
 on the full pool with no viewport filter.
 


### PR DESCRIPTION
## Summary
- `frozenAwareCameraAnchorVoxel()` (camera_anchor.hpp) pins the light-volume/occlusion-grid anchor on the cull-freeze transition instead of re-deriving from the live camera pan every frame — F10 / shot-table FREEZE now keeps lighting from the pinned window, matching what the freeze already does for the cull viewport.
- `COMPUTE_LIGHT_VOLUME`'s per-light gather loop now also records each light's outcome (seeded full / boundary-discounted / skipped + residual) into a reusable staging vector, read back via `IRSystem::lightGatherRecords()`.
- `BAKE_SUN_SHADOW_MAP` surfaces its world-placed caster count and the widened shadow-feeder AABB into `GpuStageTiming`; the perf HUD's CULL block gains CASTERS + FEEDER rows alongside the existing LIGHTS row.
- A lighting demo's `AutoScreenshotConfig::onCaptureFrame_` hook formats this state into one machine-readable `DOMAIN-STATE` log line per shot (anchor, window bounds, per-light state list, feeder AABB, caster count) — mirrors the `GUI-ASSERT` precedent, for the V3 light-verify harness (#2317) to parse.

## Test plan
- [x] `fleet-build --target IRLightingEmissive` clean; `--auto-screenshot 60 --light-boundary-sweep` — DOMAIN-STATE residuals match the sweep's documented expected values exactly (0.786 = 1−6·1/28, 0.143 = 1−24·1/28, skip past reach) and the process exits cleanly.
- [x] `fleet-build --target IRShapeDebug` clean; `--auto-screenshot 60 --cull-validate` (freeze → fly → unfreeze, 26 shots) runs clean, no crash; visually inspected freeze-reference / panned-while-frozen / unfreeze-resumed frames — entities visible, correct silhouettes, consistent shading, light glow behaves correctly throughout.
- [x] `attach-screenshots` — all 21 of `IRShapeDebug`'s default `kShots[]` proven byte-identical before/after via sha256 (expected: none of those shots engage the cull freeze, so `frozenAwareCameraAnchorVoxel()` reduces to the old `cameraAnchorVoxel()` exactly). Not staged — 42 identical PNGs add zero reviewer value; this note is the record.
- [x] `render-verify.py --target IRLightingSdfBlocker` — byte-for-byte identical failure numbers with and without this diff (scratch before/after comparison), confirming the existing gate failure is unrelated pre-existing staleness, not a regression from this PR (see #2344 below).
- [x] `optimize` — `perf_grid_matrix.sh --quick` baseline vs. head: no cell crosses the 10% regression threshold; `ComputeLightVolume`/`BuildLightOcclusionGrid` deltas are sub-threshold and sub-millisecond in absolute terms.

## Notes for reviewer
While verifying this PR I found `creations/demos/lighting/test/references/manifest.json` (target `IRLightingSdfBlocker`) is already red on `origin/master` (5/5 shots fail, likely from the recent sun-shadow-bake-coverage-splat commit `9568bb85`/#2293) — confirmed independent of this diff and filed separately as #2344. Not fixed here per scope discipline.

Closes #2315

🤖 Generated with [Claude Code](https://claude.com/claude-code)