### PR TITLE
docs/fleet: epic-steward — reconcile #2314, close out #2164

### DIFF
--- a/.fleet/plans/issue-2164.md
+++ b/.fleet/plans/issue-2164.md
@@ -181,18 +181,28 @@ the only remaining callers of those primitives are the engine mutators.
 
 ## Steward ledger
 
-reconciled-through: 2026-06-30
+reconciled-through: 2026-07-13 (EPIC CLOSED)
 proposal-pending: none
 
 ### Children
 | Child | State | PR | Plan | Last validated |
 |---|---|---|---|---|
-| #2165 | open | — | plan | 2026-06-30 |
-| #2166 | open | — | plan | 2026-06-30 |
-| #2167 | open | — | plan | 2026-06-30 |
+| #2165 | merged (P1) | #2170 | plan | 2026-07-13 |
+| #2166 | merged (P2) | #2173 | plan | 2026-07-13 |
+| #2167 | merged (P3) | #2309 | plan | 2026-07-13 |
 
 ### Decisions
 - D1 (2026-06-30): API shape = editVoxels(fn) + carve(predicate) + resyncAfterRawEdits(); one cohesive delivery split into 3 phased children; codify convention (no broad cross-system audit this round) — source: umbrella plan §Decisions (confirmed with user)
 
 ### Events
 - 2026-06-30: filed via file-epic
+- 2026-07-13 (steward close-out): all 3 children merged — P1 #2165 (PR
+  #2170, 07-01), P2 #2166 (PR #2173, 07-02), P3 #2167 (PR #2309, 07-09).
+  Closing criteria verified: (1) 3/3 children closed; (2) grep
+  `recomputeFaceOccupancy|syncActiveMask` in `creations/` (excl game) →
+  only a doc comment in `skeletal_demo/main.cpp` remains, no hand-rolled
+  pairs; (3) render-verify byte-identity + `skeletal_demo` solid carve
+  verified in the P1/P2 PR reviews. Convention codified
+  (`cpp-ecs.md` §System-owned invariants); smell check upgraded
+  (`simplify-check-ecs.md` #9). Deferred cross-system caller-finalize
+  audit filed as `fleet:coding-improvement` #2364. Umbrella closed.

--- a/.fleet/plans/issue-2314.md
+++ b/.fleet/plans/issue-2314.md
@@ -62,22 +62,22 @@ independent heads.
 
 ## Steward ledger
 
-reconciled-through: 2026-07-08
-proposal-pending: none
+reconciled-through: 2026-07-13
+proposal-pending: STEWARD PROPOSAL 2026-07-13 (S1 #2319 / PR #2343 — scope + oracle) — https://github.com/jakildev/IrredenEngine/issues/2314#issuecomment-4962885956
 
 ### Children
 | Child | State | PR | Plan | Last validated |
 |---|---|---|---|---|
-| #2310 | open | #2313 | plan | 2026-07-08 |
-| #2315 | open | — | plan | 2026-07-08 |
+| #2310 | merged | #2313 | plan | 2026-07-13 |
+| #2315 | merged (V1) | #2347 | plan | 2026-07-13 |
 | #2316 | open | — | plan | 2026-07-08 |
 | #2317 | open | — | plan | 2026-07-08 |
-| #2318 | open | — | plan | 2026-07-08 |
-| #2319 | open | — | plan | 2026-07-08 |
-| #2320 | open | — | plan | 2026-07-08 |
-| #2321 | open | — | plan | 2026-07-08 |
-| #2322 | open | — | plan | 2026-07-08 |
-| #2323 | open | — | plan | 2026-07-08 |
+| #2318 | merged | #2337 | plan | 2026-07-13 |
+| #2319 | design-proposed | #2343 | plan | 2026-07-13 |
+| #2320 | open (pending #2319 proposal — do not claim) | — | plan | 2026-07-13 |
+| #2321 | open (pending #2319 proposal — do not claim) | — | plan | 2026-07-13 |
+| #2322 | merged | #2328 | plan | 2026-07-13 |
+| #2323 | merged | #2326 | plan | 2026-07-13 |
 
 ### Decisions
 <!-- entries: D<n> (<YYYY-MM-DD>): <decision> — source: <link> -->
@@ -88,7 +88,42 @@ proposal-pending: none
   2026-07-08 design session (human).
 - D3 (2026-07-08): every child verifies at cardinal + ~30° + 45° yaw on
   both backends — source: 2026-07-08 design session (human).
+- D4 (2026-07-09, SUPERSEDED 2026-07-10 by D5): S1 #2319 self-vs-cast
+  discrimination = pack each bake write's Chebyshev *displacement scalar*
+  (0 = direct) into the sun-depth low bits; receiver widens near-rejection
+  per tap by the stored displacement — source (architect):
+  https://github.com/jakildev/IrredenEngine/pull/2343#issuecomment-4927017072
+  . Status: implemented faithfully, **measured-refuted** (85% floor
+  cast-shadow erosion — winning texels in moth-eaten regions are themselves
+  splat writes, so displacement magnitude cannot separate self from cast).
+- D5 (2026-07-10, supersedes D4): pack the *displacement vector*
+  `(quantizedDepth << 8) | dx:4 | dy:4`; receiver reconstructs the write
+  origin and rejects occluders consistent with its own plane (same-plane
+  test, splat taps only; direct taps keep the byte-identical master path) —
+  source (architect):
+  https://github.com/jakildev/IrredenEngine/pull/2343#issuecomment-4931112807
+  . Status: implemented + twinned (`c0d0ae84`); the mechanism is
+  measured-correct for its stated purpose (removes cube-top self-hit AND
+  #2270 zero-caster floor acne), but the macOS `shadow_overlay_floor`
+  acceptance anchor is contaminated by that same acne, so the *scope +
+  oracle* question is unresolved → **open STEWARD PROPOSAL 2026-07-13**
+  (proposal-pending above). D5 is not final until that proposal is answered.
 
 ### Events
 - 2026-07-08: filed via file-epic (umbrella #2314, children #2315–#2323;
   #2310/PR #2313 pre-filed the same session as the first child).
+- 2026-07-13 (steward reconcile): merged children ticked — L1 #2310 (PR
+  #2313, 07-09), L2 #2318 (PR #2337, 07-10), D1 #2322 (PR #2328, 07-09),
+  D3 #2323 spike (PR #2326, 07-09). No scope drift vs plan; #2318 matches
+  D2 (winning-light ID channel). L2 landing makes the plan's deferred
+  "per-light falloff curves" out-of-scope item now fileable (not yet filed).
+- 2026-07-13 (steward reconcile, mid-iteration): V1 #2315 merged (PR #2347)
+  while this iteration ran (master e13421ba → ff2aaf9e). Ticked + reconciled.
+  V2 #2316 (blocked by #2315) is now unblocked for pickup; its plan is
+  unchanged (depends on the V1 instrumentation as landed, no drift).
+- 2026-07-13 (steward, flow a): S1 #2319 / PR #2343 round-3 NEEDS-DESIGN
+  questions classified NOVEL (D4 + D5 both measured-refuted on the macOS
+  oracle); PR flipped `fleet:design-blocked → fleet:design-proposed`,
+  aggregated into STEWARD PROPOSAL 2026-07-13, umbrella labeled
+  `fleet:steward-proposal`. S2 #2320 / S3 #2321 bind to the #2319 ruling →
+  marked pending, do not claim.


### PR DESCRIPTION
## Summary

Epic-steward bookkeeping iteration (2026-07-13) — **docs artifacts only, no code touched.**

**#2314 (lighting/shadow domain culling) — ledger reconciled through 2026-07-13:**
- Umbrella checklist + ledger: L1 #2310, V1 #2315, L2 #2318, D1 #2322, D3 #2323 marked merged (PRs #2313 / #2347 / #2337 / #2328 / #2326).
- Folded the two architect S1 rulings into the Decisions index with their measured refutations — **D4** (scalar displacement provenance → 85% floor cast-shadow erosion) and **D5** (displacement-vector same-plane test → correct for its stated purpose, but the macOS `shadow_overlay_floor` acceptance anchor is contaminated by the #2270 floor self-acne it removes).
- Recorded the **STEWARD PROPOSAL 2026-07-13** for S1 #2319 / PR #2343: all round-3 `NEEDS-DESIGN` questions are novel (both prior rulings measured-refuted), so they're aggregated for a human / opus-architect **scope + acceptance-oracle** ruling. PR #2343 flipped `fleet:design-blocked → fleet:design-proposed`; umbrella labeled `fleet:steward-proposal`. S2 #2320 / S3 #2321 marked *pending #2319 — do not claim*.

**#2164 (encapsulate C_VoxelSetNew derived state) — closed out:**
- All three children merged (#2170 / #2173 / #2309); closing criteria verified (grep of `creations/` clean of hand-rolled resync pairs, `cpp-ecs.md` §System-owned invariants + `simplify-check-ecs.md` #9 landed).
- Deferred cross-system caller-finalize audit filed as #2364 (`fleet:coding-improvement`). Umbrella #2164 closed.

## Test plan
- [x] Docs-only (`.fleet/plans/*.md`) — no build / runtime surface.
- [x] Cited PR#/issue#/comment links verified against live GitHub state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)