### PR TITLE
docs/fleet: epic-steward — close out #667 (persist), reconcile #1933 (#1937 merged)

### DIFF
--- a/.fleet/plans/issue-1933.md
+++ b/.fleet/plans/issue-1933.md
@@ -221,21 +221,39 @@ regime (`kScatterDetachedPitchFraction`) and camera regime
 
 ## Steward ledger
 
-reconciled-through: 2026-06-21
+reconciled-through: PR #2013 merge (2026-07-13)
 proposal-pending: none
 
 ### Children
 | Child | State | PR | Plan | Last validated |
 |---|---|---|---|---|
-| #1937 | open | — | plan | 2026-06-21 |
-| #1938 | open | — | plan | 2026-06-21 |
-| #1939 | open | — | plan | 2026-06-21 |
+| #1937 | merged | #2013 | plan (stale header — see note) | 2026-07-13 |
+| #1938 | open | — | plan (amended A1) | 2026-07-13 |
+| #1939 | open | — | plan (amended A1) | 2026-07-13 |
 
 ### Decisions
-- 2026-06-21: approach picked = portable analytic edge-aware coverage; HW
+- D1 (2026-06-21): approach picked = portable analytic edge-aware coverage; HW
   conservative raster (no Metal API; GL extension non-portable on the WSL 4.5
   floor) and MSAA (integer R32I/depth resolve + 4–8× memory) ruled out by the
   source-verified capability audit.
+- D2 (2026-07-13): C1 lead backend = **Metal** (#1937, PR #2013); C2 = **GL**
+  parity (#1938). The GL→Metal lead order was flipped after planning — the child
+  titles were updated but the plan files were not; #1938/#1939 amended (A1) to
+  match. The approach (D1) is unchanged — this is a sequencing flip, not an
+  approach change. source: PR #2013 (metal shaders) + updated child titles +
+  in-code note `metal/peraxis_scatter.metal:282-283`.
 
 ### Events
-- 2026-06-21: filed via file-epic (planning of #1933)
+- 2026-06-21: filed via file-epic (planning of #1933).
+- 2026-07-13: **#1937 (C1) merged via PR #2013** — analytic edge-aware coverage
+  landed on the **Metal** backend (`metal/ir_iso_common.metal`,
+  `metal/peraxis_scatter.metal`); macOS references refreshed. Umbrella checklist
+  ticked. The GL side (`v_peraxis_scatter.glsl`, `ir_iso_common.glsl`) is still
+  on the old `scatterConservativeDilation` margin model — that is #1938's port
+  target. No scope drift vs #1937's (backend-flipped) plan intent.
+- 2026-07-13: **Drift note (record-only):** the merged child #1937's own plan
+  file (`issue-1937.md`) header/scope still reads "GL backend (C1)" — a
+  pre-merge title-flip artifact. #1937 is closed (no worker resumes it), so its
+  plan is left as-is; the authoritative issue title + PR #2013 record the truth.
+  The umbrella checklist descriptions were realigned to the current issue titles
+  during the tick (heal-shape).

--- a/.fleet/plans/issue-1938.md
+++ b/.fleet/plans/issue-1938.md
@@ -65,3 +65,32 @@ feature parity. No new design.
   `--auto-screenshot`; capture the same near-cardinal coarse-cube shots as #1937
   and compare GL↔Metal.
 - `backend-parity` skill (the primary gate for this child).
+
+## Amendments
+
+### A1 — 2026-07-13 — trigger: PR #2013 merged (#1937 C1)
+- **Decision:** C1 (#1937) landed the analytic edge-aware coverage on the
+  **Metal** backend (PR #2013 touched `metal/ir_iso_common.metal` +
+  `metal/peraxis_scatter.metal`), **not GL**. The lead backend was flipped
+  GL→Metal after this plan was written; the child titles now read #1937 =
+  "Metal backend (C1, lead)" and #1938 = "GL parity port (C2)". **This child
+  is therefore the GL parity port** — mirror the now-on-master Metal analytic
+  coverage into the GL shaders.
+- **Supersedes:** the plan's backend polarity throughout. "Scope",
+  "Verified current state", and "Affected files" describe porting GL→Metal —
+  **invert them**. The port *target* files are now
+  `engine/render/src/shaders/v_peraxis_scatter.glsl`, `f_peraxis_scatter.glsl`,
+  and `ir_iso_common.glsl` (add the analytic-coverage helper next to the GL
+  `scatterConservativeDilation` at `ir_iso_common.glsl:935`, still on the old
+  margin model). The *reference* implementation to mirror is the merged Metal
+  side: `metal/peraxis_scatter.metal` (analytic coverage + `discard_fragment()`
+  ~:373–381, interior/boundary classification) + `metal/ir_iso_common.metal`.
+  In-code confirmation: `metal/peraxis_scatter.metal:282-283` — "The GL twin
+  (v_peraxis_scatter.glsl) still carries that old coverage role; it ports to
+  this visit-bound in #1938."
+- **Acceptance criteria:** intent unchanged (crisp corners + no dashing,
+  cardinal byte-identical, backend parity). Re-read "Metal renders the same
+  result #1937 proved on GL" as "**GL** renders the same result #1937 proved on
+  **Metal**"; the `backend-parity` audit direction is now Metal→GL.
+- **By:** epic-steward — source: PR #2013 (merged Metal shaders); updated child
+  issue titles #1937/#1938; in-code note `metal/peraxis_scatter.metal:282-283`.

--- a/.fleet/plans/issue-1939.md
+++ b/.fleet/plans/issue-1939.md
@@ -84,3 +84,20 @@ Consumers: `v_peraxis_scatter.glsl:211,217-218`, `f_peraxis_scatter.glsl`,
 - The #1922 jitter harness (once on master) — temporal-stability gate.
 - `scripts/dev/perf-grid-rotate-sweep` — solidity/silhouette.
 - `render-verify` — cardinal byte-identity; `backend-parity` — GL↔Metal.
+
+## Amendments
+
+### A1 — 2026-07-13 — trigger: PR #2013 merged (#1937 C1)
+- **Decision:** The per-backend attribution in this plan is **inverted**. C1
+  (#1937) shipped **Metal** (PR #2013), and C2 (#1938) is the **GL** parity
+  port — read "#1937 Metal, #1938 GL" wherever this plan says the reverse. The
+  retire-the-tower work is backend-symmetric and **unchanged**: this child
+  still removes the six `kScatter*` margin/miter/yield symbols from **both**
+  `ir_iso_common.glsl` and `ir_iso_common.metal` in lockstep, once #1938 lands
+  GL analytic coverage (both backends then authoritative).
+- **Supersedes:** only the "#1937 GL, #1938 Metal" attribution in **Scope**. The
+  retire targets, the symbol table, `Blocked by: #1938, #1922`, and the
+  acceptance criteria are all unaffected.
+- **Acceptance criteria:** unchanged.
+- **By:** epic-steward — source: PR #2013 (merged Metal shaders); updated child
+  issue titles #1937/#1938.

--- a/.fleet/plans/issue-667.md
+++ b/.fleet/plans/issue-667.md
@@ -62,19 +62,19 @@ dump; clean on `linux-debug` + `macos-debug`; Lua `saveWorld`/`loadWorld`.
 
 ## Steward ledger
 
-reconciled-through: 2026-07-04
+reconciled-through: 2026-07-13 (close-out)
 proposal-pending: none
 
 ### Children
 | Child | State | PR | Plan | Last validated |
 |---|---|---|---|---|
-| #2212 | open | — | plan | 2026-07-04 |
-| #2213 | open | — | plan | 2026-07-04 |
-| #2214 | open | — | plan | 2026-07-04 |
-| #2215 | open | — | plan | 2026-07-04 |
-| #2216 | open | — | plan | 2026-07-04 |
-| #2217 | open | — | plan | 2026-07-04 |
-| #2218 | open | — | plan | 2026-07-04 |
+| #2212 | merged | #2225 | plan | 2026-07-13 |
+| #2213 | merged | #2228 | plan | 2026-07-13 |
+| #2214 | merged | #2230 | plan | 2026-07-13 |
+| #2215 | merged | #2238 | plan | 2026-07-13 |
+| #2216 | merged | #2239 | plan | 2026-07-13 |
+| #2217 | merged | #2240 | plan | 2026-07-13 |
+| #2218 | merged | #2244 | plan | 2026-07-13 |
 
 ### Decisions
 D1 (2026-07-03): 7 chained single-PR children, mixed model routing, queue-now — human-ratified in the triage session.
@@ -84,3 +84,5 @@ D4 (2026-07-03): C_VoxelSetNew serializes into staged mode; P6 owns the canvas-a
 
 ### Events
 - 2026-07-04: children #2212–#2218 filed with plans via the adapted file-epic flow; `fleet-validate-stack 667` PASS (7/7); all children human:approved.
+- 2026-07-13: all 7 children merged (PRs #2225/#2228/#2230/#2238/#2239/#2240/#2244, 2026-07-05..07-06). Source-verified on master: `engine/world/include/irreden/world/{save_trait,save_migration,save_registry,save_component_inventory,world_snapshot}.hpp` + `src/world_snapshot{,_relations}.cpp`; Lua `IRPersist.saveWorld/loadWorld` (`engine/script/.../lua_world_snapshot_bindings.hpp`); `creations/demos/persist_roundtrip`; `test/world/{persist_round_trip,world_snapshot,world_snapshot_relations,chunk_persistence}_test.cpp`; `.json.txt` debug dump in `world_snapshot.cpp`. Epic close-out — all 8 umbrella acceptance criteria evidenced (see #667 closure comment).
+- 2026-07-13: **Known deviation (not a gap):** relations materialize **CHILD_OF only** per D3. PARENT_TO/SIBLING_OF remain unimplemented in the engine (`setRelation` asserts), so acceptance #1/#4's PARENT_TO/SIBLING_OF wording is satisfied for the supported relation set only. Extending the `RELN` chunk is a one-line enum add (Extensibility Rule #4) if/when those relations land. No follow-up filed — adding the relation *types* is an engine-wide concern out of persist scope, and the chunk is already forward-extensible.


### PR DESCRIPTION
## Summary

Epic-steward bookkeeping — docs-only, all under `.fleet/plans/`.

- **Close out epic #667** (persist: ECS world snapshot). All 7 children (#2212–#2218) merged and source-verified on master; ledger reconciled; all 8 umbrella acceptance criteria evidenced. CHILD_OF-only relation scope recorded as a ratified deviation (PARENT_TO/SIBLING_OF are engine-wide unimplemented). Umbrella closed.
- **Reconcile epic #1933** (analytic scatter coverage). #1937 (C1) merged via PR #2013 on the **Metal** backend — the lead backend was flipped GL→Metal after planning, leaving the sibling plans stale on polarity. Amended #1938 (now the GL parity port) and #1939 (retire-tower) append-only to the merged reality; recorded the flip in the #1933 ledger.

Immediate GitHub actions were applied directly (not on this branch): #667 closed + closure comment; #1933 checklist ticked + backend labels realigned + reconcile comment.

## Test plan
- [x] Docs-only diff (4 `.fleet/plans/*.md` files); no engine code, shaders, or config touched.
- [x] All file / PR / symbol cross-references added to the ledgers/amendments verified to resolve on-tree.
- [x] Plan amendments are append-only (`## Amendments`); no plan history rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)