### PR TITLE
docs/fleet: epic-steward — rollup #1394 (API-quota children merged)

### DIFF
--- a/.fleet/plans/issue-1394.md
+++ b/.fleet/plans/issue-1394.md
@@ -54,16 +54,16 @@ with headroom visible in `fleet-gate-status` (acceptance #3). Then #1394 closes.
 
 ## Steward ledger
 
-reconciled-through: 2026-07-04
+reconciled-through: 2026-07-06 (all four code children merged)
 proposal-pending: none
 
 ### Children
 | Child | State | PR | Plan | Last validated |
 |---|---|---|---|---|
-| #2219 | open | — | plan | 2026-07-04 |
-| #2220 | open | — | plan | 2026-07-04 |
-| #2221 | open | — | plan | 2026-07-04 |
-| #2222 | open | — | plan | 2026-07-04 |
+| #2219 | merged | #2227 | plan | 2026-07-13 |
+| #2220 | merged | #2231 | plan | 2026-07-13 |
+| #2221 | merged | #2234 | plan | 2026-07-13 |
+| #2222 | merged | #2232 | plan | 2026-07-13 |
 
 ### Decisions
 D1 (2026-07-03): identity model = GitHub App; machine accounts last-resort; webhooks long-term.
@@ -72,3 +72,5 @@ D3 (2026-07-03): Q3 gates ON by default at 0.90 for core/graphql; search surface
 
 ### Events
 - 2026-07-04: children #2219–#2222 filed with plans; `fleet-validate-stack 1394` PASS (4/4); all children human:approved.
+- 2026-07-06: all four code children merged in-scope — Q1 #2219→PR #2227 (conditional-REST scout polling), Q2 #2220→PR #2231 (leader/follower centralized polling), Q3 #2221→PR #2234 (quota headroom + dispatcher gate), Q4 #2222→PR #2232 (GitHub App token plumbing). Scope-drift audit: each PR matches its Q-scope; no contradiction of D1–D3.
+- 2026-07-13: rollup — all four checklist boxes ticked. **Close-out remains blocked on the human-owned remainder** (create/install the `irreden-fleet` GitHub App + one sustained multi-device session with headroom visible in `fleet-gate-status`, per Closing criteria + umbrella acceptance #1/#3). Umbrella stays open with `fleet:needs-human`; no code touched.


### PR DESCRIPTION
## Summary
- Epic **#1394** rollup: all four API-quota children merged in-scope — Q1 #2219→#2227 (conditional-REST scout polling), Q2 #2220→#2231 (leader/follower centralized polling), Q3 #2221→#2234 (quota headroom + dispatcher gate), Q4 #2222→#2232 (GitHub App token plumbing).
- Ticked the umbrella `## Children` checklist (4/4).
- Reconciled the `## Steward ledger` through the 2026-07-06 merges: children → merged with PR refs, `reconciled-through: 2026-07-06`, scope-drift audit (each PR matches its Q-scope; no contradiction of D1–D3).

## Not closing the epic
Close-out stays gated on the **human-owned remainder** (why #1394 keeps `fleet:needs-human`): create + install the `irreden-fleet` GitHub App on both repos, then sustain one multi-device fleet session without hitting either primary limit, with headroom visible in `fleet-gate-status` (plan Closing criteria + umbrella acceptance #1/#3). Q4's code already ships with a personal-auth fallback; only its live verification is gated on the App.

## Test plan
- [x] Docs-only (`.fleet/plans/issue-1394.md`); no code touched.
- [x] Ledger PR↔child cross-refs verified against merged PRs.

Rollup bookkeeping for #1394 (does **not** close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)