### PR TITLE
fleet: timeout-guard daemon net calls + hung-lock escalation (#2362)

### DIFF
--- a/.fleet/plans/issue-2362.md
+++ b/.fleet/plans/issue-2362.md
@@ -1,0 +1,51 @@
+# Plan: fleet-rebase: timeout-guard network git ops + stale-lock detection (+ fleet-wide net-call audit)
+
+- **Issue:** #2362
+- **Model:** opus — cross-script bash with portability subtleties (shadow functions, coreutils-vs-System32 `timeout`, ssh-config idempotency), but the approach is fully specified below; no novel design remains.
+- **Date:** 2026-07-13
+
+## Verified current state (audit @ master `3035f07b`)
+
+Root cause per the 07-13 thread comment: host TCP connections to GitHub intermittently black-hole (silent death, no RST), so any unguarded network call hangs forever. Three fleet outages in 4 days. Audit of every named surface:
+
+- **`fleet-rebase`** — 13 unguarded network sites: `git fetch` L250, L265, L303, L309, L363; `git ls-remote` L266, L272; `git push` L421; `gh pr view` L176, L203; `gh pr edit` L223, L224, L297; `gh pr list` L285. Lock (L103–129): `mkdir $STATE_DIR/fleet-rebase.lock.d` + pid file; the stale-break (L110–115) fires only when the holder pid is **dead** — an alive-but-hung holder defers forever with the benign L125 message. Confirms the outage-1 mechanism.
+- **`fleet-claim`** — ~49 `gh` network invocations plus `git fetch`/`git push --force-with-lease`. Runs **inline in the dispatcher main loop** (`reservation-role`, `planning-claim`), so one hung `gh issue view` is a fleet-wide outage — exactly outage 2 (18 h).
+- **`fleet-clone-freshness.sh`** — `advance_main_clone`'s `git fetch origin master` (L116) is `|| true`-guarded against *failure* but not against *hanging*; invoked by the dispatcher at startup and per-tick. Outage 3.
+- **`fleet-dispatcher`** — already resolves `TIMEOUT_CMD` (L372–377, `timeout` → `gtimeout` → empty) but applies it **only** to tmux send-keys, and its `command -v timeout` probe has the latent Windows System32 bug. Its remaining network exposure is via child `fleet-claim` and the sourced `advance_main_clone`.
+- **Already guarded — no work needed:** `fleet-queue-ingest`'s embedded python has `timeout=15` on all subprocess `gh` calls; `fleet_gh_poll.py` has subprocess + urllib timeouts; the scout never fetches (rev-parse only).
+- **`~/.fleet/alerts/` exists** (created by fleet-up) — an alert = file drop + loud log line for the human/babysit.
+
+## Approach
+
+One task, one PR — the lib and its consumers must land together to be testable.
+
+1. **New shared lib `scripts/fleet/fleet-net.sh`** (sourced, not executed):
+   - Resolve `FLEET_TIMEOUT_CMD` once: coreutils `timeout` → `gtimeout` → empty. Verify coreutils-ness (`--version` output) before trusting a bare `timeout` on PATH — Windows System32 `timeout.exe` is an interactive wait, not a command runner. Degrade to unguarded passthrough when none resolves.
+   - Shadow functions `gh()` and `git()` that call `command gh` / `command git` internally (no recursion). `git()` scans past global flags (`-C <path>`, `-c <k=v>`, `--foo`) to find the subcommand and applies the timeout **only** to network subcommands (`fetch`, `push`, `pull`, `ls-remote`, `clone`, `remote`, `fetch-pack`, `send-pack`); everything else passes through untouched — never time-limit a local `rebase`/`checkout`.
+   - Budget: `FLEET_NET_TIMEOUT` default **120 s**, env-overridable. `timeout` exit 124 flows into existing `|| true` / `rc=$?` handling as an ordinary failure — the desired skip-and-continue degrade the call sites already implement.
+   - Why shadow instead of per-site edits: fleet-claim alone has ~49 sites; per-site churn is unreviewable, and a shadow guards *future* call sites by construction.
+2. **Source `fleet-net.sh`** in `fleet-rebase`, `fleet-claim`, and `fleet-dispatcher` (early — before the dispatcher sources `fleet-clone-freshness.sh`, so `advance_main_clone`'s fetch resolves the shadow at call time). Missing-lib fallback: skip sourcing (graceful degrade). Retire the dispatcher's inline `TIMEOUT_CMD` resolution in favor of the lib so two copies don't drift; the send-keys guard keeps working off the same var (and inherits the coreutils probe, fixing its latent Windows bug).
+3. **`fleet-rebase` hung-lock escalation:** `acquire_lock` additionally stamps `date +%s > "$LOCK_DIR/started"`. On the defer path with an **alive** holder: if `now − started > FLEET_REBASE_LOCK_HUNG_SECS` (default **1800**), log a loud `HUNG-LOCK:` line and write `~/.fleet/alerts/fleet-rebase-hung-lock` instead of only the benign message. Do **not** auto-break an alive holder. Missing `started` file (pre-fix holder during rollout) → skip the age check.
+4. **`install.sh` host-protection section** (idempotent, mirrors the zshrc snippet pattern):
+   - (a) ssh keepalives for `Host github.com` as a **marked** block in `~/.ssh/config`, with a `--no-ssh-config` opt-out. If any existing `Host github.com` block is present (e.g. a manual edit), **skip and warn** — never merge into or duplicate a user-owned block.
+   - (b) `git config --global http.lowSpeedLimit 1000` / `http.lowSpeedTime 60` (idempotent by nature).
+   - (c) If neither coreutils `timeout` nor `gtimeout` resolves: install the python shim (`scripts/fleet/timeout-shim.py` → `~/bin/timeout`, via all three tool-registry edits) and print the coreutils recommendation.
+5. **Tests** (hermetic `tests/test_*.sh`):
+   - `test_fleet_net_guard.sh` — subcommand classification (incl. `-C`/`-c` flag skip), network op gets the prefix / local op doesn't, exit-124 propagation, empty-`FLEET_TIMEOUT_CMD` passthrough, non-coreutils `timeout` rejected by the probe.
+   - `test_fleet_rebase_hung_lock.sh` — lock held by a live `sleep` holder with a backdated `started` → loud message + alert file, still defers; fresh holder → benign message only; dead holder → stale-break unchanged; missing `started` → no escalation.
+
+## Affected files
+- `scripts/fleet/fleet-net.sh` — new shared net-guard lib
+- `scripts/fleet/fleet-rebase` — source lib; `started` stamp; hung-lock escalation
+- `scripts/fleet/fleet-claim` — source lib
+- `scripts/fleet/fleet-dispatcher` — source lib early; drop the inline `TIMEOUT_CMD` resolution
+- `scripts/fleet/install.sh` — host-protection section + registry entries for the shim
+- `scripts/fleet/timeout-shim.py` — new (ships only as the (c) fallback)
+- `scripts/fleet/tests/test_fleet_net_guard.sh`, `tests/test_fleet_rebase_hung_lock.sh` — new
+
+## Gotchas
+- **Activation lag:** dispatcher/rebase/claim run from the main clone's master — the fix is inert until the PR merges and the main clone advances; a `fleet-up` bounce activates it.
+- Shadow wrappers must use `command git` / `command gh` internally or they recurse.
+- Windows System32 `timeout.exe` shadows coreutils in some PATH orders — the coreutils probe is load-bearing.
+- Exit 124 aliases with ordinary failure — verified the touched call sites use boolean success checks only.
+- `~/.ssh/config` may not exist / need 600 perms — create with `umask 077`.

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -30,3 +30,10 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
 - **A new executable ships with a `tests/test_<name>.{sh,py}`** in the same
   PR — the fleet-tooling form of the review checklist's "new feature with no
   new test"; the `simplify` pre-commit pass flags the omission.
+- **Unattended daemons timeout-guard their network calls.** The host's
+  connections to GitHub intermittently black-hole (silent TCP death), so a
+  hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,
+  `fleet-claim`) wedges the fleet indefinitely (#2362). `source
+  fleet-net.sh` — it shadows `git()`/`gh()` with a `timeout` and bounds every
+  current and future call site by construction — rather than adding per-site
+  guards. Python fetchers use their own subprocess/urllib timeouts instead.

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -142,6 +142,17 @@ else
     assert_clone_fresh() { :; }  # helper not installed yet — no-op (fail open)
 fi
 
+# Network-call timeout guard (#2362). fleet-claim runs INLINE in the dispatcher
+# main loop (reservation-role, planning-claim) across ~49 gh sites plus two git
+# net ops; one black-holed call there is a fleet-wide outage (the 18 h wedge on
+# 07-12). Sourcing fleet-net.sh shadows git()/gh() to bound every one with a
+# timeout — no per-site edits. Missing lib (main clone not yet advanced past
+# this PR) degrades to today's unguarded behavior.
+if [[ -f "$FLEET_LIB_DIR/fleet-net.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$FLEET_LIB_DIR/fleet-net.sh"
+fi
+
 # GitHub App token (#1394 Q4): guarded export so this invocation's 48 gh
 # call sites draw from the App pool. Never export GH_TOKEN="" — that would
 # defeat gh's keychain fallback on the unconfigured path.

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -87,6 +87,20 @@ done
 FLEET_LIB_DIR="${FLEET_LIB_DIR:-$(cd "$(dirname "$_fleet_dispatcher_self")" && pwd)}"
 unset _fleet_dispatcher_self
 
+# Network-call timeout guard (#2362). Source this BEFORE fleet-clone-freshness.sh
+# so advance_main_clone's `git fetch` resolves the git() shadow at call time
+# (bash binds function names when the call runs). Installs git()/gh() shadows
+# that bound every network op with a timeout — the dispatcher's own inline net
+# exposure is advance_main_clone's fetch + child fleet-claim calls, and a hang
+# in either is a fleet-wide outage (07-13 startup + 18 h loop wedges). It also
+# resolves FLEET_TIMEOUT_CMD via a coreutils-aware probe, reused for the
+# send-keys guard below. Missing lib (pre-rollout main clone) degrades to
+# unguarded, exactly today's behavior.
+if [[ -f "$FLEET_LIB_DIR/fleet-net.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$FLEET_LIB_DIR/fleet-net.sh"
+fi
+
 # Engine/game roots + main-clone freshness helper (#1810). The dispatcher
 # periodically advances the shared main clone's master in its main loop, so a
 # fleet-script fix that merges mid-session goes live without a fleet-up restart
@@ -365,16 +379,13 @@ USAGE_GATE_CLOSED_LOGGED=""
 # keeps pickup snappy without burning measurable CPU.
 POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-10}"
 
-# Which `timeout` binary to use when wrapping tmux send-keys. GNU
-# coreutils ships it as `timeout` on Linux and as `gtimeout` on macOS
-# (Homebrew coreutils, non-conflicting name). Empty string = not found;
-# dispatch_send_keys falls back to plain send-keys (today's behavior).
-TIMEOUT_CMD=""
-if command -v timeout &>/dev/null; then
-    TIMEOUT_CMD="timeout"
-elif command -v gtimeout &>/dev/null; then
-    TIMEOUT_CMD="gtimeout"
-fi
+# Which `timeout` binary to use when wrapping tmux send-keys. Reuse the net
+# lib's resolution (#2362) so there is a single source of truth, and so the
+# send-keys guard inherits its coreutils probe — a bare `command -v timeout`
+# would accept Windows System32 `timeout.exe`, an interactive wait rather than a
+# command runner. Empty when neither the lib nor a coreutils timeout is present;
+# dispatch_send_keys then falls back to plain send-keys (today's behavior).
+TIMEOUT_CMD="${FLEET_TIMEOUT_CMD:-}"
 
 # Periodic safety-net re-arm for merger. The merger's projection IS
 # responsive to PR state changes, so we only re-arm when the natural

--- a/scripts/fleet/fleet-net.sh
+++ b/scripts/fleet/fleet-net.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# fleet-net.sh — bound every network call an unattended fleet daemon makes, so a
+# black-holed GitHub connection (silent TCP death, no RST) fails fast instead of
+# hanging forever. (#2362)
+#
+# The problem this solves: the host's connections to GitHub intermittently
+# black-hole. Any unguarded `git fetch` / `git push` / `gh …` then blocks on a
+# network read that never returns — three fleet-wide outages in four days, each
+# a single hung call: fleet-rebase's fetch holding the rebase lock for 3 days;
+# the dispatcher main loop wedged 18 h on an inline `fleet-claim … gh issue
+# view`; a fresh dispatcher hung at startup on its clone-freshness fetch.
+#
+# The fix is a pair of shadow functions — `git()` and `gh()` — that prefix a
+# `timeout` to network operations. A script SOURCES this lib once and every
+# subsequent `git`/`gh` call it makes (including calls inside functions it later
+# sources, since bash resolves function names at call time) is guarded, with no
+# per-call-site edits. fleet-claim alone has ~49 `gh` sites; a shadow guards
+# them all — and every future site — by construction.
+#
+# Source of truth: scripts/fleet/fleet-net.sh in the engine repo.
+# Installed to ~/bin/fleet-net.sh (as a symlink) by scripts/fleet/install.sh —
+# it must be symlinked alongside the other fleet scripts so the FLEET_LIB_DIR
+# source pattern resolves through ~/bin, the same way fleet-common.sh and
+# fleet-clone-freshness.sh do.
+#
+# Usage (bash consumers — fleet-rebase / fleet-claim / fleet-dispatcher):
+#   source "$FLEET_LIB_DIR/fleet-net.sh"     # FLEET_LIB_DIR is symlink-resolved
+#   git -C "$wt" fetch origin master         # now bounded by FLEET_NET_TIMEOUT
+#
+# The scout is python and does NOT source this — python subprocesses invoke the
+# `git`/`gh` executables directly (no bash function resolution), and its own
+# fetchers (fleet_gh_poll.py) already carry urllib/subprocess timeouts.
+#
+# Env:
+#   FLEET_TIMEOUT_CMD   — override the resolved timeout runner (e.g. a test
+#                         double, or "" to force the unguarded passthrough).
+#   FLEET_NET_TIMEOUT   — per-call budget in seconds (default 120).
+
+# --- Resolve a coreutils-compatible `timeout` runner, once -------------------
+# GNU coreutils ships it as `timeout` on Linux and `gtimeout` on macOS
+# (Homebrew, non-conflicting name). A bare `command -v timeout` is NOT enough:
+# Windows System32 ships an unrelated `timeout.exe` (an interactive wait, not a
+# command runner) that can shadow coreutils in some PATH orders. Probe
+# `--version` for the coreutils signature so the wrong binary is rejected; the
+# ~/bin python fallback shim (install.sh step c) advertises "coreutils" in its
+# own --version so it passes the same probe.
+_fleet_net_is_coreutils_timeout() {
+    command -v "$1" >/dev/null 2>&1 || return 1
+    "$1" --version 2>/dev/null | grep -qi 'coreutils' || return 1
+    return 0
+}
+
+_fleet_net_resolve_timeout_cmd() {
+    local c
+    for c in timeout gtimeout; do
+        if _fleet_net_is_coreutils_timeout "$c"; then
+            printf '%s' "$c"
+            return 0
+        fi
+    done
+    printf ''  # none found — callers degrade to unguarded passthrough
+    return 0
+}
+
+# Respect an inherited value (a parent daemon may export it so children skip the
+# re-probe); otherwise resolve it now. Empty is a valid resolved value meaning
+# "no timeout binary on this host" — the shadows then pass straight through.
+FLEET_TIMEOUT_CMD="${FLEET_TIMEOUT_CMD-$(_fleet_net_resolve_timeout_cmd)}"
+FLEET_NET_TIMEOUT="${FLEET_NET_TIMEOUT:-120}"
+
+# --- git() shadow: guard network subcommands only ----------------------------
+# A false timeout on a LOCAL op (rebase, checkout) would corrupt the worktree
+# mid-operation — the exact hazard the rebase lock exists to prevent — so the
+# timeout is applied ONLY when the resolved subcommand is a network verb.
+# Everything else passes through untouched. Misparsing a flag can at worst miss
+# guarding a network op (degrades to today's unguarded behavior); it can never
+# apply a timeout to a local op, because that requires the parsed subcommand to
+# literally be a network verb.
+git() {
+    local tmo="${FLEET_TIMEOUT_CMD:-}"
+    if [[ -z "$tmo" ]]; then
+        command git "$@"
+        return $?
+    fi
+    # Scan past git's global options to find the subcommand. The only global
+    # flags that consume a SEPARATE following token are `-C <path>` and
+    # `-c <name=value>`; every other global flag is either `--flag` or
+    # `--flag=value` (self-contained). fleet's call sites use `git -C <wt> …`.
+    local -a a=("$@")
+    local i=0 n=${#a[@]} sub=""
+    while (( i < n )); do
+        case "${a[i]}" in
+            -C|-c) i=$((i + 2)); continue ;;
+            -*)    i=$((i + 1)); continue ;;
+            *)     sub="${a[i]}"; break ;;
+        esac
+    done
+    case "$sub" in
+        fetch|push|pull|clone|ls-remote|remote|fetch-pack|send-pack)
+            command "$tmo" "$FLEET_NET_TIMEOUT" git "$@"
+            return $?
+            ;;
+        *)
+            command git "$@"
+            return $?
+            ;;
+    esac
+}
+
+# --- gh() shadow: every gh call is a network call ----------------------------
+# No subcommand parsing needed — the GitHub CLI hits the API for essentially
+# everything, so guard unconditionally.
+gh() {
+    local tmo="${FLEET_TIMEOUT_CMD:-}"
+    if [[ -z "$tmo" ]]; then
+        command gh "$@"
+        return $?
+    fi
+    command "$tmo" "$FLEET_NET_TIMEOUT" gh "$@"
+    return $?
+}

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -41,6 +41,23 @@ SLICE="$STATE_DIR/projections/merger.json"
 TRIGGERS_DIR="$STATE_DIR/triggers"
 SCRATCH_ROOT="${FLEET_REBASE_SCRATCH:-$HOME/.fleet/rebase-scratch}"
 
+# Network-call timeout guard (#2362). Sourcing fleet-net.sh installs git()/gh()
+# shadow wrappers that bound every network op with a timeout, so a black-holed
+# GitHub fetch/push can't hang this pass forever while it holds the rebase lock
+# (the 3-day outage that motivated this). FLEET_LIB_DIR is symlink-resolved so
+# the lib resolves through ~/bin the same way the other sourced libs do; a
+# missing lib (main clone not yet advanced past this PR) degrades to unguarded.
+_fleet_rebase_self="${BASH_SOURCE[0]}"
+while [[ -L "$_fleet_rebase_self" ]]; do
+    _fleet_rebase_self="$(readlink "$_fleet_rebase_self")"
+done
+FLEET_LIB_DIR="${FLEET_LIB_DIR:-$(cd "$(dirname "$_fleet_rebase_self")" && pwd)}"
+unset _fleet_rebase_self
+if [[ -f "$FLEET_LIB_DIR/fleet-net.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$FLEET_LIB_DIR/fleet-net.sh"
+fi
+
 DRY_RUN=0
 REARM=0
 AUTO=0
@@ -101,9 +118,23 @@ export FLEET_REBASE_SKIP_RE="$SKIP_LABEL_RE"
 # skips the EXIT trap) — without the break, a dead lock would silently
 # eat every future merger trigger.
 LOCK_DIR="$STATE_DIR/fleet-rebase.lock.d"
+# How long an ALIVE holder may hold the lock before the defer path escalates
+# loudly instead of logging the benign concurrency message. Generous — a real
+# tier-0 pass is seconds; anything near 30 min is wedged, not busy.
+FLEET_REBASE_LOCK_HUNG_SECS="${FLEET_REBASE_LOCK_HUNG_SECS:-1800}"
+ALERTS_DIR="${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}"
+
+# Stamp the lock we just created with our pid and acquisition time. The
+# `started` stamp powers the hung-lock escalation below; the EXIT trap removes
+# the whole LOCK_DIR, so both files vanish on a clean release.
+stamp_lock_holder() {
+    echo $$ > "$LOCK_DIR/pid"
+    date +%s > "$LOCK_DIR/started"
+}
+
 acquire_lock() {
     if mkdir "$LOCK_DIR" 2>/dev/null; then
-        echo $$ > "$LOCK_DIR/pid"
+        stamp_lock_holder
         return 0
     fi
     local holder
@@ -112,16 +143,45 @@ acquire_lock() {
         log "breaking stale lock (holder pid '${holder:-unknown}' not running)"
         rm -rf "$LOCK_DIR"
         if mkdir "$LOCK_DIR" 2>/dev/null; then
-            echo $$ > "$LOCK_DIR/pid"
+            stamp_lock_holder
             return 0
         fi
     fi
     return 1
 }
+
+# Hung-lock escalation (#2362): the benign "deferring to the LLM pass" message
+# below reads as ordinary concurrency, so a holder that is alive but wedged on a
+# black-holed network call (the outage that motivated this) went unseen for
+# days. When the current holder has held the lock past a generous ceiling, log
+# loudly and drop an alert file for the human / babysit. We do NOT auto-break an
+# alive holder — a mid-rebase kill corrupts the scratch worktree (see the
+# acquire_lock rationale). With every net op now timeout-bounded this alert
+# should be rare-to-never; it exists to make the next silent wedge visible.
+escalate_if_hung_lock() {
+    local started now age holder
+    started=$(cat "$LOCK_DIR/started" 2>/dev/null || true)
+    # Missing/garbage stamp (a pre-fix holder still running mid-rollout) → skip
+    # the age check rather than guess an age.
+    [[ "$started" =~ ^[0-9]+$ ]] || return 0
+    now=$(date +%s)
+    age=$(( now - started ))
+    (( age > FLEET_REBASE_LOCK_HUNG_SECS )) || return 0
+    holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo unknown)
+    log "HUNG-LOCK: $LOCK_DIR held ${age}s by pid $holder (> ${FLEET_REBASE_LOCK_HUNG_SECS}s ceiling) — a wedged holder is starving tier-0 conflict rebasing; investigate (see #2362). Not auto-breaking an alive holder."
+    mkdir -p "$ALERTS_DIR" 2>/dev/null || true
+    printf 'fleet-rebase hung lock: host=%s holder_pid=%s age_secs=%s at=%s\n' \
+        "$(hostname 2>/dev/null || echo '?')" "$holder" "$age" \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+        > "$ALERTS_DIR/fleet-rebase-hung-lock" 2>/dev/null || true
+}
+
 if ! acquire_lock; then
     # A live concurrent run owns the pass. Hand this trigger's work to
     # the LLM pass rather than dropping it — the trigger was already
-    # consumed by the dispatcher before we were spawned.
+    # consumed by the dispatcher before we were spawned. Escalate first if the
+    # holder has been wedged past the ceiling.
+    escalate_if_hung_lock
     log "another fleet-rebase run holds $LOCK_DIR; deferring to the LLM pass"
     rearm_llm
     exit 0

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -53,14 +53,19 @@ esac
 
 INSTALL_APPEND_ZSHRC=1
 [[ -n "${IRREDEN_INSTALL_SKIP_ZSHRC:-}" ]] && INSTALL_APPEND_ZSHRC=0
+INSTALL_APPEND_SSH_CONFIG=1
+[[ -n "${IRREDEN_INSTALL_SKIP_SSH_CONFIG:-}" ]] && INSTALL_APPEND_SSH_CONFIG=0
 for arg in "$@"; do
     case "$arg" in
         --no-zshrc)
             INSTALL_APPEND_ZSHRC=0
             ;;
+        --no-ssh-config)
+            INSTALL_APPEND_SSH_CONFIG=0
+            ;;
         -h | --help)
             cat <<'EOF'
-Usage: install.sh [--no-zshrc]
+Usage: install.sh [--no-zshrc] [--no-ssh-config]
 
   Symlinks fleet scripts to ~/bin/, role slash commands to
   ~/.claude/commands/, and shell completions (bash + zsh helpers).
@@ -70,8 +75,15 @@ Usage: install.sh [--no-zshrc]
   zsh, or ~/.zshrc already exists — avoids creating ~/.zshrc on bash-only
   Linux). Skips if the marker is already present (safe to re-run).
 
-  --no-zshrc   Do not modify ~/.zshrc (still symlinks ~/.zsh/completions/).
-               Same effect: IRREDEN_INSTALL_SKIP_ZSHRC=1 install.sh
+  Also applies host protections against GitHub connection black-holes (#2362):
+  a marked ssh-keepalive block for Host github.com in ~/.ssh/config, git
+  http.lowSpeed* globals, and a ~/bin/timeout shim when no coreutils timeout
+  is present. All idempotent; an existing Host github.com block is left alone.
+
+  --no-zshrc       Do not modify ~/.zshrc (still symlinks ~/.zsh/completions/).
+                   Same effect: IRREDEN_INSTALL_SKIP_ZSHRC=1 install.sh
+  --no-ssh-config  Do not modify ~/.ssh/config (still sets git globals + shim).
+                   Same effect: IRREDEN_INSTALL_SKIP_SSH_CONFIG=1 install.sh
 EOF
             exit 0
             ;;
@@ -151,6 +163,13 @@ FLEET_COMMON_SRC="$SCRIPT_DIR/fleet-common.sh"
 FLEET_COMMON_DEST="$HOME/bin/fleet-common.sh"
 FLEET_CLONE_FRESHNESS_SRC="$SCRIPT_DIR/fleet-clone-freshness.sh"
 FLEET_CLONE_FRESHNESS_DEST="$HOME/bin/fleet-clone-freshness.sh"
+FLEET_NET_SRC="$SCRIPT_DIR/fleet-net.sh"
+FLEET_NET_DEST="$HOME/bin/fleet-net.sh"
+# timeout-shim.py installs as ~/bin/timeout ONLY when the host has no coreutils
+# timeout/gtimeout (host-protection section, step c) — declared here so the
+# chmod loop keeps it executable; its symlink is conditional, not in Step 1.
+TIMEOUT_SHIM_SRC="$SCRIPT_DIR/timeout-shim.py"
+TIMEOUT_SHIM_DEST="$HOME/bin/timeout"
 FLEET_BUILD_SRC="$SCRIPT_DIR/fleet-build"
 FLEET_BUILD_DEST="$HOME/bin/fleet-build"
 FLEET_DEBUG_SRC="$SCRIPT_DIR/fleet-debug"
@@ -244,7 +263,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_COMMON_SRC" "$FLEET_CLONE_FRESHNESS_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_TRANSITION_SRC" "$FLEET_REVIEW_VERDICT_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_PR_CLEAR_SRC" "$FLEET_PR_CLAIM_FEEDBACK_SRC" "$FLEET_PR_DETACH_SRC" "$FLEET_PR_AMEND_SRC" "$FLEET_ISSUE_SRC" "$FLEET_GH_POLL_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_GATE_STATUS_SRC" "$FLEET_QUEUE_INGEST_SRC" "$FLEET_PLAN_LINT_SRC" "$FLEET_QUEUE_LIST_SRC" "$FLEET_RECONCILE_AMENDMENTS_SRC" "$FLEET_ITERATION_SUMMARY_SRC" "$FLEET_EDIT_SRC" "$FLEET_NIT_CLOSE_SRC" "$FLEET_VALIDATE_STACK_SRC" "$FLEET_EPIC_STATUS_SRC" "$FLEET_VALIDATE_ROLES_SRC" "$FLEET_ASSERT_WT_SRC" "$WITNESS_SRC" "$SOLO_ARCHITECT_SRC" "$FLEET_REBASE_SRC" "$FLEET_GH_TOKEN_SRC" "$FLEET_SESSION_TRACK_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_COMMON_SRC" "$FLEET_CLONE_FRESHNESS_SRC" "$FLEET_NET_SRC" "$TIMEOUT_SHIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_TRANSITION_SRC" "$FLEET_REVIEW_VERDICT_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_PR_CLEAR_SRC" "$FLEET_PR_CLAIM_FEEDBACK_SRC" "$FLEET_PR_DETACH_SRC" "$FLEET_PR_AMEND_SRC" "$FLEET_ISSUE_SRC" "$FLEET_GH_POLL_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_GATE_STATUS_SRC" "$FLEET_QUEUE_INGEST_SRC" "$FLEET_PLAN_LINT_SRC" "$FLEET_QUEUE_LIST_SRC" "$FLEET_RECONCILE_AMENDMENTS_SRC" "$FLEET_ITERATION_SUMMARY_SRC" "$FLEET_EDIT_SRC" "$FLEET_NIT_CLOSE_SRC" "$FLEET_VALIDATE_STACK_SRC" "$FLEET_EPIC_STATUS_SRC" "$FLEET_VALIDATE_ROLES_SRC" "$FLEET_ASSERT_WT_SRC" "$WITNESS_SRC" "$SOLO_ARCHITECT_SRC" "$FLEET_REBASE_SRC" "$FLEET_GH_TOKEN_SRC" "$FLEET_SESSION_TRACK_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -279,6 +298,14 @@ fi
 if [[ -f "$FLEET_CLONE_FRESHNESS_SRC" ]]; then
     ln -sf "$FLEET_CLONE_FRESHNESS_SRC" "$FLEET_CLONE_FRESHNESS_DEST"
     echo "symlinked $FLEET_CLONE_FRESHNESS_DEST -> $FLEET_CLONE_FRESHNESS_SRC"
+fi
+
+# fleet-net.sh (the network-timeout guard, #2362) is a sourced lib like
+# fleet-common.sh — symlink it into ~/bin so the FLEET_LIB_DIR source pattern in
+# fleet-rebase / fleet-claim / fleet-dispatcher resolves it through ~/bin.
+if [[ -f "$FLEET_NET_SRC" ]]; then
+    ln -sf "$FLEET_NET_SRC" "$FLEET_NET_DEST"
+    echo "symlinked $FLEET_NET_DEST -> $FLEET_NET_SRC"
 fi
 
 if [[ -f "$FLEET_BUILD_SRC" ]]; then
@@ -660,6 +687,83 @@ if [[ -f "$FLEET_ZSH_COMP_SRC" ]]; then
         echo "    [[ -r $ZSH_COMP_DIR/irreden-fleet.zsh ]] && source $ZSH_COMP_DIR/irreden-fleet.zsh"
     fi
     echo "  Then \`fleet-run IR<Tab>\` lists built executables, not cwd files."
+fi
+
+# ----------------------------------------------------------------------
+# Step 5: host protections against GitHub connection black-holes (#2362)
+# ----------------------------------------------------------------------
+# The fleet host's TCP connections to GitHub intermittently die silently (no
+# RST), hanging any unguarded network call forever — three fleet-wide outages
+# in four days. fleet-net.sh (installed above) bounds every git/gh call inside
+# the daemons with a `timeout`; these host-level settings make a black-holed
+# connection self-terminate at the transport layer too, and guarantee a
+# `timeout` binary exists for the guard. All idempotent; safe to re-run.
+
+# (a) ssh keepalives for github.com — a black-holed ssh session that would
+# otherwise hang forever self-terminates in ~60s (interval 15 x count 4).
+# Written only as a MARKED block, and ONLY when no Host github.com block exists
+# yet: ssh is first-match-wins, so a second block would be silently ignored, and
+# merging into a user-owned block is not ours to do.
+SSH_CONFIG="$HOME/.ssh/config"
+SSH_MARKER="# IRREDEN_ENGINE: github.com ssh keepalives (install.sh, #2362)"
+if ((INSTALL_APPEND_SSH_CONFIG)); then
+    if [[ -f "$SSH_CONFIG" ]] && grep -qF "$SSH_MARKER" "$SSH_CONFIG" 2>/dev/null; then
+        echo "note: github.com ssh keepalives already present in $SSH_CONFIG (marker unchanged)."
+    elif [[ -f "$SSH_CONFIG" ]] && grep -qiE '^[[:space:]]*Host[[:space:]].*github\.com' "$SSH_CONFIG" 2>/dev/null; then
+        echo "note: $SSH_CONFIG already has a Host github.com block (user-owned) — leaving it alone."
+        echo "      For black-hole protection, ensure it sets ServerAliveInterval 15 / ServerAliveCountMax 4 / ConnectTimeout 15."
+    else
+        # Ensure ~/.ssh (700) exists and, if the config is absent, create it 600
+        # before appending — ssh refuses a group/world-writable setup. An
+        # existing file keeps its own mode (no chmod of user files).
+        ( umask 077; mkdir -p "$HOME/.ssh"; [[ -e "$SSH_CONFIG" ]] || : > "$SSH_CONFIG" ) 2>/dev/null || true
+        if {
+            echo ""
+            echo "$SSH_MARKER"
+            echo "Host github.com"
+            echo "    ServerAliveInterval 15"
+            echo "    ServerAliveCountMax 4"
+            echo "    ConnectTimeout 15"
+            echo "    IPQoS throughput"
+        } >>"$SSH_CONFIG" 2>/dev/null; then
+            echo "appended github.com ssh keepalives to $SSH_CONFIG"
+        else
+            echo "install.sh: could not write $SSH_CONFIG — add a Host github.com block with ServerAliveInterval 15 manually." >&2
+        fi
+    fi
+else
+    echo "note: skipped ~/.ssh/config (--no-ssh-config or IRREDEN_INSTALL_SKIP_SSH_CONFIG)."
+fi
+
+# (b) Bound git-over-HTTPS: abort a transfer stalled below 1000 B/s for 60s.
+# Set only when unset, so an intentional user value is respected.
+if command -v git >/dev/null 2>&1; then
+    git config --global --get http.lowSpeedLimit >/dev/null 2>&1 || \
+        git config --global http.lowSpeedLimit 1000
+    git config --global --get http.lowSpeedTime >/dev/null 2>&1 || \
+        git config --global http.lowSpeedTime 60
+    echo "ensured git http.lowSpeedLimit / http.lowSpeedTime globals (bounds stalled HTTPS transfers)."
+fi
+
+# (c) Guarantee a coreutils-compatible `timeout` for fleet-net.sh's guard. When
+# the host ships neither `timeout` nor `gtimeout`, install the python shim as
+# ~/bin/timeout (its --version advertises "coreutils" so the lib's probe accepts
+# it). A host that has real coreutils uses that; the shim is a last resort.
+_install_has_coreutils_timeout() {
+    local c
+    for c in timeout gtimeout; do
+        if command -v "$c" >/dev/null 2>&1 && "$c" --version 2>/dev/null | grep -qi coreutils; then
+            return 0
+        fi
+    done
+    return 1
+}
+if _install_has_coreutils_timeout; then
+    echo "note: coreutils timeout/gtimeout present — fleet-net.sh network guard is active."
+elif [[ -f "$TIMEOUT_SHIM_SRC" ]]; then
+    ln -sf "$TIMEOUT_SHIM_SRC" "$TIMEOUT_SHIM_DEST"
+    echo "symlinked $TIMEOUT_SHIM_DEST -> $TIMEOUT_SHIM_SRC (no coreutils timeout found; using the fleet shim)"
+    echo "note: for a native guard, install GNU coreutils (Linux: apt install coreutils; macOS: brew install coreutils -> gtimeout)."
 fi
 
 # Stamp this successful symlink pass so fleet-up / fleet-dispatch-wrap can skip

--- a/scripts/fleet/tests/test_fleet_net_guard.sh
+++ b/scripts/fleet/tests/test_fleet_net_guard.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests for scripts/fleet/fleet-net.sh — the network-call timeout guard (#2362).
+#
+# Hermetic: no live git/gh, no network. A temp bindir holds fake `timeout`,
+# `git`, and `gh` on PATH front. The shadow functions call `command timeout …`
+# and `command git`/`command gh`, which do a normal PATH lookup (command only
+# skips shell functions/aliases), so the fakes stand in for the real binaries.
+# The fake `timeout` prints a marker so a test can prove the guard fired.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+LIB="$SCRIPT_DIR/fleet-net.sh"
+SHIM="$SCRIPT_DIR/timeout-shim.py"
+
+if [[ ! -f "$LIB" ]]; then
+    echo "SKIP: lib not found at $LIB" >&2
+    exit 0
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+ok()   { echo "  ok: $1";   PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# --- fake binaries on PATH ---------------------------------------------------
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+# Fake timeout: marker on stderr, then either force an exit code (FT_RC, to
+# simulate a kill) or exec the wrapped command.
+cat > "$BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+echo "TIMEOUT-INVOKED budget=$1" >&2
+shift
+if [[ -n "${FT_RC:-}" ]]; then
+    exit "$FT_RC"
+fi
+exec "$@"
+EOF
+
+# Fake git/gh: echo which one ran + args, so a test can confirm the subcommand
+# reached the binary and (via the marker's absence) that a local op wasn't
+# guarded.
+cat > "$BIN/git" <<'EOF'
+#!/usr/bin/env bash
+echo "GIT-RAN args=$*"
+EOF
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "GH-RAN args=$*"
+EOF
+chmod +x "$BIN/timeout" "$BIN/git" "$BIN/gh"
+export PATH="$BIN:$PATH"
+
+# Source the lib with FLEET_TIMEOUT_CMD pinned to our fake, so we don't depend
+# on the host actually having coreutils timeout.
+export FLEET_TIMEOUT_CMD="timeout"
+export FLEET_NET_TIMEOUT="7"
+# shellcheck source=/dev/null
+source "$LIB"
+
+# --- T1: network subcommand is guarded ---------------------------------------
+echo "T1: git fetch is wrapped in the timeout guard"
+out=$(git -C /tmp fetch origin master 2>&1 || true)
+echo "$out" | grep -q "TIMEOUT-INVOKED budget=7" && ok "fetch invoked timeout (budget passed)" || fail "fetch not guarded: $out"
+echo "$out" | grep -q "GIT-RAN args=-C /tmp fetch origin master" && ok "fetch reached git with intact args" || fail "fetch args wrong: $out"
+
+# --- T2: local subcommand passes through unguarded ---------------------------
+echo "T2: git rev-parse (local) is NOT wrapped"
+out=$(git -C /tmp rev-parse HEAD 2>&1 || true)
+echo "$out" | grep -q "TIMEOUT-INVOKED" && fail "local op was wrongly guarded: $out" || ok "rev-parse not guarded (no timeout)"
+echo "$out" | grep -q "GIT-RAN args=-C /tmp rev-parse HEAD" && ok "rev-parse reached git" || fail "rev-parse args wrong: $out"
+
+# --- T3: -c global flag is skipped when finding the subcommand ----------------
+echo "T3: git -c k=v push finds 'push' past the -c flag"
+out=$(git -c protocol.version=2 push origin HEAD 2>&1 || true)
+echo "$out" | grep -q "TIMEOUT-INVOKED" && ok "push guarded past -c flag" || fail "push not guarded: $out"
+
+# --- T3b: a local op behind -C is still not guarded --------------------------
+echo "T3b: git -C <path> checkout (local) stays unguarded"
+out=$(git -C /tmp checkout -b x 2>&1 || true)
+echo "$out" | grep -q "TIMEOUT-INVOKED" && fail "checkout wrongly guarded: $out" || ok "checkout not guarded"
+
+# --- T4: every gh call is guarded --------------------------------------------
+echo "T4: gh is always wrapped"
+out=$(gh pr view 5 --json state 2>&1 || true)
+echo "$out" | grep -q "TIMEOUT-INVOKED" && ok "gh guarded" || fail "gh not guarded: $out"
+echo "$out" | grep -q "GH-RAN args=pr view 5 --json state" && ok "gh reached binary with intact args" || fail "gh args wrong: $out"
+
+# --- T5: exit 124 (timeout kill) propagates through the shadow ----------------
+echo "T5: a timed-out network op propagates exit 124"
+export FT_RC=124
+git -C /tmp fetch origin >/dev/null 2>&1 && rc=0 || rc=$?
+unset FT_RC
+[[ "$rc" == "124" ]] && ok "fetch returned 124 on timeout" || fail "expected 124, got $rc"
+export FT_RC=124
+gh pr list >/dev/null 2>&1 && rc=0 || rc=$?
+unset FT_RC
+[[ "$rc" == "124" ]] && ok "gh returned 124 on timeout" || fail "expected 124, got $rc"
+
+# --- T6: empty FLEET_TIMEOUT_CMD is a pure passthrough -----------------------
+echo "T6: empty FLEET_TIMEOUT_CMD passes through unguarded"
+out=$(FLEET_TIMEOUT_CMD="" git -C /tmp fetch origin 2>&1 || true)
+echo "$out" | grep -q "TIMEOUT-INVOKED" && fail "guarded despite empty cmd: $out" || ok "no guard when FLEET_TIMEOUT_CMD empty"
+echo "$out" | grep -q "GIT-RAN" && ok "git still ran (passthrough)" || fail "git did not run in passthrough: $out"
+
+# --- T7: the coreutils probe rejects a non-coreutils timeout -----------------
+echo "T7: coreutils probe accepts/rejects by --version"
+cat > "$BIN/faketrue" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "--version" ]] && echo "faketrue (GNU coreutils) 9.0" && exit 0
+exit 0
+EOF
+cat > "$BIN/fakebusybox" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "--version" ]] && echo "BusyBox v1.36 multi-call binary" && exit 0
+exit 0
+EOF
+chmod +x "$BIN/faketrue" "$BIN/fakebusybox"
+if _fleet_net_is_coreutils_timeout faketrue; then ok "probe accepts a coreutils --version"; else fail "probe rejected a coreutils runner"; fi
+if _fleet_net_is_coreutils_timeout fakebusybox; then fail "probe accepted a non-coreutils runner"; else ok "probe rejects a non-coreutils runner"; fi
+if _fleet_net_is_coreutils_timeout definitely-not-on-path-xyz; then fail "probe accepted a missing binary"; else ok "probe rejects a missing binary"; fi
+
+# --- T8: the fallback shim advertises coreutils (so the probe accepts it) -----
+echo "T8: timeout-shim.py --version passes the probe"
+if [[ -f "$SHIM" ]] && command -v python3 >/dev/null 2>&1; then
+    python3 "$SHIM" --version 2>/dev/null | grep -qi coreutils && ok "shim --version contains 'coreutils'" || fail "shim --version lacks coreutils marker"
+    # And it actually enforces a timeout: a 1s budget on a 30s sleep -> 124.
+    python3 "$SHIM" 1 sleep 30 >/dev/null 2>&1 && rc=0 || rc=$?
+    [[ "$rc" == "124" ]] && ok "shim returns 124 when the command overruns" || fail "shim timeout rc=$rc, expected 124"
+    # A command that finishes in time propagates its own exit code.
+    python3 "$SHIM" 5 sh -c 'exit 3' >/dev/null 2>&1 && rc=0 || rc=$?
+    [[ "$rc" == "3" ]] && ok "shim propagates the child exit code" || fail "shim exit passthrough rc=$rc, expected 3"
+else
+    echo "  SKIP: shim or python3 unavailable"
+fi
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_rebase_hung_lock.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_hung_lock.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Tests for fleet-rebase's hung-lock escalation (#2362).
+#
+# Drives the real `fleet-rebase --auto` against a pre-seeded lock directory in a
+# temp FLEET_STATE_DIR. The lock check runs before the merger-slice check, so no
+# slice is needed. The EXIT trap that removes the lock is registered only AFTER
+# acquire succeeds, so on the defer path our seeded lock survives for assertions.
+#
+# Matrix:
+#   alive holder + backdated `started`  -> loud HUNG-LOCK + alert file, still defers
+#   alive holder + fresh `started`      -> benign defer only, no alert
+#   dead holder                         -> stale-break acquires (no escalation)
+#   alive holder + missing `started`    -> no escalation (skip the age check)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REBASE="$SCRIPT_DIR/fleet-rebase"
+
+if [[ ! -x "$REBASE" ]]; then
+    echo "SKIP: fleet-rebase not found/executable at $REBASE" >&2
+    exit 0
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+LIVE_PIDS=()
+cleanup() {
+    local p
+    for p in "${LIVE_PIDS[@]:-}"; do
+        [[ -n "$p" ]] && kill "$p" 2>/dev/null
+        true  # never let a kill of an already-dead holder fail the EXIT trap (set -e)
+    done
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+    return 0
+}
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+ok()   { echo "  ok: $1";   PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SDIR="$TMPROOT/state"
+ADIR="$TMPROOT/alerts"
+LOCK="$SDIR/fleet-rebase.lock.d"
+ALERT="$ADIR/fleet-rebase-hung-lock"
+mkdir -p "$SDIR"
+
+# Spawn a fresh long-lived process to stand in for an "alive holder"; sets
+# HOLDER_PID. A dedicated holder per subtest avoids the job-control reaping that
+# would silently kill a single shared background pid across command
+# substitutions. Sets a global (not echoed via $(...)) so the `sleep &` runs in
+# THIS shell — a subshell background job would leak past cleanup's tracking.
+HOLDER_PID=""
+spawn_live() {
+    sleep 600 &
+    HOLDER_PID=$!
+    LIVE_PIDS+=("$HOLDER_PID")
+}
+
+run_rebase() {  # runs the real script against the temp dirs; captures combined output
+    FLEET_STATE_DIR="$SDIR" \
+    FLEET_ALERTS_DIR="$ADIR" \
+    "$REBASE" --auto 2>&1 || true
+}
+
+seed_lock() {   # $1 = pid, $2 = started epoch ("" = omit the started file)
+    rm -rf "$LOCK" "$ADIR"
+    mkdir -p "$LOCK"
+    echo "$1" > "$LOCK/pid"
+    [[ -n "$2" ]] && echo "$2" > "$LOCK/started"
+    return 0
+}
+
+now=$(date +%s)
+
+# --- T1: alive holder held past the ceiling -> escalate ----------------------
+echo "T1: alive holder + backdated started -> HUNG-LOCK + alert, still defers"
+spawn_live; hp=$HOLDER_PID
+seed_lock "$hp" "$(( now - 4000 ))"   # 4000s > default 1800s ceiling
+out=$(run_rebase)
+echo "$out" | grep -q "HUNG-LOCK" && ok "loud HUNG-LOCK logged" || fail "no HUNG-LOCK: $out"
+echo "$out" | grep -q "deferring to the LLM pass" && ok "still defers (does not break an alive lock)" || fail "did not defer: $out"
+[[ -f "$ALERT" ]] && ok "alert file written" || fail "no alert file at $ALERT"
+grep -q "holder_pid=$hp" "$ALERT" 2>/dev/null && ok "alert names the holder pid" || fail "alert missing holder pid"
+[[ -f "$LOCK/pid" ]] && ok "seeded lock left intact (not broken)" || fail "lock was removed on the defer path"
+
+# --- T2: alive holder, fresh -> benign defer only ----------------------------
+echo "T2: alive holder + fresh started -> benign defer, no escalation"
+spawn_live; hp=$HOLDER_PID
+seed_lock "$hp" "$now"
+out=$(run_rebase)
+echo "$out" | grep -q "deferring to the LLM pass" && ok "defers" || fail "did not defer: $out"
+echo "$out" | grep -q "HUNG-LOCK" && fail "escalated a fresh holder: $out" || ok "no HUNG-LOCK for a fresh holder"
+[[ -f "$ALERT" ]] && fail "wrote an alert for a fresh holder" || ok "no alert file for a fresh holder"
+
+# --- T3: dead holder -> stale-break acquires, no escalation ------------------
+echo "T3: dead holder -> breaks the stale lock, no escalation"
+# A pid that has already exited and been reaped: the subshell running `echo $$`
+# is collected by the command substitution, so this pid is dead (kill -0 fails)
+# with no lingering holder to clean up and no job-control `wait` warning.
+dead=$(sh -c 'echo $$')
+seed_lock "$dead" "$(( now - 4000 ))"     # old, but the holder is dead
+out=$(run_rebase)
+echo "$out" | grep -q "breaking stale lock" && ok "breaks a dead holder's lock" || fail "did not break dead lock: $out"
+echo "$out" | grep -q "HUNG-LOCK" && fail "escalated a dead holder: $out" || ok "no escalation for a dead holder"
+
+# --- T4: missing started stamp -> no escalation (skip the age check) ----------
+echo "T4: alive holder, missing started -> no escalation"
+spawn_live; hp=$HOLDER_PID
+seed_lock "$hp" ""                         # pid but no started file
+out=$(run_rebase)
+echo "$out" | grep -q "deferring to the LLM pass" && ok "defers" || fail "did not defer: $out"
+echo "$out" | grep -q "HUNG-LOCK" && fail "escalated without a started stamp: $out" || ok "no escalation when started is absent"
+[[ -f "$ALERT" ]] && fail "wrote an alert without a started stamp" || ok "no alert without a started stamp"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/scripts/fleet/timeout-shim.py
+++ b/scripts/fleet/timeout-shim.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Minimal coreutils-`timeout` stand-in for hosts that ship neither.
+
+Installed to ~/bin/timeout by scripts/fleet/install.sh (step c) ONLY when
+neither coreutils `timeout` nor `gtimeout` resolves, so fleet-net.sh's
+`timeout <secs> <cmd...>` guard has a runner. It implements just the slice the
+fleet uses: a leading duration in seconds, then the command to run.
+
+`--version` advertises "coreutils" so fleet-net.sh's probe
+(`timeout --version | grep -qi coreutils`) accepts this shim exactly as it
+accepts the real thing — the probe exists to reject Windows System32
+timeout.exe, and this shim is a genuine command runner, so it should pass.
+
+Exit codes mirror coreutils: 124 on timeout, 125 on shim usage error, 126/127
+for exec failures, 128+signal if the child is killed by a signal.
+"""
+
+import signal
+import subprocess
+import sys
+
+# Seconds to wait after SIGTERM before escalating to SIGKILL, matching the
+# spirit of coreutils `timeout -k`: a child wedged on a black-holed socket may
+# ignore SIGTERM, and the whole point of the guard is that it cannot hang.
+KILL_GRACE_SECONDS = 5.0
+
+
+def _parse_duration(raw):
+    """Parse a coreutils-style duration. The fleet only ever passes plain
+    integer seconds; also accept a trailing s/m/h/d suffix for parity."""
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    mult = 1
+    if raw and raw[-1] in units:
+        mult = units[raw[-1]]
+        raw = raw[:-1]
+    try:
+        return float(raw) * mult
+    except ValueError:
+        sys.stderr.write(f"timeout-shim: invalid duration '{raw}'\n")
+        sys.exit(125)
+
+
+def main(argv):
+    if not argv or argv[0] in ("-h", "--help"):
+        sys.stderr.write("usage: timeout <duration>[smhd] <command> [arg...]\n")
+        return 0 if argv[:1] in (["-h"], ["--help"]) else 125
+    if argv[0] == "--version":
+        sys.stdout.write("fleet timeout-shim (coreutils-compatible) 1.0\n")
+        return 0
+
+    duration = _parse_duration(argv[0])
+    cmd = argv[1:]
+    if not cmd:
+        sys.stderr.write("timeout-shim: missing command\n")
+        return 125
+
+    try:
+        proc = subprocess.Popen(cmd)
+    except FileNotFoundError:
+        sys.stderr.write(f"timeout-shim: {cmd[0]}: command not found\n")
+        return 127
+    except OSError as exc:
+        sys.stderr.write(f"timeout-shim: {cmd[0]}: {exc}\n")
+        return 126
+
+    try:
+        rc = proc.wait(timeout=duration)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.wait(timeout=KILL_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        return 124
+
+    # coreutils reports a signal-killed child as 128+signum.
+    if rc < 0:
+        return 128 + (-rc)
+    return rc
+
+
+if __name__ == "__main__":
+    # Restore default SIGPIPE so a downstream `| head` closing the pipe doesn't
+    # raise inside the shim (fleet log pipelines do this).
+    try:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    except (AttributeError, ValueError):
+        pass  # SIGPIPE is absent on Windows — nothing to reset.
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Bounds every network call in the unattended fleet daemons so a black-holed GitHub connection fails fast instead of hanging forever — three fleet-wide outages in 4 days were all this one defect.
- **New `scripts/fleet/fleet-net.sh`**: a sourced lib shadowing `git()`/`gh()` with a coreutils `timeout` (resolved once via a `--version` probe that rejects Windows System32 `timeout.exe`), guarding every current and future net call site by construction. Sourced by `fleet-rebase`, `fleet-claim`, `fleet-dispatcher`. The dispatcher's duplicate inline `TIMEOUT_CMD` resolution is retired into the lib; the send-keys guard reuses it and inherits the coreutils probe.
- **`fleet-rebase` hung-lock escalation**: stamps the lock's acquisition time; on the defer path, an alive holder past a 30-min ceiling logs a loud `HUNG-LOCK` line and drops `~/.fleet/alerts/fleet-rebase-hung-lock` — the benign "deferring" message previously masked a 3-day wedge. Never auto-breaks an alive holder.
- **`install.sh` host protections** (idempotent, `--no-ssh-config` opt-out): a marked `Host github.com` ssh-keepalive block (skips a pre-existing user-owned block), git `http.lowSpeed*` globals, and a `timeout-shim.py` fallback installed as `~/bin/timeout` when no coreutils timeout exists.

## Test plan
- [x] `tests/test_fleet_net_guard.sh` — 18/18 (net-op guarded, local-op passthrough, `-C`/`-c` flag skip, exit-124 propagation, empty-cmd passthrough, coreutils probe accept/reject, shim `--version`/timeout/exit-passthrough).
- [x] `tests/test_fleet_rebase_hung_lock.sh` — 13/13 (alive+old → escalate + alert; alive+fresh → benign defer; dead holder → stale-break; missing stamp → no escalation).
- [x] Existing suite green: rebase inherited-drop 14/0, stale-conflict 7/0, clone-freshness 16/0, install-refresh 18/0, dispatcher github-gate 6/0, claim acquire 13/0.
- [x] `ruff check scripts/` clean; `bash -n` on all touched scripts.

## Notes
- **Activation lag:** the daemons run from the main clone's master, so this fix is inert until the PR merges + the main clone advances + the fleet bounces (`fleet-up`).
- **Exit-124 aliasing audited:** `fleet-claim` has no numeric exit-code branches on git/gh; the dispatcher's `rc` checks are on a `fleet-claim` subprocess (124 → "not assigned", safe); `fleet-rebase` uses boolean success checks (124 → "leave for LLM").

Closes #2362

🤖 Generated with [Claude Code](https://claude.com/claude-code)