### PR TITLE
fleet: tier-0 auto-merge lane for pure .fleet/plans PRs

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -36,6 +36,12 @@ You poll open PRs on **both repos** (engine + game) every 10 minutes.
 For each PR in CONFLICTING state, you try to auto-resolve and push, or
 mark it for the human if the conflict is non-mechanical.
 
+**You never merge PRs.** The fleet's only auto-merge is the tier-0
+plan-file lane in `fleet-rebase` (approved + MERGEABLE + diff purely
+under `.fleet/plans/**`, live-verified — see FLEET.md § "Who merges").
+Everything that reaches this LLM pass is rebase/label/handoff work;
+never run `gh pr merge`.
+
 **Both repos, two passes.** Steps 1–6 below are the **engine pass**
 (cwd = your engine worktree, `repos.engine.prs[]`, default `gh` repo).
 After the engine pass, the **game pass** repeats the *core conflict
@@ -835,6 +841,10 @@ See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`]
 
 - **Only push the PR branch with `--force-with-lease`**, never `--force`.
   The push fails if upstream changed under you (parallel author push).
+- **Never `gh pr merge`.** Merging is either the human's click or the
+  tier-0 plan-file auto-merge lane in `fleet-rebase` — the LLM pass has
+  no merge verb by design, so a prompt drift or misread label can never
+  land code on master.
 - **Never `gh pr review --approve` or `--request-changes`.** All fleet
   agents share one GitHub account and GitHub rejects formal review
   actions on your own PRs. Use `--comment` for status posts

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -557,7 +557,9 @@ These apply to every fleet role. Each role file lists only the
 additional role-specific restrictions.
 
 - **Never `git push origin master`. Never `--force` push.** Never call
-  `gh pr merge`. The human merges.
+  `gh pr merge`. The human merges. (The sole auto-merge in the fleet is
+  the deterministic tier-0 plan-file lane inside the `fleet-rebase`
+  script — see FLEET.md § "Who merges". No LLM role merges anything.)
 - **Never run `cmake --preset`** — only `cmake --build` against the
   already-configured tree.
 - **Never touch the `.claude/worktrees/` layout.**

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -303,7 +303,9 @@ that needs justification in the linked issue.
 3. **Keep `fleet:approved`** — the PR is internally consistent;
    the prior reviewer approval stands. `fleet:human-deferred` parks
    re-review of the deferred concern on the diff as it stands now —
-   it is NOT a merge-gate (every PR is human-merged). It holds only
+   it is NOT a merge-gate (a `fleet:human-deferred` PR is always
+   human-merged — the label sits outside the tier-0 auto-merge
+   allowlist, FLEET.md § "Who merges"). It holds only
    while the diff is unchanged: if later commits land (a conflict
    resolution, a human push), whoever pushes drops the label and the
    PR re-enters normal review, which honors the linked issue and does

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -19,7 +19,8 @@ This repo runs a parallel-agent workflow. The rules:
    It resets the worktree to a fresh branch off `origin/master`. Do not keep
    adding unrelated commits to the same PR branch.
 4. **A separate reviewer agent** (running the `review-pr` skill in its own
-   worktree) looks at each PR. The user merges.
+   worktree) looks at each PR. The user merges — with one carve-out for
+   pure plan-file PRs; see "Who merges" below.
 5. **Never `--force` push to `master`.** Never use `--no-verify` to skip hooks
    unless the user explicitly asks.
 6. **Shared task queue lives in GitHub Issues.** Pick the next unblocked
@@ -32,6 +33,37 @@ This repo runs a parallel-agent workflow. The rules:
 
 See `fleet-queue-list` for the current queue and `.claude/skills/` for the
 exact commit/PR/review flows.
+
+### Who merges
+
+Every PR is merged by the human, with exactly one carve-out: **tier-0
+`fleet-rebase` squash-merges plan-file PRs** — steward rollups,
+close-outs, and umbrella plan filings whose diff touches only
+`.fleet/plans/**`. These have zero build/runtime surface, still pass
+through fleet review (`fleet:approved` is required), and are the PRs
+most likely to conflict with their own siblings while queued for a
+human click.
+
+The lane is deliberately narrow and re-verifies everything **live**
+(REST, not the scout cache) immediately before merging:
+
+- `fleet:approved` present, PR OPEN, base `master`, GitHub reports
+  mergeable.
+- **Label allowlist, not blocklist** — any label outside
+  `fleet:approved` / `fleet:merger-cooldown` / `fleet:stacked-rebase` /
+  `fleet:authored-on-*` / `fleet:verified-*` disqualifies. Every
+  `human:*` label, `fleet:human-deferred`, `fleet:changes-made`,
+  `fleet:needs-opus-recheck`, smoke labels, and any label added in the
+  future all default to human-merge.
+- Diff verified via the PR files endpoint: ≥1 file, every path under
+  `.fleet/plans/`, and refuses diffs it can't fully enumerate.
+- Capped at 3 merges per run; each merge flips the scout hash and
+  re-fires the merger, so longer queues drain across wakes.
+
+The **LLM merger pass never merges anything** (role-merger.md Hard
+rules) — keeping the merge verb out of the prompt-driven tier means a
+misread label can never land code on master. Merged plan PRs get a
+`— fleet merger` provenance comment.
 
 ### How `fleet-claim` enforces single-claim atomicity
 
@@ -450,7 +482,8 @@ opus list.
 - Nits-only feedback fixes (`fleet:has-nits`).
 - The **merger LLM pass** — and most merger wakes never reach an LLM at
   all: `fleet-rebase` (tier-0) clears clean rebases of approved stacked
-  or behind PRs mechanically for zero tokens, and only re-arms the
+  or behind PRs mechanically for zero tokens, auto-merges pure
+  plan-file PRs (see "Who merges"), and only re-arms the
   sonnet pass when conflicts or unhandled states remain. The
   `fleet:semantic-conflict` handoff to an opus+-class worker/human is unchanged.
 

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -392,9 +392,11 @@ Specifically, **never pass these via `--label` when filing**:
     the reviewer could re-apply `fleet:needs-fix`). `fleet:approved`
     is kept (PR is internally OK).
     **Scope: it parks re-review of the deferred concern on the diff
-    as it stood at defer time. It is NOT a merge-gate.** Every PR is
-    human-merged, so "the human decides whether to merge" is true of
-    every approved PR and is *not* what this label is for. While the
+    as it stood at defer time. It is NOT a merge-gate.** A PR carrying
+    it is always human-merged anyway — the label sits outside the
+    tier-0 auto-merge allowlist (FLEET.md § "Who merges"), so "the
+    human decides whether to merge" is guaranteed for it and is *not*
+    what this label is for. While the
     diff is unchanged, reviewer agents leave it alone and never
     re-apply `fleet:needs-fix` for the deferred concern — the human is
     the decision-maker on it.

--- a/docs/fleet/README.md
+++ b/docs/fleet/README.md
@@ -205,6 +205,8 @@ merger rebases                       ──►  resolves mechanical
         │
         ▼
 human merges via GitHub UI
+(pure .fleet/plans PRs auto-merge
+ via tier-0 — FLEET.md § Who merges)
         │
         ▼
 issue closes automatically (Closes #N in PR body)

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -22,6 +22,17 @@
 #   - Conflicting PRs on master: attempt the rebase anyway — it's free;
 #     an actual conflict aborts cleanly and goes to the LLM pass.
 #
+# Auto-merge lane (plan-file PRs only): an approved, MERGEABLE, master-based
+# PR whose diff touches ONLY .fleet/plans/** (steward rollups, close-outs,
+# umbrella plan filings) is squash-merged here — zero build/runtime surface,
+# already fleet-reviewed, and the class most likely to conflict with its own
+# siblings while queued for a human click. Every gate is re-verified live
+# (REST, not the scout-tick-old slice) immediately before the merge, and the
+# label check is allowlist-shaped: any label outside a small benign set
+# (including every human:* label) disqualifies, so new labels default to
+# human-merge. Everything else stays human-merged; the LLM merger pass never
+# merges anything (role-merger.md Hard rules).
+#
 # Trigger protocol (shared with fleet-dispatcher's merger interception):
 #   empty trigger  -> dispatcher spawns this script and consumes the trigger
 #   content "llm"  -> dispatcher runs the LLM merger pass
@@ -94,6 +105,20 @@ rearm_llm() {
 # FLEET_REBASE_SKIP_RE and the pre-push re-verify greps it directly.
 SKIP_LABEL_RE='fleet:semantic-conflict|fleet:wip|human:wip|fleet:needs-fix|human:needs-fix|human:blocker|human:re-review|fleet:design-blocked|fleet:amending-|fleet:blocker|fleet:needs-info|fleet:fork-of-other-pr|fleet:needs-linux-smoke|fleet:needs-macos-smoke'
 export FLEET_REBASE_SKIP_RE="$SKIP_LABEL_RE"
+
+# Auto-merge lane gates. MERGE_LABEL_ALLOW_RE is the benign-label allowlist:
+# a merge candidate must carry fleet:approved and NOTHING outside this set.
+# Allowlist (not blocklist) so any label this script has never heard of —
+# fleet:human-deferred, fleet:changes-made, fleet:needs-opus-recheck, any
+# human:* — disqualifies by default and the PR stays on the human's click.
+# MERGE_PATH_RE is the only diff surface the lane may merge; the LLM pass and
+# the human own everything else. Cap 3 per run: each merge flips the scout
+# hash and re-fires the merger, so a longer queue drains across wakes anyway.
+MERGE_PATH_RE='^\.fleet/plans/'
+MERGE_LABEL_ALLOW_RE='^fleet:(approved|merger-cooldown|stacked-rebase|authored-on-[a-z0-9-]+|verified-[a-z0-9-]+)$'
+export FLEET_MERGE_ALLOW_RE="$MERGE_LABEL_ALLOW_RE"
+MERGE_CAP=3
+MERGED=0
 
 # Serialization: a second fleet-rebase against the same scratch worktree
 # would corrupt an in-flight rebase. mkdir is the atomic lock; the pid
@@ -223,6 +248,91 @@ cleanup_stale_conflict() {
     gh pr edit "$pr" --repo "$repo_slug" --remove-label "fleet:semantic-conflict" >/dev/null 2>&1 || true
     gh pr edit "$pr" --repo "$repo_slug" --remove-label "fleet:merger-cooldown"   >/dev/null 2>&1 || true
     log "$repo_key#$pr: removed stale fleet:semantic-conflict (fail-then-succeed race, #1654)"
+}
+
+# Auto-merge one plan-file PR. Returns 0 = merged (or would merge, dry-run),
+# 1 = not merged (stays on the human's click; counted like llm-other so the
+# re-arm behavior for approved+MERGEABLE PRs is unchanged from before this
+# lane existed). Every gate re-verifies LIVE via REST — the slice is a scout
+# tick old and labels churn faster than the cache refreshes; REST rather
+# than `gh pr view` (GraphQL) because the GraphQL quota exhausts
+# independently under fleet load.
+attempt_merge() {
+    local repo_key="$1" pr="$2"
+    local repo_slug
+    repo_slug=$(repo_slug_for "$repo_key")
+
+    if (( MERGED >= MERGE_CAP )); then
+        log "$repo_key#$pr: auto-merge cap ($MERGE_CAP) reached this run; next wake picks it up"
+        return 1
+    fi
+
+    # Live state + label gate. REST `mergeable` is true/false/null (null =
+    # GitHub still computing) — only an explicit true proceeds.
+    local tsv state base_ref mergeable labels_csv
+    tsv=$(gh api "repos/$repo_slug/pulls/$pr" \
+        --jq '[.state, .base.ref, (.mergeable|tostring), ([.labels[].name]|join(","))] | @tsv' \
+        2>/dev/null) || {
+        log "$repo_key#$pr: live PR fetch failed; not auto-merging"
+        return 1
+    }
+    IFS=$'\t' read -r state base_ref mergeable labels_csv <<< "$tsv"
+    if [[ "$state" != "open" || "$base_ref" != "master" || "$mergeable" != "true" ]]; then
+        log "$repo_key#$pr: live state (state=$state base=$base_ref mergeable=$mergeable) not auto-mergeable"
+        return 1
+    fi
+    if [[ ",$labels_csv," != *",fleet:approved,"* ]]; then
+        log "$repo_key#$pr: fleet:approved gone since the scout tick; not auto-merging"
+        return 1
+    fi
+    local bad_labels
+    bad_labels=$(printf '%s' "$labels_csv" | tr ',' '\n' | grep -Ev "$MERGE_LABEL_ALLOW_RE" || true)
+    if [[ -n "$bad_labels" ]]; then
+        log "$repo_key#$pr: label(s) outside the auto-merge allowlist ($(printf '%s' "$bad_labels" | head -1)); human merges"
+        return 1
+    fi
+
+    # Diff-surface gate: every changed path must sit under .fleet/plans/.
+    # per_page=100 returns one page; a full page means the diff may be
+    # truncated and therefore unverifiable — never merge what we can't see.
+    local files n_files off_path
+    files=$(gh api "repos/$repo_slug/pulls/$pr/files?per_page=100" \
+        --jq '.[].filename' 2>/dev/null) || {
+        log "$repo_key#$pr: file-list fetch failed; not auto-merging"
+        return 1
+    }
+    n_files=$(printf '%s\n' "$files" | grep -c . || true)
+    if (( n_files == 0 )); then
+        log "$repo_key#$pr: empty diff; not auto-merging"
+        return 1
+    fi
+    if (( n_files >= 100 )); then
+        log "$repo_key#$pr: $n_files+ files — too large to verify; human merges"
+        return 1
+    fi
+    off_path=$(printf '%s\n' "$files" | grep -Ev "$MERGE_PATH_RE" | head -1 || true)
+    if [[ -n "$off_path" ]]; then
+        log "$repo_key#$pr: diff not pure .fleet/plans ($off_path); human merges"
+        return 1
+    fi
+
+    if (( DRY_RUN )); then
+        MERGED=$((MERGED + 1))
+        log "$repo_key#$pr: pure plan-file PR ($n_files file(s)) — would squash-merge (dry-run)"
+        return 0
+    fi
+    if gh pr merge "$pr" --repo "$repo_slug" --squash >/dev/null 2>&1; then
+        MERGED=$((MERGED + 1))
+        log "$repo_key#$pr: auto-merged (pure .fleet/plans diff, fleet:approved) — zero tokens"
+        # Provenance comment so a human scanning the thread sees this was
+        # the tier-0 lane, not a manual merge. Best-effort.
+        gh pr comment "$pr" --repo "$repo_slug" \
+            --body "Auto-merged by tier-0 fleet-rebase: diff touches only \`.fleet/plans/\` and the PR carried \`fleet:approved\` with no disqualifying labels. — fleet merger" \
+            >/dev/null 2>&1 || true
+        return 0
+    fi
+    log "$repo_key#$pr: gh pr merge failed; leaving for the human"
+    return 1
 }
 
 # Attempt one PR. Returns 0 = cleanly rebased+pushed (or nothing to do),
@@ -434,9 +544,12 @@ fi
 
 # Triage the slice. One line per PR:
 #   <repo> <number> <head> <base> <verdict>
-# verdict: attempt | skip-labels | llm-other
+# verdict: attempt | merge-candidate | skip-labels | llm-other
 # - attempt: approved, no skip labels, and either stacked (base!=master)
 #   or not cleanly MERGEABLE — tier-0 tries the rebase.
+# - merge-candidate: approved, MERGEABLE, base==master, and every label
+#   inside the auto-merge allowlist — attempt_merge live-verifies (including
+#   the pure-.fleet/plans diff check the slice can't answer) and merges.
 # - skip-labels: parked with another agent/human; neither tier touches it.
 # - llm-other: any other merger-actionable state this script doesn't
 #   handle (merge-ready label upkeep, stack-coordination transients,
@@ -445,6 +558,7 @@ mapfile -t PR_LINES < <(python3 - "$SLICE" <<'PYEOF'
 import json, os, re, sys
 
 skip_re = re.compile(os.environ["FLEET_REBASE_SKIP_RE"])
+merge_allow_re = re.compile(os.environ["FLEET_MERGE_ALLOW_RE"])
 
 try:
     with open(sys.argv[1]) as f:
@@ -496,6 +610,12 @@ for pr in data.get("prs", []):
         verdict = "llm-other"
     elif approved and (base != "master" or mergeable not in ("MERGEABLE", "UNKNOWN", "", None)):
         verdict = "attempt"
+    elif (approved and base == "master" and mergeable == "MERGEABLE"
+            and all(merge_allow_re.match(l) for l in labels)):
+        # Pre-filter for the auto-merge lane on the (stale) slice labels so
+        # PRs with any label outside the allowlist never cost gh calls;
+        # attempt_merge re-verifies everything live, plus the diff surface.
+        verdict = "merge-candidate"
     else:
         verdict = "llm-other"
     print(f"{repo} {number} {head} {base} {verdict}")
@@ -517,6 +637,15 @@ for line in "${PR_LINES[@]:-}"; do
                 LLM_REMAINING=$((LLM_REMAINING + 1))
             fi
             ;;
+        merge-candidate)
+            # Not-merged candidates count toward LLM_REMAINING — before this
+            # lane existed every approved+MERGEABLE PR was llm-other, so a
+            # candidate that fails the live verify (or isn't a pure plan-file
+            # diff) re-arms the LLM pass exactly as it always did.
+            if ! attempt_merge "$repo_key" "$pr"; then
+                LLM_REMAINING=$((LLM_REMAINING + 1))
+            fi
+            ;;
         stale-conflict)
             # Second concurrent pass succeeded but left the first pass's
             # fleet:semantic-conflict behind (#1654). Remove it so the PR
@@ -534,7 +663,7 @@ for line in "${PR_LINES[@]:-}"; do
     esac
 done
 
-log "done: attempted=$ATTEMPTED cleared=$CLEARED llm_remaining=$LLM_REMAINING"
+log "done: attempted=$ATTEMPTED cleared=$CLEARED merged=$MERGED llm_remaining=$LLM_REMAINING"
 
 if (( LLM_REMAINING > 0 )); then
     rearm_llm

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -268,17 +268,25 @@ attempt_merge() {
     fi
 
     # Live state + label gate. REST `mergeable` is true/false/null (null =
-    # GitHub still computing) — only an explicit true proceeds.
-    local tsv state base_ref mergeable labels_csv
+    # GitHub still computing) — only an explicit true proceeds. head.sha is
+    # captured from the SAME fetch and pins the eventual merge via
+    # --match-head-commit: the verify and the merge are separate round-trips,
+    # so without the pin a commit pushed in that window would merge with a
+    # diff nobody verified.
+    local tsv state base_ref mergeable head_sha labels_csv
     tsv=$(gh api "repos/$repo_slug/pulls/$pr" \
-        --jq '[.state, .base.ref, (.mergeable|tostring), ([.labels[].name]|join(","))] | @tsv' \
+        --jq '[.state, .base.ref, (.mergeable|tostring), .head.sha, ([.labels[].name]|join(","))] | @tsv' \
         2>/dev/null) || {
         log "$repo_key#$pr: live PR fetch failed; not auto-merging"
         return 1
     }
-    IFS=$'\t' read -r state base_ref mergeable labels_csv <<< "$tsv"
+    IFS=$'\t' read -r state base_ref mergeable head_sha labels_csv <<< "$tsv"
     if [[ "$state" != "open" || "$base_ref" != "master" || "$mergeable" != "true" ]]; then
         log "$repo_key#$pr: live state (state=$state base=$base_ref mergeable=$mergeable) not auto-mergeable"
+        return 1
+    fi
+    if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
+        log "$repo_key#$pr: no head SHA in live fetch; not auto-merging"
         return 1
     fi
     if [[ ",$labels_csv," != *",fleet:approved,"* ]]; then
@@ -295,6 +303,10 @@ attempt_merge() {
     # Diff-surface gate: every changed path must sit under .fleet/plans/.
     # per_page=100 returns one page; a full page means the diff may be
     # truncated and therefore unverifiable — never merge what we can't see.
+    # Assumption: .filename is the post-rename path, so a rename INTO
+    # .fleet/plans/ from outside would pass this gate. Acceptable in a
+    # single-operator fleet where plan PRs are steward-authored; revisit if
+    # external contributors ever gain a path to fleet:approved.
     local files n_files off_path
     files=$(gh api "repos/$repo_slug/pulls/$pr/files?per_page=100" \
         --jq '.[].filename' 2>/dev/null) || {
@@ -321,9 +333,10 @@ attempt_merge() {
         log "$repo_key#$pr: pure plan-file PR ($n_files file(s)) — would squash-merge (dry-run)"
         return 0
     fi
-    if gh pr merge "$pr" --repo "$repo_slug" --squash >/dev/null 2>&1; then
+    if gh pr merge "$pr" --repo "$repo_slug" --squash \
+            --match-head-commit "$head_sha" >/dev/null 2>&1; then
         MERGED=$((MERGED + 1))
-        log "$repo_key#$pr: auto-merged (pure .fleet/plans diff, fleet:approved) — zero tokens"
+        log "$repo_key#$pr: auto-merged at ${head_sha:0:12} (pure .fleet/plans diff, fleet:approved) — zero tokens"
         # Provenance comment so a human scanning the thread sees this was
         # the tier-0 lane, not a manual merge. Best-effort.
         gh pr comment "$pr" --repo "$repo_slug" \

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1811,11 +1811,14 @@ def _merger_action_signal(labels, mergeable, base_ref):
     must not loop on the PR), but the projection omitted them, so an
     approved-then-needs-fix PR (e.g. game #144) was projected
     `merge-ready` and woke the merger every scout tick to find nothing
-    to do. No merge hazard today — the fleet doesn't auto-merge — but the
-    wasted wakes are real and the projection/gate disagreement is a
-    latent footgun. These are durable reviewer/human labels, not
-    merger-set transients, so skipping them preserves the self-trigger
-    invariant above.
+    to do. And since tier-0 fleet-rebase grew its plan-file auto-merge
+    lane, `merge-ready` is no longer wake-only: it feeds that lane's
+    merge-candidate triage. This skip set is the first of three gates
+    (projection skip -> triage label-allowlist -> live REST re-verify
+    in attempt_merge), so keeping it consistent with the merge gate is
+    load-bearing, not just a wasted-wake fix. These are durable
+    reviewer/human labels, not merger-set transients, so skipping them
+    preserves the self-trigger invariant above.
     """
     skip = labels & {
         "fleet:wip", "human:wip", "fleet:blocker",

--- a/scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
@@ -217,7 +217,7 @@ write_slice '[{"repo":"engine","number":200,"headRefName":"feat-child","baseRefN
 T1=$(run_rebase)
 assert_contains "$T1" "retargeting PR to master" "T1 took the retarget path"
 assert_contains "$T1" "dropping inherited prefix at ${B1:0:12}" "T1 dropped the inherited prefix at the boundary"
-assert_contains "$T1" "attempted=1 cleared=1 llm_remaining=0" "T1 tier-0 cleared the PR (no LLM bail)"
+assert_contains "$T1" "attempted=1 cleared=1 merged=0 llm_remaining=0" "T1 tier-0 cleared the PR (no LLM bail)"
 assert_absent   "$T1" "changed-file set drifted" "T1 no spurious file-set drift"
 assert_absent   "$T1" "conflicts; leaving for LLM" "T1 no conflict bail"
 
@@ -227,7 +227,7 @@ write_slice '[{"repo":"engine","number":201,"headRefName":"feat-child2","baseRef
 T2=$(run_rebase)
 assert_contains "$T2" "dropping inherited prefix at ${B1B:0:12}" "T2 still attempts the prefix drop"
 assert_contains "$T2" "(inherited-prefix drop) conflicts; leaving for LLM" "T2 own-commit conflict bails to LLM"
-assert_contains "$T2" "attempted=1 cleared=0 llm_remaining=1" "T2 left for the LLM pass"
+assert_contains "$T2" "attempted=1 cleared=0 merged=0 llm_remaining=1" "T2 left for the LLM pass"
 
 # === T3: parent edited after the child forked -> fork-point fallback drops ==
 echo "T3: parent amended post-fork (recorded head is a sibling) -> fork-point fallback drops + clears"
@@ -236,7 +236,7 @@ T3=$(run_rebase)
 assert_contains "$T3" "retargeting PR to master" "T3 took the retarget path"
 assert_contains "$T3" "parent edited post-fork; deriving inherited boundary from child fork point at ${P_FORK:0:12}" "T3 used the fork-point fallback at the boundary"
 assert_absent   "$T3" "dropping inherited prefix at" "T3 did NOT take the is-ancestor fast path"
-assert_contains "$T3" "attempted=1 cleared=1 llm_remaining=0" "T3 tier-0 cleared the PR (no LLM bail)"
+assert_contains "$T3" "attempted=1 cleared=1 merged=0 llm_remaining=0" "T3 tier-0 cleared the PR (no LLM bail)"
 assert_absent   "$T3" "changed-file set drifted" "T3 no spurious file-set drift"
 assert_absent   "$T3" "conflicts; leaving for LLM" "T3 no conflict bail"
 

--- a/scripts/fleet/tests/test_fleet_rebase_plan_automerge.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_plan_automerge.sh
@@ -100,9 +100,9 @@ write_slice() {
     printf '{"prs": %s}\n' "$1" > "$FLEET_STATE_DIR/projections/merger.json"
 }
 
-# stub_pr <number> <state> <base> <mergeable> <labels-csv>
+# stub_pr <number> <state> <base> <mergeable> <labels-csv> [head-sha]
 stub_pr() {
-    printf '%s\t%s\t%s\t%s\n' "$2" "$3" "$4" "$5" > "$GH_STUB_DIR/pr_$1.tsv"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$2" "$3" "$4" "${6:-sha$1}" "$5" > "$GH_STUB_DIR/pr_$1.tsv"
 }
 
 # stub_files <number> <path>...
@@ -136,8 +136,8 @@ stub_files 400 ".fleet/plans/issue-1394.md" ".fleet/plans/issue-667.md"
 T1=$(run_rebase)
 assert_contains "$T1" "engine#400: auto-merged" "T1 logs the auto-merge"
 assert_contains "$T1" "merged=1 llm_remaining=0" "T1 summary counts the merge, no re-arm"
-assert_contains "$(cat "$GH_STUB_LOG")" "pr merge 400 --repo jakildev/IrredenEngine --squash" \
-    "T1 gh pr merge --squash invoked"
+assert_contains "$(cat "$GH_STUB_LOG")" "pr merge 400 --repo jakildev/IrredenEngine --squash --match-head-commit sha400" \
+    "T1 gh pr merge --squash invoked, pinned to the live-verified head SHA"
 assert_contains "$(cat "$GH_STUB_LOG")" "pr comment 400" "T1 provenance comment posted"
 
 # === T2: mixed diff → refused ==================================================
@@ -208,6 +208,16 @@ write_slice "${slice%,}]"
 T7=$(run_rebase)
 assert_contains "$T7" "merged=3 llm_remaining=1" "T7 cap merges 3, defers 1"
 assert_contains "$T7" "auto-merge cap (3) reached this run" "T7 cap log line"
+
+# === T8: live fetch returns no head SHA -> refused =============================
+echo "T8: null head SHA in live fetch -> refused (nothing to pin the merge to)"
+reset_stub
+write_slice "[$PLAN_SLICE_PR]"
+stub_pr 400 open master true "fleet:approved,fleet:authored-on-macos" "null"
+stub_files 400 ".fleet/plans/issue-1394.md"
+T8=$(run_rebase)
+assert_contains "$T8" "no head SHA in live fetch" "T8 head-SHA gate fires"
+assert_absent "$(cat "$GH_STUB_LOG")" "pr merge" "T8 gh pr merge never invoked"
 
 # --- Summary ------------------------------------------------------------------
 echo ""

--- a/scripts/fleet/tests/test_fleet_rebase_plan_automerge.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_plan_automerge.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Tests for fleet-rebase's tier-0 plan-file auto-merge lane.
+#
+# The lane squash-merges an approved, MERGEABLE, master-based PR whose diff
+# touches ONLY .fleet/plans/** — steward rollups, close-outs, umbrella plan
+# filings. Everything else stays on the human's merge click. The triage
+# pre-filters on the slice's labels (allowlist: any unknown label
+# disqualifies), then attempt_merge re-verifies state/labels live via REST
+# and checks the diff surface via the pulls/<N>/files endpoint.
+#
+#   T1: pure .fleet/plans diff, benign labels → squash-merged.
+#   T2: mixed diff (plan file + engine source) → not merged, llm-other count.
+#   T3: slice label outside the allowlist (fleet:human-deferred) → never a
+#       merge candidate; zero gh calls for it.
+#   T4: slice labels clean but LIVE labels drifted (human:needs-fix appeared
+#       since the scout tick) → live verify refuses, not merged.
+#   T5: live mergeable flipped to false (sibling plan PR merged first) →
+#       live verify refuses, not merged.
+#   T6: --dry-run on a pure plan PR → logs "would squash-merge", gh pr merge
+#       never invoked.
+#   T7: four eligible plan PRs → cap merges 3, defers the 4th, re-arms via
+#       llm_remaining.
+#
+# The gh stub serves canned per-PR REST responses from $GH_STUB_DIR and
+# records every invocation to $GH_STUB_LOG — no live GitHub anywhere.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REBASE="$SCRIPT_DIR/fleet-rebase"
+
+if [[ ! -x "$REBASE" ]]; then
+    echo "test setup: fleet-rebase not executable at $REBASE" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    if [[ -n "$TMPROOT" && -d "$TMPROOT" ]]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        expected to find: $needle"
+        echo "        in: "; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    fi
+}
+
+assert_absent() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        did NOT expect: $needle"
+        echo "        in: "; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    else
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    fi
+}
+
+# --- Sandbox ------------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT"
+export FLEET_STATE_DIR="$TMPROOT/.fleet/state"
+export FLEET_REBASE_SCRATCH="$TMPROOT/.fleet/rebase-scratch"
+export GH_STUB_DIR="$TMPROOT/gh-stub"
+export GH_STUB_LOG="$TMPROOT/gh-stub/calls.log"
+mkdir -p "$FLEET_STATE_DIR/projections" "$TMPROOT/bin" "$GH_STUB_DIR"
+
+# Recording gh stub: `gh api repos/<slug>/pulls/<N>` serves pr_<N>.tsv,
+# `.../pulls/<N>/files...` serves files_<N>.txt (missing file → exit 1, the
+# fail-closed mock-miss rule); everything else records and succeeds.
+cat > "$TMPROOT/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_STUB_LOG"
+if [[ "${1:-}" == "api" ]]; then
+    n=$(printf '%s' "$2" | grep -oE 'pulls/[0-9]+' | grep -oE '[0-9]+')
+    if [[ "$2" == *"/files"* ]]; then
+        cat "$GH_STUB_DIR/files_$n.txt" 2>/dev/null || exit 1
+    else
+        cat "$GH_STUB_DIR/pr_$n.tsv" 2>/dev/null || exit 1
+    fi
+    exit 0
+fi
+exit 0
+GHEOF
+chmod +x "$TMPROOT/bin/gh"
+export PATH="$TMPROOT/bin:$PATH"
+
+write_slice() {
+    printf '{"prs": %s}\n' "$1" > "$FLEET_STATE_DIR/projections/merger.json"
+}
+
+# stub_pr <number> <state> <base> <mergeable> <labels-csv>
+stub_pr() {
+    printf '%s\t%s\t%s\t%s\n' "$2" "$3" "$4" "$5" > "$GH_STUB_DIR/pr_$1.tsv"
+}
+
+# stub_files <number> <path>...
+stub_files() {
+    local n="$1"; shift
+    printf '%s\n' "$@" > "$GH_STUB_DIR/files_$n.txt"
+}
+
+reset_stub() {
+    rm -f "$GH_STUB_DIR"/pr_*.tsv "$GH_STUB_DIR"/files_*.txt "$GH_STUB_LOG"
+    touch "$GH_STUB_LOG"
+}
+
+run_rebase() {
+    "$REBASE" --auto 2>&1 || true
+}
+
+PLAN_SLICE_PR='{
+  "repo":"engine","number":400,
+  "headRefName":"claude/steward-rollup","baseRefName":"master",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:authored-on-macos"]
+}'
+
+# === T1: pure plan diff → squash-merged ========================================
+echo "T1: pure .fleet/plans diff -> squash-merged"
+reset_stub
+write_slice "[$PLAN_SLICE_PR]"
+stub_pr 400 open master true "fleet:approved,fleet:authored-on-macos"
+stub_files 400 ".fleet/plans/issue-1394.md" ".fleet/plans/issue-667.md"
+T1=$(run_rebase)
+assert_contains "$T1" "engine#400: auto-merged" "T1 logs the auto-merge"
+assert_contains "$T1" "merged=1 llm_remaining=0" "T1 summary counts the merge, no re-arm"
+assert_contains "$(cat "$GH_STUB_LOG")" "pr merge 400 --repo jakildev/IrredenEngine --squash" \
+    "T1 gh pr merge --squash invoked"
+assert_contains "$(cat "$GH_STUB_LOG")" "pr comment 400" "T1 provenance comment posted"
+
+# === T2: mixed diff → refused ==================================================
+echo "T2: plan file + engine source in one diff -> not merged"
+reset_stub
+write_slice "[$PLAN_SLICE_PR]"
+stub_pr 400 open master true "fleet:approved,fleet:authored-on-macos"
+stub_files 400 ".fleet/plans/issue-1394.md" "engine/render/ir_render_canvas.cpp"
+T2=$(run_rebase)
+assert_contains "$T2" "diff not pure .fleet/plans (engine/render/ir_render_canvas.cpp)" \
+    "T2 names the offending path"
+assert_contains "$T2" "merged=0 llm_remaining=1" "T2 not merged, counted for re-arm"
+assert_absent "$(cat "$GH_STUB_LOG")" "pr merge" "T2 gh pr merge never invoked"
+
+# === T3: slice label outside allowlist → never a candidate ====================
+echo "T3: fleet:human-deferred in slice labels -> not a merge candidate"
+reset_stub
+write_slice '[{
+  "repo":"engine","number":401,
+  "headRefName":"claude/deferred-pr","baseRefName":"master",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:human-deferred"]
+}]'
+T3=$(run_rebase)
+assert_contains "$T3" "merged=0 llm_remaining=1" "T3 stays llm-other"
+assert_absent "$(cat "$GH_STUB_LOG")" "pulls/401" "T3 zero gh calls for the PR"
+
+# === T4: live labels drifted since the scout tick ==============================
+echo "T4: live labels grew human:needs-fix -> live verify refuses"
+reset_stub
+write_slice "[$PLAN_SLICE_PR]"
+stub_pr 400 open master true "fleet:approved,human:needs-fix"
+stub_files 400 ".fleet/plans/issue-1394.md"
+T4=$(run_rebase)
+assert_contains "$T4" "label(s) outside the auto-merge allowlist" "T4 live label gate fires"
+assert_absent "$(cat "$GH_STUB_LOG")" "pr merge" "T4 gh pr merge never invoked"
+
+# === T5: live mergeable flipped false ==========================================
+echo "T5: live mergeable=false (sibling merged first) -> refused"
+reset_stub
+write_slice "[$PLAN_SLICE_PR]"
+stub_pr 400 open master false "fleet:approved,fleet:authored-on-macos"
+stub_files 400 ".fleet/plans/issue-1394.md"
+T5=$(run_rebase)
+assert_contains "$T5" "not auto-mergeable" "T5 live state gate fires"
+assert_absent "$(cat "$GH_STUB_LOG")" "pr merge" "T5 gh pr merge never invoked"
+
+# === T6: dry-run never merges ==================================================
+echo "T6: --dry-run -> logs intent, no merge call"
+reset_stub
+write_slice "[$PLAN_SLICE_PR]"
+stub_pr 400 open master true "fleet:approved,fleet:authored-on-macos"
+stub_files 400 ".fleet/plans/issue-1394.md"
+T6=$("$REBASE" --auto --dry-run 2>&1 || true)
+assert_contains "$T6" "would squash-merge (dry-run)" "T6 dry-run logs intent"
+assert_absent "$(cat "$GH_STUB_LOG")" "pr merge" "T6 gh pr merge never invoked"
+
+# === T7: cap at 3 per run ======================================================
+echo "T7: four eligible plan PRs -> 3 merged, 4th deferred + re-arm"
+reset_stub
+slice="["
+for n in 410 411 412 413; do
+    stub_pr "$n" open master true "fleet:approved"
+    stub_files "$n" ".fleet/plans/issue-$n.md"
+    slice+="{\"repo\":\"engine\",\"number\":$n,\"headRefName\":\"claude/plan-$n\",\"baseRefName\":\"master\",\"mergeable\":\"MERGEABLE\",\"labels\":[\"fleet:approved\"]},"
+done
+write_slice "${slice%,}]"
+T7=$(run_rebase)
+assert_contains "$T7" "merged=3 llm_remaining=1" "T7 cap merges 3, defers 1"
+assert_contains "$T7" "auto-merge cap (3) reached this run" "T7 cap log line"
+
+# --- Summary ------------------------------------------------------------------
+echo ""
+echo "fleet-rebase plan-automerge tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- New tier-0 auto-merge lane in `fleet-rebase`: squash-merges PRs that are `fleet:approved` + MERGEABLE + based on `master` and whose diff touches **only** `.fleet/plans/**` (steward rollups, close-outs, umbrella plan filings). Everything else stays on the human's merge click.
- Eligibility is allowlist-shaped and re-verified **live** (REST) immediately before the merge: any label outside `fleet:approved` / `fleet:merger-cooldown` / `fleet:stacked-rebase` / `fleet:authored-on-*` / `fleet:verified-*` disqualifies (every `human:*`, `fleet:human-deferred`, `fleet:changes-made`, smoke labels, and future labels default to human-merge); the file gate refuses empty or unverifiable (100+-file) diffs. Cap 3 merges/run; merged PRs get a `— fleet merger` provenance comment.
- The LLM merger pass gains an explicit **never `gh pr merge`** hard rule — the merge verb lives only in the deterministic script tier.
- Docs: new FLEET.md § "Who merges"; CLAUDE-BASELINE hard rule, FLEET-FEEDBACK-HANDLING, fleet-labels-reference (`fleet:human-deferred`), and docs/fleet/README diagram updated to cite the carve-out; scout `_merger_action_signal` docstring notes its skip set is now the first gate of the merge lane.
- Tests: new `test_fleet_rebase_plan_automerge.sh` (17 assertions: merge, mixed-diff refusal, slice/live label gates, mergeable flip, dry-run, cap); inherited-drop test assertions updated for the new `merged=N` summary field.

## Test plan
- [x] `test_fleet_rebase_plan_automerge.sh` — 17/17 pass (hermetic gh stub, no live GitHub)
- [x] `test_fleet_rebase_stale_conflict_cleanup.sh` — 7/7 pass
- [x] `test_fleet_rebase_inherited_drop.sh` — 14/14 pass
- [x] `bash -n scripts/fleet/fleet-rebase`; `ruff check scripts/` clean

## Notes for reviewer
No open engine PR is currently eligible (verified: zero approved plan-file PRs open), so nothing merges on the first wake after this lands. The scout's `merge-ready` projection already wakes the merger for approved+MERGEABLE PRs — this PR consumes that existing signal; no scout logic change, docstring only. Since `~/bin/fleet-rebase` symlinks into the main clone, the lane activates on this host when the clone returns to an updated `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)