### PR TITLE
fleet: fleet-up restores both main clones to an up-to-date master

### DIFF
--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -195,11 +195,19 @@ restore_main_clone_to_master() {
 
     local branch
     branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+
+    # Tracked WIP wins over the restore on EITHER path (parked branch or already
+    # on master). This must gate before the ff-advance below: _ff_advance's
+    # ff-only refuses only when the incoming commits *overlap* the dirty files —
+    # a disjoint dirty tree on master would otherwise be advanced silently
+    # underneath uncommitted work, contradicting the "never touch, warn loudly"
+    # invariant documented above.
+    if [[ -n "$tracked_dirty" ]]; then
+        echo "fleet-clone-freshness: $root has tracked modifications on '$branch' — leaving it alone (live WIP wins). Claims stay blocked until it is clean and on master; commit or ship the WIP, then rerun fleet-up." >&2
+        return 0
+    fi
+
     if [[ "$branch" != "master" ]]; then
-        if [[ -n "$tracked_dirty" ]]; then
-            echo "fleet-clone-freshness: $root is parked on '$branch' WITH tracked modifications — leaving it alone (live WIP wins). Claims stay blocked until it returns to master; commit or ship the WIP, then rerun fleet-up." >&2
-            return 0
-        fi
         if git -C "$root" checkout master --quiet 2>/dev/null; then
             echo "fleet-clone-freshness: $root returned to master (was on '$branch', no tracked WIP)." >&2
         else

--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -37,6 +37,13 @@
 #   advance_main_clone  <repo_root>  — guarded, rate-limited fetch + ff-only
 #                                     advance of a clean on-master clone. Never
 #                                     switches branches, never resets --hard.
+#   restore_main_clone_to_master <repo_root>
+#                                   — fleet-up-time stronger variant: returns a
+#                                     clone parked off-master (PR branch from a
+#                                     cursor session, reviewer scratch leftover,
+#                                     detached HEAD) to master when no tracked
+#                                     WIP is at risk, then ff-advances. Never
+#                                     touches a tree with tracked modifications.
 #
 # Env:
 #   FLEET_SKIP_CLONE_FRESHNESS=1  — disable the assert_clone_fresh claim gate
@@ -131,7 +138,17 @@ advance_main_clone() {
         echo "fleet-clone-freshness: $root has uncommitted changes — skipping advance." >&2
         return 0
     fi
-    # Guard 3: master must be a pure ancestor of origin/master (fast-forwardable).
+    # Guard 3 + the ff itself live in the shared tail.
+    _ff_advance_to_origin_master "$root"
+    return 0
+}
+
+# _ff_advance_to_origin_master <repo_root>
+# Shared tail of advance_main_clone / restore_main_clone_to_master: guarded
+# ff-only advance of an on-master clone whose origin/master ref is current
+# (callers own the fetch). Diverged or up-to-date → no-op. Always returns 0.
+_ff_advance_to_origin_master() {
+    local root="$1"
     if ! git -C "$root" merge-base --is-ancestor master origin/master 2>/dev/null; then
         echo "fleet-clone-freshness: $root master has diverged from origin/master — skipping advance (human fixup needed)." >&2
         return 0
@@ -141,10 +158,57 @@ advance_main_clone() {
     if [[ "${behind:-0}" -le 0 ]]; then
         return 0  # already current (or ahead — left to the human)
     fi
+    # ff-only refuses on its own rather than clobber a tracked modification
+    # that overlaps the incoming commits; a disjoint dirty tree advances fine.
     if git -C "$root" merge --ff-only origin/master --quiet 2>/dev/null; then
         echo "fleet-clone-freshness: advanced $root master by $behind commit(s) to origin/master." >&2
     else
-        echo "fleet-clone-freshness: ff-only advance of $root failed (concurrent git op?) — leaving as-is." >&2
+        echo "fleet-clone-freshness: ff-only advance of $root refused (overlapping local changes or concurrent git op) — leaving as-is." >&2
     fi
+    return 0
+}
+
+# restore_main_clone_to_master <repo_root>
+# fleet-up-time restore: get the shared main clone back onto an up-to-date
+# master before the fleet starts. A clone parked off-master (a cursor session's
+# PR branch, a stranded reviewer scratch branch, a detached HEAD) freezes the
+# local master ref while origin advances, and assert_clone_fresh then refuses
+# every claim — a silent whole-fleet stall (2026-07-13). advance_main_clone
+# deliberately never switches branches (it runs unattended every dispatcher
+# tick); this variant runs at the one moment branch-switching is safe to want,
+# with WIP protection:
+#   - tracked modifications anywhere (staged or not) → never touch, warn loudly.
+#     Untracked files don't block: `git checkout` refuses on its own if one
+#     would be overwritten, and stray junk files (0-byte `=`, .review-body.md)
+#     are exactly what used to wedge the old flow.
+#   - off-master + clean → checkout master.
+#   - then ff-advance master to origin/master (fetch is the caller's job at
+#     fleet-up; a cheap refresh here keeps standalone use correct).
+# Always returns 0 — a skipped restore must not abort a `set -e` fleet-up; the
+# warning + the claim gate's own refusal are the signal.
+restore_main_clone_to_master() {
+    local root="$1"
+    [[ -d "$root/.git" ]] || return 0
+
+    local tracked_dirty
+    tracked_dirty="$(git -C "$root" status --porcelain 2>/dev/null | grep -v '^??' || true)"
+
+    local branch
+    branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+    if [[ "$branch" != "master" ]]; then
+        if [[ -n "$tracked_dirty" ]]; then
+            echo "fleet-clone-freshness: $root is parked on '$branch' WITH tracked modifications — leaving it alone (live WIP wins). Claims stay blocked until it returns to master; commit or ship the WIP, then rerun fleet-up." >&2
+            return 0
+        fi
+        if git -C "$root" checkout master --quiet 2>/dev/null; then
+            echo "fleet-clone-freshness: $root returned to master (was on '$branch', no tracked WIP)." >&2
+        else
+            echo "fleet-clone-freshness: $root checkout master failed (was on '$branch') — leaving as-is (human fixup needed)." >&2
+            return 0
+        fi
+    fi
+
+    git -C "$root" fetch origin master --quiet 2>/dev/null || true
+    _ff_advance_to_origin_master "$root"
     return 0
 }

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -43,7 +43,8 @@ if [[ -f "$_FLEET_CLONE_FRESHNESS_SH" ]]; then
     # shellcheck source=/dev/null
     source "$_FLEET_CLONE_FRESHNESS_SH"
 else
-    advance_main_clone() { :; }  # helper not installed yet — no-op
+    advance_main_clone() { :; }            # helper not installed yet — no-op
+    restore_main_clone_to_master() { :; }  # helper not installed yet — no-op
 fi
 unset _FLEET_CLONE_FRESHNESS_SH
 
@@ -481,9 +482,12 @@ migrate_legacy_worker_worktrees() {
 
 (cd "$ENGINE" && git fetch origin --quiet) || {
     echo "fleet-up: engine git fetch failed" >&2; exit 1; }
-# Advance the engine main clone before resetting worktrees, so a just-merged
-# fleet-script fix is live for this session's scout/claim/dispatcher. (#1810)
-advance_main_clone "$ENGINE"
+# Restore the engine main clone to an up-to-date master before resetting
+# worktrees: switches back from a parked branch when no tracked WIP is at risk
+# (a parked clone freezes the master ref and the freshness guard then blocks
+# every claim), then ff-advances so a just-merged fleet-script fix is live for
+# this session's scout/claim/dispatcher. (#1810)
+restore_main_clone_to_master "$ENGINE"
 
 ensure_worktree "$ENGINE" .claude/worktrees/opus-architect    fleet/opus-architect
 migrate_legacy_worker_worktrees "$ENGINE"
@@ -514,7 +518,7 @@ fi
 if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
         echo "fleet-up: game git fetch failed (continuing without game panes)" >&2; }
-    advance_main_clone "$GAME"  # keep the game main clone current too (#1810)
+    restore_main_clone_to_master "$GAME"  # game main clone back on current master too (#1810)
     ensure_worktree "$GAME" .claude/worktrees/game-architect  fleet/game-architect
     # Worker panes cover both engine and game queues; each of the four
     # worker panes gets its own game worktree to cd into for game tasks.

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -206,6 +206,23 @@ else
     fail "restore errored on missing repo"
 fi
 
+# --- T14: ALREADY on master, disjoint tracked dirty file -> NOT advanced -------
+# The restore-side mirror of T6: a disjoint dirty tree would ff-advance fine on
+# its own (the incoming commits touch a different file), so only the tracked-WIP
+# guard stops it. Covers the guard firing on-master, not just on a parked
+# branch. See #2378.
+echo "T14: on master with disjoint tracked WIP -> master NOT advanced"
+git_q "$CLONE2" checkout master
+on_master_head=$(git -C "$CLONE2" rev-parse master)
+echo "disjoint-wip" > "$CLONE2/other"   # tracked WIP on a file the incoming commit won't touch
+git_q "$CLONE2" add other
+push_new_commit t14                      # origin advances 'file' (disjoint from 'other')
+out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
+[[ "$(git -C "$CLONE2" rev-parse master)" == "$on_master_head" ]] \
+    && ok "on-master disjoint-dirty clone NOT advanced" || fail "advanced master under uncommitted WIP"
+grep -q "disjoint-wip" "$CLONE2/other" && ok "on-master WIP preserved" || fail "WIP lost"
+echo "$out" | grep -q "live WIP wins" && ok "warns loudly on-master too" || fail "no WIP warning: $out"
+
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -153,6 +153,59 @@ behind=$(clone_behind_count "$TMPROOT/does-not-exist")
 [[ "$behind" == "0" ]] && ok "clone_behind_count 0 for missing repo" || fail "behind=$behind for missing repo"
 if advance_main_clone "$TMPROOT/does-not-exist" 2>/dev/null; then ok "advance no-ops on missing repo"; else fail "advance errored on missing repo"; fi
 
+# --- restore_main_clone_to_master (fleet-up-time restore) --------------------
+# Fresh fixture: CLONE is left diverged by T7, so restore tests get their own.
+CLONE2="$TMPROOT/clone2"
+git clone -q "$ORIGIN" "$CLONE2"
+git -C "$CLONE2" config user.email t@t
+git -C "$CLONE2" config user.name test
+
+# --- T9: parked on a feature branch, clean tree -> restored + ff-advanced ----
+echo "T9: parked branch, clean tree -> checkout master + ff-advance"
+git_q "$CLONE2" checkout -b claude/parked-pr
+push_new_commit t9
+git_q "$CLONE2" fetch origin master
+out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
+branch=$(git -C "$CLONE2" rev-parse --abbrev-ref HEAD)
+[[ "$branch" == "master" ]] && ok "returned to master" || fail "still on $branch"
+[[ "$(git -C "$CLONE2" rev-parse master)" == "$(git -C "$CLONE2" rev-parse origin/master)" ]] \
+    && ok "master ff-advanced to origin/master" || fail "master not advanced"
+echo "$out" | grep -q "returned to master" && ok "logs the restore" || fail "no restore log: $out"
+
+# --- T10: parked branch WITH tracked modification -> untouched ----------------
+echo "T10: parked branch with tracked WIP -> left alone"
+git_q "$CLONE2" checkout -b claude/live-wip
+echo "wip" >> "$CLONE2/file"
+out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
+branch=$(git -C "$CLONE2" rev-parse --abbrev-ref HEAD)
+[[ "$branch" == "claude/live-wip" ]] && ok "branch untouched" || fail "branch switched to $branch"
+grep -q "wip" "$CLONE2/file" && ok "WIP preserved" || fail "WIP lost"
+echo "$out" | grep -q "live WIP wins" && ok "warns loudly" || fail "no WIP warning: $out"
+git_q "$CLONE2" checkout -- file   # clean up for T11
+
+# --- T11: parked branch with only untracked junk -> restored, junk kept ------
+echo "T11: parked branch with untracked junk only -> restored"
+touch "$CLONE2/.review-body.md"
+out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
+branch=$(git -C "$CLONE2" rev-parse --abbrev-ref HEAD)
+[[ "$branch" == "master" ]] && ok "returned to master past untracked junk" || fail "still on $branch"
+[[ -f "$CLONE2/.review-body.md" ]] && ok "untracked file preserved" || fail "untracked file lost"
+
+# --- T12: detached HEAD, clean -> restored ------------------------------------
+echo "T12: detached HEAD, clean tree -> restored to master"
+git_q "$CLONE2" checkout --detach origin/master
+out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
+branch=$(git -C "$CLONE2" rev-parse --abbrev-ref HEAD)
+[[ "$branch" == "master" ]] && ok "detached HEAD returned to master" || fail "HEAD is $branch"
+
+# --- T13: missing repo is a safe no-op ----------------------------------------
+echo "T13: nonexistent root is a safe no-op for restore"
+if restore_main_clone_to_master "$TMPROOT/does-not-exist" 2>/dev/null; then
+    ok "restore no-ops on missing repo"
+else
+    fail "restore errored on missing repo"
+fi
+
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- `fleet-up` now restores **both** main clones (engine + game) to an up-to-date `master` before bringing the fleet online, closing the silent whole-fleet stall hit twice on 2026-07-13: a clone parked off-master freezes its local `master` ref, and the #1810 freshness guard then refuses every claim while workers fast-exit with nothing visible to the human.
- New `restore_main_clone_to_master` in `fleet-clone-freshness.sh`, called by `fleet-up` in place of the weaker `advance_main_clone` (which stays as-is for the unattended dispatcher tick — it must never switch branches):
  - tracked modifications (staged or unstaged) anywhere → never touch, loud warning ("live WIP wins")
  - parked branch / detached HEAD with no tracked WIP → `checkout master`; untracked junk files (0-byte `=`, `.review-body.md`) no longer wedge it
  - then ff-advance to `origin/master`; the ff tail is factored into `_ff_advance_to_origin_master`, shared with `advance_main_clone`, so the two variants can't drift
- Tests: `test_clone_freshness.sh` extended with T9–T13 (parked-clean restore + ff, tracked-WIP untouched, untracked-junk restore, detached HEAD, missing-repo no-op) — 26/26 pass.

## Test plan
- [x] `scripts/fleet/tests/test_clone_freshness.sh` — 26/26 (hermetic throwaway git repos)
- [x] `bash -n` on `fleet-up` and `fleet-clone-freshness.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)