### PR TITLE
fleet: extract shared bash test assertion helpers into tests/lib_assert.sh

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -30,6 +30,11 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
 - **A new executable ships with a `tests/test_<name>.{sh,py}`** in the same
   PR — the fleet-tooling form of the review checklist's "new feature with no
   new test"; the `simplify` pre-commit pass flags the omission.
+- **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
+  `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
+  `summarize` exit idiom — don't re-copy the helpers into a new test.
+  Genuinely test-specific asserts (path existence, exit codes) stay local,
+  built on `ok`/`bad`.
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,

--- a/scripts/fleet/tests/lib_assert.sh
+++ b/scripts/fleet/tests/lib_assert.sh
@@ -1,0 +1,66 @@
+# Shared assertion helpers for the bash tests in this directory. Sourced,
+# never executed — the name deliberately avoids the test_*.sh pattern so
+# anything that globs for tests skips it:
+#
+#     source "$(dirname "$0")/lib_assert.sh"
+#
+# Provides the PASS/FAIL counters, ok/bad bumpers, the assert_* family, and
+# summarize. End every test with summarize (optionally with a suite label)
+# as the last command so the script's exit status reflects the failure
+# count:
+#
+#     summarize "fleet-foo tests"
+#
+# assert_contains / assert_absent match the needle as a fixed string
+# (grep -F), one line at a time — a needle spanning a newline never
+# matches. Tests that need path-existence or exit-code assertions define
+# those locally (see test_fleet_claim_safety_guards.sh).
+
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        ok "$msg"
+    else
+        bad "$msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        ok "$msg"
+    else
+        bad "$msg"
+        echo "        expected to find: $needle"
+        echo "        in:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    fi
+}
+
+assert_absent() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        bad "$msg"
+        echo "        did NOT expect: $needle"
+        echo "        in:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    else
+        ok "$msg"
+    fi
+}
+
+summarize() {
+    echo ""
+    if [[ $# -gt 0 ]]; then
+        echo "$1: $PASS passed, $FAIL failed"
+    else
+        echo "passed: $PASS  failed: $FAIL"
+    fi
+    [[ "$FAIL" -eq 0 ]]
+}

--- a/scripts/fleet/tests/test_babysit_launch.sh
+++ b/scripts/fleet/tests/test_babysit_launch.sh
@@ -29,45 +29,14 @@ if [[ ! -x "$BABYSIT" ]]; then
     exit 1
 fi
 
-PASS=0
-FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=""
 
 cleanup() {
     [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
 }
 trap cleanup EXIT
-
-assert_eq() {
-    local actual="$1" expected="$2" msg="$3"
-    if [[ "$actual" == "$expected" ]]; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        expected: $expected"
-        echo "        actual:   $actual"
-    fi
-}
-
-assert_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if [[ "$haystack" == *"$needle"* ]]; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        '$needle' not found in: $haystack"
-    fi
-}
-
-assert_not_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if [[ "$haystack" != *"$needle"* ]]; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        '$needle' unexpectedly present in: $haystack"
-    fi
-}
 
 TMPROOT=$(mktemp -d)
 # Stub claude/tmux/gh so nothing real launches even if a path slips past the
@@ -95,8 +64,8 @@ echo "$SID" > "$H1/.fleet/sessions/opus-architect.session-id"
 out=$(launch_for "$H1" 'claude-opus-4-8[1m]' opus-architect)
 assert_eq "$out" "claude --model claude-opus-4-8[1m] --effort xhigh --resume $SID" \
     "resume argv is exactly --model/--effort/--resume <id>, no trailing prompt"
-assert_not_contains "$out" "last working on" "resume carries no 'last working on' nudge"
-assert_not_contains "$out" "resume our previous" "resume carries no 'resume our previous' nudge"
+assert_absent "$out" "last working on" "resume carries no 'last working on' nudge"
+assert_absent "$out" "resume our previous" "resume carries no 'resume our previous' nudge"
 
 # --- T2: first-ever launch bootstraps via the role command ------------------
 echo "T2: first-ever architect launch uses --session-id + role command"
@@ -106,8 +75,8 @@ assert_contains "$out" "--session-id " "first launch passes --session-id"
 assert_contains "$out" "/role-opus-architect live" "first launch fires the role slash command"
 # the session-id file is now persisted for the next fleet-up to resume
 [[ -f "$H2/.fleet/sessions/opus-architect.session-id" ]] \
-    && { PASS=$((PASS + 1)); echo "  ok: first launch persisted the session-id file"; } \
-    || { FAIL=$((FAIL + 1)); echo "  FAIL: session-id file not written on first launch"; }
+    && ok "first launch persisted the session-id file" \
+    || bad "session-id file not written on first launch"
 
 # --- T3: game-architect resume path resolves the same way -------------------
 echo "T3: game-architect resume also drops the prompt"
@@ -131,6 +100,4 @@ assert_eq "$track" \
     "session-track: file=$H1/.fleet/sessions/opus-architect.session-id role=opus-architect mode=live" \
     "architect exports sidecar path, role, and mode for the hook"
 
-echo
-echo "passed: $PASS  failed: $FAIL"
-[[ "$FAIL" -eq 0 ]]
+summarize

--- a/scripts/fleet/tests/test_dispatcher_dry_run_mode.sh
+++ b/scripts/fleet/tests/test_dispatcher_dry_run_mode.sh
@@ -25,40 +25,14 @@ if [[ ! -x "$DISPATCHER" ]]; then
     exit 1
 fi
 
-PASS=0
-FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=""
 
 cleanup() {
     [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
 }
 trap cleanup EXIT
-
-assert_eq() {
-    local actual="$1" expected="$2" msg="$3"
-    if [[ "$actual" == "$expected" ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg"
-        echo "        expected: $expected"
-        echo "        actual:   $actual"
-    fi
-}
-
-assert_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if [[ "$haystack" == *"$needle"* ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg"
-        echo "        needle:   $needle"
-        echo "        haystack: $haystack"
-    fi
-}
 
 TMPROOT=$(mktemp -d)
 export FLEET_STATE_DIR="$TMPROOT/state"
@@ -95,9 +69,9 @@ assert_eq "${cmd_absent##* }" "live" "absent sentinel: trailing mode arg default
 # --- Test 3: usage error on missing args -----------------------------------
 echo "T3: --print-dispatch-command with missing pane_key → usage error"
 if "$DISPATCHER" --print-dispatch-command worker >/dev/null 2>&1; then
-    FAIL=$((FAIL + 1)); echo "  FAIL: missing pane_key should exit non-zero"
+    bad "missing pane_key should exit non-zero"
 else
-    PASS=$((PASS + 1)); echo "  ok: missing pane_key exits non-zero"
+    ok "missing pane_key exits non-zero"
 fi
 
 # --- Test 4: fleet-dispatch-wrap runs /role-<role> <mode> ------------------
@@ -138,6 +112,4 @@ else
     echo "  skip: fleet-dispatch-wrap not found at $WRAP"
 fi
 
-echo
-echo "passed: $PASS  failed: $FAIL"
-[[ "$FAIL" -eq 0 ]]
+summarize

--- a/scripts/fleet/tests/test_fleet_claim_safety_guards.sh
+++ b/scripts/fleet/tests/test_fleet_claim_safety_guards.sh
@@ -32,8 +32,8 @@ if [[ ! -x "$FLEET_CLAIM" ]]; then
     exit 1
 fi
 
-PASS=0
-FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=""
 
 cleanup() {
@@ -44,11 +44,9 @@ trap cleanup EXIT
 assert_exit() {
     local actual_exit="$1" expected_exit="$2" msg="$3"
     if [[ "$actual_exit" -eq "$expected_exit" ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
+        ok "$msg"
     else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg"
+        bad "$msg"
         echo "        expected exit: $expected_exit"
         echo "        actual exit:   $actual_exit"
     fi
@@ -57,48 +55,18 @@ assert_exit() {
 assert_no_dir() {
     local dir="$1" msg="$2"
     if [[ ! -d "$dir" ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
+        ok "$msg"
     else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg (dir exists: $dir)"
+        bad "$msg (dir exists: $dir)"
     fi
 }
 
 assert_dir() {
     local dir="$1" msg="$2"
     if [[ -d "$dir" ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
+        ok "$msg"
     else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg (dir missing: $dir)"
-    fi
-}
-
-assert_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if [[ "$haystack" == *"$needle"* ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg"
-        echo "        expected to contain: $needle"
-        echo "        actual:              $haystack"
-    fi
-}
-
-assert_not_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if [[ "$haystack" != *"$needle"* ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg"
-        echo "        expected NOT to contain: $needle"
-        echo "        actual:                  $haystack"
+        bad "$msg (dir missing: $dir)"
     fi
 }
 
@@ -245,13 +213,13 @@ release_quiet 5002
 echo "T8: --stackable-on <url> is not misflagged as a trailing --repo"
 err=$("$FLEET_CLAIM" claim 5002 test-agent \
         --stackable-on https://github.com/jakildev/IrredenEngine/pull/123 2>&1 1>/dev/null) || true
-assert_not_contains "$err" "must precede the subcommand" "stackable-on URL doesn't trip the --repo scan"
+assert_absent "$err" "must precede the subcommand" "stackable-on URL doesn't trip the --repo scan"
 
 # --- T9: cleanup keeps its own trailing --repo (exemption) ------------------
 echo "T9: cleanup exemption — trailing --repo is not hard-errored"
 err=$("$FLEET_CLAIM" cleanup --repo jakildev/IrredenEngine 2>&1 1>/dev/null) && actual=0 || actual=$?
 assert_exit "$actual" 0 "cleanup --repo <owner/repo> (empty claims) → exit 0"
-assert_not_contains "$err" "must precede the subcommand" "cleanup's trailing --repo is exempt"
+assert_absent "$err" "must precede the subcommand" "cleanup's trailing --repo is exempt"
 
 # --- T10: reconcile keeps its own trailing --repo (exemption) ---------------
 # reconcile parses its args before any gh/state access, so a trailing --repo
@@ -261,8 +229,6 @@ echo "T10: reconcile exemption — trailing --repo reaches reconcile's own parse
 err=$("$FLEET_CLAIM" reconcile --repo jakildev/IrredenEngine --bogus-flag 2>&1 1>/dev/null) && actual=0 || actual=$?
 assert_exit "$actual" 2 "reconcile --repo <owner/repo> --bogus-flag → exit 2 (its own error)"
 assert_contains "$err" "reconcile: unknown arg" "reconcile's own parser saw the trailing --repo"
-assert_not_contains "$err" "must precede the subcommand" "reconcile's trailing --repo is exempt from Guard 2"
+assert_absent "$err" "must precede the subcommand" "reconcile's trailing --repo is exempt from Guard 2"
 
-echo ""
-echo "PASS: $PASS  FAIL: $FAIL"
-[[ "$FAIL" -eq 0 ]]
+summarize

--- a/scripts/fleet/tests/test_fleet_gh_token.sh
+++ b/scripts/fleet/tests/test_fleet_gh_token.sh
@@ -19,17 +19,12 @@ SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 GHT="$SCRIPT_DIR/fleet-gh-token"
 [[ -x "$GHT" ]] || { echo "test setup: fleet-gh-token not executable at $GHT" >&2; exit 1; }
 
-PASS=0; FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=$(mktemp -d)
 cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
 trap cleanup EXIT
-ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
-bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
-assert_eq() {
-    local actual="$1" expected="$2" msg="$3"
-    if [[ "$actual" == "$expected" ]]; then ok "$msg"; else bad "$msg (expected [$expected], got [$actual])"; fi
-}
-assert_absent() { [[ -e "$1" ]] && bad "$2" || ok "$2"; }
+assert_no_path() { [[ -e "$1" ]] && bad "$2" || ok "$2"; }
 
 # --- throwaway RSA signing key + isolated conf/state ---
 KEY="$TMPROOT/app-key.pem"
@@ -92,7 +87,7 @@ rm -f "$CURL_STUB_ARGS"
 set +e; out=$(run_ght "$sd" 2>/dev/null); rc=$?; set -e
 assert_eq "$out" "ghs_CACHED" "cache hit -> serves cached token"
 assert_eq "$rc" "0" "cache hit -> exit 0"
-assert_absent "$CURL_STUB_ARGS" "cache hit -> no mint (curl not called)"
+assert_no_path "$CURL_STUB_ARGS" "cache hit -> no mint (curl not called)"
 
 # --- Case 3: cache miss → mints, writes cache, and the JWT is well-formed ---
 sd="$TMPROOT/s3"; mkdir -p "$sd"
@@ -133,7 +128,7 @@ write_cache "$sd" "ghs_FRESH" 400   # outside the 300s margin → serve cache
 rm -f "$CURL_STUB_ARGS"
 set +e; out=$(run_ght "$sd" 2>/dev/null); set -e
 assert_eq "$out" "ghs_FRESH" "outside stale margin -> serves cache"
-assert_absent "$CURL_STUB_ARGS" "outside stale margin -> no mint"
+assert_no_path "$CURL_STUB_ARGS" "outside stale margin -> no mint"
 
 # --- Case 5: lock held by a dead owner → cleaned up, then mints ---
 sd="$TMPROOT/s5"; mkdir -p "$sd"
@@ -146,7 +141,7 @@ rm -f "$CURL_STUB_ARGS"
 set +e; out=$(run_ght "$sd" 2>/dev/null); rc=$?; set -e
 assert_eq "$out" "ghs_AFTERCLEAN" "stale-owner lock -> cleaned and mints"
 assert_eq "$rc" "0" "stale-owner lock -> exit 0"
-assert_absent "$sd/gh-app-token.lock" "stale-owner lock -> lock released at exit"
+assert_no_path "$sd/gh-app-token.lock" "stale-owner lock -> lock released at exit"
 
 # --- Case 6: lock held by a LIVE owner → fall back to still-valid cache, no mint ---
 sd="$TMPROOT/s6"; mkdir -p "$sd"
@@ -161,7 +156,7 @@ set +e; out=$(run_ght "$sd" 2>/dev/null); rc=$?; set -e
 LOCK_TRIES=""
 assert_eq "$out" "ghs_WITHINMARGIN" "live-owner contention -> serves still-valid cache"
 assert_eq "$rc" "0" "live-owner contention -> exit 0"
-assert_absent "$CURL_STUB_ARGS" "live-owner contention -> no mint"
+assert_no_path "$CURL_STUB_ARGS" "live-owner contention -> no mint"
 
 # --- Case 7: group/other-readable signing key → warns on stderr, still serves ---
 sd="$TMPROOT/s7"; mkdir -p "$sd"
@@ -180,7 +175,4 @@ set -e
 assert_eq "$rc" "0" "loose-perm key -> still exit 0 (warn, not fail)"
 case "$err" in *"group/other-readable"*) ok "loose-perm key -> warns on stderr";; *) bad "loose-perm key -> missing warning: [$err]";; esac
 
-echo "================================"
-echo "  PASS: $PASS    FAIL: $FAIL"
-echo "================================"
-[[ "$FAIL" -eq 0 ]]
+summarize "fleet-gh-token tests"

--- a/scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
@@ -36,8 +36,8 @@ if [[ ! -x "$REBASE" ]]; then
     exit 1
 fi
 
-PASS=0
-FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=""
 
 cleanup() {
@@ -49,28 +49,6 @@ cleanup() {
     fi
 }
 trap cleanup EXIT
-
-assert_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        expected to find: $needle"
-        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
-    fi
-}
-
-assert_absent() {
-    local haystack="$1" needle="$2" msg="$3"
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        did NOT expect: $needle"
-        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
-    else
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    fi
-}
 
 # --- Sandbox ---------------------------------------------------------------
 TMPROOT=$(mktemp -d)
@@ -241,6 +219,4 @@ assert_absent   "$T3" "changed-file set drifted" "T3 no spurious file-set drift"
 assert_absent   "$T3" "conflicts; leaving for LLM" "T3 no conflict bail"
 
 # --- Summary ---------------------------------------------------------------
-echo ""
-echo "fleet-rebase inherited-drop tests: $PASS passed, $FAIL failed"
-[[ "$FAIL" -eq 0 ]]
+summarize "fleet-rebase inherited-drop tests"

--- a/scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
@@ -36,8 +36,8 @@ if [[ ! -x "$REBASE" ]]; then
     exit 1
 fi
 
-PASS=0
-FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=""
 
 cleanup() {
@@ -46,28 +46,6 @@ cleanup() {
     fi
 }
 trap cleanup EXIT
-
-assert_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        expected to find: $needle"
-        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
-    fi
-}
-
-assert_absent() {
-    local haystack="$1" needle="$2" msg="$3"
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        did NOT expect: $needle"
-        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
-    else
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    fi
-}
 
 # --- Sandbox ------------------------------------------------------------------
 TMPROOT=$(mktemp -d)
@@ -176,6 +154,4 @@ assert_absent "$T4" "would remove" \
     "T4 no stale label -> no cleanup"
 
 # --- Summary ------------------------------------------------------------------
-echo ""
-echo "fleet-rebase stale-conflict cleanup tests: $PASS passed, $FAIL failed"
-[[ "$FAIL" -eq 0 ]]
+summarize "fleet-rebase stale-conflict cleanup tests"

--- a/scripts/fleet/tests/test_session_track.sh
+++ b/scripts/fleet/tests/test_session_track.sh
@@ -36,35 +36,14 @@ if [[ ! -x "$TRACK" ]]; then
     exit 1
 fi
 
-PASS=0
-FAIL=0
+source "$(dirname "$0")/lib_assert.sh"
+
 TMPROOT=""
 
 cleanup() {
     [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
 }
 trap cleanup EXIT
-
-assert_eq() {
-    local actual="$1" expected="$2" msg="$3"
-    if [[ "$actual" == "$expected" ]]; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        expected: $expected"
-        echo "        actual:   $actual"
-    fi
-}
-
-assert_contains() {
-    local haystack="$1" needle="$2" msg="$3"
-    if [[ "$haystack" == *"$needle"* ]]; then
-        PASS=$((PASS + 1)); echo "  ok: $msg"
-    else
-        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
-        echo "        '$needle' not found in: $haystack"
-    fi
-}
 
 TMPROOT=$(mktemp -d -t fleet-session-track-test)
 
@@ -142,6 +121,4 @@ for bad in 'not json' '{}' '{"source":"clear"}' '{"session_id":""}' '{"session_i
 done
 assert_eq "$(cat "$F2")" "$before" "sidecar unchanged by malformed payloads"
 
-echo
-echo "passed: $PASS  failed: $FAIL"
-[[ "$FAIL" -eq 0 ]]
+summarize


### PR DESCRIPTION
## Summary
- New `scripts/fleet/tests/lib_assert.sh`: shared PASS/FAIL counters, `ok`/`bad`, `assert_eq`, `assert_contains`, `assert_absent`, and a `summarize` exit idiom for the bash test suite. Canonicalized on the fixed-string `grep -qF` matcher with indented-haystack diagnostics (the richest of the previously drifting copies).
- Converted the 7 tests that carried local copies to `source "$(dirname "$0")/lib_assert.sh"`: `test_fleet_rebase_inherited_drop.sh`, `test_fleet_rebase_stale_conflict_cleanup.sh`, `test_dispatcher_dry_run_mode.sh`, `test_session_track.sh`, `test_babysit_launch.sh`, `test_fleet_claim_safety_guards.sh`, `test_fleet_gh_token.sh`.
- `assert_not_contains` call sites → `assert_absent` (same semantics); gh_token's path-existence `assert_absent` renamed `assert_no_path` to free the name for the haystack form. File-specific asserts (`assert_exit`, `assert_dir`, `assert_no_dir`, `assert_no_path`) stay local, rebuilt on `ok`/`bad`.
- `scripts/fleet/CLAUDE.md` authoring rules now point new bash tests at the shared lib.

Net −103 lines. `test_fleet_rebase_plan_automerge.sh` (named in the task brief) does not exist in the tree; the actual carrier set was these 7.

## Test plan
- [x] All 7 converted tests pass (`PASS`/`FAIL` tallies: 14, 7, 13, 29, 8, 20, 23 — each identical to its pre-conversion run at HEAD, verified by re-running the originals side by side)
- [x] Failure path smoke-checked: `summarize` exits 1 and diagnostics render for `assert_contains`/`assert_absent`/`assert_eq` misses
- [x] `bash -n` clean on the lib and all 7 tests

## Notes for reviewer
~40 other tests under `scripts/fleet/tests/` still define local `assert_eq`/`ok`/`bad` copies — deliberately out of scope (this PR covers the `assert_contains`/`assert_absent` carriers); a follow-up task is queued for the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)