### PR TITLE
fleet: cwd-proof reviewer scratch resets + clone-freshness self-heal

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -69,10 +69,15 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
 1. `pwd` — confirm you are in the `opus-reviewer` worktree.
 2. **Discover repo slugs** — see [docs/agents/FLEET-CACHE.md § Repo slug discovery](../../docs/agents/FLEET-CACHE.md#repo-slug-discovery).
 3. Confirm you are on the throwaway branch
-   `claude/opus-reviewer-scratch`. If not, run these two commands
+   `claude/opus-reviewer-scratch`. If not, run these three commands
    separately (do NOT wrap in `cd ... &&`):
+   `fleet-assert-worktree opus-reviewer`
    `git -C ~/src/IrredenEngine fetch origin --quiet`
-   `git checkout -B claude/opus-reviewer-scratch origin/master`
+   `git -C ~/src/IrredenEngine/.claude/worktrees/opus-reviewer checkout -B claude/opus-reviewer-scratch origin/master`
+   The `-C` worktree path keeps the reset out of the shared main
+   clones even if the shell cwd drifted; if the assert fails, `cd`
+   back into your worktree first. See
+   [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline).
 4. **Read the shared fleet state cache** with the Read tool:
    `~/.fleet/state/state.json`. One Read replaces the two `gh pr
    list --json reviews,labels,...` calls that used to live here —
@@ -212,10 +217,17 @@ iteration of polling, reviewing, and exiting cleanly:
       If the gate decides "do not post a verdict," release the claim
       and move on.
    d. **Engine PRs:** Invoke the `review-pr` skill on the PR.
-      **Game PRs:** Read the diff with `fleet-pr diff <N> --repo game`
-      and review manually (you cannot check out game PRs into this
-      engine worktree). For game conventions, read
-      `~/src/IrredenEngine/creations/game/CLAUDE.md`.
+      **Game PRs:** game-PR review is **diff-only** — you have no
+      game worktree, and you must NOT check the PR out in the shared
+      game main clone (`creations/game`) or `cd` into it: a checkout
+      there freezes the game clone's master and blocks every game
+      claim fleet-wide (see
+      [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
+      Read the diff with `fleet-pr diff <N> --repo game`, file
+      context with read-only `git -C
+      ~/src/IrredenEngine/creations/game show origin/master:<path>`
+      or the Read tool, and review manually. For game conventions,
+      read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
    e. Focus your review on the items Sonnet could not confirm — do
       not duplicate work Sonnet already did. Your review body should
       explicitly call out the Sonnet review by saying "Sonnet flagged
@@ -247,10 +259,18 @@ iteration of polling, reviewing, and exiting cleanly:
    re-review round over a renamed variable.
 3. **Reset to scratch branch.** After reviewing all candidates (or if
    none existed), return to the scratch branch so no PR branch is left
-   checked out — other agents may need to check out the same branch:
-   `git checkout -B claude/opus-reviewer-scratch origin/master`
-   This prevents "branch already checked out in worktree" errors when
-   a worker agent tries to check out a PR branch you just reviewed.
+   checked out — other agents may need to check out the same branch.
+   Run as two separate commands (no `&&`):
+   `fleet-assert-worktree opus-reviewer`
+   `git -C ~/src/IrredenEngine/.claude/worktrees/opus-reviewer checkout -B claude/opus-reviewer-scratch origin/master`
+   The `-C` worktree path is mandatory — a bare `git checkout -B`
+   resolves against the shell's persisted cwd, and after a game-PR
+   pass that cwd can be the shared game main clone (see
+   [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
+   If the assert fails, `cd` back into your worktree before
+   continuing. This prevents "branch already checked out in worktree"
+   errors when a worker agent tries to check out a PR branch you just
+   reviewed.
 4. **Shutdown.** See [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/FLEET-RUNTIME.md#per-iteration-shutdown--final-step).
    `fleet-iteration-summary opus-reviewer "<PR numbers reviewed, verdicts, snags — under 100 words.>"`
    Reviewers do not reserve worktrees, so skip `release-worktree`; the

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -44,10 +44,15 @@ treat it as a hard rule for this role.
 2. **Discover repo slugs** — see [docs/agents/FLEET-CACHE.md § Repo slug discovery](../../docs/agents/FLEET-CACHE.md#repo-slug-discovery).
 3. Confirm you are on the throwaway branch:
    `git branch --show-current` should report something like
-   `claude/sonnet-reviewer-scratch`. If not, run these two commands
+   `claude/sonnet-reviewer-scratch`. If not, run these three commands
    separately (do NOT wrap in `cd ... &&`):
+   `fleet-assert-worktree sonnet-reviewer`
    `git -C ~/src/IrredenEngine fetch origin --quiet`
-   `git checkout -B claude/sonnet-reviewer-scratch origin/master`
+   `git -C ~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer checkout -B claude/sonnet-reviewer-scratch origin/master`
+   The `-C` worktree path keeps the reset out of the shared main
+   clones even if the shell cwd drifted; if the assert fails, `cd`
+   back into your worktree first. See
+   [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline).
    `gh pr checkout` will rewrite this branch on each review.
 4. **Read the shared fleet state cache** with the Read tool:
    `~/.fleet/state/state.json`. One Read replaces the two `gh pr
@@ -158,11 +163,18 @@ iteration of polling, reviewing, and exiting cleanly:
    c. **Run the review.**
       - **Engine PRs** (default repo): Invoke the `review-pr` skill
         with the PR number.
-      - **Game PRs** (`<game-repo>`): you cannot check out game PRs
-        into this engine worktree. Read the diff with `fleet-pr diff
-        <N> --repo game`, the PR details with `fleet-pr view <N>
-        --repo game`, and review manually — focus on code quality,
-        style, and obvious bugs. For game-specific conventions, read
+      - **Game PRs** (`<game-repo>`): game-PR review is **diff-only**
+        — you have no game worktree, and you must NOT check the PR out
+        in the shared game main clone (`creations/game`) or `cd` into
+        it: a checkout there freezes the game clone's master and
+        blocks every game claim fleet-wide (see
+        [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
+        Read the diff with `fleet-pr diff <N> --repo game`, the PR
+        details with `fleet-pr view <N> --repo game`, file context
+        with read-only `git -C ~/src/IrredenEngine/creations/game
+        show origin/master:<path>` or the Read tool, and review
+        manually — focus on code quality, style, and obvious bugs.
+        For game-specific conventions, read
         `~/src/IrredenEngine/creations/game/CLAUDE.md`.
    d. **Post the review body.** See
       [REVIEWER-PROTOCOL.md § Posting the review body](../../docs/agents/REVIEWER-PROTOCOL.md#posting-the-review-body)
@@ -216,10 +228,18 @@ iteration of polling, reviewing, and exiting cleanly:
    cost of a full re-review.
 3. **Reset to scratch branch.** After reviewing all candidates (or if
    none existed), return to the scratch branch so no PR branch is left
-   checked out — other agents may need to check out the same branch:
-   `git checkout -B claude/sonnet-reviewer-scratch origin/master`
-   This prevents "branch already checked out in worktree" errors when
-   a worker agent tries to check out a PR branch you just reviewed.
+   checked out — other agents may need to check out the same branch.
+   Run as two separate commands (no `&&`):
+   `fleet-assert-worktree sonnet-reviewer`
+   `git -C ~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer checkout -B claude/sonnet-reviewer-scratch origin/master`
+   The `-C` worktree path is mandatory — a bare `git checkout -B`
+   resolves against the shell's persisted cwd, and after a game-PR
+   pass that cwd can be the shared game main clone (see
+   [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
+   If the assert fails, `cd` back into your worktree before
+   continuing. This prevents "branch already checked out in worktree"
+   errors when a worker agent tries to check out a PR branch you just
+   reviewed.
 4. **Shutdown.** See [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/FLEET-RUNTIME.md#per-iteration-shutdown--final-step).
    `fleet-iteration-summary sonnet-reviewer "<PR numbers reviewed, verdicts, snags — under 100 words.>"`
    Reviewers do not reserve worktrees, so skip `release-worktree`; the

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -895,8 +895,7 @@ protesting.
 Before starting a reviewer session:
 
 ```bash
-cd ~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer
-git checkout -B claude/sonnet-reviewer-scratch origin/master
+git -C ~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer checkout -B claude/sonnet-reviewer-scratch origin/master
 ```
 
 Then inside the session you can `gh pr checkout 42`, review, post the

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -900,8 +900,14 @@ git checkout -B claude/sonnet-reviewer-scratch origin/master
 ```
 
 Then inside the session you can `gh pr checkout 42`, review, post the
-comment, and `git checkout -B claude/sonnet-reviewer-scratch origin/master`
-again for the next PR.
+comment, and re-park for the next PR with
+`git -C ~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer checkout -B claude/sonnet-reviewer-scratch origin/master`
+— always through the explicit `-C` worktree path, never a bare
+`git checkout -B`: the agent shell's cwd persists across commands, and
+a reset that resolves against a drifted cwd parks the scratch branch in
+a shared MAIN clone (the game clone got frozen this way twice; see
+`docs/agents/REVIEWER-PROTOCOL.md` § "Scratch reset & main-clone cwd
+discipline").
 
 Don't commit or push from a reviewer worktree. The `review-pr` skill
 enforces this, but a human reviewer should know too.

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -62,6 +62,49 @@ on your part — just don't expect to see mid-amend PRs.
 
 ---
 
+## Scratch reset & main-clone cwd discipline
+
+Both reviewer roles park their worktree on a throwaway branch
+(`claude/<role>-scratch`) at startup and re-park after the last
+candidate. Two rules keep that reset from contaminating shared state:
+
+**1. The reset must be cwd-proof.** The Bash tool's working directory
+persists across calls, so a `cd` from earlier in the iteration
+silently redirects a bare `git checkout -B …` at whatever repo the
+shell happens to be sitting in — observed twice landing a reviewer
+scratch branch in the shared game MAIN clone (2026-07-09,
+2026-07-13). Run the reset as two separate commands (no `&&`), with
+the checkout going through an explicit `-C` worktree path so the cwd
+is irrelevant:
+
+```
+fleet-assert-worktree <your-worktree-name>
+git -C ~/src/IrredenEngine/.claude/worktrees/<your-worktree-name> checkout -B claude/<role>-scratch origin/master
+```
+
+If `fleet-assert-worktree` exits non-zero, the shell has drifted out
+of your worktree — later relative-path steps (`.review-body.md`)
+would misroute too. Run
+`cd ~/src/IrredenEngine/.claude/worktrees/<your-worktree-name>` as
+its own Bash call, re-run the assert, then do the reset.
+
+**2. Never run mutating git in a shared MAIN clone** — neither the
+engine clone (`~/src/IrredenEngine`) nor the game clone
+(`~/src/IrredenEngine/creations/game`). Reviewers have **no game
+worktree**, and "you cannot check out game PRs into this engine
+worktree" does NOT mean "check them out in the game clone instead" —
+it means game-PR review is diff-only. Read the diff with `fleet-pr
+diff <N> --repo game`; read game file context with read-only
+commands (`git -C ~/src/IrredenEngine/creations/game show
+origin/master:<path>`, `… log`, `… ls-tree`) or the Read tool. Never
+`cd` there, never `gh pr checkout` there, never
+`checkout`/`switch`/`reset`/`stash` there. A reviewer scratch branch
+parked in the game main clone freezes that clone's master ref, and
+the clone-freshness gate (`assert_clone_fresh`) then refuses EVERY
+game-repo claim fleet-wide until the clone is put back on master.
+
+---
+
 ## Stack awareness — gate on upstream status, then note context
 
 A stacked PR's `baseRefName` IS its upstream PR's `headRefName`. The
@@ -359,6 +402,13 @@ role file.
 - **Never commit, push, or open PRs from a reviewer worktree.** The
   `review-pr` skill documents this as an anti-pattern; treat it as a
   hard rule.
+- **Never `cd` into or run mutating git in a shared MAIN clone**
+  (engine `~/src/IrredenEngine` or game
+  `~/src/IrredenEngine/creations/game`), and always use the
+  `fleet-assert-worktree` + `git -C <your-worktree>` form for the
+  scratch reset — see § Scratch reset & main-clone cwd discipline. A
+  scratch branch parked in a main clone freezes its master and blocks
+  every claim on that repo via the clone-freshness gate.
 - **Never `gh pr review --approve` or `--request-changes`.** All fleet
   agents share one GitHub account and GitHub rejects formal review
   actions on your own PRs. Always use `--comment` with a clear verdict

--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -36,7 +36,11 @@
 #                                     rev-parse only, NEVER fetches.
 #   advance_main_clone  <repo_root>  — guarded, rate-limited fetch + ff-only
 #                                     advance of a clean on-master clone. Never
-#                                     switches branches, never resets --hard.
+#                                     resets --hard; never switches branches
+#                                     except the one self-heal case: a clean
+#                                     tree parked on a claude/*-reviewer-scratch
+#                                     branch (provably junk from a reviewer cwd
+#                                     drift) is put back on master.
 #   restore_main_clone_to_master <repo_root>
 #                                   — fleet-up-time stronger variant: returns a
 #                                     clone parked off-master (PR branch from a
@@ -100,7 +104,8 @@ assert_clone_fresh() {
 # Guarded, rate-limited fast-forward of the main clone's master. Safe on the
 # shared main checkout: advances ONLY when the clone is on branch master, has a
 # clean working tree, and master is a strict pure-ancestor of origin/master
-# (i.e. a real fast-forward). Any guard miss → skip + warn, never mutate. Mirrors
+# (i.e. a real fast-forward). Any guard miss → skip + warn, never mutate —
+# except the reviewer-scratch self-heal in guard 1 (see comment there). Mirrors
 # fleet-up's reset_worktree dirty-guard idiom. Always returns 0 so a `set -e`
 # caller is never aborted by a skipped advance.
 advance_main_clone() {
@@ -125,14 +130,32 @@ advance_main_clone() {
 
     # Guard 1: must be on branch master (never touch a checked-out feature
     # branch — agents occasionally check one out in the shared main clone).
-    local branch
+    # Exception: a reviewer scratch branch (claude/<role>-reviewer-scratch) is a
+    # per-iteration throwaway that only ever belongs in .claude/worktrees/* —
+    # one parked HERE is provably junk left by a reviewer whose shell cwd
+    # drifted into the main clone, and it freezes master (blocking every claim
+    # on this repo via assert_clone_fresh) until fixed. Self-heal: with a clean
+    # tree, put the clone back on master, drop the junk branch, and fall
+    # through to the normal advance.
+    local branch dirty
     branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
     if [[ "$branch" != "master" ]]; then
-        echo "fleet-clone-freshness: $root is on '$branch' (not master) — skipping advance." >&2
-        return 0
+        dirty="$(git -C "$root" status --porcelain 2>/dev/null || echo SKIP)"
+        if [[ "$branch" == claude/*-reviewer-scratch && -z "$dirty" ]]; then
+            if git -C "$root" checkout master --quiet 2>/dev/null; then
+                git -C "$root" branch -D "$branch" --quiet 2>/dev/null || true
+                echo "fleet-clone-freshness: $root was parked on reviewer scratch branch '$branch' (clean tree) — self-healed back to master and deleted the junk branch." >&2
+                branch=master
+            else
+                echo "fleet-clone-freshness: $root parked on '$branch' but 'git checkout master' failed — master is FROZEN and every claim on this repo will be refused until a human fixes it (git -C $root checkout master)." >&2
+                return 0
+            fi
+        else
+            echo "fleet-clone-freshness: $root is on '$branch' (not master) — skipping advance. master is FROZEN and every claim on this repo will be refused until it is put back (git -C $root checkout master)." >&2
+            return 0
+        fi
     fi
     # Guard 2: clean working tree (never clobber uncommitted work).
-    local dirty
     dirty="$(git -C "$root" status --porcelain 2>/dev/null || echo SKIP)"
     if [[ -n "$dirty" && "$dirty" != "SKIP" ]]; then
         echo "fleet-clone-freshness: $root has uncommitted changes — skipping advance." >&2

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -120,6 +120,33 @@ echo "$out" | grep -q "not master" && ok "warns about non-master clone" || fail 
 git_q "$CLONE" checkout master
 git_q "$CLONE" branch -D feature/x
 
+# --- T5b: reviewer-scratch self-heal — clean tree parked on scratch heals ----
+echo "T5b: reviewer-scratch self-heal (clean tree)"
+reset_rate_limit
+advance_main_clone "$CLONE" 2>/dev/null            # sync to origin first
+git_q "$CLONE" checkout -B claude/opus-reviewer-scratch origin/master
+push_new_commit s1
+reset_rate_limit
+out=$(advance_main_clone "$CLONE" 2>&1 || true)
+[[ "$(git -C "$CLONE" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "clone put back on master" || fail "clone still on $(git -C "$CLONE" rev-parse --abbrev-ref HEAD)"
+behind=$(clone_behind_count "$CLONE")
+[[ "$behind" == "0" ]] && ok "advance continued after self-heal (behind 0)" || fail "behind=$behind after self-heal"
+if git -C "$CLONE" rev-parse --verify --quiet refs/heads/claude/opus-reviewer-scratch >/dev/null; then fail "junk scratch branch not deleted"; else ok "junk scratch branch deleted"; fi
+echo "$out" | grep -q "self-healed" && ok "logs the self-heal" || fail "no self-heal log: $out"
+
+# --- T5c: reviewer-scratch + dirty tree — refuse self-heal, warn loudly ------
+echo "T5c: reviewer-scratch with dirty tree is NOT self-healed"
+git_q "$CLONE" checkout -B claude/sonnet-reviewer-scratch origin/master
+echo "dirt" >> "$CLONE/file"
+push_new_commit s2
+reset_rate_limit
+out=$(advance_main_clone "$CLONE" 2>&1 || true)
+[[ "$(git -C "$CLONE" rev-parse --abbrev-ref HEAD)" == "claude/sonnet-reviewer-scratch" ]] && ok "dirty scratch clone left untouched" || fail "branch changed on dirty scratch clone"
+echo "$out" | grep -q "FROZEN" && ok "loud frozen-master warning" || fail "no loud warning: $out"
+git_q "$CLONE" checkout -- file
+git_q "$CLONE" checkout master
+git_q "$CLONE" branch -D claude/sonnet-reviewer-scratch
+
 # --- T6: dirty guard — never clobber uncommitted work ------------------------
 echo "T6: dirty working tree guard"
 reset_rate_limit


### PR DESCRIPTION
## Summary
- Reviewer roles twice stranded the shared game main clone (`creations/game`) on `claude/<role>-reviewer-scratch` branches (opus 07-09, sonnet 07-13), freezing its master ref and blocking all game-repo claims via the clone-freshness guard. Root cause: the role docs' bare `git checkout -B claude/<role>-scratch origin/master` resolves against the Bash session's persisted cwd, and the game-PR pass sends reviewers into `creations/game` for file context.
- Both reviewer role docs (`role-sonnet-reviewer.md`, `role-opus-reviewer.md`) now run `fleet-assert-worktree <role>` + an explicit `git -C ~/src/IrredenEngine/.claude/worktrees/<role>` scratch reset at both reset sites (startup step 3 and loop step 3).
- Game-PR review steps rewritten as **diff-only**: "cannot check out into this engine worktree" no longer reads as "check out in the game clone instead"; file context comes from read-only `git -C creations/game show origin/master:<path>` or the Read tool.
- New canonical section in `REVIEWER-PROTOCOL.md` ("Scratch reset & main-clone cwd discipline") + a reviewer hard rule, so the two role docs can't drift; `AGENT_FLEET_SETUP.md` §9 updated to match.
- `fleet-clone-freshness.sh advance_main_clone` now **self-heals** the provably-junk case — main clone parked on `claude/*-reviewer-scratch` with a clean tree is checked back out to master, the junk branch deleted, and the ff-advance continues — and its skip warnings now say loudly that master is FROZEN and all claims on the repo will be refused, with the remedy command.

## Test plan
- [x] `bash scripts/fleet/tests/test_clone_freshness.sh` — 22/22 pass, including new T5b (clean reviewer-scratch park self-heals to master, junk branch deleted, advance continues) and T5c (dirty reviewer-scratch park refused with loud FROZEN warning).
- [x] `fleet-validate-roles` passes.
- [ ] Human merge required: touches gated self-config (`.claude/commands/role-*.md`).

## Notes for reviewer
The self-heal deliberately triggers ONLY on `claude/*-reviewer-scratch` + clean tree — any other parked branch or a dirty tree keeps the existing skip-and-warn behavior (now louder). Guard-1's dirty check runs before the branch switch, so uncommitted work can never be clobbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)