### PR TITLE
fleet: break the dispatch-wrap stale-resume loop

### DIFF
--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -160,9 +160,23 @@ worktree_in_flight() {
     local _resv; _resv=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
     [[ -n "$_resv" ]] && return 0
     local _br; _br=$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    [[ "$_br" == claude/* ]] || return 1
-    [[ -n "$(git -C "$PWD" status --porcelain 2>/dev/null)" ]] && return 0
-    local _ahead; _ahead=$(git -C "$PWD" rev-list --count origin/master..HEAD 2>/dev/null || echo 0)
+    # Task branches only. Scratch branches (claude/<x>-scratch) are throwaway
+    # by definition and must never pin a resume — worker-2 spent 07-09→07-14
+    # resuming a dead session because its scratch branch matched claude/*.
+    [[ "$_br" == claude/* && "$_br" != *-scratch ]] || return 1
+    # Tracked modifications only. Untracked leftovers (a screenshots dir from
+    # a shipped task, stray body files) are junk, not work a resumed session
+    # would continue.
+    [[ -n "$(git -C "$PWD" status --porcelain 2>/dev/null | grep -v '^??')" ]] && return 0
+    # Unpushed commits. Measure against the branch's OWN remote ref when one
+    # exists — a fully-pushed branch loses nothing by going fresh, and a
+    # squash-merged branch stays "ahead of origin/master" forever. Fall back
+    # to origin/master only for a never-pushed branch.
+    local _upstream="origin/master"
+    if git -C "$PWD" rev-parse --verify --quiet "refs/remotes/origin/$_br" >/dev/null 2>&1; then
+        _upstream="origin/$_br"
+    fi
+    local _ahead; _ahead=$(git -C "$PWD" rev-list --count "$_upstream..HEAD" 2>/dev/null || echo 0)
     [[ "$_ahead" =~ ^[0-9]+$ && "$_ahead" -gt 0 ]] && return 0
     return 1
 }
@@ -282,7 +296,23 @@ if (( _resume_role )); then
     if (( RESUMED )) && [[ "$rc" != "0" ]]; then
         rm -f "$SIDECAR"
     elif worktree_in_flight; then
-        :   # keep the sidecar — resume on the next dispatch
+        if (( RESUMED )); then
+            # Bounded resumes: a resumed session that exits CLEANLY while the
+            # worktree still looks in-flight gets one more try, then the
+            # sidecar clears and the next dispatch goes fresh (the
+            # claim/reservation path re-derives the task). An unbounded keep
+            # re-resumes a conversation that considers itself finished — the
+            # "No task to resume." $0.04 no-op loop — every dispatch forever.
+            _resumes=$(_read_sidecar resumes); _resumes=${_resumes:-0}
+            if [[ "$_resumes" =~ ^[0-9]+$ ]] && (( _resumes >= 1 )); then
+                rm -f "$SIDECAR"
+                echo "fleet-dispatch-wrap: resumed session exited clean twice with the worktree still in-flight — clearing sidecar; next dispatch goes fresh" >&2
+            else
+                python3 -c "import json;p='$SIDECAR';d=json.load(open(p));d['resumes']=int(d.get('resumes') or 0)+1;json.dump(d,open(p,'w'))" 2>/dev/null \
+                    || rm -f "$SIDECAR"
+            fi
+        fi
+        # fresh launch + in-flight: keep the sidecar — resume on the next dispatch
     else
         rm -f "$SIDECAR"
     fi

--- a/scripts/fleet/tests/test_dispatch_wrap_session.sh
+++ b/scripts/fleet/tests/test_dispatch_wrap_session.sh
@@ -58,8 +58,13 @@ cat > "$BIN/git" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
   *"rev-parse --abbrev-ref HEAD"*) echo "${STUB_BRANCH:-master}" ;;
-  *"status --porcelain"*) [[ -n "${STUB_DIRTY:-}" ]] && echo " M f" ;;
-  *"rev-list --count"*) echo "${STUB_AHEAD:-0}" ;;
+  *"rev-parse --verify --quiet refs/remotes/origin/"*) exit "${STUB_REMOTE_REF_RC:-1}" ;;
+  *"status --porcelain"*)
+    [[ -n "${STUB_DIRTY:-}" ]] && echo " M f"
+    [[ -n "${STUB_UNTRACKED:-}" ]] && echo "?? junk/"
+    ;;
+  *"rev-list --count origin/master..HEAD"*) echo "${STUB_AHEAD:-0}" ;;
+  *"rev-list --count"*) echo "${STUB_AHEAD_OWN:-0}" ;;
   *) : ;;
 esac
 exit 0
@@ -164,6 +169,35 @@ grep -q -- '^--repo game planning-release 7 worker-1$' "$FLEET_CLAIM_LOG" \
   || bad "resume: no planning-release call: $(cat "$FLEET_CLAIM_LOG")"
 unset FLEET_CLAIM_LOG
 rm -f "$SIDECAR"
+
+# --- in-flight false positives + resume-loop breaker (worker-2, 07-09→07-14) --
+echo "T11: scratch branch is never in-flight — sidecar cleared even when dirty"
+rm -f "$SIDECAR"
+STUB_BRANCH="claude/worker-1-scratch" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ ! -f "$SIDECAR" ]] && ok "scratch branch cleared the sidecar" || bad "scratch branch kept the sidecar"
+
+echo "T12: untracked-only junk is not in-flight — sidecar cleared"
+rm -f "$SIDECAR"
+STUB_BRANCH="claude/123-foo" STUB_UNTRACKED=1 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ ! -f "$SIDECAR" ]] && ok "untracked-only cleared the sidecar" || bad "untracked junk kept the sidecar"
+
+echo "T13: fully-pushed branch (own remote ref current) is not in-flight"
+rm -f "$SIDECAR"
+# Remote ref exists (RC=0); 0 unpushed vs own ref; 5 "ahead" of master (the
+# squash-merge illusion) — must clear.
+STUB_BRANCH="claude/123-foo" STUB_REMOTE_REF_RC=0 STUB_AHEAD=5 STUB_AHEAD_OWN=0 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ ! -f "$SIDECAR" ]] && ok "pushed branch cleared the sidecar (no squash-merge pin)" || bad "pushed branch kept the sidecar"
+
+echo "T14: resume-loop breaker — clean resumed exit twice while in-flight clears"
+printf '{"session_id":"SID-LOOP","role":"worker","model":"sonnet","effort":"high","created_epoch":1}\n' > "$SIDECAR"
+# 1st resumed clean exit, genuinely in-flight (task branch + tracked dirty): kept, resumes=1.
+STUB_BRANCH="claude/123-foo" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap sonnet high worker
+[[ -f "$SIDECAR" ]] && ok "1st clean resume kept the sidecar" || bad "1st clean resume cleared too early"
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert d.get('resumes')==1" 2>/dev/null \
+  && ok "resume counter recorded (resumes=1)" || bad "resume counter missing/wrong: $(cat "$SIDECAR" 2>/dev/null)"
+# 2nd resumed clean exit, still in-flight: breaker fires, sidecar cleared.
+STUB_BRANCH="claude/123-foo" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap sonnet high worker
+[[ ! -f "$SIDECAR" ]] && ok "2nd clean resume cleared the sidecar (loop broken)" || bad "2nd clean resume kept the sidecar (loop!)"
 
 echo
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- Fixes the worker lane's silent degradation (Jul 9 → Jul 14): `fleet-dispatch-wrap` resumed the same finished session on every worker-2 dispatch — one "No task to resume." turn, clean exit, sidecar kept — because `worktree_in_flight` false-positived on (a) the throwaway `claude/worker-2-scratch` branch matching the `claude/*` task-branch glob and (b) an untracked leftover screenshots dir counting as uncommitted work. Each resume also overrides the dispatcher's class (opus/xhigh requests degraded to sonnet no-ops), and three fast exits stood the whole worker lane down while semantic-conflict PRs sat unclaimed.
- `worktree_in_flight` now: excludes `*-scratch` branches; counts only tracked modifications (`status --porcelain` minus `??`); measures unpushed commits against the branch's **own** remote ref when one exists (squash-merged branches look "ahead of origin/master" forever) with the origin/master fallback kept for never-pushed branches.
- Defense in depth — bounded resumes: a resumed session that exits cleanly while the worktree still looks in-flight gets exactly one more resume (a `resumes` counter in the sidecar), then the sidecar clears and the next dispatch goes fresh via the claim/reservation path. No stale-state false positive can loop unbounded again.
- Operational recovery already applied on this host (stale sidecar deleted, junk cleaned, worker re-armed); this PR is the durable fix.

## Test plan
- [x] `test_dispatch_wrap_session.sh` — 29/29 (new T11 scratch-branch, T12 untracked-only, T13 pushed-branch/squash-illusion, T14 two-strike resume breaker; T1–T10 unchanged)
- [x] `bash -n scripts/fleet/fleet-dispatch-wrap`

## Notes for reviewer
The lifecycle semantics for genuine interruptions are preserved: hard kill → sidecar survives → resume once; a genuinely in-flight clean exit still gets one resume before the breaker fires. T6/T6b/T6c pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)