### PR TITLE
docs/fleet: cwd-proof scratch resets in worker, merger, smoke docs

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -80,9 +80,18 @@ the cooldown label prevents an immediate retry.
    `[merger] Auto-rebases stale PRs and auto-resolves whitespace-only conflicts. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `merger` worktree.
 2. Reset to the throwaway branch unconditionally — `-B` makes it
-   idempotent. Run as two separate Bash calls:
+   idempotent. Run as three separate Bash calls (do NOT wrap in
+   `cd ... &&`):
+   `fleet-assert-worktree merger`
    `git -C ~/src/IrredenEngine fetch origin --quiet`
-   `git checkout -B claude/merger-scratch origin/master`
+   `git -C ~/src/IrredenEngine/.claude/worktrees/merger checkout -B claude/merger-scratch origin/master`
+   A bare `git checkout -B` resolves against the Bash tool's persisted
+   cwd and has parked scratch branches in shared main clones, freezing
+   their master and blocking claims via the clone-freshness gate — the
+   explicit `-C` worktree path makes the reset cwd-proof. If the
+   assert fails, `cd` back into the merger worktree as its own Bash
+   call first (see
+   [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
 3. Print `merger standing by` (or `merger standing by (dry-run)`
    if Mode above is `dry-run`). Don't pre-fetch the PR list —
    the first loop iteration does that and any startup-time fetch
@@ -176,7 +185,7 @@ exit cleanly:
      `git checkout --detach origin/<headRefName>`
 
      After running the 5a.5 ii actions, reset to scratch (step 5f):
-     `git checkout -B claude/merger-scratch origin/master`.
+     `git -C ~/src/IrredenEngine/.claude/worktrees/merger checkout -B claude/merger-scratch origin/master`.
 
      Log: `... reconcile: base #<N> merged, re-targeted + rebased onto master`.
 
@@ -295,7 +304,7 @@ exit cleanly:
       - Log: `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: cascade-rebase conflict onto #<base-pr-number>, labeled fleet:needs-base-update`
 
    d. **Reset to scratch.** Same as step 5f:
-      `git checkout -B claude/merger-scratch origin/master`
+      `git -C ~/src/IrredenEngine/.claude/worktrees/merger checkout -B claude/merger-scratch origin/master`
 
 3. Filter to candidates. A PR is a candidate if:
    - `mergeable == "CONFLICTING"`, OR
@@ -744,8 +753,11 @@ exit cleanly:
       fail), return to the scratch branch so the next iteration
       starts clean. With detached HEAD in step a this reset no
       longer matters for unblocking other agents (the branch was
-      never claimed) — it's purely worktree hygiene:
-      `git checkout -B claude/merger-scratch origin/master`
+      never claimed) — it's purely worktree hygiene. Use the explicit
+      `-C` worktree path (a bare checkout resolves against the shell's
+      persisted cwd and can park the scratch branch in a shared main
+      clone — see startup step 2):
+      `git -C ~/src/IrredenEngine/.claude/worktrees/merger checkout -B claude/merger-scratch origin/master`
 
 ## Game-repo pass
 
@@ -765,8 +777,13 @@ worktree, and `gh` target change.
 - **PR source** — read `repos.game.prs[]` from the cache (not
   `repos.engine.prs[]`).
 - **Scratch branch** — reset the game worktree to scratch up front and
-  after each PR: `git checkout -B claude/merger-scratch origin/master`
-  (run from the game worktree, so `origin` is the game remote).
+  after each PR:
+  `git -C ~/src/IrredenEngine/creations/game/.claude/worktrees/merger checkout -B claude/merger-scratch origin/master`
+  The `-C` path targets the game WORKTREE (never the shared game main
+  clone `~/src/IrredenEngine/creations/game` — a scratch branch parked
+  there freezes the game clone's master and blocks every game claim
+  via the clone-freshness gate) and resolves `origin` to the game
+  remote regardless of where the shell cwd has drifted.
 - **Shared cap** — the "at most 2 candidates per iteration" cap is a
   **single budget across both passes**. If the engine pass already
   rebased 2 PRs, do the game cooldown-clear (below) but process zero

--- a/.claude/commands/role-smoke-worker.md
+++ b/.claude/commands/role-smoke-worker.md
@@ -55,11 +55,19 @@ See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNT
 
 3. Confirm you are on the scratch branch:
    `git branch --show-current` should report `claude/<your-worktree-basename>-scratch`.
-   If not, check out the scratch branch before proceeding:
+   If not, check out the scratch branch before proceeding — run each
+   command as its own Bash call (do NOT wrap in `cd ... &&`):
    ```
+   fleet-assert-worktree <your-worktree-basename>
    git fetch origin --quiet
-   git checkout -B claude/<your-worktree-basename>-scratch origin/master
+   git -C ~/src/IrredenEngine/.claude/worktrees/<your-worktree-basename> checkout -B claude/<your-worktree-basename>-scratch origin/master
    ```
+   A bare `git checkout -B` resolves against the Bash tool's persisted
+   cwd and has parked scratch branches in shared main clones — the
+   explicit `-C` worktree path makes the reset cwd-proof. If the
+   assert fails, `cd` back into your worktree as its own Bash call
+   first (see
+   [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
    `gh pr checkout` will rewrite this branch for each smoke run.
 
 4. **Detect your host key** from `uname -s`:
@@ -193,8 +201,13 @@ failed:
 
 ```
 fleet-claim review-release <N> <your-worktree-basename>
-git checkout -B claude/<your-worktree-basename>-scratch origin/master
+fleet-assert-worktree <your-worktree-basename>
+git -C ~/src/IrredenEngine/.claude/worktrees/<your-worktree-basename> checkout -B claude/<your-worktree-basename>-scratch origin/master
 ```
+
+Same cwd-proofing as startup step 3: the `-C` worktree path keeps the
+reset out of the shared main clones even if the shell cwd drifted; if
+the assert fails, `cd` back into your worktree first.
 
 ### Step 7 — shutdown
 

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -488,7 +488,15 @@ Do the work, then exit cleanly:
        checkout` runs there):
        `fleet-claim resolving-release <N> <your-worktree-basename>`
        (game: `fleet-claim --repo game resolving-release <N> <your-worktree-basename>`)
-       `git checkout -B claude/<your-worktree-basename>-scratch origin/master`
+       `fleet-assert-worktree <your-worktree-basename>`
+       `git -C ~/src/IrredenEngine/.claude/worktrees/<your-worktree-basename> checkout -B claude/<your-worktree-basename>-scratch origin/master`
+       (game PR: `git -C ~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-basename> checkout -B claude/<your-worktree-basename>-scratch origin/master`)
+       A bare `git checkout -B` resolves against the Bash tool's
+       persisted cwd and has parked scratch branches in shared main
+       clones — the explicit `-C` worktree path makes the reset
+       cwd-proof. If the assert fails, `cd` back into your worktree
+       as its own Bash call first (see
+       [REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](../../docs/agents/REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
        The `build-game` dir, if you created one, is reused next iteration
        — leave it.
 

--- a/docs/agents/FLEET-CROSS-HOST-SMOKE.md
+++ b/docs/agents/FLEET-CROSS-HOST-SMOKE.md
@@ -241,8 +241,16 @@ smoke passed or failed:
 
 ```
 fleet-claim review-release <N> <your-worktree-basename>
-git checkout -B claude/<your-worktree-basename>-scratch origin/master
+fleet-assert-worktree <your-worktree-basename>
+git -C ~/src/IrredenEngine/.claude/worktrees/<your-worktree-basename> checkout -B claude/<your-worktree-basename>-scratch origin/master
 ```
+
+Run each command as its own Bash call. A bare `git checkout -B`
+resolves against the Bash tool's persisted cwd and has parked scratch
+branches in shared main clones — the explicit `-C` worktree path makes
+the reset cwd-proof. If the assert fails, `cd` back into your worktree
+as its own Bash call first (see
+[REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline](REVIEWER-PROTOCOL.md#scratch-reset--main-clone-cwd-discipline)).
 
 Queue-tick's `cleanup --gh` would sweep a forgotten
 `fleet:reviewing-*` label after 30 min, but during that window the


### PR DESCRIPTION
## Summary
- Applies the PR #2381 scratch-reset hardening (`fleet-assert-worktree` guard + explicit `git -C <worktree-path>`) to the remaining bare-cwd `git checkout -B claude/*-scratch origin/master` sites: worker step 1c.k, all five merger reset sites (startup, step 2.5 reconcile, step 2.6.d cascade, step 5f, game pass), both smoke-worker sites (startup + release/reset), and the cross-host smoke protocol's release+reset block.
- Worker and smoke-worker resets stay parameterized by worktree basename; worker's step 1c.k gains the game-worktree variant for game PRs.
- The merger game pass now spells out the game worktree path (`creations/game/.claude/worktrees/merger`) so the reset can never resolve against the shared game main clone and freeze its master.

## Test plan
- [ ] `grep -rn "checkout -B claude/" .claude/commands/ docs/` shows no remaining bare (non-`git -C`) scratch resets outside the reviewer docs covered by #2381
- [ ] Cross-reference links resolve after #2381 merges (see note below)

## Notes for reviewer
- Docs-only diff; every touched file is gated self-config (`role-*.md`) or fleet protocol docs — **needs human merge**.
- Companion to PR #2381: the cited anchor `REVIEWER-PROTOCOL.md § Scratch reset & main-clone cwd discipline` is added by that PR, so merge #2381 first (or accept a briefly forward-referencing link — the file itself already exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)