### PR TITLE
docs/fleet: absorb coding-improvement batch — 15 rules across 12 surfaces

### DIFF
--- a/.claude/agents/review-invariant-render.md
+++ b/.claude/agents/review-invariant-render.md
@@ -37,6 +37,8 @@ For changed files under `engine/render/`, `engine/prefabs/irreden/render/`, or a
 
 8. **Position-component selection.** A render system reading `C_Position3D` for visual placement instead of `C_PositionGlobal3D` (`APPLY_POSITION_OFFSET` has already folded any modifier-driven offset into globalPos).
 
+9. **Transient shared-slot restoration.** A new function that `bindRange`s/`bindBase`s a `kBufferIndex_*` slot already bound elsewhere to a different buffer (the reuse-transiently gotcha in `engine/render/CLAUDE.md` §Gotchas — e.g. `kBufferIndex_PerAxisCell{Compacted,Indirect}`, `kBufferIndex_CompactedVoxelIndices`, `kBufferIndex_IndirectDispatchParams`) must restore the original binding before returning — do not assume a downstream system restores it; that only holds until a pipeline reorder. Also confirm the aliasing constant's declaration comment in `ir_render_types.hpp` lists the new transient consumer, so a "who uses slot N" audit finds it.
+
 ## Lighting stage (additional checks)
 
 If the diff touches `system_*ao*`, `system_*shadow*`, `system_*flood*`, `system_*fog*`, `system_build_light_occlusion_grid*`, or `c_compute_*shadow*.glsl` / `.metal`:

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -462,7 +462,15 @@ Do the work, then exit cleanly:
        watertight when the worker resolves before the merger fires):
        `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:merger-cooldown"`
        Then jump to step k (reset).
-    j. **Resolution failed (escalation).** When to escalate:
+    j. **Resolution failed (escalation).** Before escalating, scan the PR
+       thread (`gh pr view <N> --comments`) for an architect /
+       `fleet:design-*` direction posted since the conflict arose: if an
+       in-thread ruling already resolves the conflicting intent, execute
+       it (or route via the `fleet:design-unblocked` path) instead of
+       re-asking the human — escalating past an existing ruling produces a
+       contradictory-signal PR and an avoidable human round-trip (#2257:
+       the escalation ignored a re-scope direction posted 30 minutes
+       earlier in the same thread). When to escalate:
        - The two sides did substantively different things and you
          can't tell from the code which intent should win (master
          rewrote a function, PR also rewrote it, neither is a

--- a/.claude/rules/cpp-ecs-smells.md
+++ b/.claude/rules/cpp-ecs-smells.md
@@ -100,3 +100,14 @@ In any system `tick` function:
   the integer at the binding boundary. See
   [`cpp-lua-enums.md`](cpp-lua-enums.md) for the full pattern and
   allowlist.
+
+- **A Lua `createEntityBatch*` call whose factory-argument count differs
+  from the C++ `registerCreateEntityBatchFunction<...>` registration arity**
+  for that name. The generated binding
+  (`wrapCreateEntityBatchWithFunctions<...>`) reads exactly N positional
+  factories and Lua silently ignores args past a C function's fixed arity —
+  so "add a component by appending one more factory" (correct for C++
+  `createEntity` spawns) silently no-ops: no error, the component never
+  attaches, and a system whose archetype requires it just never matches.
+  Adding a factory means extending the C++ registration's template arity in
+  the same change.

--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -82,11 +82,21 @@ selection heuristic, in order:
 
 1. **Diff touches `creations/demos/<name>/`** → use `IR<NameCamelCase>`
    (e.g. `shape_debug/` → `IRShapeDebug`).
-2. **Diff touches only engine render code** (`engine/render/**`,
+2. **Diff touches the sun-shadow / lighting / AO shader family**
+   (`ir_sun_*`, `c_bake_sun_shadow_map`, `c_clear_sun_shadow_map`,
+   `c_compute_sun_shadow`, `ir_sun_shadow_sample`, `c_compute_voxel_ao`,
+   `c_lighting_to_trixel`, `c_*light_volume*`) → use `IRCanvasStress` and
+   run **both** passes with
+   `--debug-overlay shadow|ao|light_level --no-auto-rotate --no-spin`
+   (pick the overlay matching the effect; the freeze flags keep the pose
+   comparable). These effects do not render in `shape_debug`, so its
+   before/after shots come out byte-identical and read as "no visual
+   change" (#2343).
+3. **Diff touches only other engine render code** (`engine/render/**`,
    `engine/prefabs/irreden/render/**`, shaders) → default to
    `IRShapeDebug`, which exercises the trixel pipeline most broadly
    and ships `--auto-screenshot`.
-3. **Ambiguous** (multiple demo directories touched, or a mix of
+4. **Ambiguous** (multiple demo directories touched, or a mix of
    render and non-render paths) → prompt the worker for the demo
    name. Do not guess in ambiguous cases; a wrong demo produces
    useless screenshots.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -64,6 +64,20 @@ issue.
 - New shader file not following the `c_` / `v_` / `f_` / `g_` prefix.
 - Canvas allocation before the canvas entity exists.
 - Compute dispatch size doesn't match `voxelDispatchGridForCount()`.
+- A shader that writes indirect-dispatch dims from a runtime count without
+  capping `numGroupsX` at 1024 and spilling to `numGroupsY` (mirror
+  `writeDispatchDims()` in `c_voxel_visibility_compact.glsl`) — an uncapped
+  1-D grid is undefined past 65535 groups.
+- A new runtime *uniform* mode-branch added to a hot compute kernel (voxel
+  stage 1/2, `c_shapes_to_trixel`, lighting / sun-shadow / particle
+  kernels) — predicated, not skipped; should be a compile-time `#if`
+  specialization from a shared body
+  (`docs/design/gpu-stage-timing-cost-model.md` §2).
+- A rebased shader-kernel/encoding PR whose fork predates a carrier or
+  encoding migration on master: verify every `encode*`/`decode*` call's
+  arity and that the migration's carrier is threaded on the enabled path —
+  byte-identity at default doesn't prove it
+  (`engine/render/CLAUDE.md` §"Verifying render changes").
 - new `*.glsl` added without a matching `*.metal` counterpart (if parity is
   intentionally deferred, the PR body must acknowledge it and reference a
   follow-up task).
@@ -160,6 +174,14 @@ verdict footer if any of these surfaces are touched)
   to** this engine checklist. The engine checklist is the baseline; the
   creation's `CLAUDE.md` is the delta. Apply both. If the subdirectory has a
   dedicated `REVIEW.md`, prefer it for review-specific rules.
+
+**Flow docs** (markdown-only PRs skip the code checklist — still check this)
+- A bash fence in a changed `.md` that runs `gh pr edit|create` /
+  `gh issue create` with `--body "$var"` instead of `--body-file`, or that
+  consumes a `$var` in a `--body`/substitution line never assigned in the
+  same fence — a worker running it literally executes `--body ""` and wipes
+  the PR body (#2342; the `--body-file` rule generalizes
+  REVIEWER-PROTOCOL.md §Posting the review body to flow docs).
 
 **Fleet scripts** (if the diff touches `scripts/fleet/`)
 - Inline comments — layout diagrams, role-list blocks, `--help` banners —

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -326,6 +326,14 @@ tool with no test_*; add one against a stubbed environment (see
 `scripts/fleet/CLAUDE.md` §Authoring rules for the hermeticity bar)."
 Report, don't auto-fix.
 
+The same rule fires on **non-trivial bash embedded inline in a changed
+`.github/workflows/*.yml` `run:` block** — logic that defines a shell
+function, loops/branches over multiple commands, or exceeds ~15 lines.
+Flag: "extract to a `scripts/fleet/*.sh` executable with a hermetic
+`tests/test_*.sh` and call it from the workflow" — inline `run:` logic
+ships with zero CI signal and no local-sandbox test (#2290's `net_patch_id`
+classify bug). Report, don't auto-fix.
+
 ### 2c. Serialized-struct version-bump check
 
 See `engine/asset/CLAUDE.md` §"Automated version-bump detection" for the full
@@ -374,6 +382,27 @@ Also check:
 - Hand-rolled compute dispatch sizes — should use
   `voxelDispatchGridForCount()` rather than computing `(n+63)/64`
   manually.
+- A **GPU shader** (`.glsl`/`.metal`) that writes indirect-dispatch dims
+  from a runtime count must cap `numGroupsX` at `kMaxDispatchGroupsX`
+  (1024) and spill the remainder into `numGroupsY` — mirror
+  `writeDispatchDims()` in `c_voxel_visibility_compact.glsl`; consumers
+  recover the flat group index as `groupId.x + groupId.y * numGroupsX`.
+  An uncapped 1-D `numGroupsX = divCeil(count, tile)` with
+  `numGroupsY = 1` is undefined past 65535 groups — silently dropped
+  cells, no error (#2273).
+- A dispatch function that `bindRange`s/`bindBase`s a shared
+  `kBufferIndex_*` slot (one bound elsewhere to a different buffer — the
+  reuse-transiently gotcha in `engine/render/CLAUDE.md` §Gotchas) and
+  returns without restoring the original binding. The same function must
+  restore; don't rely on a downstream system's restore surviving a
+  pipeline reorder (#2273).
+- A changed stats format row in `system_perf_stats_overlay.hpp` whose
+  minimum rendered width (leading label + each printf conversion spec's
+  minimum field width + literal separators, computed per `\n`-delimited
+  row) exceeds the overlay's documented column budget
+  `kPerfStatsColumnTrixels / kGlyphStepX` (= 22 chars) — an over-budget
+  row silently clips on the fixed-width panel; split it into two rows
+  (#2347).
 - 3D-world-coord values being mixed with iso-2D-coord values without
   going through `IRMath::pos3DtoPos2DIso` or a named helper. The two
   spaces are not interchangeable.
@@ -608,6 +637,13 @@ top-level `CLAUDE.md` and module-level `CLAUDE.md` files.
     avoid).
   - Decorative emoji bullets (`❌`, `✅`) — codebase convention is bare
     list bullets.
+- **PR/issue-body writes in bash fences.** A flow-doc fence that runs
+  `gh pr edit|create` or `gh issue create` with `--body "$var"` — require
+  `--body-file` after assembling the body (REVIEWER-PROTOCOL.md's
+  shell-substitution rule, generalized to flow docs). Also flag a `$var`
+  consumed in a `--body` or `${var//…}` substitution line with no `var=`
+  assignment earlier in the same fence — a worker running the snippet
+  literally executes `--body ""` and wipes the entire PR body (#2342).
 - **Broken cross-refs.** Every `[text](path)` / `[text](path#anchor)`
   link in the diff resolves to an existing file / heading. Section
   references cited as `§Foo` match an actual `## Foo` heading. Named

--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -24,11 +24,16 @@ between "branch is ready" and "PR is finalized."
 fleet-build --target <name>
 ```
 
-**If the diff adds files under `engine/prefabs/**/systems/`**, also
-build `IrredenEngineTest` (or the engine static library) — creation
-targets like `IRShapeDebug` only link the systems they reference, so
-a new system with a missing `SystemName` enum entry is a silent
-linker error from the creation perspective.
+**If the diff adds files under `engine/prefabs/**/systems/` — or changes
+the signature of any free function or method consumed elsewhere in the
+tree** — also build `IrredenEngineTest` (or the engine static library)
+before the PR claims its test plan is green. Creation targets like
+`IRShapeDebug` only compile and link what they reference, so a demo-only
+build is blind both to a new system's missing `SystemName` enum entry
+(silent linker error) and to stale call sites of a changed signature that
+live only in `test/**` (#2313: nine call sites in
+`test/render/per_canvas_light_scope_test.cpp` broke the suite build while
+the PR's demo targets built green).
 
 If the touched code has an executable target, run it to confirm it
 launches cleanly:

--- a/docs/agents/skills/attach-screenshots.md
+++ b/docs/agents/skills/attach-screenshots.md
@@ -94,10 +94,18 @@ selection heuristic, in order:
 
 1. **Diff touches `creations/demos/<name>/`** → use the matching
    `IR<NameCamelCase>` target.
-2. **Diff touches only engine render code** (matching the render-scoped
-   **visual-file globs**) → use the **default demo**, which exercises the
-   trixel pipeline most broadly and ships `--auto-screenshot`.
-3. **Ambiguous** (multiple demo directories touched, or a mix of render and
+2. **Diff touches an effect family the default demo does not render**
+   (per the repo wrapper's effect-routing table — e.g. the engine's
+   sun-shadow / lighting / AO shaders, which only produce a visible delta
+   in the lighting-capable stress demo under a `--debug-overlay` mode at a
+   frozen pose) → use the routed demo and flags for **both** passes. The
+   default demo's before/after shots for such diffs are byte-identical and
+   read as "no visual change", giving the reviewer zero evidence.
+3. **Diff touches only other engine render code** (matching the
+   render-scoped **visual-file globs**) → use the **default demo**, which
+   exercises the trixel pipeline most broadly and ships
+   `--auto-screenshot`.
+4. **Ambiguous** (multiple demo directories touched, or a mix of render and
    non-render paths) → prompt the worker for the demo name. Do not guess in
    ambiguous cases; a wrong demo produces useless screenshots.
 

--- a/docs/design/gpu-stage-timing-cost-model.md
+++ b/docs/design/gpu-stage-timing-cost-model.md
@@ -82,6 +82,19 @@ a measurement says otherwise on a specific path:
   grid is fixed CPU-side at `dispatchCompute` time; an invocation that
   returns immediately still launched. PR #2266 capped shadow-feeder
   micro-grids via early-return and measured no change in `voxelStage1`.
+- **A runtime *uniform* mode-branch in a hot kernel is predicated, not
+  skipped** — its instructions decode on every invocation even when the
+  branch is never taken, so it taxes the kernel at all inputs. #2325 Step B
+  v1 selected visible-vs-feeder via a `feederPass` uniform inside the shared
+  stage-1 kernel and regressed zoom8 `voxelStage1` +16 %; a disarm probe
+  (gate off, dispatch skipped) held the taxed number, proving the cost was
+  shader-side predication of the strided divides, not dispatch overhead.
+  Prefer a **compile-time `#if` specialization** from one shared source body:
+  two thin wrappers `#define` the mode and `#include` the body, and each
+  Metal variant registers in `threadgroupSizeForFunctionName` +
+  `functionUsesImageAtomicScratch`. Specializing measured the tax away
+  (zoom8 `voxelStage1` 5.97 → 5.33 ms, zoom16 win retained). See
+  `docs/design/voxel-feeder-split.md` §"#2258 Step B".
 - **The stage-1 raster body is not where the high-zoom cost lives — but the
   stage-1 *dispatch* still carries ~half of it.** Forcing *every* voxel to a
   single 1×1 micro-tap (a 256× per-invocation body reduction at zoom 16) left

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -258,6 +258,14 @@ If the PR intentionally changes silhouettes / lighting / shading
 model, call out the intentional drift in the description so reviewers
 know the new crop is the new baseline rather than a regression.
 
+**Sun-shadow / lighting / AO shader diffs don't show in the default demo.**
+For a diff touching the sun-shadow / lighting / AO shader family the
+`attach-screenshots` picker routes to the lighting-capable stress demo with
+a `--debug-overlay` mode at a frozen pose (`IRCanvasStress --debug-overlay
+shadow|ao|light_level --no-auto-rotate --no-spin`) — the default
+`IRShapeDebug` suite renders none of those effects, so its before/after
+pairs come out byte-identical and read as "no visual change" (#2343).
+
 **Occlusion diagnostics for rotated voxel content: use `--checkerboard`,
 not `--depth-color`.** `--depth-color` quantizes hue in 4/3-world-unit
 bands; at any non-cardinal yaw the bands beat against the 1-unit voxel
@@ -343,6 +351,27 @@ binding-6 voxel upload, not a detached-revoxelize bake) can silently never
 reach the shader, and a "compiles + byte-identical at default" merge ships a
 feature that doesn't function in its actual use case (#1989 per-trixel
 priority caught exactly this on resume).
+
+**The disabled-direction complement: a "gated-off / byte-identical on path
+X" claim that leans on a shared shader predicate is empirical, not
+structural.** Multi-dispatch passes (per-axis resolve, world-placed resolve,
+resolve-then-bake) read resident shared UBO state (`FrameDataVoxelToCanvas`,
+`FrameDataSun`) that the C++ driver patches per dispatch, so a gate over
+that state is a decode-path predicate — a sibling dispatch may deliberately
+spoof the gated field (the per-axis resolve zeroes `residualYaw` to reuse
+the cardinal recovery) and take the gated path spuriously (#2293).
+Positively verify which dispatches actually take the gated path, or drive
+the intent from a dedicated per-dispatch C++ value so the byte-identity
+holds by construction.
+
+**Rebasing a shader-kernel or encoding PR past a carrier/encoding migration
+on master:** re-verify against master's *current* source — (a) every
+`encode*`/`decode*` helper call's arity and signature, and (b) that any
+polarity/priority/flip carrier the migration added is threaded through the
+rebased kernel on the ENABLED path. Byte-identity at default does not prove
+the carrier survived the rebase: an extracted or open-coded kernel that
+forked pre-migration compiles and passes cardinal byte-identity while
+silently dropping the carrier on the rotated/enabled path (#2325 vs #2207).
 
 ### Verifying temporal stability (per-frame jitter)
 
@@ -815,6 +844,11 @@ parity with voxel-pool primary shapes.
   garbage from the previous frame.
 - **Dispatch limits.** `kMaxDispatchGroupsX = 1024` (≈1M voxels before
   hitting the second dispatch dimension). Very large voxel counts slow.
+- **Mode branches in hot compute kernels: compile-time-specialize, don't
+  uniform-branch.** A runtime *uniform* branch is predicated, not skipped —
+  its instructions decode on every invocation even when never taken, taxing
+  the kernel at all inputs. Prefer a `#if` specialization from one shared
+  source body. See `docs/design/gpu-stage-timing-cost-model.md` §2.
 - **Render mode × subdivision × zoom.** `SMOOTH` mode multiplies positions
   by `subdivisions × zoom`. Changing any of these mid-frame is a perf
   cliff and can desync chunk visibility.

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -372,7 +372,11 @@ compile: the heap-owning opted-in components (`C_Name`, `C_Skeleton`,
 primary-template `static_assert`. Add each component to the curated list as its
 serializer lands; the full-inventory path (a per-component serializer pass + a
 `HasExplicitSaveSerialize<C>` filter over `AllEngineComponents`) is tracked
-downstream. The registry is built **fresh per call** — cheap (a few
+downstream. **Adding a component here must also extend
+`test/script/lua_world_snapshot_test.cpp` with a round-trip case through the
+actual `IRPersist` Lua surface** — a standalone `SaveSerialize<C>` unit test
+(e.g. `voxel_set_serialize_test.cpp`) covers the serializer but leaves the
+wiring itself (registry entry → Lua binding → reload) unverified (#2244). The registry is built **fresh per call** — cheap (a few
 allocations, never a per-frame path) and, unlike a process-static, its
 session-local `ComponentId`s always match the live `EntityManager`.
 

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -35,6 +35,21 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   `summarize` exit idiom — don't re-copy the helpers into a new test.
   Genuinely test-specific asserts (path existence, exit codes) stay local,
   built on `ok`/`bad`.
+- **`git merge --ff-only` is not a dirty-tree guard.** It refuses only when
+  the incoming commits *overlap* the dirty files; a **disjoint** dirty tree
+  fast-forwards silently — WIP-loss-adjacent on a shared clone. Any path
+  that advances or restores a shared clone's branch gates on an explicit
+  `git status --porcelain` tracked-dirty check *before* the fetch/merge,
+  and the guard covers **every** branch path, not just the off-master arm
+  (#2378: the on-master arm fell through to an unguarded ff-advance).
+- **Config-file generators preserve hand-edits under every emitted key.**
+  A generator that wholesale-rewrites a config file (`fleet-up`'s
+  `write_worktree_settings` → `settings.local.json`) must carry
+  preservation logic — and a test — for **each** key it emits; adding a new
+  generated key means extending the preservation in the same change, or the
+  next regeneration silently clobbers human edits under that key (#2284:
+  the first `hooks` key repeated the lesson `permissions.allow` already
+  encoded).
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,


### PR DESCRIPTION
## Summary

Human-cued `triage-coding-improvements` batch over the 18 open `fleet:coding-improvement` tickets. Verdicts (all human-approved at triage): **14 ACCEPT, 1 RESCOPE, 2 ROUTE-OUT, 1 DEFER, 0 REJECT.** Gated self-config files in this diff are expected — this is the human-cued triage lane; the diff maps 1:1 to the digest below.

### Accepted → applied

| Ticket | Surface | Rule |
|---|---|---|
| #2359 | `engine/render/CLAUDE.md` §Verifying render changes (+ review-pr backstop) | rebase past a carrier/encoding migration → re-verify helper arity + carrier on the enabled path |
| #2338 | `engine/render/CLAUDE.md` §Verifying render changes | spoofed-shared-predicate "gated-off" claims are empirical, not structural (disabled-direction complement of #1989) |
| #2355 | `docs/design/gpu-stage-timing-cost-model.md` §2 + render gotcha + review-pr backstop | uniform mode-branch in a hot kernel is predicated, not skipped → compile-time `#if` specialization |
| #2379 | both attach-screenshots pickers + render CLAUDE.md note | sun-shadow/lighting/AO shader diffs route to `IRCanvasStress --debug-overlay … --no-auto-rotate --no-spin`, not `IRShapeDebug` |
| #2345 | `simplify` §9a + review-pr "Flow docs" backstop | flow-doc `gh … --body "$var"` → `--body-file`; flag never-assigned `$var` in a fence |
| #2294 | `simplify` §2b Check 10 extension | non-trivial inline bash in workflow `run:` blocks → extract to tested `scripts/fleet/*.sh` |
| #2276 | `simplify` §5 + review-pr backstop | shader-authored indirect-dispatch dims must cap `numGroupsX` at 1024 + spill to Y (mirror `writeDispatchDims()`) |
| #2351 | `simplify` §5 | perf-overlay format rows must fit the 22-char column budget (min printf width per row) |
| #2277 | `review-invariant-render` item 9 + `simplify` §5 backstop | borrowed shared `kBufferIndex_*` slot must be restored in the same function; alias comment lists new consumers |
| #2382 | `scripts/fleet/CLAUDE.md` §Authoring rules | `--ff-only` is not a dirty-tree guard; explicit porcelain check on every branch path |
| #2285 | `scripts/fleet/CLAUDE.md` §Authoring rules | config generators preserve hand-edits under every emitted key |
| #2283 | `role-worker.md` step 1c(j) | scan PR thread for an existing architect ruling before escalating a semantic conflict to human |
| #2329 | `docs/agents/AUTHOR-PIPELINE.md` §Build and run | consumed-signature changes (not just new systems) trigger the full `IrredenEngineTest` build |
| #2261 | `engine/world/CLAUDE.md` §Process-default registry | registry additions must extend the IRPersist Lua round-trip test (prior DEFER; unblocked by #2244's merge) |

### Rescoped

- #2389 → doc rule only, in `.claude/rules/cpp-ecs-smells.md` §Lua-side ECS bindings (Lua `createEntityBatch*` factory count must match the C++ registration arity). The proposed `simplify-check-ecs` cross-language arity check is deferred until recurrence — real implementation work for a single-occurrence ticket.

### Routed out (Step 5)

- #2354 → code work split to #2397 (`IRMath::wrapToRange` helper + migrate 4 hand-rolled sites + the `cpp-math.md` bullet, which can't land before the helper exists). Closed via this PR with #2397 carrying the remainder.
- #2364 → de-labeled (engine-wide "caller must finalize" audit is code/audit work, not a convention edit); stays open as a plain issue for queue approval.

### Deferred (left open)

- #1865 — device-backend graceful-degradation tests; unchanged prior verdict, unblocks on a second device backend shipping without them.

### Closed-loop findings

- #2237 (closed-completed) created simplify Check 10; #2294 is that gap recurring one surface over (inline workflow bash) — extension applied.
- #1775 (closed-completed) landed the "reuse via bindRange" rule; the "then restore" half went unenforced → #2277's checklist item is the escalate-placement move.
- #2024 (closed-completed) landed the enabled-direction byte-identity rule; #2338 is its genuine disabled-direction sibling, placed beside it.

### Applied-placement note

#2277's mechanical backstop landed in `simplify` §5 rather than `simplify-scan-render-leak` (the ticket's either/or): that scanner explicitly filters to files *outside* the render dirs, while the restore check targets render systems — §5 is the render-scoped inline check, same enforcement position.

## Test plan

- [x] All cited symbols/paths verified against the tree (`writeDispatchDims`, `kPerfStatsColumnTrixels`/`kGlyphStepX` (176/8 = 22), `wrapCreateEntityBatchWithFunctions`, `test/script/lua_world_snapshot_test.cpp`, `IRCanvasStress` + `--debug-overlay`/freeze flags, REVIEWER-PROTOCOL.md §Posting the review body, `voxel-feeder-split.md` §"#2258 Step B", `ir_render_types.hpp` slot aliases)
- [x] Docs-only diff — no build surface
- [ ] Reviewer: confirm the diff maps 1:1 to the digest above

Closes #2261
Closes #2276
Closes #2277
Closes #2283
Closes #2285
Closes #2294
Closes #2329
Closes #2338
Closes #2345
Closes #2351
Closes #2354
Closes #2355
Closes #2359
Closes #2379
Closes #2382
Closes #2389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
