### PR TITLE
fleet: cluster GL-host starvation entries in review-fleet-feedback

### DIFF
--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -124,6 +124,16 @@ SIGNATURES: list[tuple[str, re.Pattern]] = [
         r"(?=.*(silent|no-op|zero\s+finding|no\s+coverage|under-report|miss"
         r"|do(?:\s+not|n.t)\s+exist|not\s+present|working[- ]?tree|origin.?master"
         r"|committed\s+state))", re.I | re.S)),
+    # macOS/Metal panes finding zero class-viable work because the queue is
+    # saturated with GL-host-gated tasks (#1998). Must sit before
+    # queue-staleness: these entries often say "queue ... starved" and would
+    # otherwise be swallowed there — but the queue is fresh; the work is
+    # host-incompatible.
+    ("gl-host-starvation", re.compile(
+        r"(?=.*(GL[- ]host|needs-gl-host|GL[- ]saturated|GL-only"
+        r"|macOS[- ]viable|Metal\s+pane))"
+        r"(?=.*(starv|idle|churn|no[- ]op|zero|0\s+pickable|blocked"
+        r"|covered|skip))", re.I | re.S)),
     ("queue-staleness", re.compile(
         r"(queue.*(staleness|stale-queue|starved|wall|wedge|wedged|starving|race|backlog|invisible)"
         r"|stale-queue\s+wall|fleet:queued\b.*(diverge|no\s+TASKS|ingest))", re.I)),

--- a/scripts/fleet/tests/test_review_feedback_parse_dt.py
+++ b/scripts/fleet/tests/test_review_feedback_parse_dt.py
@@ -90,5 +90,38 @@ class TestRecurrenceFires(unittest.TestCase):
                             for m in mutations))
 
 
+class TestGlHostStarvationSignature(unittest.TestCase):
+    """gl-host-starvation must catch the macOS-pane starvation entries that
+    previously fell through as singletons, and must win over queue-staleness
+    for "queue ... GL-host-starved" phrasing (first match wins)."""
+
+    def _sig(self, headline, body=""):
+        e = Entry(ts="2026-07-14", role="worker-4", headline=headline,
+                  body=[body] if body else [])
+        return _mod.signature_for(e)
+
+    def test_observed_starvation_headlines_cluster(self):
+        for h in (
+            "~06:24Z — opus macOS pane: zero macOS-viable opus work (GL-host churn, #1998)",
+            "macOS opus pane idle: all opus tasks are GL-host or covered",
+            "macOS opus pane: 0 pickable tasks (all opus candidates GL-host-blocked)",
+            "opus queue GL-host-starved on this host",
+        ):
+            self.assertEqual(self._sig(h), "gl-host-starvation", h)
+
+    def test_body_line_participates(self):
+        # Headline alone lacks the starvation token; the first body line
+        # supplies it (signature_for matches headline + first body line).
+        self.assertEqual(
+            self._sig("opus iteration (macOS/Metal) — GL-saturated queue",
+                      body="every candidate skipped as GL-host-gated"),
+            "gl-host-starvation")
+
+    def test_plain_queue_staleness_still_routes_there(self):
+        self.assertEqual(
+            self._sig("queue starved: fleet:queued diverged, ingest never ran"),
+            "queue-staleness")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a `gl-host-starvation` signature to `scripts/fleet/review-fleet-feedback`'s SIGNATURES table. The 2026-07-14 review-fleet-feedback run found 4+ same-day entries across worker-1/worker-4 about macOS/Metal opus panes finding zero class-viable work (GL-host-gated queue, #1998) — all falling through as singletons, invisible to the closed-loop tracker.
- Placed ahead of `queue-staleness` (first match wins): "opus queue GL-host-starved" phrasing would otherwise be swallowed there, but the queue is fresh — the work is host-incompatible, a different fix surface.
- Classification tests added to `scripts/fleet/tests/test_review_feedback_parse_dt.py`: the four observed headlines route to the new signature, body-line participation works, and plain queue-staleness phrasing still routes to `queue-staleness`.

## Test plan

- [x] `python3 -m unittest scripts.fleet.tests.test_review_feedback_parse_dt` — 9/9 pass (3 new)
- [x] `ruff check` clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
