### PR TITLE
engine/math: add wrapToRange + migrate hand-rolled fmod wrap sites (#2397)

### DIFF
--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -28,6 +28,7 @@ The wrapper layer in [`engine/math/include/irreden/`](../../engine/math/include/
 | `std::min(a, b)` / `std::max(a, b)` / `std::clamp(...)` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
 | `std::sin(x)` / `std::cos(x)` / `std::abs(x)` | `IRMath::sin(x)` / `IRMath::cos(x)` / `IRMath::abs(x)` |
 | `std::cbrt(x)` | `IRMath::cbrt(x)` |
+| `std::fmod(x, p)` + `if (v < 0) v += p`, or `while` ±2π wrap loops | `IRMath::wrapToRange(x, p)` / `IRMath::wrapAngleTwoPi(a)` / `IRMath::wrapAnglePi(a)` |
 
 ## Iso projection: never inline the equations
 

--- a/.fleet/plans/issue-2397.md
+++ b/.fleet/plans/issue-2397.md
@@ -1,0 +1,105 @@
+## Plan: engine/math: IRMath::wrapToRange helper + migrate hand-rolled fmod+correction sites
+
+- **Issue:** #2397
+- **Model:** sonnet — every edit is prescribed below (signatures, sites, boundary semantics); no design choice remains
+- **Date:** 2026-07-14
+
+### Verified current state
+
+Grep sweep over `engine/` + `creations/` for `fmod` **and** for the while-loop / `±kTwoPi` wrap idiom (checked at `origin/master` b8311c12). The issue's four sites are confirmed, and the sweep found **three more** the body missed — the full candidate set is seven:
+
+1. `engine/prefabs/irreden/update/components/component_periodic_idle.hpp:146-149` (`valueAtAngle`) — `IRMath::fmod` + negative correction → `[0, 2π)`.
+2. `engine/prefabs/irreden/render/camera.hpp:87-95` (`wrapYaw`) — fmod + correction → `[-π, π)`, then an ε-clamp to `-π + 1e-4` (pitchFromQuat validity guard).
+3. `engine/prefabs/irreden/update/systems/system_action_animation.hpp:64-70` — `std::fmod` + correction on **double** (`C_RhythmicLaunch::elapsedSeconds_`/`periodSeconds_`). Live cpp-math violation.
+4. `engine/prefabs/irreden/update/systems/system_spring_platform.hpp:138-142` — same double idiom. Live cpp-math violation.
+5. **(new)** `engine/prefabs/irreden/render/camera.hpp:72-77` (`yawFromQuat`) — identical fmod+correction+`-π` shift as `wrapYaw`, inlined.
+6. **(new)** `engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp:401` — bare `std::fmod` (no correction; the accumulator is non-negative). Live cpp-math violation.
+7. **(new)** `engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp:328-334` — private static `wrapToPi` while-loop wrap, one caller (line 235).
+
+`IRMath` today: `fmod` is float-only (`ir_math.hpp:357`); `kPi`/`kTwoPi` are float constexprs; no wrap helper exists. `.claude/rules/cpp-math.md` has no wrap bullet (the #2399 batch deliberately left it for this ticket; originating #2354 is closed as split into this issue). Math unit tests live in `test/math/*_test.cpp` (gtest), each file explicitly listed in `test/CMakeLists.txt` under the `IrredenEngineTest` target.
+
+### Scope
+
+Add `IRMath::wrapToRange` + `wrapAngleTwoPi` / `wrapAnglePi`, migrate all seven hand-rolled sites, add the cpp-math rule bullet, and cover the helper with headless unit tests. One task, one PR.
+
+### Approach
+
+**1. Helper** in `engine/math/include/irreden/ir_math.hpp`, adjacent to `fmod` (~line 356):
+
+```cpp
+/// Wrap x into [0, range) (right half-open). Floor-mod semantics: negative x
+/// wraps correctly, matching GLSL/Metal `mod(x, y)` for range > 0, so CPU and
+/// GPU phase math agree (same rationale as roundHalfUp). Caller guarantees
+/// range > 0.
+template <typename T>
+inline T wrapToRange(T x, T range) {
+    static_assert(std::is_floating_point_v<T>);
+    T wrapped = std::fmod(x, range);
+    if (wrapped < T(0))
+        wrapped += range;
+    // A tiny-negative fmod result can round to exactly `range` after the
+    // correction; fold it back so the contract stays right-half-open.
+    if (wrapped >= range)
+        wrapped = T(0);
+    return wrapped;
+}
+
+/// Wrap an angle into [0, 2π).
+inline float wrapAngleTwoPi(float a) { return wrapToRange(a, kTwoPi); }
+
+/// Wrap an angle into [-π, π).
+inline float wrapAnglePi(float a) { return wrapToRange(a + kPi, kTwoPi) - kPi; }
+```
+
+The template (not a float overload) is load-bearing: sites 3–4 wrap **double** periods, and routing them through float `IRMath::fmod` would silently degrade long-running `elapsedSeconds_` precision. `std::fmod` inside `engine/math/` is the sanctioned wrapper location. Do **not** remove `IRMath::fmod` (it stays the raw-remainder primitive; engine API removal rule).
+
+**2. Migrations** (behavior-preserving unless noted):
+
+- Site 1 → `float wrapped = IRMath::wrapAngleTwoPi(angle);`
+- Site 2 → `return IRMath::max(IRMath::wrapAnglePi(yaw), -IRMath::kPi + 1e-4f);` — **keep the ε-clamp and its comment**; only the fmod+correction+shift collapses.
+- Site 5 → `return IRMath::wrapAnglePi(2.0f * IRMath::atan2(q.z, q.w));`
+- Sites 3, 4 → `IRMath::wrapToRange(launch.elapsedSeconds_, launch.periodSeconds_)` (deduces `T = double`; existing `periodSeconds_ > 0` guards already precede both calls).
+- Site 6 → `IRMath::wrapToRange(motion.timeSeconds_, motion.periodSeconds_)` — identical for the non-negative accumulator, and fixes the `std::fmod` violation.
+- Site 7 → delete local `wrapToPi`, call `IRMath::wrapAnglePi` at line 235; update the comment at line 321. Boundary note: the while-loop kept `+π` (closed), `wrapAnglePi` maps it to `-π` (half-open) — the same physical angle mod 2π; the value feeds rotation deltas, so this is safe. Say so in the commit message.
+
+**3. Rule text** — one row in the `.claude/rules/cpp-math.md` "What to use instead" table:
+
+| Don't write | Write |
+|---|---|
+| `std::fmod(x, p)` + `if (v < 0) v += p`, or `while` ±2π loops | `IRMath::wrapToRange(x, p)` / `IRMath::wrapAngleTwoPi(a)` / `IRMath::wrapAnglePi(a)` |
+
+(`.claude/rules/` is not gated self-config; #2399 merged edits to this file through the normal PR flow.)
+
+**4. Tests** — new `test/math/ir_math_wrap_test.cpp`, registered in `test/CMakeLists.txt`:
+
+- `wrapToRange`: in-range identity; negative input lands in `[0, range)`; multi-cycle input; `x == range` → 0; tiny-negative float input (e.g. `-1e-10f`, range `kTwoPi`) stays **strictly** `< range` (the fold-back edge); double instantiation with a large elapsed (e.g. `1e6 + 0.25`, period `1.0`) → `0.25` within double tolerance.
+- `wrapAngleTwoPi`: negative angle, `2π` → 0, many-cycle input.
+- `wrapAnglePi`: `0 → 0`; `π → -π`; `-π → -π`; `3π → -π`; values just below `π` stay positive.
+
+### Affected files
+
+- `engine/math/include/irreden/ir_math.hpp` — add `wrapToRange` + two angle wrappers (needs `<type_traits>` if not already included)
+- `engine/prefabs/irreden/update/components/component_periodic_idle.hpp` — site 1
+- `engine/prefabs/irreden/render/camera.hpp` — sites 2, 5
+- `engine/prefabs/irreden/update/systems/system_action_animation.hpp` — site 3
+- `engine/prefabs/irreden/update/systems/system_spring_platform.hpp` — site 4
+- `engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp` — site 6
+- `engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp` — site 7 (delete local helper)
+- `.claude/rules/cpp-math.md` — one table row
+- `test/math/ir_math_wrap_test.cpp` — new
+- `test/CMakeLists.txt` — register the new test file
+
+### Acceptance criteria
+
+- Zero `std::fmod` remains outside `engine/math/` and `tools/**` (grep-clean).
+- Zero hand-rolled fmod-or-while wrap-corrections remain at the seven sites; `system_gizmo_drag.hpp` no longer defines `wrapToPi`.
+- `IrredenEngineTest` builds and passes headless (all new wrap cases green), on any host.
+- `wrapYaw` still returns strictly `> -π` (ε-clamp preserved — pitchFromQuat contract).
+- Engine builds for a render target (e.g. `fleet-build --target IRShapeDebug`) — the touched headers are include-heavy.
+
+### Gotchas
+
+- **Do not route sites 3/4 through float** — that is the one way this mechanical task can silently regress runtime behavior (rhythm-sync timing drift as `elapsedSeconds_` grows).
+- The `wrapped >= range` fold-back is not paranoia: `fmod(-1e-10f, kTwoPi) + kTwoPi` rounds to exactly `kTwoPi` in float, which would violate the `[0, range)` contract and, downstream, `valueAtAngle`'s stage lookup.
+- `wrapAnglePi` composes as `wrapToRange(a + kPi, kTwoPi) - kPi`; since `wrapToRange` is strictly `< kTwoPi`, the result is strictly `< kPi` — no extra guard needed there.
+- Behavior deltas to disclose in the PR body (both intentional, both safe): site 7's `+π ↦ -π` boundary change; site 6 gains negative-input correctness it never exercises today.

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstdint>
 #include <random>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -356,6 +357,32 @@ template <typename T> constexpr auto fract(const T &value) {
 /// Floating-point remainder: x - y * trunc(x / y). std::fmod equivalent.
 inline float fmod(float x, float y) {
     return std::fmod(x, y);
+}
+
+/// Wrap @p x into [0, range) (right half-open). Floor-mod semantics: negative
+/// x wraps correctly, matching GLSL/Metal `mod(x, y)` for range > 0, so CPU and
+/// GPU phase math agree (same rationale as roundHalfUp). Caller guarantees
+/// range > 0.
+template <typename T> inline T wrapToRange(T x, T range) {
+    static_assert(std::is_floating_point_v<T>);
+    T wrapped = std::fmod(x, range);
+    if (wrapped < T(0))
+        wrapped += range;
+    // A tiny-negative fmod result can round to exactly `range` after the
+    // correction; fold it back so the contract stays right-half-open.
+    if (wrapped >= range)
+        wrapped = T(0);
+    return wrapped;
+}
+
+/// Wrap an angle into [0, 2*pi).
+inline float wrapAngleTwoPi(float a) {
+    return wrapToRange(a, kTwoPi);
+}
+
+/// Wrap an angle into [-pi, pi).
+inline float wrapAnglePi(float a) {
+    return wrapToRange(a + kPi, kTwoPi) - kPi;
 }
 
 /// Fractional part of the absolute value; always in [0, 1). Ignores sign.

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -69,11 +69,7 @@ inline IRComponents::C_LocalTransform *cameraTransform() {
 // For q = qZ(yaw) × qX(pitch): atan2(q.z, q.w) = yaw/2 when pitch is
 // clamped to ±(π/2 − ε) as guaranteed by clampPitch.
 inline float yawFromQuat(const IRMath::vec4 &q) {
-    float yaw = 2.0f * IRMath::atan2(q.z, q.w);
-    yaw = IRMath::fmod(yaw + IRMath::kPi, IRMath::kTwoPi);
-    if (yaw < 0.0f)
-        yaw += IRMath::kTwoPi;
-    return yaw - IRMath::kPi;
+    return IRMath::wrapAnglePi(2.0f * IRMath::atan2(q.z, q.w));
 }
 
 // Extract X-pitch from the ZX-composed camera quaternion.
@@ -85,13 +81,9 @@ inline float pitchFromQuat(const IRMath::vec4 &q) {
 }
 
 inline float wrapYaw(float yaw) {
-    float wrapped = IRMath::fmod(yaw + IRMath::kPi, IRMath::kTwoPi);
-    if (wrapped < 0.0f)
-        wrapped += IRMath::kTwoPi;
-    wrapped = wrapped - IRMath::kPi;
     // Keep strictly above -π so pitchFromQuat's atan2(q.x, q.w) stays valid.
     // The 1e-4 gap is invisible to the rasterizer (<1/10 000 of π/2 ≈ 0°0.006').
-    return IRMath::max(wrapped, -IRMath::kPi + 1e-4f);
+    return IRMath::max(IRMath::wrapAnglePi(yaw), -IRMath::kPi + 1e-4f);
 }
 
 static constexpr float kPitchLimit = IRMath::kHalfPi - 0.01f;

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp
@@ -13,7 +13,6 @@ using namespace IRMath;
 
 namespace IRComponents {
 
-
 enum class BackgroundTypes { kSingleColor, kGradient, kGradientRandom, kPulsePattern };
 
 struct C_TriangleCanvasBackground {
@@ -71,7 +70,8 @@ struct C_TriangleCanvasBackground {
         float pulseSpeed = 1.0f,
         int patternScale = 10
     )
-        : C_TriangleCanvasBackground(type, std::vector<Color>{colorA, colorB}, size, pulseSpeed, patternScale
+        : C_TriangleCanvasBackground(
+              type, std::vector<Color>{colorA, colorB}, size, pulseSpeed, patternScale
           ) {}
 
     // Default
@@ -181,15 +181,21 @@ struct C_TriangleCanvasBackground {
 
             // TODO(perf): Move pulse/interference color transform to a trixel->trixel compute pass.
             // Notes for future migration:
-            // 1) Keep this CPU side responsible only for low-frequency state (pattern mask / parameters),
-            //    then dispatch compute once per frame for animated color evaluation in trixel space.
-            // 2) Use ping-pong textures (read from A, write to B, then swap) to avoid undefined read/write
+            // 1) Keep this CPU side responsible only for low-frequency state (pattern mask /
+            // parameters),
+            //    then dispatch compute once per frame for animated color evaluation in trixel
+            //    space.
+            // 2) Use ping-pong textures (read from A, write to B, then swap) to avoid undefined
+            // read/write
             //    hazards on the same image in one dispatch.
-            // 3) Preserve current iso-space phase projection and timing params so visual output matches:
-            //    - primary/secondary directions, phase scales, speed multipliers, start offsets, mix.
+            // 3) Preserve current iso-space phase projection and timing params so visual output
+            // matches:
+            //    - primary/secondary directions, phase scales, speed multipliers, start offsets,
+            //    mix.
             // 4) Insert proper barriers after dispatch (image/texture fetch visibility) before the
             //    framebuffer pass samples the output trixel color texture.
-            // 5) Prefer one invocation per trixel texel (not per-fragment) since each trixel resolves
+            // 5) Prefer one invocation per trixel texel (not per-fragment) since each trixel
+            // resolves
             //    to a uniform color in this effect.
             for (int y = 0; y < m_size.y; y++) {
                 for (int x = 0; x < m_size.x; x++) {
@@ -215,7 +221,8 @@ struct C_TriangleCanvasBackground {
                         m_pulsePhase * m_pulseWaveSecondarySpeedMultiplier +
                         m_pulseWaveSecondaryStartOffset + phaseOffsetSecondary
                     );
-                    const float combined = IRMath::mix(primary, secondary, m_pulseWaveInterferenceMix);
+                    const float combined =
+                        IRMath::mix(primary, secondary, m_pulseWaveInterferenceMix);
                     const float wave = 0.5f + 0.5f * combined;
                     const Color colorPulseA = IRMath::lerpColor(colorA, colorB, wave);
                     const Color colorPulseB = IRMath::lerpColor(colorB, colorA, wave);
@@ -398,7 +405,7 @@ struct C_TriangleCanvasBackground {
             return fallbackDirection;
         }
         motion.timeSeconds_ += dt;
-        const float wrapped = std::fmod(motion.timeSeconds_, motion.periodSeconds_);
+        const float wrapped = IRMath::wrapToRange(motion.timeSeconds_, motion.periodSeconds_);
         const float normalized = wrapped / motion.periodSeconds_;
         const bool forward = normalized < 0.5f;
         const float phaseT = forward ? (normalized * 2.0f) : ((normalized - 0.5f) * 2.0f);
@@ -412,7 +419,6 @@ struct C_TriangleCanvasBackground {
             fallbackDirection
         );
     }
-
 };
 
 } // namespace IRComponents

--- a/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
+++ b/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
@@ -232,7 +232,7 @@ template <> struct System<GIZMO_DRAG> {
         }
         case IRComponents::GizmoKind::ROTATE_RING: {
             const float currentAngle = cursorCanvasAngle(mouseCanvasIso_);
-            float delta = wrapToPi(currentAngle - dragStartRotateAngle_);
+            float delta = IRMath::wrapAnglePi(currentAngle - dragStartRotateAngle_);
             if (shiftHeld_) {
                 delta = IRMath::round(delta / kRotateSnapStep) * kRotateSnapStep;
             }
@@ -318,19 +318,11 @@ template <> struct System<GIZMO_DRAG> {
     // iso position, in radians. Both terms live in the rasterYaw-
     // rotated canvas iso frame (mousePosition2DIsoWorldRender ↔
     // pos3DtoPos2DIso(rotateCardinalZ(worldPos))) so the relative
-    // vector is camera-pan invariant. wrapToPi normalizes deltas
-    // across the ±π discontinuity.
+    // vector is camera-pan invariant. IRMath::wrapAnglePi normalizes
+    // deltas across the ±π discontinuity.
     float cursorCanvasAngle(IRMath::vec2 cursorCanvas) const {
         const IRMath::vec2 delta = cursorCanvas - dragAnchorScreenIso_;
         return IRMath::atan2(delta.y, delta.x);
-    }
-
-    static float wrapToPi(float a) {
-        while (a > IRMath::kPi)
-            a -= IRMath::kTwoPi;
-        while (a < -IRMath::kPi)
-            a += IRMath::kTwoPi;
-        return a;
     }
 };
 

--- a/engine/prefabs/irreden/update/components/component_periodic_idle.hpp
+++ b/engine/prefabs/irreden/update/components/component_periodic_idle.hpp
@@ -143,10 +143,7 @@ struct C_PeriodicIdle {
     // then runs the same stage-search + easing tick() does, so the result
     // matches the running animation exactly.
     vec3 valueAtAngle(float angle) const {
-        float wrapped = IRMath::fmod(angle, IRMath::kTwoPi);
-        if (wrapped < 0.0f) {
-            wrapped += IRMath::kTwoPi;
-        }
+        float wrapped = IRMath::wrapAngleTwoPi(angle);
         return evaluateStage(wrapped, stages_[advanceStageIndex(wrapped, 0)]);
     }
 

--- a/engine/prefabs/irreden/update/systems/system_action_animation.hpp
+++ b/engine/prefabs/irreden/update/systems/system_action_animation.hpp
@@ -21,26 +21,30 @@ namespace IRSystem {
 
 template <> struct System<ACTION_ANIMATION> {
     static SystemId create() {
-        static std::unordered_map<IREntity::EntityId, const C_AnimationClip*> clipCache;
+        static std::unordered_map<IREntity::EntityId, const C_AnimationClip *> clipCache;
 
         return createSystem<C_ActionAnimation, C_LocalTransform, C_ContactEvent>(
             "ActionAnimation",
             [](C_ActionAnimation &anim,
                C_LocalTransform &localXform,
                const C_ContactEvent &contact) {
-                if (anim.bindingCount_ <= 0) return;
+                if (anim.bindingCount_ <= 0)
+                    return;
 
                 if (!anim.originInitialized_) {
                     anim.origin_ = localXform.translation_;
                     anim.originInitialized_ = true;
                 }
 
-                auto fetchClip = [](IREntity::EntityId id) -> const C_AnimationClip* {
-                    if (id == IREntity::kNullEntity) return nullptr;
+                auto fetchClip = [](IREntity::EntityId id) -> const C_AnimationClip * {
+                    if (id == IREntity::kNullEntity)
+                        return nullptr;
                     auto it = clipCache.find(id);
-                    if (it != clipCache.end()) return it->second;
+                    if (it != clipCache.end())
+                        return it->second;
                     auto opt = IREntity::getComponentOptional<C_AnimationClip>(id);
-                    if (!opt.has_value()) return nullptr;
+                    if (!opt.has_value())
+                        return nullptr;
                     clipCache[id] = opt.value();
                     return opt.value();
                 };
@@ -51,23 +55,19 @@ template <> struct System<ACTION_ANIMATION> {
                         return contact.entered_;
 
                     case ANIM_TRIGGER_TIMER_SYNC:
-                        if (contact.touching_ &&
-                            contact.otherEntity_ != IREntity::kNullEntity) {
-                            auto launchOpt =
-                                IREntity::getComponentOptional<C_RhythmicLaunch>(
-                                    contact.otherEntity_);
+                        if (contact.touching_ && contact.otherEntity_ != IREntity::kNullEntity) {
+                            auto launchOpt = IREntity::getComponentOptional<C_RhythmicLaunch>(
+                                contact.otherEntity_
+                            );
                             if (launchOpt.has_value()) {
                                 const auto &launch = *launchOpt.value();
                                 if (launch.periodSeconds_ <= 0.0) {
                                     return false;
                                 }
-                                double elapsedWrapped = std::fmod(
+                                double elapsedWrapped = IRMath::wrapToRange(
                                     launch.elapsedSeconds_,
                                     launch.periodSeconds_
                                 );
-                                if (elapsedWrapped < 0.0) {
-                                    elapsedWrapped += launch.periodSeconds_;
-                                }
                                 double timeUntilFire = launch.periodSeconds_ - elapsedWrapped;
                                 return timeUntilFire <= binding.timerSyncLeadSeconds_ &&
                                        timeUntilFire >= 0.0;
@@ -82,8 +82,7 @@ template <> struct System<ACTION_ANIMATION> {
                     }
                 };
 
-                const double dt = static_cast<double>(
-                    IRTime::deltaTime(IRTime::UPDATE));
+                const double dt = static_cast<double>(IRTime::deltaTime(IRTime::UPDATE));
 
                 // --- Trigger check ---
                 for (int i = 0; i < anim.bindingCount_; ++i) {
@@ -112,8 +111,8 @@ template <> struct System<ACTION_ANIMATION> {
 
                 // --- Hold position when idle ---
                 if (!anim.isPlaying()) {
-                    localXform.translation_ = anim.origin_ +
-                        anim.direction_ * anim.currentDisplacement_;
+                    localXform.translation_ =
+                        anim.origin_ + anim.direction_ * anim.currentDisplacement_;
                     return;
                 }
 
@@ -132,20 +131,20 @@ template <> struct System<ACTION_ANIMATION> {
 
                 const auto &phase = clip->phases_[anim.currentPhase_];
                 double phaseDur = phase.durationSeconds_;
-                if (phaseDur <= 0.0) phaseDur = 0.001;
+                if (phaseDur <= 0.0)
+                    phaseDur = 0.001;
 
                 double t = anim.phaseElapsed_ / phaseDur;
-                if (t > 1.0) t = 1.0;
+                if (t > 1.0)
+                    t = 1.0;
 
                 float startDisp = phase.startDisplacement_;
                 if (anim.currentPhase_ == 0 && anim.hasPhaseStartOverride_) {
                     startDisp = anim.phaseStartOverride_;
                 }
 
-                float eased = kEasingFunctions.at(phase.easingFunction_)(
-                    static_cast<float>(t));
-                float displacement = IRMath::mix(
-                    startDisp, phase.endDisplacement_, eased);
+                float eased = kEasingFunctions.at(phase.easingFunction_)(static_cast<float>(t));
+                float displacement = IRMath::mix(startDisp, phase.endDisplacement_, eased);
 
                 anim.currentDisplacement_ = displacement;
                 localXform.translation_ = anim.origin_ + anim.direction_ * displacement;
@@ -167,8 +166,8 @@ template <> struct System<ACTION_ANIMATION> {
                         anim.currentDisplacement_ =
                             clip->phases_[clip->phaseCount_ - 1].endDisplacement_;
                         anim.stopClip();
-                        localXform.translation_ = anim.origin_ +
-                            anim.direction_ * anim.currentDisplacement_;
+                        localXform.translation_ =
+                            anim.origin_ + anim.direction_ * anim.currentDisplacement_;
                         return;
                     }
                 }

--- a/engine/prefabs/irreden/update/systems/system_spring_platform.hpp
+++ b/engine/prefabs/irreden/update/systems/system_spring_platform.hpp
@@ -20,18 +20,15 @@ namespace IRSystem {
 
 template <> struct System<SPRING_PLATFORM> {
     static SystemId create() {
-        return createSystem<
-            C_SpringPlatform,
-            C_LocalTransform,
-            C_Velocity3D,
-            C_ContactEvent>(
+        return createSystem<C_SpringPlatform, C_LocalTransform, C_Velocity3D, C_ContactEvent>(
             "SpringPlatform",
             [](C_SpringPlatform &spring,
                C_LocalTransform &localXform,
                C_Velocity3D &velocity,
                const C_ContactEvent &contact) {
                 const float dt = IRTime::deltaTime(IRTime::UPDATE);
-                if (dt <= 0.0f) return;
+                if (dt <= 0.0f)
+                    return;
 
                 if (!spring.originInitialized_) {
                     spring.origin_ = localXform.translation_;
@@ -39,28 +36,25 @@ template <> struct System<SPRING_PLATFORM> {
                 }
 
                 spring.previousDisplacement_ = spring.displacement_;
-                spring.displacement_ = IRMath::dot(
-                    localXform.translation_ - spring.origin_, spring.direction_);
+                spring.displacement_ =
+                    IRMath::dot(localXform.translation_ - spring.origin_, spring.direction_);
 
                 const float lockPoint = spring.length_ * spring.lockRatio_;
                 const float maxOvershoot = spring.length_ * spring.overshootRatio_;
 
                 // ── Impact ──
                 if (contact.entered_ &&
-                    (spring.state_ == SPRING_IDLE ||
-                     spring.state_ == SPRING_REBOUNDING)) {
+                    (spring.state_ == SPRING_IDLE || spring.state_ == SPRING_REBOUNDING)) {
                     float impactSpeed = 0.0f;
                     if (contact.otherEntity_ != IREntity::kNullEntity) {
-                        auto velOpt = IREntity::getComponentOptional<C_Velocity3D>(
-                            contact.otherEntity_);
+                        auto velOpt =
+                            IREntity::getComponentOptional<C_Velocity3D>(contact.otherEntity_);
                         if (velOpt.has_value()) {
                             vec3 bv = velOpt.value()->velocity_;
-                            impactSpeed = std::abs(
-                                IRMath::dot(bv, spring.direction_));
+                            impactSpeed = std::abs(IRMath::dot(bv, spring.direction_));
                         }
                     }
-                    spring.springVelocity_ =
-                        spring.absorptionRatio_ * impactSpeed;
+                    spring.springVelocity_ = spring.absorptionRatio_ * impactSpeed;
                     spring.state_ = SPRING_CATCHING;
                     spring.catchReachedMax_ = false;
                     spring.oscillationCount_ = 0;
@@ -81,19 +75,18 @@ template <> struct System<SPRING_PLATFORM> {
                         }
                     } else {
                         float offset = spring.displacement_ - lockPoint;
-                        float prevOffset =
-                            spring.previousDisplacement_ - lockPoint;
+                        float prevOffset = spring.previousDisplacement_ - lockPoint;
                         if (prevOffset * offset < 0.0f) {
                             spring.oscillationCount_++;
                         }
 
                         bool settling = spring.maxCatchOscillations_ > 0 &&
-                            spring.oscillationCount_ >= spring.maxCatchOscillations_;
+                                        spring.oscillationCount_ >= spring.maxCatchOscillations_;
 
                         if (settling) {
                             float rate = 1.0f - std::exp(-spring.settleSpeed_ * 60.0f * dt);
-                            spring.displacement_ = IRMath::mix(
-                                spring.displacement_, lockPoint, rate);
+                            spring.displacement_ =
+                                IRMath::mix(spring.displacement_, lockPoint, rate);
                             spring.springVelocity_ = 0.0f;
                             localXform.translation_ =
                                 spring.origin_ + spring.direction_ * spring.displacement_;
@@ -107,12 +100,11 @@ template <> struct System<SPRING_PLATFORM> {
                         } else {
                             float force = -spring.stiffness_ * offset;
                             spring.springVelocity_ += force * dt;
-                            spring.springVelocity_ *= IRMath::max(
-                                0.0f, 1.0f - spring.damping_ * dt);
+                            spring.springVelocity_ *=
+                                IRMath::max(0.0f, 1.0f - spring.damping_ * dt);
 
                             if (spring.maxCatchOscillations_ <= 0 &&
-                                std::abs(spring.springVelocity_) <=
-                                    spring.settleSpeed_ &&
+                                std::abs(spring.springVelocity_) <= spring.settleSpeed_ &&
                                 std::abs(offset) < 0.5f) {
                                 spring.displacement_ = lockPoint;
                                 spring.springVelocity_ = 0.0f;
@@ -126,24 +118,18 @@ template <> struct System<SPRING_PLATFORM> {
                 if (spring.state_ == SPRING_LOCKED) {
                     spring.springVelocity_ = 0.0f;
                     localXform.translation_ = spring.origin_ + spring.direction_ * lockPoint;
-                    if (contact.touching_ &&
-                        contact.otherEntity_ != IREntity::kNullEntity) {
+                    if (contact.touching_ && contact.otherEntity_ != IREntity::kNullEntity) {
                         auto launchOpt =
-                            IREntity::getComponentOptional<C_RhythmicLaunch>(
-                                contact.otherEntity_);
+                            IREntity::getComponentOptional<C_RhythmicLaunch>(contact.otherEntity_);
                         if (launchOpt.has_value()) {
                             const auto &launch = *launchOpt.value();
-                            if (!launch.atMaxLaunches() &&
-                                launch.periodSeconds_ > 0.0) {
-                                double elapsed = std::fmod(
+                            if (!launch.atMaxLaunches() && launch.periodSeconds_ > 0.0) {
+                                double elapsed = IRMath::wrapToRange(
                                     launch.elapsedSeconds_,
-                                    launch.periodSeconds_);
-                                if (elapsed < 0.0)
-                                    elapsed += launch.periodSeconds_;
-                                double remaining =
-                                    launch.periodSeconds_ - elapsed;
-                                if (remaining <= spring.loadLeadSeconds_ &&
-                                    remaining >= 0.0) {
+                                    launch.periodSeconds_
+                                );
+                                double remaining = launch.periodSeconds_ - elapsed;
+                                if (remaining <= spring.loadLeadSeconds_ && remaining >= 0.0) {
                                     spring.state_ = SPRING_ANTICIPATING;
                                 }
                             }
@@ -155,16 +141,14 @@ template <> struct System<SPRING_PLATFORM> {
                 if (spring.state_ == SPRING_ANTICIPATING) {
                     float target = spring.length_;
                     float error = target - spring.displacement_;
-                    spring.springVelocity_ +=
-                        error * spring.stiffness_ * 2.0f * dt;
-                    spring.springVelocity_ *= IRMath::max(
-                        0.0f, 1.0f - spring.damping_ * 2.0f * dt);
+                    spring.springVelocity_ += error * spring.stiffness_ * 2.0f * dt;
+                    spring.springVelocity_ *= IRMath::max(0.0f, 1.0f - spring.damping_ * 2.0f * dt);
                 }
 
                 // ── Launch ──
                 if (spring.launchRequested_) {
-                    float launchSpeed = std::sqrt(
-                        spring.stiffness_ * spring.length_ * spring.length_);
+                    float launchSpeed =
+                        std::sqrt(spring.stiffness_ * spring.length_ * spring.length_);
                     spring.springVelocity_ = -launchSpeed;
                     spring.state_ = SPRING_LAUNCHING;
                     spring.launchRequested_ = false;
@@ -172,38 +156,32 @@ template <> struct System<SPRING_PLATFORM> {
                 }
 
                 // ── LAUNCHING -> REBOUNDING transition ──
-                if (spring.state_ == SPRING_LAUNCHING &&
-                    spring.displacement_ <= 0.0f) {
+                if (spring.state_ == SPRING_LAUNCHING && spring.displacement_ <= 0.0f) {
                     spring.state_ = SPRING_REBOUNDING;
                 }
                 // ── Count oscillations during rebound ──
                 // Skip the initial downward crossing (transition frame) so that
                 // maxLaunchOscillations=1 means one visible bounce past origin.
                 else if (spring.state_ == SPRING_REBOUNDING) {
-                    if (spring.previousDisplacement_ *
-                            spring.displacement_ < 0.0f) {
+                    if (spring.previousDisplacement_ * spring.displacement_ < 0.0f) {
                         spring.oscillationCount_++;
                     }
                 }
 
                 // ── Check if launch settle should activate ──
                 bool launchSettling = spring.state_ == SPRING_REBOUNDING &&
-                    spring.maxLaunchOscillations_ > 0 &&
-                    spring.oscillationCount_ >= spring.maxLaunchOscillations_;
+                                      spring.maxLaunchOscillations_ > 0 &&
+                                      spring.oscillationCount_ >= spring.maxLaunchOscillations_;
 
                 // ── LAUNCHING / REBOUNDING physics ──
-                if ((spring.state_ == SPRING_LAUNCHING ||
-                     spring.state_ == SPRING_REBOUNDING) && !launchSettling) {
-                    float force =
-                        -spring.stiffness_ * spring.displacement_;
+                if ((spring.state_ == SPRING_LAUNCHING || spring.state_ == SPRING_REBOUNDING) &&
+                    !launchSettling) {
+                    float force = -spring.stiffness_ * spring.displacement_;
                     spring.springVelocity_ += force * dt;
-                    spring.springVelocity_ *= IRMath::max(
-                        0.0f, 1.0f - spring.damping_ * dt);
+                    spring.springVelocity_ *= IRMath::max(0.0f, 1.0f - spring.damping_ * dt);
 
-                    if (spring.state_ == SPRING_REBOUNDING &&
-                        spring.maxLaunchOscillations_ <= 0 &&
-                        std::abs(spring.springVelocity_) <=
-                            spring.settleSpeed_ &&
+                    if (spring.state_ == SPRING_REBOUNDING && spring.maxLaunchOscillations_ <= 0 &&
+                        std::abs(spring.springVelocity_) <= spring.settleSpeed_ &&
                         std::abs(spring.displacement_) < 0.5f) {
                         spring.displacement_ = 0.0f;
                         spring.springVelocity_ = 0.0f;
@@ -215,20 +193,17 @@ template <> struct System<SPRING_PLATFORM> {
                 }
 
                 // ── Clamp: downward at length, upward at overshoot ──
-                if (spring.displacement_ > spring.length_ &&
-                    spring.springVelocity_ > 0.0f) {
+                if (spring.displacement_ > spring.length_ && spring.springVelocity_ > 0.0f) {
                     spring.springVelocity_ = 0.0f;
                 }
-                if (spring.displacement_ < -maxOvershoot &&
-                    spring.springVelocity_ < 0.0f) {
+                if (spring.displacement_ < -maxOvershoot && spring.springVelocity_ < 0.0f) {
                     spring.springVelocity_ = 0.0f;
                 }
 
                 // ── Launch settle ──
                 if (launchSettling) {
                     float rate = 1.0f - std::exp(-spring.settleSpeed_ * 60.0f * dt);
-                    spring.displacement_ = IRMath::mix(
-                        spring.displacement_, 0.0f, rate);
+                    spring.displacement_ = IRMath::mix(spring.displacement_, 0.0f, rate);
                     spring.springVelocity_ = 0.0f;
                     localXform.translation_ =
                         spring.origin_ + spring.direction_ * spring.displacement_;
@@ -243,16 +218,14 @@ template <> struct System<SPRING_PLATFORM> {
                 }
 
                 // ── Output velocity ──
-                velocity.velocity_ =
-                    spring.direction_ * spring.springVelocity_;
+                velocity.velocity_ = spring.direction_ * spring.springVelocity_;
 
                 // ── Color progress ──
                 switch (spring.state_) {
                 case SPRING_CATCHING:
                     if (!spring.catchReachedMax_) {
-                        spring.colorProgress_ = IRMath::clamp(
-                            spring.displacement_ / spring.length_,
-                            0.0f, 1.0f);
+                        spring.colorProgress_ =
+                            IRMath::clamp(spring.displacement_ / spring.length_, 0.0f, 1.0f);
                     } else {
                         spring.colorProgress_ = 1.0f;
                     }
@@ -262,9 +235,8 @@ template <> struct System<SPRING_PLATFORM> {
                     spring.colorProgress_ = 1.0f;
                     break;
                 case SPRING_LAUNCHING:
-                    spring.colorProgress_ = IRMath::clamp(
-                        spring.displacement_ / spring.length_,
-                        0.0f, 1.0f);
+                    spring.colorProgress_ =
+                        IRMath::clamp(spring.displacement_ / spring.length_, 0.0f, 1.0f);
                     break;
                 case SPRING_REBOUNDING:
                 case SPRING_IDLE:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(IrredenEngineTest
   ecs/voxel_set_target_canvas_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp
+  math/ir_math_wrap_test.cpp
   math/ir_math_viewport_helpers_test.cpp
   math/camera_subpixel_test.cpp
   math/ir_math_color_layout_test.cpp

--- a/test/math/ir_math_wrap_test.cpp
+++ b/test/math/ir_math_wrap_test.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_math.hpp>
+
+namespace {
+
+constexpr float kTolerance = 1e-5f;
+
+// --- wrapToRange -----------------------------------------------------------
+
+TEST(IRMathWrapToRange, InRangePositiveIsIdentity) {
+    EXPECT_NEAR(IRMath::wrapToRange(1.5f, IRMath::kTwoPi), 1.5f, kTolerance);
+    EXPECT_NEAR(IRMath::wrapToRange(0.0f, IRMath::kTwoPi), 0.0f, kTolerance);
+}
+
+TEST(IRMathWrapToRange, NegativeInputLandsInRange) {
+    const float wrapped = IRMath::wrapToRange(-1.0f, IRMath::kTwoPi);
+    EXPECT_GE(wrapped, 0.0f);
+    EXPECT_LT(wrapped, IRMath::kTwoPi);
+    EXPECT_NEAR(wrapped, IRMath::kTwoPi - 1.0f, kTolerance);
+}
+
+TEST(IRMathWrapToRange, MultiCycleInputWrapsToSinglePeriod) {
+    const float wrapped = IRMath::wrapToRange(IRMath::kTwoPi * 3.0f + 0.5f, IRMath::kTwoPi);
+    EXPECT_GE(wrapped, 0.0f);
+    EXPECT_LT(wrapped, IRMath::kTwoPi);
+    EXPECT_NEAR(wrapped, 0.5f, 1e-3f);
+}
+
+TEST(IRMathWrapToRange, ExactRangeFoldsToZero) {
+    EXPECT_NEAR(IRMath::wrapToRange(IRMath::kTwoPi, IRMath::kTwoPi), 0.0f, kTolerance);
+}
+
+// A tiny-negative input rounds to exactly `range` after the +range correction
+// in float; the fold-back must keep the result strictly inside [0, range).
+TEST(IRMathWrapToRange, TinyNegativeStaysStrictlyBelowRange) {
+    const float wrapped = IRMath::wrapToRange(-1e-10f, IRMath::kTwoPi);
+    EXPECT_GE(wrapped, 0.0f);
+    EXPECT_LT(wrapped, IRMath::kTwoPi);
+}
+
+// Sites 3/4 wrap `double` periods; routing them through float would drift as
+// elapsedSeconds_ grows, so the template must instantiate on double.
+TEST(IRMathWrapToRange, DoubleInstantiationPreservesPrecision) {
+    const double wrapped = IRMath::wrapToRange(1e6 + 0.25, 1.0);
+    EXPECT_NEAR(wrapped, 0.25, 1e-9);
+}
+
+// --- wrapAngleTwoPi --------------------------------------------------------
+
+TEST(IRMathWrapAngleTwoPi, NegativeAngleWrapsPositive) {
+    const float wrapped = IRMath::wrapAngleTwoPi(-1.0f);
+    EXPECT_GE(wrapped, 0.0f);
+    EXPECT_LT(wrapped, IRMath::kTwoPi);
+    EXPECT_NEAR(wrapped, IRMath::kTwoPi - 1.0f, kTolerance);
+}
+
+TEST(IRMathWrapAngleTwoPi, TwoPiWrapsToZero) {
+    EXPECT_NEAR(IRMath::wrapAngleTwoPi(IRMath::kTwoPi), 0.0f, kTolerance);
+}
+
+TEST(IRMathWrapAngleTwoPi, ManyCycleInput) {
+    const float wrapped = IRMath::wrapAngleTwoPi(IRMath::kTwoPi * 5.0f + 1.0f);
+    EXPECT_NEAR(wrapped, 1.0f, 1e-3f);
+}
+
+// --- wrapAnglePi -----------------------------------------------------------
+
+TEST(IRMathWrapAnglePi, ZeroIsIdentity) {
+    EXPECT_NEAR(IRMath::wrapAnglePi(0.0f), 0.0f, kTolerance);
+}
+
+// [-π, π) is right-half-open: +π maps to -π (same physical angle mod 2π).
+TEST(IRMathWrapAnglePi, PositivePiMapsToNegativePi) {
+    EXPECT_NEAR(IRMath::wrapAnglePi(IRMath::kPi), -IRMath::kPi, kTolerance);
+}
+
+TEST(IRMathWrapAnglePi, NegativePiStaysNegativePi) {
+    EXPECT_NEAR(IRMath::wrapAnglePi(-IRMath::kPi), -IRMath::kPi, kTolerance);
+}
+
+TEST(IRMathWrapAnglePi, ThreePiMapsToNegativePi) {
+    EXPECT_NEAR(IRMath::wrapAnglePi(3.0f * IRMath::kPi), -IRMath::kPi, kTolerance);
+}
+
+TEST(IRMathWrapAnglePi, JustBelowPiStaysPositive) {
+    const float wrapped = IRMath::wrapAnglePi(IRMath::kPi - 0.01f);
+    EXPECT_GT(wrapped, 0.0f);
+    EXPECT_LT(wrapped, IRMath::kPi);
+    EXPECT_NEAR(wrapped, IRMath::kPi - 0.01f, kTolerance);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add `IRMath::wrapToRange(x, range)` -> `[0, range)` (floor-mod, correct negative handling, right-half-open) plus thin angle wrappers `wrapAngleTwoPi` -> `[0, 2pi)` and `wrapAnglePi` -> `[-pi, pi)`, adjacent to `IRMath::fmod` in `ir_math.hpp`.
- Migrate seven hand-rolled `fmod`+negative-correction / `while`-loop wrap idioms to the helpers (four were live `std::fmod` cpp-math violations): `component_periodic_idle::valueAtAngle`, `camera::wrapYaw` + `yawFromQuat`, `system_action_animation`, `system_spring_platform`, `component_triangle_canvas_background`, `system_gizmo_drag` (local `wrapToPi` deleted).
- The template deduces `double` at the two rhythm-timing sites so long-running `elapsedSeconds_` keeps full precision; the raw `IRMath::fmod` primitive is retained (engine API removal rule).
- Add a `.claude/rules/cpp-math.md` substitution row and a headless `test/math/ir_math_wrap_test.cpp` (14 cases: negative / multi-cycle / exact-boundary / tiny-negative fold-back / double instantiation).

## Behavior deltas (both intentional, both safe)
- `system_gizmo_drag`: the rotate-drag delta wrap moves from the closed `[-pi, pi]` while-loop to the half-open `[-pi, pi)` wrapper, so exactly `+pi` now maps to `-pi` -- the same physical angle mod 2pi, and the value feeds rotation deltas.
- `component_triangle_canvas_background`: the motion accumulator gains negative-input correctness (the accumulator is non-negative today, so no runtime change).
- `camera::wrapYaw` still returns strictly `> -pi` (epsilon-clamp preserved -- the pitchFromQuat contract).

## Test plan
- [x] `IrredenEngineTest` builds + passes headless -- 1339/1339, including 14 new wrap cases.
- [x] `IRShapeDebug` builds (macos-debug / Metal) -- the touched headers are include-heavy.
- [x] No visual delta: auto-screenshot output is byte-identical to `origin/master` through the render sequence (both hit the same pre-existing macOS/Metal shutdown segfault at shot 17 `zoom8_yaw180`, the T-336 / #2031 static-destruction family -- unrelated to this change), so screenshots would be uninformative and are omitted.
- [x] grep-clean: zero `std::fmod` outside `engine/math/` + `tools/`, zero hand-rolled wrap-correction sites, no `wrapToPi`.

Closes #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
