### PR TITLE
docs/fleet: require a measured mechanism premise before plan phases (#2401)

### DIFF
--- a/.fleet/plans/issue-2401.md
+++ b/.fleet/plans/issue-2401.md
@@ -1,0 +1,60 @@
+## Plan: fleet/planning — plans must verify a measurable mechanism premise before phases build on it (fix-014 recurring)
+
+- **Issue:** #2401
+- **Model:** sonnet — rule text, lint delta, and test cases are fully specified below; no design choice remains
+- **Date:** 2026-07-14
+
+### Scope
+
+Make "the plan's lever rests on an unmeasured mechanism claim" a named, checkable planning defect. Three deltas: (1) a premise-verification (phase-0) requirement in PLANNING-PROTOCOL.md step 2, (2) mirror lines in the step-4 plan-review rigor list, (3) one conservative WARN in `fleet-plan-lint` with hermetic tests. A gated-lane follow-up issue carries the two-line inline mirror for the opus reviewer's role doc.
+
+### Verified current state
+
+Source-checked against `origin/master` @ b8311c12 (2026-07-14):
+
+- `docs/agents/PLANNING-PROTOCOL.md` step 2 requires "Verified current state + confirmed repro" and exhaustive negative/gap-claim verification, but nothing about measurable mechanism premises (cost attribution, path dominance, a stage actually firing). Step 4's rigor list (verified state / single approach / sibling reconciliation / cross-system audit) has no unmeasured-mechanism line. The acceptance-criteria bullet has no positive-fire rule.
+- `scripts/fleet/fleet-plan-lint` (read in full): hard-fails on no `## Plan` / deferred-approach phrases / >=2 core sections missing; warns on missing Affected files, Gotchas, current-state signal, Model tag. No mechanism-vs-measurement signal of any kind. Existing hermetic test at `scripts/fleet/tests/test_fleet_plan_lint.sh` uses a PATH-shim fake `gh` with fixtures derived from a `GOOD_PLAN` env var.
+- The positive-fire rule exists today only on the render author surface (`engine/render/CLAUDE.md` enabled-path rule, #1989/#2338, landed via PR #2399); grep for `positive-fire|vacuous` over `docs/agents/` = 0 hits — the planning surfaces don't carry it.
+- `.claude/commands/role-opus-reviewer.md` "Plan-review pass" step 2 judges plans "against PLANNING-PROTOCOL.md step-2 rigor" **by reference**, then enumerates four example checks inline. New rigor items placed in PLANNING-PROTOCOL.md therefore bind the reviewer without a gated edit; only the inline enumeration needs a two-line mirror, and role-`*.md` edits are blocked for autonomous workers (human-cued gated lane, as this issue's Area line states).
+- The measurement sources the issue names all exist: per-system timer rows, `--auto-profile` tables, the disarm-probe methodology in `docs/design/gpu-stage-timing-cost-model.md` §3.
+
+Sibling / in-flight reconciliation: #2402 (fix-011, worktree-scoped-edit enforcement, being planned concurrently by worker-4) is a disjoint surface — no file overlap. PR #2399 (merged 2026-07-14) carries the render-surface positive-fire complement; this task cross-references it, never duplicates it. No open PR touches PLANNING-PROTOCOL.md or fleet-plan-lint (checked #2393, #2403, #2405).
+
+### Approach
+
+Phase 0 does not apply to this task itself: the premise here is process-recurrence data, already measured — fix-014 flipped to recurring with 8 occurrences since PR #2038 (`~/.fleet/feedback/.fix-log.jsonl`).
+
+1. **Plan file first.** Commit this plan as `.fleet/plans/issue-2401.md` (first commit of the implementation branch, per #1932).
+2. **`docs/agents/PLANNING-PROTOCOL.md` step 2** — insert a new bullet directly after "**Verified current state + confirmed repro.**":
+   - **"Mechanism premises are measured, not asserted (phase 0)."** When any phase's lever depends on a measurable mechanism claim — where a cost lives (body-side vs dispatch-bound), which code path dominates, that a stage/mode fires at all, that two values share one storage/shape — the plan must either **(i)** cite an existing measurement with its source (a per-system timer row, an `--auto-profile` table, a disarm probe per `docs/design/gpu-stage-timing-cost-model.md` §3, a DOMAIN-STATE log), or **(ii)** name a cheap probe as **phase 0 of the Approach**: what the implementer runs, the expected reading that confirms the premise, and the bail path if refuted (stop; comment the measurement on the issue; design-block or flag for re-plan — never build the dependent phases on a refuted premise). Cite the recurrences compactly: #2258 (assumed body-side, measured dispatch-bound), #2256/#2271/#2273 (parallel efforts on mutually-invalidated premises), #2278 (vacuous gate), #2321 (unverified singleton/same-shape premise).
+   - Deliberately **not** a new required `###` section — a new core section would re-lint every existing queued plan into a bounce. It is a conditional content rule inside the existing structure.
+3. **Same file, acceptance-criteria bullet** — add: acceptance tests named in a plan must be **positive-fire**: at least one named check observably fires with the feature ON (a count > 0, an asserted probe reading, a visible delta). "Gate passes at default / byte-identical output" alone proves the OFF path is a no-op, not the premise — mirror of the #1989/#2338 enabled-path rule (`engine/render/CLAUDE.md`), which PR #2399 established render-side.
+4. **Same file, step 4 rigor list** — append two mirror lines to the reviewer's judgment: "does any phase assume an unmeasured mechanism? (cited measurement or phase-0 probe required)" and "are the named acceptance tests positive-fire?".
+5. **`scripts/fleet/fleet-plan-lint`** — one new soft signal in the warn block (never hard-fail, per the script's false-bounce contract): if the lowercased plan contains any mechanism-lever keyword (`"bottleneck"`, `"dominated by"`, `"dispatch-bound"`, `"fill-bound"`, `"the cost is"`, `"hot path"`, `"perf lever"`, `"should be cheap"`) and none of the citation keywords (`"measur"`, `"timer"`, `"auto-profile"`, `"disarm"`, `"probe"`, `"profil"`, `"domain-state"`), print `warn #N: mechanism-lever language without a measurement citation or phase-0 probe`. Match style identical to the existing `low`-substring checks; update the header-comment warn list.
+6. **`scripts/fleet/tests/test_fleet_plan_lint.sh`** — two new fixtures via the existing `GOOD_PLAN`-mutation pattern in the PATH-shim fake gh: (i) a plan whose Approach claims "the cost is dominated by the resolve loop" with no citation keyword → expect exit 0 **and** the new warn line present (the warn must be observed firing); (ii) the same plan plus "confirmed by a disarm probe" → expect the warn absent. Keep the shim hermetic (a mock miss must fail, never fall through to live `gh` — scripts/fleet/CLAUDE.md).
+7. **Gated-lane follow-up.** File a no-label issue per TASK-FILING.md: "role-opus-reviewer: add unmeasured-mechanism + positive-fire lines to the plan-review judgment enumeration (#2401 follow-up, gated)". Link it in the PR body. Non-blocking — the by-reference binding in the reviewer doc already picks the rule up.
+
+One task, one PR — no stack.
+
+### Affected files
+
+- `docs/agents/PLANNING-PROTOCOL.md` — step-2 phase-0 premise bullet, positive-fire acceptance rule, step-4 mirror lines
+- `scripts/fleet/fleet-plan-lint` — one new WARN + header-comment warn list
+- `scripts/fleet/tests/test_fleet_plan_lint.sh` — warn-fires + warn-absent cases
+- `.fleet/plans/issue-2401.md` — this plan (first commit)
+- *(follow-up issue only, not this PR: `.claude/commands/role-opus-reviewer.md` two-line mirror — gated)*
+
+### Acceptance criteria
+
+- `bash scripts/fleet/tests/test_fleet_plan_lint.sh` → 0 FAIL, including the two new cases; the warn-fires case demonstrates the new warn actually printing (positive-fire applied to its own backstop).
+- Lint behavior unchanged for hard-fail: a mechanism-lever plan without citation still exits 0 (warn-only).
+- PLANNING-PROTOCOL.md step 2 names both satisfaction routes (cited measurement | phase-0 probe with expected reading + bail path) and all four recurrence refs; step 4 carries both mirror lines.
+- PR diff contains no gated self-config file; follow-up issue filed and linked.
+
+### Gotchas
+
+- **WARN only.** A hard-fail here false-bounces narrative plans and burns a full re-plan round — the lint's own header pins this contract.
+- Do not put the role-doc mirror in the PR: the commit gate deterministically blocks role-`*.md` pushes from workers; escalating class does not help (route = follow-up issue, human-cued lane).
+- Keep the keyword lists short and conservative; noisy warns erode the signal the Opus pass weighs. Substring-match on the existing `low` variable, same as current checks.
+- Word the phase-0 doc rule so it cannot be read as approach-deferral: phase 0 verifies the premise of the **already-picked** approach; a refuted premise routes to design-block/re-plan, not to a mid-implementation choice between approaches. Keep the DEFER-phrase lint list in mind when phrasing examples.
+- Plans and these docs are engine-public — engine terminology only.

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -101,6 +101,24 @@ For each `fleet:needs-plan` issue:
      wrong-by-construction defect into the plan (#1814: "destroying an entity
      doesn't free its ResourceIds" was false for ~8 of 9 components; the
      prescribed hook would have double-freed them).
+   - **Mechanism premises are measured, not asserted (phase 0).** When any
+     phase's lever depends on a measurable mechanism claim — where a cost
+     lives (body-side vs dispatch-bound), which code path dominates, that a
+     stage/mode fires at all, that two values share one storage or shape — the
+     plan must either **(i)** cite an existing measurement with its source (a
+     per-system timer row, an `--auto-profile` table, a disarm probe per
+     [`docs/design/gpu-stage-timing-cost-model.md § 3`](../design/gpu-stage-timing-cost-model.md),
+     a DOMAIN-STATE log), or **(ii)** name a cheap probe as **phase 0 of the
+     Approach**: what the implementer runs, the expected reading that confirms
+     the premise, and the bail path if it is refuted (stop; comment the
+     measurement on the issue; design-block or flag for re-plan — never build
+     the dependent phases on a refuted premise). Phase 0 verifies the premise
+     of the **already-picked** approach — it is not approach-deferral: a
+     refuted premise routes to design-block/re-plan, never to a
+     mid-implementation choice between approaches. Recurrences: #2258 (assumed
+     body-side, measured dispatch-bound), #2256/#2271/#2273 (parallel efforts
+     on mutually-invalidated premises), #2278 (vacuous gate), #2321
+     (unverified singleton / same-shape premise).
    - **One approach, picked.** Step-by-step: which files, what order,
      key decisions — and the plan **commits to a single approach**.
      Deferring the choice to the worker ("confirm during
@@ -119,7 +137,13 @@ For each `fleet:needs-plan` issue:
    - Suggested model tag (`[fable]`, `[opus]`, or `[sonnet]`) for each
      piece — same criteria as the plan's `**Model:**` line (FLEET.md
      §"Model split")
-   - Acceptance criteria
+   - **Acceptance criteria** — and the named acceptance tests must be
+     **positive-fire**: at least one named check observably fires with the
+     feature ON (a count > 0, an asserted probe reading, a visible delta). A
+     gate that passes at default / on byte-identical output alone proves the
+     OFF path is a no-op, not that the premise holds — mirror of the
+     enabled-path rule (`engine/render/CLAUDE.md`, #1989/#2338; PR #2399
+     landed it render-side).
    - Known gotchas or pitfalls
    - **Cross-system audit (when planning a deletion or migration of a
      shared resource** — component, SSBO, GPU buffer, system,
@@ -238,7 +262,9 @@ For each `fleet:needs-plan` issue:
    reviewer (the architect, or the opus reviewer loop) reads the `## Plan`
    comment and judges it *as a plan* against the step-2 rigor — verified current
    state, a single committed approach, sibling/in-flight reconciliation, a
-   cross-system audit where one is required:
+   cross-system audit where one is required, no phase assuming an unmeasured
+   mechanism (a cited measurement or phase-0 probe is required), and
+   positive-fire acceptance tests:
    - **Sound →** remove `fleet:plan-review`. The issue is queue-ready **unless**
      it also carries `human:review-plan` (a high-stakes hold) — in that case it
      stays held for the human's approach sign-off; the scout queues it only once

--- a/scripts/fleet/fleet-plan-lint
+++ b/scripts/fleet/fleet-plan-lint
@@ -27,6 +27,8 @@
 #   - no `### Affected files` / `### Gotchas` section
 #   - no verified-current-state / repro signal
 #   - no `**Model:**` tag
+#   - mechanism-lever language (cost attribution / path dominance / a stage
+#     firing) with no measurement citation or phase-0 probe (#2401)
 #
 # Source of truth: scripts/fleet/fleet-plan-lint in the engine repo.
 set -euo pipefail
@@ -135,6 +137,17 @@ if not any(k in low for k in (
     warn.append("no verified-current-state / repro signal")
 if "**model:**" not in low and not re.search(r"(?im)^\s*-?\s*\*\*model", plan):
     warn.append("no '**Model:**' tag")
+
+# Mechanism-lever language resting on an unmeasured premise (#2401, fix-014):
+# a plan that leans on a cost / path-dominance / stage-fires claim but cites no
+# measurement and names no phase-0 probe is the recurring "premise disproved in
+# implementation" defect. Conservative substring match on `low`, warn-only.
+MECH_LEVER = ("bottleneck", "dominated by", "dispatch-bound", "fill-bound",
+              "the cost is", "hot path", "perf lever", "should be cheap")
+MECH_CITE = ("measur", "timer", "auto-profile", "disarm", "probe", "profil",
+             "domain-state")
+if any(k in low for k in MECH_LEVER) and not any(k in low for k in MECH_CITE):
+    warn.append("mechanism-lever language without a measurement citation or phase-0 probe")
 
 for w in warn:
     print(f"warn #{issue}: {w}")

--- a/scripts/fleet/tests/test_fleet_plan_lint.sh
+++ b/scripts/fleet/tests/test_fleet_plan_lint.sh
@@ -61,6 +61,12 @@ DEFER = GOOD.replace("one approach: edit foo.cpp then bar.cpp",
                      "decide during implementation whether to edit foo or bar")
 SPIKE = GOOD.replace("one approach: edit foo.cpp then bar.cpp",
                      "investigation spike - decide during investigation")
+# #2401: a mechanism-lever premise (cost/path-dominance claim) with no
+# measurement citation should warn; the same plan citing a disarm probe should not.
+LEVER = GOOD.replace("one approach: edit foo.cpp then bar.cpp",
+                     "the cost is dominated by the resolve loop; one approach: edit foo.cpp")
+LEVER_CITED = LEVER.replace("dominated by the resolve loop",
+                            "dominated by the resolve loop, confirmed by a disarm probe")
 F = {
   "100": {"title": "sound task", "comments": [{"body": GOOD}]},
   "101": {"title": "defer task", "comments": [{"body": DEFER}]},
@@ -68,6 +74,8 @@ F = {
   "103": {"title": "skeletal", "comments": [{"body": "## Plan: skeletal\n\nwe should do it somehow"}]},
   "104": {"title": "investigation spike for X", "comments": [{"body": SPIKE}]},
   "105": {"title": "tbd task", "comments": [{"body": GOOD + "\n\nopen question: TBD"}]},
+  "106": {"title": "lever task", "comments": [{"body": LEVER}]},
+  "107": {"title": "lever cited task", "comments": [{"body": LEVER_CITED}]},
 }
 print(json.dumps(F.get(num, {"title": "missing", "comments": []})))
 PYEOF
@@ -87,6 +95,14 @@ pass_out=$("$LINT" 100 2>&1 || true)
 case "$pass_out" in *"PASS #100"*) ok "sound plan prints PASS line";; *) bad "sound PASS line missing: [$pass_out]";; esac
 defer_out=$("$LINT" 101 2>&1 || true)
 case "$defer_out" in *deferred-approach*) ok "defer fail names the phrase";; *) bad "defer phrase not named: [$defer_out]";; esac
+# #2401 — mechanism-lever premise without a measurement citation: warn fires, exit still 0.
+"$LINT" 106 >/dev/null 2>&1; assert_exit $? 0 "mechanism-lever w/o citation -> exit 0 (warn only)"
+lever_out=$("$LINT" 106 2>&1 || true)
+case "$lever_out" in *"mechanism-lever language"*) ok "mechanism-lever warn fires";; *) bad "mechanism-lever warn missing: [$lever_out]";; esac
+# Same plan citing a disarm probe -> warn suppressed.
+"$LINT" 107 >/dev/null 2>&1; assert_exit $? 0 "mechanism-lever w/ citation -> exit 0"
+cited_out=$("$LINT" 107 2>&1 || true)
+case "$cited_out" in *"mechanism-lever language"*) bad "mechanism-lever warn should be absent when premise cited: [$cited_out]";; *) ok "mechanism-lever warn absent when premise cited";; esac
 "$LINT" --repo bogus 100 >/dev/null 2>&1; assert_exit $? 2 "bad --repo -> usage exit 2"
 set -e
 


### PR DESCRIPTION
## Summary
- **PLANNING-PROTOCOL.md step 2** — new phase-0 bullet *"Mechanism premises are measured, not asserted."* When a phase's lever depends on a measurable mechanism claim (where a cost lives — body-side vs dispatch-bound, which path dominates, that a stage/mode fires, that two values share one storage/shape) the plan must either **(i)** cite an existing measurement (per-system timer row, `--auto-profile` table, disarm probe per `gpu-stage-timing-cost-model.md §3`, DOMAIN-STATE log) or **(ii)** name a cheap **phase-0 probe** with the expected reading and a bail path if refuted. Worded so it can't be read as approach-deferral — phase 0 verifies the *already-picked* approach.
- Same file — acceptance tests named in a plan must be **positive-fire** (≥1 named check observably fires with the feature ON); "passes at default / byte-identical output" alone proves only the OFF path is a no-op. Step 4's plan-review rigor list mirrors both new items.
- **`scripts/fleet/fleet-plan-lint`** — one conservative **warn-only** signal: mechanism-lever language (`bottleneck`, `dominated by`, `dispatch-bound`, `the cost is`, …) with none of the citation keywords (`measur`, `timer`, `auto-profile`, `disarm`, `probe`, `profil`, `domain-state`). Never hard-fails — the lint's false-bounce contract.
- **Hermetic tests** — warn-fires + warn-absent fixtures via the existing `GOOD_PLAN`-mutation PATH-shim. Plan committed as the first commit (per #1932).

Recurring fleet-feedback defect **fix-014** (8 occurrences since PR #2038): a plan asserts a mechanism premise implementation then disproves, burning a full implement + escalation round — #2258 (assumed body-side, measured dispatch-bound), #2256/#2271/#2273 (mutually-invalidated premises), #2278 (vacuous gate), #2321 (unverified singleton/same-shape).

The gated `role-opus-reviewer.md` inline mirror is split to follow-up **#2407** — the reviewer already binds the new rigor *by reference* (PLANNING-PROTOCOL.md step 2); only the inline example enumeration needs the two-line mirror, which a worker can't push (gated self-config).

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_plan_lint.sh` → PASS 13 / FAIL 0 (incl. the two new mechanism-lever cases; warn-fires case observes the warn actually printing)
- [x] `fleet-plan-lint 2401` → PASS, 0 warnings — the #2401 plan itself does not trip the new warn (it cites measurements)
- [x] `ruff check scripts/fleet/` → All checks passed
- [x] No gated self-config file in the diff; no C++ touched

Closes #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
