### PR TITLE
docs: architect attaches a plan when self-approving a standalone ticket

### DIFF
--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -252,6 +252,20 @@ filing for mechanical tasks (the worker plans those; a high-stakes worker-planne
 issue then holds on `human:review-plan` for your sign-off — see
 [`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) step 3).
 
+**If you'll queue it yourself, attach the plan — even for mechanical tickets.**
+The rule above draws the line at "planned with the human," but the sharper
+trigger is *who approves it*. If **you** will stamp `human:approved` in the same
+session you file a standalone ticket — rather than handing it to the human's
+async triage — post the `## Plan` comment at file time. You have the context
+right then; a short plan (verified current state, one picked approach,
+verification) skips the round-trip; and `fleet-queue-ingest` otherwise bounces
+your own approved-but-plan-less issue straight to `fleet:needs-plan`. This is the
+same file-with-plan discipline `file-epic` already gives every epic child — a
+standalone ticket you queue deserves it too. Reserve deliberate plan-less filing
+for when you *want* a worker to plan it: then leave it for the human's
+needs-plan triage instead of self-approving, or tag `[no-plan]` if it is trivial
+enough to skip planning outright.
+
 **Multi-issue stacks (epic decomposition).** When the work decomposes into a
 stack of N issues that each depend on the prior — the canonical smooth-yaw /
 SO(3) / rotation / streaming patterns — do NOT hand-file the children. Invoke


### PR DESCRIPTION
## Summary
- Adds a filing-time rule to `docs/agents/architect-protocol.md` §Filing tasks: when the architect will stamp `human:approved` on a standalone ticket in the same session it's filed, attach the `## Plan` comment at file time — the same file-with-plan discipline `file-epic` already gives every epic child.
- Keeps the escape valve explicit: to route a mechanical ticket through worker planning, leave it for the human's `fleet:needs-plan` triage instead of self-approving, or tag `[no-plan]`.

## Context
The protocol already says to file human-planned tasks with a `## Plan` comment and lets mechanical tasks be worker-planned. The gap this closes is the *self-approve* case: when the architect files **and** approves a standalone ticket in one pass, a plan-less issue is bounced by `fleet-queue-ingest` to `fleet:needs-plan`. The sharper trigger is "who approves it" — if it's you, attach the plan. Surfaced when an architect-filed standalone cleanup ticket went out plan-less alongside an epic whose children (via `file-epic`) all carried plans.

## Test plan
- [ ] Docs-only; renders cleanly under §Filing tasks. No code changed, but this does add a new behavioral trigger for the architect role (attach-plan-on-self-approve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

