### PR TITLE
fleet: enforce worktree-scoped edits/cwd by assignment (#2402)

### DIFF
--- a/.fleet/plans/issue-2402.md
+++ b/.fleet/plans/issue-2402.md
@@ -1,0 +1,80 @@
+## Plan: fleet: mechanically enforce worktree-scoped edits/cwd — doc rules keep failing (fix-011 recurring)
+
+- **Issue:** #2402
+- **Model:** opus — careful bash/python hook + generator work with fail-open/fail-closed subtleties and preservation tests; the approach below is fully committed, no novel design left
+- **Date:** 2026-07-14
+
+### Verified current state (audit — issue item 1)
+
+Coverage map of today's enforcement, verified against the scripts on `origin/master`:
+
+| Surface | Mechanism | Verified gap |
+|---|---|---|
+| Edit/Write/MultiEdit, engine-launched sessions | `fleet-guard-worktree-edit` PreToolUse hook, wired via the checked-in engine `.claude/settings.json` (`$CLAUDE_PROJECT_DIR/scripts/fleet/…`) | Derives the worktree from the **dynamic session cwd**. Two fail-open holes: (a) cwd drifts to the main clone → `case */.claude/worktrees/*` doesn't match → **no restriction at all** (the worker-1 2026-07-07 Edit-misroute mechanism); (b) cwd in any *other* agent's worktree → guard re-derives to that worktree and allows writes there. |
+| Edit/Write/MultiEdit, game-repo-launched sessions | **nothing** | Game repo's checked-in `.claude/settings.json` has no `hooks` key and the game repo has no `scripts/fleet/`; meanwhile the generated game-worktree `settings.local.json` grants `additionalDirectories` access to the engine main clone. Game sessions can write anywhere in either clone unguarded. |
+| Legitimate agent state writes (`~/.fleet/*`, auto-memory dir) | denied by the same guard (outside worktree root) | Over-blocking trains the documented Bash-heredoc workaround — i.e. the guard teaches agents the bypass channel. |
+| Bash git mutations | `fleet-assert-worktree`, called by `fleet-pr-checkout-detached` (script-level) and by the `commit-and-push` / `start-next-task` skills (doc-level, per PR #1332) | `fleet-pr-amend-push` (push runs from cwd repo; only the amend-ref sentinel protects it — a stale sentinel in a main clone would push from there), `fleet-review-verdict` `--agent` path (the #2153/#2326 wrong-tree verdict/body flow), and `fleet-edit` (a file-writing CLI that bypasses the PreToolUse hook entirely) have no assert. |
+| Bash cd drift in reviewer resets | PR #2381 (merged): assert + `git -C` discipline in reviewer scratch flows | Complementary; not touched here. |
+
+Premise of the issue confirmed: enforcement exists but is cwd-derived and engine-only, so exactly the drifted-cwd and game-side cases recur (fix-011: 5 occurrences since PR #1332).
+
+### Scope
+
+Make worktree scoping **assignment-derived instead of cwd-derived**, extend it to game-repo sessions, stop over-blocking the legitimate agent-state write paths, and add `fleet-assert-worktree` to the three mutating wrappers that lack it. Explicit non-goal: no PreToolUse hook on Bash (parsing arbitrary shell for paths over-blocks and risks wedging the fleet); raw-Bash drift stays covered at the wrapper boundaries plus the merged PR #2381 discipline.
+
+### Approach
+
+1. **`scripts/fleet/fleet-up` — `write_worktree_settings()` emits the assignment.** For every generated worktree `settings.local.json`, add:
+   - `"env": {"FLEET_ASSIGNED_WORKTREE": "<abs worktree path>"}` — the authoritative identity signal, available to hooks and every Bash call in sessions launched from that worktree.
+   - a PreToolUse hook group (`Edit|Write|MultiEdit`) invoking the **engine clone's** copy of the guard by absolute path baked at generation time (`$ENGINE/scripts/fleet/fleet-guard-worktree-edit`), wrapped in an `[ -x … ] && … || true` so a missing/renamed script fails open (never wedge the fleet; also avoids `~/bin` staleness — #2262 is in flight on that surface). Engine-launched sessions will double-fire (project-settings hook + this one); that is accepted — two identical verdicts, deny still wins, one extra subprocess per edit.
+   - Per the `scripts/fleet/CLAUDE.md` §Authoring-rules preservation contract (#2284): extend the fleet-owned-hook marker match (currently `fleet-session-track` only) to also recognize `fleet-guard-worktree-edit` so regeneration replaces stale variants rather than duplicating, preserve hand-added keys under the new `env` key (merge, fleet's key wins only for `FLEET_ASSIGNED_WORKTREE`), and extend `tests/test_worktree_settings_hooks.sh` for both new keys in the same change.
+   - `game-architect` / game `epic-steward` calls pass `repo_root=$GAME`, which has no `scripts/fleet` — the hook path must come from `$ENGINE` (global in `fleet-up`), not from `repo_root`.
+
+2. **`scripts/fleet/fleet-guard-worktree-edit` — dual-mode rework.**
+   - **Assignment mode (`FLEET_ASSIGNED_WORKTREE` set):** ignore cwd entirely. Allow a mutation iff the target path is inside: (a) any `*/.claude/worktrees/<basename>/` worktree whose basename equals the assigned one — this covers the engine+game worktree pair of the same pane with one rule while still excluding sibling agents (keep the existing trailing-slash prefix idiom); (b) `~/.fleet/`; (c) `/tmp/` and `/private/tmp/` (macOS canonical form); (d) the auto-memory dir (`~/.claude/projects/*/memory/`). Everything else — main clones included, **regardless of where cwd drifted** — is denied. Relative paths: resolve against the hook-input cwd first, then apply the same test (closes the drifted-cwd + relative-path hole).
+   - **Legacy mode (env unset):** current cwd-derived behavior, byte-for-byte semantics — human sessions in the main clone and hand-made worktrees (e.g. experiment worktrees) stay unaffected.
+   - Keep the existing failure discipline: parse/jq failure fails OPEN; a policy deny uses the `hookSpecificOutput` deny form with the corrective message (extend it to name `FLEET_ASSIGNED_WORKTREE` and the allowlist).
+   - New hermetic `tests/test_guard_worktree_edit.sh` (none exists today) driving the script with synthetic hook JSON on stdin: the deny/allow matrix above, both modes, plus fail-open on malformed input.
+
+3. **Wrapper asserts (issue item 2).**
+   - `fleet-pr-amend-push`: `fleet-assert-worktree` (no-arg form) before the push — closes the stale-sentinel-in-main-clone case.
+   - `fleet-review-verdict`: on the `--agent` path only, assert with the agent name as expected basename (`fleet-assert-worktree "$agent"`) before applying the verdict; the no-`--agent` human carve-out keeps working from anywhere, mirroring the wrapper's existing dual-use design.
+   - `fleet-edit`: when `FLEET_ASSIGNED_WORKTREE` is set, refuse a target file outside the same allowlist as the hook (same-basename worktrees + `~/.fleet` + tmp dirs); unset → unchanged. This closes the "Edit-tool-equivalent CLI" bypass.
+   - Explicitly NOT asserted: `fleet-rebase`, `fleet-state-scout`, `fleet-queue-ingest`, `fleet-claim`, `fleet-clone-freshness.sh` — these legitimately run from the main clone (merger/scout/dispatcher lanes).
+   - Optional belt, warn-only: `fleet-build` prints a one-line warning when its cwd resolves to a main clone (the "fix had no effect" precursor); never fails — humans build main clones deliberately.
+
+4. **Docs (non-gated only).** Update the guard's header comment and `scripts/fleet/CLAUDE.md` (a one-bullet note that worktree scoping is assignment-derived via `FLEET_ASSIGNED_WORKTREE`). Do NOT touch role docs or SKILL.md files (gated self-config; #1332 already put the doc-level rules there — this ticket is the enforcement side precisely because those keep failing).
+
+### Affected files
+
+- `scripts/fleet/fleet-up` — `write_worktree_settings()`: `env` key, guard hook group, marker + preservation extensions
+- `scripts/fleet/fleet-guard-worktree-edit` — dual-mode rework
+- `scripts/fleet/fleet-pr-amend-push` — assert before push
+- `scripts/fleet/fleet-review-verdict` — assert on the `--agent` path
+- `scripts/fleet/fleet-edit` — allowlist check on target path
+- `scripts/fleet/fleet-build` — warn-only main-clone cwd notice (optional belt)
+- `scripts/fleet/tests/test_worktree_settings_hooks.sh` — extend for `env` + guard-hook emission/preservation
+- `scripts/fleet/tests/test_guard_worktree_edit.sh` — new
+- `scripts/fleet/tests/test_fleet_edit_scope.sh` (or extend an existing fleet-edit test if one exists) — new coverage for the `fleet-edit` allowlist
+- `scripts/fleet/CLAUDE.md` — one authoring-rule note
+
+### Acceptance criteria
+
+- Hermetic tests (source `tests/lib_assert.sh`; no live GitHub, no live `~/.fleet`) pass for the full guard matrix: with `FLEET_ASSIGNED_WORKTREE` set — main-clone absolute write denied **even when hook-input cwd is the main clone**; sibling-agent worktree denied; same-basename game worktree allowed; `~/.fleet`, `/tmp`, `/private/tmp`, memory-dir writes allowed; relative path resolved-then-tested; malformed JSON fails open. With it unset — current behavior unchanged.
+- `test_worktree_settings_hooks.sh` proves: both new keys emitted; a stale fleet guard-hook variant is replaced, not duplicated; hand-added hooks and hand-added `env` entries survive regeneration.
+- `fleet-pr-amend-push` and `fleet-review-verdict --agent …` exit non-zero with the assert message when run from a main-clone cwd, and work unchanged from a worktree.
+- `fleet-edit` refuses a main-clone target under assignment mode; unchanged otherwise.
+- `ruff check scripts/` clean; all existing `scripts/fleet/tests/` still pass.
+- Grep-verifiable: no role-doc / SKILL.md / `.claude/commands` diffs in the PR.
+
+### Gotchas
+
+- **Fail-open vs fail-closed:** parse failures fail open (hook must never wedge the fleet); policy verdicts fail closed. Don't invert either.
+- **#2284 preservation rule:** every newly emitted `settings.local.json` key ships its preservation logic + test in the same change — `env` and the second hook group both count.
+- **macOS path canonicalization:** the kernel resolves `/tmp` → `/private/tmp` before the hook sees it; allowlist both, and compare realpath-normalized prefixes where cheap to do so.
+- **Don't depend on `~/bin`:** #2262 (install-symlink-lag) is in flight; the hook command must reference the engine clone / worktree copy by absolute path. No `install.sh` manifest change is needed (the guard is already installed; behavior changes ride the repo copies the settings point at).
+- **`fleet-claim`/scout/ingest run from the main clone by design** — adding asserts there would break the fleet; the not-asserted list above is deliberate.
+- **Sibling-prefix trap:** keep the trailing-slash prefix-match idiom so `worker-1-foo` can't prefix-match `worker-1`.
+- **MultiEdit shares `tool_input.file_path`;** `NotebookEdit` (`notebook_path`) stays outside the matcher — out of scope.
+- **Engine-public wording** in all comments/messages (this repo is public; no game-content terminology).
+

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -50,6 +50,17 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   next regeneration silently clobbers human edits under that key (#2284:
   the first `hooks` key repeated the lesson `permissions.allow` already
   encoded).
+- **Worktree scoping is assignment-derived, not cwd-derived (#2402).**
+  `fleet-up` bakes `FLEET_ASSIGNED_WORKTREE` (the absolute worktree path) into
+  each generated `settings.local.json` `env`; when set, `fleet-guard-worktree-edit`
+  and `fleet-edit` allow a mutation only inside that worktree (engine **or** game,
+  matched by basename), `$HOME/.fleet`, `/tmp`, `/private/tmp`, or the auto-memory
+  dir — so a drifted cwd can't misroute an edit into the shared main clone. Env
+  unset ⇒ the legacy cwd-derived behavior (human / non-fleet sessions). The
+  allowlist mirrors the settings' `additionalDirectories`; extend both together.
+  Mutating git wrappers (`fleet-pr-amend-push`, `fleet-review-verdict --agent`)
+  call `fleet-assert-worktree`; scout / ingest / claim / rebase legitimately run
+  from the main clone and are deliberately NOT asserted.
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,

--- a/scripts/fleet/fleet-build
+++ b/scripts/fleet/fleet-build
@@ -12,6 +12,16 @@
 
 set -euo pipefail
 
+# Warn-only worktree-cwd notice (#2402): building from a shared main clone is a
+# common "my fix had no effect" precursor — the change landed in a worktree while
+# the build ran here. NEVER fail (humans build main clones deliberately; the
+# merger / platform-catchup build from clones by design), just surface the drift.
+_bld_tl=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -n "$_bld_tl" && "$_bld_tl" != */.claude/worktrees/* ]]; then
+    echo "fleet-build: NOTE — cwd ($_bld_tl) is a main clone, not a fleet worktree." >&2
+    echo "             if you edited files in a worktree, this build won't see them (#2402)." >&2
+fi
+
 # Resolve ir-build through the symlinked-script discipline used by every
 # other ir-* tool. Prefer the source tree adjacent to this shim (works
 # from a worktree before install.sh runs); fall back to PATH lookup.

--- a/scripts/fleet/fleet-edit
+++ b/scripts/fleet/fleet-edit
@@ -45,6 +45,30 @@ replace_all="${4:-}"
 [[ -f "$old_file" ]] || { echo "fleet-edit: old-file not found: $old_file" >&2; exit 1; }
 [[ -f "$new_file" ]] || { echo "fleet-edit: new-file not found: $new_file" >&2; exit 1; }
 
+# Worktree-scope guard (#2402): fleet-edit is an Edit-tool-equivalent CLI, so it
+# bypasses the PreToolUse edit hook. Under an assignment (FLEET_ASSIGNED_WORKTREE
+# set) apply the SAME allowlist the hook enforces so a misrouted CLI edit can't
+# land in a shared main clone. Unset (human / legacy session) → unchanged.
+if [[ -n "${FLEET_ASSIGNED_WORKTREE:-}" ]]; then
+    _wt_name=$(basename "$FLEET_ASSIGNED_WORKTREE" 2>/dev/null || true)
+    # Resolve the target to an absolute path (it exists — checked above).
+    _abs=$(cd "$(dirname "$target")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$target")")
+    _abs="${_abs:-$target}"
+    _ok=0
+    case "$_abs/" in
+        */.claude/worktrees/"$_wt_name"/*) _ok=1 ;;   # this pane's worktree (engine or game)
+    esac
+    case "$_abs" in
+        "$HOME"/.fleet/*|/tmp/*|/private/tmp/*|"$HOME"/.claude/projects/*/memory/*) _ok=1 ;;
+    esac
+    if [[ "$_ok" -ne 1 ]]; then
+        echo "fleet-edit: REFUSING to edit '$target' — outside your assigned worktree." >&2
+        echo "  assigned worktree: $FLEET_ASSIGNED_WORKTREE" >&2
+        echo "  allowed: your worktree, \$HOME/.fleet, /tmp, /private/tmp, the auto-memory dir (#2402)." >&2
+        exit 1
+    fi
+fi
+
 exec python3 - "$target" "$old_file" "$new_file" "$replace_all" <<'PYEOF'
 import sys, pathlib
 

--- a/scripts/fleet/fleet-guard-worktree-edit
+++ b/scripts/fleet/fleet-guard-worktree-edit
@@ -1,25 +1,38 @@
 #!/usr/bin/env bash
 # fleet-guard-worktree-edit — PreToolUse hook for Edit | Write | MultiEdit.
 #
-# Refuses an edit whose absolute file_path lands OUTSIDE the fleet worktree the
-# session is working in. A fleet agent runs with its cwd inside
-# `.../.claude/worktrees/<name>/`; if it edits via a bare
-# `~/src/IrredenEngine/engine/...` absolute path, the write silently hits the
-# shared MAIN clone instead of the worktree. `fleet-build` (run in the worktree)
-# then compiles nothing and the agent wrongly concludes its fix "had no effect"
-# (observed on PR #1310 / #1336). The #1332 worktree-identity preflight guards
-# Bash/git, NOT the file tools — this closes that gap by enforcement instead of
-# role-doc discipline.
+# Refuses an edit whose target file_path lands OUTSIDE the fleet worktree the
+# session is assigned to. A fleet agent runs from `.../.claude/worktrees/<name>/`;
+# if it edits via a bare `~/src/IrredenEngine/engine/...` absolute path (or a
+# relative path while its cwd has drifted into the shared main clone), the write
+# silently hits the MAIN clone instead of the worktree. `fleet-build` (run in
+# the worktree) then compiles nothing and the agent wrongly concludes its fix
+# "had no effect" (observed on PR #1310 / #1336). The #1332 worktree-identity
+# preflight guards Bash/git, NOT the file tools — this closes that gap by
+# enforcement instead of role-doc discipline.
 #
-# Scope: ONLY constrains sessions whose cwd is inside a fleet worktree. The main
-# clone and isolated (e.g. /tmp) worktrees are unaffected. Relative paths
-# (resolved against the in-worktree cwd) are always allowed; only an absolute
-# path escaping the worktree root is blocked. Reads are NOT gated — the matcher
-# is Edit|Write|MultiEdit only (the silent-misroute hazard is mutations).
+# Two modes (#2402):
+#   * ASSIGNMENT mode — `FLEET_ASSIGNED_WORKTREE` is set (fleet-up bakes it into
+#     each generated worktree's settings.local.json `env`). Worktree identity is
+#     the ASSIGNED path, never the session cwd, so the guard holds even when cwd
+#     drifts into a main clone or a sibling agent's worktree. Allowed targets:
+#       - any `*/.claude/worktrees/<assigned-basename>/…` (covers this pane's
+#         engine + game worktree pair with one rule, excludes sibling agents),
+#       - `$HOME/.fleet/…`  (heartbeats, plans, claims, summaries),
+#       - `/tmp/…` and `/private/tmp/…` (macOS canonical form),
+#       - `$HOME/.claude/projects/*/memory/…` (auto-memory).
+#     A relative target is resolved against the hook-input cwd first, then tested
+#     the same way — so a relative edit from a drifted cwd is caught too.
+#   * LEGACY mode — env unset: the original cwd-derived behavior, byte-for-byte,
+#     so human sessions in the main clone and hand-made (e.g. /tmp) worktrees are
+#     unaffected.
+#
+# Scope: the matcher is Edit|Write|MultiEdit only — reads are never gated (the
+# silent-misroute hazard is mutations).
 #
 # Contract: reads the PreToolUse JSON on stdin; denies via the
-# hookSpecificOutput JSON form. ANY parse failure or missing field fails OPEN
-# (exit 0) — a hook must never wedge the fleet.
+# hookSpecificOutput JSON form. ANY parse failure, missing field, or unusable
+# assignment fails OPEN (exit 0) — a hook must never wedge the fleet.
 set -uo pipefail
 
 input=$(cat 2>/dev/null || true)
@@ -28,15 +41,77 @@ input=$(cat 2>/dev/null || true)
 cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
 
+# No path → nothing to constrain.
+[[ -z "$file" ]] && exit 0
+
+home="$HOME"
+
+# deny <reason> — emit the hookSpecificOutput deny form (exit 0). If jq can't
+# produce the JSON, fall back to the exit-2 block form so the guard still fires
+# rather than failing open on a policy deny.
+deny() {
+    jq -n --arg r "$1" \
+        '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}' \
+        2>/dev/null && exit 0
+    printf '%s\n' "$1" >&2
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# ASSIGNMENT mode: identity comes from FLEET_ASSIGNED_WORKTREE, not cwd.
+# ---------------------------------------------------------------------------
+if [[ -n "${FLEET_ASSIGNED_WORKTREE:-}" ]]; then
+    assigned_name=$(basename "$FLEET_ASSIGNED_WORKTREE" 2>/dev/null || true)
+    # Unusable assignment (empty / root / '.') → can't derive a basename to
+    # test against; fail open rather than over-block every edit.
+    case "$assigned_name" in
+        ""|"/"|".") exit 0 ;;
+    esac
+
+    # Relative target → resolve against the hook-input cwd, then test as an
+    # absolute path. If cwd is unknown we can't resolve it → fail open.
+    case "$file" in
+        /*) ;;
+        *)  [[ -z "$cwd" ]] && exit 0
+            file="$cwd/$file" ;;
+    esac
+
+    # Allow: this pane's own worktree (engine or game — same basename). Trailing
+    # slash on both sides so a sibling worktree like `<name>-foo` can't
+    # prefix-match `<name>`.
+    case "$file/" in
+        */.claude/worktrees/"$assigned_name"/*) exit 0 ;;
+    esac
+    # Allow: fleet state, scratch dirs, auto-memory.
+    case "$file" in
+        "$home"/.fleet/*)                    exit 0 ;;
+        /tmp/*|/private/tmp/*)               exit 0 ;;
+        "$home"/.claude/projects/*/memory/*) exit 0 ;;
+    esac
+
+    deny "fleet worktree guard (assignment mode): refusing to edit a path outside your assigned worktree.
+  assigned worktree: $FLEET_ASSIGNED_WORKTREE  (basename: $assigned_name)
+  edit target:       $file
+Allowed targets are your own worktree (engine or game, matched by basename),
+\$HOME/.fleet, /tmp, /private/tmp, and the auto-memory dir. This path is none of
+those — it points into the shared main clone or another agent's worktree,
+regardless of where your shell cwd drifted. Editing it there silently misroutes
+the write — fleet-build runs in your worktree and compiles nothing, so the
+change looks like it 'had no effect' (PR #1310 / #1336). Redo this edit with a
+path INSIDE your worktree."
+fi
+
+# ---------------------------------------------------------------------------
+# LEGACY mode (FLEET_ASSIGNED_WORKTREE unset): cwd-derived, unchanged.
+# ---------------------------------------------------------------------------
 # Not in a fleet worktree → no restriction.
 case "$cwd" in
     */.claude/worktrees/*) ;;
     *) exit 0 ;;
 esac
 
-# No path, or a relative path (the tools resolve it against the in-worktree
-# cwd, so it stays in-worktree) → allow.
-[[ -z "$file" ]] && exit 0
+# A relative path (the tools resolve it against the in-worktree cwd, so it stays
+# in-worktree) → allow.
 case "$file" in
     /*) ;;
     *)  exit 0 ;;
@@ -56,7 +131,7 @@ case "$file/" in
 esac
 
 # Outside the worktree → deny with a corrective message.
-reason="fleet worktree guard: refusing to edit a path outside your worktree.
+deny "fleet worktree guard: refusing to edit a path outside your worktree.
   your worktree: $wt_root
   edit target:   $file
 You are working in a fleet worktree, but this absolute path points into the
@@ -64,12 +139,3 @@ shared main clone (or a sibling worktree). Editing it there silently misroutes
 the write — fleet-build runs in your worktree and compiles nothing, so the
 change looks like it 'had no effect' (PR #1310 / #1336). Redo this edit with a
 path INSIDE your worktree, or a path relative to your current directory."
-
-jq -n --arg r "$reason" \
-    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}' \
-    2>/dev/null && exit 0
-
-# jq output failed for some reason — fall back to the exit-2 block form so the
-# guard still fires rather than failing open on a deny.
-printf '%s\n' "$reason" >&2
-exit 2

--- a/scripts/fleet/fleet-guard-worktree-edit
+++ b/scripts/fleet/fleet-guard-worktree-edit
@@ -22,7 +22,10 @@
 #       - `/tmp/…` and `/private/tmp/…` (macOS canonical form),
 #       - `$HOME/.claude/projects/*/memory/…` (auto-memory).
 #     A relative target is resolved against the hook-input cwd first, then tested
-#     the same way — so a relative edit from a drifted cwd is caught too.
+#     the same way — so a relative edit from a drifted cwd is caught too. Before
+#     the containment tests, '.'/'..' segments are lexically collapsed, so a
+#     '..'-laden target (relative or absolute) can't pass the literal match while
+#     resolving outside the allowed set.
 #   * LEGACY mode — env unset: the original cwd-derived behavior, byte-for-byte,
 #     so human sessions in the main clone and hand-made (e.g. /tmp) worktrees are
 #     unaffected.
@@ -57,6 +60,24 @@ deny() {
     exit 2
 }
 
+# normalize_path <abs-path> — lexically collapse '.', '..', and repeated
+# slashes without touching the filesystem (the target may not exist yet, and
+# the guard is pure string logic). '..' above root clamps at root, matching
+# kernel path resolution. Always called via $(…), so the subshell keeps the
+# `set -f` (no-glob during word split) from leaking.
+normalize_path() {
+    set -f
+    local IFS='/' seg out=""
+    for seg in $1; do
+        case "$seg" in
+            ""|".") ;;
+            "..")   out="${out%/*}" ;;
+            *)      out="$out/$seg" ;;
+        esac
+    done
+    printf '%s' "${out:-/}"
+}
+
 # ---------------------------------------------------------------------------
 # ASSIGNMENT mode: identity comes from FLEET_ASSIGNED_WORKTREE, not cwd.
 # ---------------------------------------------------------------------------
@@ -75,6 +96,12 @@ if [[ -n "${FLEET_ASSIGNED_WORKTREE:-}" ]]; then
         *)  [[ -z "$cwd" ]] && exit 0
             file="$cwd/$file" ;;
     esac
+
+    # Collapse '.'/'..' BEFORE the containment tests: they are literal string
+    # matches, so an un-normalized <worktree>/../../../engine/foo.cpp would
+    # pass the worktree match (and /tmp/../… would ride the scratch allowlist)
+    # while resolving outside.
+    file=$(normalize_path "$file")
 
     # Allow: this pane's own worktree (engine or game — same basename). Trailing
     # slash on both sides so a sibling worktree like `<name>-foo` can't

--- a/scripts/fleet/fleet-pr-amend-push
+++ b/scripts/fleet/fleet-pr-amend-push
@@ -57,6 +57,25 @@ if [[ -z "$git_dir" ]]; then
     exit 1
 fi
 
+# Worktree-scope guard (#2402): the push below runs from the cwd repo, and a
+# stale amend-ref sentinel in a shared main clone would route it from the wrong
+# tree. Refuse unless cwd is a fleet worktree. Resolve the sibling helper the
+# same way the other fleet-* tools do; fall back to an inline structural check if
+# it isn't linked yet (e.g. before install.sh has run).
+guard="${BASH_SOURCE[0]}"
+while [[ -L "$guard" ]]; do guard="$(readlink "$guard")"; done
+guard="$(cd "$(dirname "$guard")" && pwd)/fleet-assert-worktree"
+if [[ -x "$guard" ]]; then
+    "$guard" || exit 1
+else
+    _tl=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [[ -n "$_tl" && "$_tl" != */.claude/worktrees/* && -z "${FLEET_ALLOW_MAIN_CLONE:-}" ]]; then
+        echo "fleet-pr-amend-push: REFUSING — cwd ($_tl) is not a fleet worktree (#2402)." >&2
+        echo "  cd into your worktree before pushing an amendment. Human override: FLEET_ALLOW_MAIN_CLONE=1" >&2
+        exit 1
+    fi
+fi
+
 sentinel="$git_dir/fleet-amend-ref"
 if [[ ! -f "$sentinel" ]]; then
     echo "fleet-pr-amend-push: $sentinel missing — was fleet-pr-checkout-detached run in this worktree?" >&2

--- a/scripts/fleet/fleet-review-verdict
+++ b/scripts/fleet/fleet-review-verdict
@@ -150,6 +150,18 @@ repo_args=()
 # Omitting --agent is the interactive-human carve-out (no claim to hold).
 # ----------------------------------------------------------------------
 if [[ -n "$agent" ]]; then
+    # Worktree-scope guard (#2402): an --agent verdict must be applied from THAT
+    # agent's own worktree. The #2153/#2326 misroute stamped a verdict / posted a
+    # review body from wrong-tree state; assert cwd is the agent's worktree before
+    # any label write. The no-agent human carve-out never reaches here, so it
+    # still runs from anywhere. Fail open if the helper isn't linked yet — the
+    # claim check below remains the primary misroute guard.
+    _wtguard="${BASH_SOURCE[0]}"
+    while [[ -L "$_wtguard" ]]; do _wtguard="$(readlink "$_wtguard")"; done
+    _wtguard="$(cd "$(dirname "$_wtguard")" && pwd)/fleet-assert-worktree"
+    if [[ -x "$_wtguard" ]]; then
+        "$_wtguard" "$agent" || exit 1
+    fi
     if ! command -v fleet-claim >/dev/null 2>&1; then
         echo "$PROG: fleet-claim not found (needed to derive the host key)." >&2
         exit 1

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -834,11 +834,18 @@ write_worktree_settings() {
     # Baseline allows that every fleet agent needs (beyond the user-level
     # ~/.claude/settings.json entries). These cover tools the agents use
     # during freeform work that aren't in the user-level allowlist.
-    python3 - "$settings_file" "$repo_root" <<'PYEOF'
+    # argv[3] = the absolute worktree path (baked into FLEET_ASSIGNED_WORKTREE so
+    # the edit guard derives worktree identity from the ASSIGNMENT, not the drift-
+    # prone session cwd). argv[4] = $ENGINE — the guard hook lives under the engine
+    # clone's scripts/fleet, which game-side worktrees (repo_root=$GAME) can't reach
+    # via repo_root; the engine root is the stable source for the hook path (#2402).
+    python3 - "$settings_file" "$repo_root" "$wt" "$ENGINE" <<'PYEOF'
 import json, sys, os
 
 settings_file = sys.argv[1]
 repo_root     = sys.argv[2]
+worktree      = sys.argv[3]
+engine_root   = sys.argv[4]
 
 baseline = [
     "Edit(*)",
@@ -916,6 +923,7 @@ baseline = [
 # The catch-all "Bash(python3:*)" baseline entry covers all python3 use.
 existing_extra = []
 existing_hooks = {}
+existing_env = {}
 if os.path.isfile(settings_file):
     try:
         d = json.load(open(settings_file))
@@ -924,6 +932,8 @@ if os.path.isfile(settings_file):
                 existing_extra.append(a)
         if isinstance(d.get("hooks"), dict):
             existing_hooks = d["hooks"]
+        if isinstance(d.get("env"), dict):
+            existing_env = d["env"]
     except Exception:
         pass  # malformed file — start fresh with baseline only
 
@@ -968,14 +978,33 @@ session_track_cmd = (
     " && fleet-session-track || true"
 )
 
+# PreToolUse edit guard (#2402): reject Edit/Write/MultiEdit whose target
+# escapes this pane's worktree, using the assignment (FLEET_ASSIGNED_WORKTREE
+# below) rather than the drift-prone session cwd. The command references the
+# engine clone's copy by ABSOLUTE path baked at generation time — game-side
+# worktrees have no scripts/fleet of their own, and ~/bin symlinks can lag an
+# install (#2262). Wrapped in `[ -x … ] && … || true` so a missing/renamed
+# guard fails OPEN (a hook must never wedge the fleet). Engine-launched
+# sessions also carry this guard via the checked-in project settings.json; the
+# double-fire is accepted (two identical verdicts; deny still wins).
+guard_path = f"{engine_root}/scripts/fleet/fleet-guard-worktree-edit"
+guard_cmd = f'[ -x "{guard_path}" ] && "{guard_path}" || true'
+
 # Hand-added hooks survive regeneration the same way user-granted allow
-# entries do: keep every hook group from the previous file except the
-# fleet's own (matched on the fleet-session-track marker, so a stale
-# variant of the fleet hook is replaced rather than duplicated).
+# entries do: keep every hook group from the previous file except the fleet's
+# own (matched on either fleet-hook marker, so a stale variant of a fleet hook
+# is replaced rather than duplicated).
+FLEET_HOOK_MARKERS = ("fleet-session-track", "fleet-guard-worktree-edit")
 hooks_out = {
     "SessionStart": [
         {"hooks": [{"type": "command", "command": session_track_cmd}]}
-    ]
+    ],
+    "PreToolUse": [
+        {
+            "matcher": "Edit|Write|MultiEdit",
+            "hooks": [{"type": "command", "command": guard_cmd}],
+        }
+    ],
 }
 for event, groups in existing_hooks.items():
     if not isinstance(groups, list):
@@ -985,11 +1014,19 @@ for event, groups in existing_hooks.items():
             continue
         cmds = group.get("hooks")
         if isinstance(cmds, list) and any(
-            isinstance(h, dict) and "fleet-session-track" in str(h.get("command", ""))
+            isinstance(h, dict)
+            and any(m in str(h.get("command", "")) for m in FLEET_HOOK_MARKERS)
             for h in cmds
         ):
             continue
         hooks_out.setdefault(event, []).append(group)
+
+# env: the authoritative worktree-identity signal for the edit guard and every
+# Bash call in sessions launched from this worktree. Hand-added env entries
+# survive regeneration (same contract as allow/hooks, #2284); fleet wins only on
+# its own key.
+env_out = dict(existing_env)
+env_out["FLEET_ASSIGNED_WORKTREE"] = worktree
 
 out = {
     "permissions": {
@@ -997,6 +1034,7 @@ out = {
         "allow": all_allows,
         "defaultMode": "auto",
     },
+    "env": env_out,
     "hooks": hooks_out,
 }
 

--- a/scripts/fleet/tests/test_fleet_amend_push_scope.sh
+++ b/scripts/fleet/tests/test_fleet_amend_push_scope.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tests for fleet-pr-amend-push's #2402 worktree-scope assert: the push runs
+# from the cwd repo, so a stale amend-ref sentinel in a shared main clone would
+# route it from the wrong tree. The wrapper now calls fleet-assert-worktree
+# before touching the sentinel — refuse from a main clone, proceed from a
+# worktree.
+#
+# Hermetic: `git init`s two sandbox repos (a "main clone" whose toplevel lacks
+# the /.claude/worktrees/ segment, and a worktree-shaped one) and drives the real
+# wrapper. No network is reached — the assert and the sentinel-missing check both
+# precede any git fetch/push.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$(dirname "$0")/lib_assert.sh"
+
+WRAPPER="$SCRIPT_DIR/fleet-pr-amend-push"
+[[ -x "$WRAPPER" ]] || { echo "test setup: fleet-pr-amend-push not executable at $WRAPPER" >&2; exit 1; }
+
+TMPROOT=$(mktemp -d -t fleet-amend-scope)
+trap '[[ -n "${TMPROOT:-}" ]] && rm -rf "$TMPROOT"' EXIT
+
+MAIN="$TMPROOT/mainclone"
+WT="$TMPROOT/eng/.claude/worktrees/worker-3"
+mkdir -p "$MAIN" "$WT"
+git -C "$MAIN" init -q
+git -C "$WT" init -q
+
+# run <cwd> [env-assignments...] → prints "<exit>\n<stderr>"
+run_in() {
+    local dir="$1"; shift
+    ( cd "$dir" && "$@" "$WRAPPER" >/dev/null 2>"$TMPROOT/err"; echo "$?" )
+}
+
+echo "main clone: assert refuses before the sentinel is read"
+rc=$(run_in "$MAIN")
+assert_eq "$rc" "1" "amend-push refuses from a main-clone cwd (exit 1)"
+assert_contains "$(cat "$TMPROOT/err")" "NOT a fleet worktree" \
+    "refusal names the worktree guard"
+
+echo "worktree: assert passes, falls through to the sentinel-missing check"
+rc=$(run_in "$WT")
+assert_eq "$rc" "1" "amend-push proceeds past the assert in a worktree (then sentinel-missing)"
+assert_contains "$(cat "$TMPROOT/err")" "missing" \
+    "got past the assert to the sentinel check (proves the assert allowed it)"
+
+echo "main clone + FLEET_ALLOW_MAIN_CLONE: override lets it reach the sentinel check"
+rc=$(run_in "$MAIN" env FLEET_ALLOW_MAIN_CLONE=1)
+assert_eq "$rc" "1" "override reaches the sentinel-missing check (not the worktree refusal)"
+assert_absent "$(cat "$TMPROOT/err")" "NOT a fleet worktree" \
+    "override suppresses the worktree refusal"
+
+summarize "fleet-pr-amend-push scope-guard tests"

--- a/scripts/fleet/tests/test_fleet_edit_scope.sh
+++ b/scripts/fleet/tests/test_fleet_edit_scope.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tests for fleet-edit's #2402 worktree-scope guard: under an assignment
+# (FLEET_ASSIGNED_WORKTREE set) fleet-edit — an Edit-tool-equivalent CLI that
+# bypasses the PreToolUse hook — must refuse a target outside the same allowlist
+# the hook enforces (own worktree, $HOME/.fleet, /tmp, /private/tmp, auto-memory),
+# and must be unchanged when the env is unset.
+#
+# Hermetic: builds a synthetic worktree layout and drives the real fleet-edit.
+# The deny-case fixture is rooted under $HOME (NOT mktemp's default /tmp): /tmp is
+# an unconditional allowlist entry, so a "main clone" simulated there would be
+# allowed and couldn't exercise a refusal. The one temp root is trap-removed.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$(dirname "$0")/lib_assert.sh"
+
+FLEET_EDIT="$SCRIPT_DIR/fleet-edit"
+[[ -x "$FLEET_EDIT" ]] || { echo "test setup: fleet-edit not executable at $FLEET_EDIT" >&2; exit 1; }
+
+# Deny-case root under $HOME so a non-worktree path isn't swept up by the
+# /tmp allowlist. Name avoids the ~/.fleet allowlist prefix.
+ROOT=$(mktemp -d "$HOME/.ir-fleet-edit-scope-test.XXXXXX")
+# Explicitly under /tmp (resolves to /private/tmp on macOS) — NOT mktemp's
+# default $TMPDIR, which on macOS is /var/folders and (correctly) not on the
+# allowlist. This exercises the /tmp allow rule.
+TMP_ALLOWED=$(mktemp -d /tmp/fleet-edit-scope.XXXXXX)
+cleanup() {
+    [[ -n "${ROOT:-}" && "$ROOT" == "$HOME"/.ir-fleet-edit-scope-test.* ]] && rm -rf "$ROOT"
+    [[ -n "${TMP_ALLOWED:-}" ]] && rm -rf "$TMP_ALLOWED"
+}
+trap cleanup EXIT
+
+ASSIGNED="$ROOT/eng/.claude/worktrees/worker-3"
+mkdir -p "$ASSIGNED/scripts" "$ROOT/eng/engine"
+
+OLD=$(mktemp -t fe-old.XXXXXX); NEW=$(mktemp -t fe-new.XXXXXX)
+printf 'alpha\n'  > "$OLD"
+printf 'omega\n'  > "$NEW"
+trap 'cleanup; rm -f "$OLD" "$NEW"' EXIT
+
+# run_edit <assigned-env> <target> → prints "EXIT:<code>" then the target's content
+run_edit() {
+    local ec
+    FLEET_ASSIGNED_WORKTREE="$1" "$FLEET_EDIT" "$2" "$OLD" "$NEW" >/dev/null 2>&1
+    ec=$?
+    echo "$ec"
+}
+
+# --- assignment mode: in-worktree target allowed -----------------------------
+echo "assignment mode: in-worktree target is edited"
+IN="$ASSIGNED/scripts/f.txt"; printf 'alpha\n' > "$IN"
+assert_eq "$(run_edit "$ASSIGNED" "$IN")" "0" "in-worktree edit succeeds (exit 0)"
+assert_eq "$(cat "$IN")" "omega" "in-worktree file content replaced"
+
+# --- assignment mode: main-clone target refused ------------------------------
+echo "assignment mode: main-clone target refused, file untouched"
+OUT="$ROOT/eng/engine/main.cpp"; printf 'alpha\n' > "$OUT"
+assert_eq "$(run_edit "$ASSIGNED" "$OUT")" "1" "main-clone edit refused (exit 1)"
+assert_eq "$(cat "$OUT")" "alpha" "refused file content unchanged"
+
+# refusal message names the guard
+refuse_msg=$(FLEET_ASSIGNED_WORKTREE="$ASSIGNED" "$FLEET_EDIT" "$OUT" "$OLD" "$NEW" 2>&1 || true)
+assert_contains "$refuse_msg" "REFUSING to edit" "refusal prints a corrective message"
+
+# --- assignment mode: /tmp target allowed ------------------------------------
+echo "assignment mode: /tmp target allowed"
+TMPF="$TMP_ALLOWED/f.txt"; printf 'alpha\n' > "$TMPF"
+assert_eq "$(run_edit "$ASSIGNED" "$TMPF")" "0" "/tmp edit succeeds under assignment"
+assert_eq "$(cat "$TMPF")" "omega" "/tmp file content replaced"
+
+# --- env unset: legacy behavior unchanged (main-clone target allowed) --------
+echo "env unset: main-clone target allowed (unchanged)"
+OUT2="$ROOT/eng/engine/legacy.cpp"; printf 'alpha\n' > "$OUT2"
+assert_eq "$(run_edit "" "$OUT2")" "0" "unset env → no scope restriction (exit 0)"
+assert_eq "$(cat "$OUT2")" "omega" "legacy edit applied"
+
+summarize "fleet-edit scope-guard tests"

--- a/scripts/fleet/tests/test_fleet_review_verdict.sh
+++ b/scripts/fleet/tests/test_fleet_review_verdict.sh
@@ -103,6 +103,12 @@ chmod +x "$BIN/fleet-claim"
 
 export PATH="$BIN:$PATH"
 
+# The #2402 worktree-scope assert (fleet-assert-worktree "$agent") now fronts the
+# --agent path. These cases exercise the CLAIM guard, not worktree scoping, and
+# run from an arbitrary cwd — allow the main-clone override so they stay
+# cwd-independent. T12 drops it to prove the worktree assert actually fires.
+export FLEET_ALLOW_MAIN_CLONE=1
+
 set_labels() {  # set_labels <N> <label...>
     local num="$1"; shift
     : >"$STORE/pr-${num}"
@@ -217,6 +223,22 @@ assert_eq "$(run verdict-approve 108 --agent=)" "2" "T11 empty --agent= exits 2"
 assert_eq "$(ft_calls)" "0" "T11 did NOT delegate on empty --agent="
 assert_eq "$(grep -c 'pr view' "$GH_LOG" 2>/dev/null || true)" "0" \
     "T11 did NOT read labels (rejected before the guard, not carved out)"
+
+# === T12: #2402 worktree-scope assert fronts the --agent path =============
+# With the override dropped and cwd a non-worktree dir, the worktree assert must
+# block BEFORE the claim read (exit 1, no gh view). The no-agent carve-out is
+# unaffected — still delegates from anywhere.
+echo "T12: worktree-scope assert fronts --agent (fires from a non-worktree cwd)"
+reset_logs
+set_labels 109 fleet:reviewing-mac-worker-2 fleet:wip
+rc=$(cd "$TMPROOT" && FLEET_ALLOW_MAIN_CLONE= "$WRAPPER" verdict-approve 109 --agent worker-2 >/dev/null 2>&1; echo $?)
+assert_eq "$rc" "1" "T12 worktree assert blocks the --agent verdict from a non-worktree cwd"
+assert_eq "$(grep -c 'pr view' "$GH_LOG" 2>/dev/null || true)" "0" \
+    "T12 blocked before the claim read"
+reset_logs
+set_labels 110 fleet:wip
+rc=$(cd "$TMPROOT" && FLEET_ALLOW_MAIN_CLONE= "$WRAPPER" verdict-approve 110 >/dev/null 2>&1; echo $?)
+assert_eq "$rc" "0" "T12 no-agent carve-out still delegates from a non-worktree cwd"
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_guard_worktree_edit.sh
+++ b/scripts/fleet/tests/test_guard_worktree_edit.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for fleet-guard-worktree-edit — the PreToolUse Edit|Write|MultiEdit hook
+# that refuses edits escaping the agent's worktree.
+#
+# The guard reads PreToolUse JSON on stdin and (on a policy deny) emits a
+# hookSpecificOutput deny form on stdout; an allow is exit 0 with no deny JSON,
+# and any parse failure fails OPEN. This test drives the script directly with
+# synthetic hook JSON (built with jq so paths are escaped safely) across both
+# modes — hermetic: no live GitHub, no live ~/.fleet, and the paths are pure
+# string stand-ins the guard never touches on disk.
+#
+# Covers:
+#   ASSIGNMENT mode (FLEET_ASSIGNED_WORKTREE set) — identity from the assignment,
+#     never cwd: a main-clone absolute write is denied even when the hook-input
+#     cwd IS the main clone; a sibling agent's worktree is denied; the same-
+#     basename game worktree is allowed; ~/.fleet, /tmp, /private/tmp, and the
+#     auto-memory dir are allowed; a relative path is resolved against the drifted
+#     cwd then tested; the sibling-prefix (worker-3-foo vs worker-3) trap.
+#   LEGACY mode (env unset) — the original cwd-derived behavior, unchanged.
+#   Fail-open — malformed JSON and an empty file field never wedge (exit 0, allow).
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$(dirname "$0")/lib_assert.sh"
+
+GUARD="$SCRIPT_DIR/fleet-guard-worktree-edit"
+if [[ ! -x "$GUARD" ]]; then
+    echo "test setup: guard not executable at $GUARD" >&2
+    exit 1
+fi
+
+# Synthetic layout (never created on disk — the guard is pure string logic).
+ASSIGNED="/eng/.claude/worktrees/worker-3"           # this pane's engine worktree
+GAME_WT="/game/.claude/worktrees/worker-3"           # same pane, game clone
+SIBLING="/eng/.claude/worktrees/worker-1"            # another agent
+PREFIX_TRAP="/eng/.claude/worktrees/worker-3-foo"    # sibling-prefix decoy
+MAIN="/eng"                                          # shared main clone
+
+# verdict <assigned-env> <cwd> <file> → prints DENY or allow.
+verdict() {
+    local input out
+    input=$(jq -n --arg cwd "$2" --arg f "$3" '{cwd:$cwd, tool_input:{file_path:$f}}')
+    out=$(printf '%s' "$input" | FLEET_ASSIGNED_WORKTREE="$1" bash "$GUARD" 2>/dev/null || true)
+    if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
+        echo DENY
+    else
+        echo allow
+    fi
+}
+
+echo "ASSIGNMENT mode (FLEET_ASSIGNED_WORKTREE=$ASSIGNED):"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "$MAIN/engine/foo.cpp")" DENY \
+    "abs main-clone write denied even when cwd IS the main clone (drifted-cwd hole)"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "$ASSIGNED/scripts/x.sh")" allow \
+    "abs write inside the assigned worktree allowed"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "$SIBLING/x.sh")" DENY \
+    "sibling agent's worktree denied"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "$GAME_WT/src/x.cpp")" allow \
+    "same-basename game worktree allowed (one rule covers the engine+game pair)"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "$PREFIX_TRAP/x.sh")" DENY \
+    "sibling-prefix worker-3-foo cannot prefix-match worker-3"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "$HOME/.fleet/handoff/worker-3.md")" allow \
+    "\$HOME/.fleet write allowed"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "/tmp/scratch")" allow \
+    "/tmp write allowed"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "/private/tmp/scratch")" allow \
+    "/private/tmp write allowed (macOS canonical form)"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "$HOME/.claude/projects/xyz/memory/m.md")" allow \
+    "auto-memory dir write allowed"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "engine/foo.cpp")" DENY \
+    "relative path resolved against a drifted main-clone cwd is denied"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "scripts/x.sh")" allow \
+    "relative path resolved against an in-worktree cwd is allowed"
+
+echo "LEGACY mode (env unset):"
+assert_eq "$(verdict "" "$ASSIGNED" "$MAIN/engine/foo.cpp")" DENY \
+    "cwd in worktree + abs path to main clone denied"
+assert_eq "$(verdict "" "$ASSIGNED" "$ASSIGNED/scripts/x.sh")" allow \
+    "cwd in worktree + abs path in worktree allowed"
+assert_eq "$(verdict "" "$MAIN" "$MAIN/engine/foo.cpp")" allow \
+    "cwd in main clone → unrestricted (human / non-fleet session)"
+assert_eq "$(verdict "" "$ASSIGNED" "engine/foo.cpp")" allow \
+    "cwd in worktree + relative path allowed (resolves in-worktree)"
+
+echo "fail-open:"
+malformed_ec() {
+    printf '%s' '{not json' | FLEET_ASSIGNED_WORKTREE="$ASSIGNED" bash "$GUARD" >/dev/null 2>&1
+    echo $?
+}
+assert_eq "$(malformed_ec)" "0" "malformed JSON fails open (exit 0)"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "")" allow \
+    "empty file field allowed (nothing to constrain)"
+
+summarize "fleet-guard-worktree-edit tests"

--- a/scripts/fleet/tests/test_guard_worktree_edit.sh
+++ b/scripts/fleet/tests/test_guard_worktree_edit.sh
@@ -15,7 +15,9 @@
 #     cwd IS the main clone; a sibling agent's worktree is denied; the same-
 #     basename game worktree is allowed; ~/.fleet, /tmp, /private/tmp, and the
 #     auto-memory dir are allowed; a relative path is resolved against the drifted
-#     cwd then tested; the sibling-prefix (worker-3-foo vs worker-3) trap.
+#     cwd then tested; the sibling-prefix (worker-3-foo vs worker-3) trap; a
+#     '..'-bearing target (relative or absolute) is lexically collapsed before the
+#     containment tests, so it can't pass the literal match while resolving out.
 #   LEGACY mode (env unset) — the original cwd-derived behavior, unchanged.
 #   Fail-open — malformed JSON and an empty file field never wedge (exit 0, allow).
 
@@ -72,6 +74,14 @@ assert_eq "$(verdict "$ASSIGNED" "$MAIN" "engine/foo.cpp")" DENY \
     "relative path resolved against a drifted main-clone cwd is denied"
 assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "scripts/x.sh")" allow \
     "relative path resolved against an in-worktree cwd is allowed"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "../../../engine/foo.cpp")" DENY \
+    "relative ..-escape from the assigned worktree cwd denied (resolves to main clone)"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "$ASSIGNED/../../../engine/foo.cpp")" DENY \
+    "abs target embedding the assigned worktree + ..-escape denied"
+assert_eq "$(verdict "$ASSIGNED" "$ASSIGNED" "$ASSIGNED/scripts/../src/x.cpp")" allow \
+    "..-bearing target that stays inside the worktree allowed (no over-block)"
+assert_eq "$(verdict "$ASSIGNED" "$MAIN" "/tmp/../eng/engine/foo.cpp")" DENY \
+    "/tmp/..-escape cannot ride the scratch-dir allowlist"
 
 echo "LEGACY mode (env unset):"
 assert_eq "$(verdict "" "$ASSIGNED" "$MAIN/engine/foo.cpp")" DENY \

--- a/scripts/fleet/tests/test_worktree_settings_hooks.sh
+++ b/scripts/fleet/tests/test_worktree_settings_hooks.sh
@@ -19,6 +19,11 @@
 #   - a stale fleet-session-track variant is replaced by the current command,
 #     not duplicated
 #   - malformed JSON falls back to a clean baseline write
+#   - the FLEET_ASSIGNED_WORKTREE env key + the PreToolUse edit-guard hook are
+#     emitted, the guard command references the engine clone by absolute path,
+#     and both keys carry #2284 preservation: hand-added env entries + non-fleet
+#     PreToolUse groups survive regeneration, a stale fleet guard-hook variant is
+#     replaced not duplicated, and fleet wins only on its own env key (#2402)
 
 set -euo pipefail
 
@@ -59,9 +64,16 @@ assert_eq() {
 
 TMPROOT=$(mktemp -d -t fleet-settings-hooks)
 
-# Regenerate <settings-file> the way fleet-up does (repo_root is inert here).
+# Regenerate <settings-file> the way fleet-up does. repo_root is inert here;
+# the worktree (argv[3], → FLEET_ASSIGNED_WORKTREE) and engine root (argv[4], →
+# guard hook path) default to sandbox stand-ins so existing single-arg callers
+# keep working. Pass args 2/3 to override for the env/guard-path assertions.
+#   regen <settings-file> [worktree] [engine-root]
+DEFAULT_WT="$TMPROOT/eng/.claude/worktrees/worker-9"
+DEFAULT_ENG="$TMPROOT/eng"
 regen() {
-    printf '%s\n' "$PY_SRC" | python3 - "$1" "$TMPROOT/repo"
+    printf '%s\n' "$PY_SRC" | python3 - "$1" "$TMPROOT/repo" \
+        "${2:-$DEFAULT_WT}" "${3:-$DEFAULT_ENG}"
 }
 
 # q <settings-file> <python expr over parsed dict d> — prints the expr value.
@@ -121,10 +133,62 @@ echo "T4: malformed settings file regenerates baseline"
 F4="$TMPROOT/t4/settings.local.json"; mkdir -p "$TMPROOT/t4"
 echo '{not json' > "$F4"
 regen "$F4"
-assert_eq "$(q "$F4" "sorted(d['hooks'])")" "['SessionStart']" \
-    "malformed file yields fleet-only hooks"
+assert_eq "$(q "$F4" "sorted(d['hooks'])")" "['PreToolUse', 'SessionStart']" \
+    "malformed file yields fleet-only hooks (SessionStart + PreToolUse guard)"
 assert_eq "$(q "$F4" "d['permissions']['defaultMode']")" "auto" \
     "baseline permissions written"
+assert_eq "$(q "$F4" "'FLEET_ASSIGNED_WORKTREE' in d.get('env', {})")" "True" \
+    "baseline write still emits the env assignment key"
+
+# --- T5: fresh write emits the env assignment + PreToolUse edit guard ---------
+echo "T5: fresh write emits FLEET_ASSIGNED_WORKTREE env + the PreToolUse guard"
+F5="$TMPROOT/t5/settings.local.json"; mkdir -p "$TMPROOT/t5"
+regen "$F5" "/eng/.claude/worktrees/worker-3" "/eng"
+assert_eq "$(q "$F5" "d['env']['FLEET_ASSIGNED_WORKTREE']")" "/eng/.claude/worktrees/worker-3" \
+    "env carries the assigned worktree path (argv[3])"
+assert_eq "$(q "$F5" "d['hooks']['PreToolUse'][0]['matcher']")" "Edit|Write|MultiEdit" \
+    "PreToolUse guard matches Edit|Write|MultiEdit"
+assert_eq "$(q "$F5" "'/eng/scripts/fleet/fleet-guard-worktree-edit' in d['hooks']['PreToolUse'][0]['hooks'][0]['command']")" \
+    "True" "guard command references the engine clone by absolute path (argv[4], not repo_root)"
+assert_eq "$(q "$F5" "d['hooks']['PreToolUse'][0]['hooks'][0]['command'].endswith('|| true')")" \
+    "True" "guard command is wrapped to fail OPEN on a missing script"
+
+# --- T6: hand-added env survives; fleet wins only on its own env key ----------
+echo "T6: hand-added env entries survive regeneration; fleet key wins"
+F6="$TMPROOT/t6/settings.local.json"; mkdir -p "$TMPROOT/t6"
+python3 - "$F6" <<'SEED'
+import json, sys
+json.dump({
+    "env": {"MY_TOKEN": "keep-me", "FLEET_ASSIGNED_WORKTREE": "/stale/path"},
+}, open(sys.argv[1], "w"))
+SEED
+regen "$F6" "/eng/.claude/worktrees/worker-7" "/eng"
+assert_eq "$(q "$F6" "d['env']['MY_TOKEN']")" "keep-me" \
+    "hand-added env entry preserved"
+assert_eq "$(q "$F6" "d['env']['FLEET_ASSIGNED_WORKTREE']")" "/eng/.claude/worktrees/worker-7" \
+    "fleet key overrides a stale hand value (fleet wins only on its own key)"
+
+# --- T7: stale fleet guard-hook variant replaced; hand PreToolUse preserved ---
+echo "T7: stale fleet guard-hook variant replaced, non-fleet PreToolUse preserved"
+F7="$TMPROOT/t7/settings.local.json"; mkdir -p "$TMPROOT/t7"
+python3 - "$F7" <<'SEED'
+import json, sys
+json.dump({
+    "hooks": {
+        "PreToolUse": [
+            # stale variant of the fleet's own guard (bare, no [ -x ] wrapper)
+            {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "fleet-guard-worktree-edit"}]},
+            # a human's own PreToolUse hook — must survive
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hand-added-pre"}]},
+        ],
+    },
+}, open(sys.argv[1], "w"))
+SEED
+regen "$F7" "/eng/.claude/worktrees/worker-3" "/eng"
+assert_eq "$(q "$F7" "len([g for g in d['hooks']['PreToolUse'] if 'fleet-guard-worktree-edit' in str(g)])")" \
+    "1" "exactly one fleet guard group after regen (stale variant replaced)"
+assert_eq "$(q "$F7" "'echo hand-added-pre' in str(d['hooks']['PreToolUse'])")" \
+    "True" "hand-added non-fleet PreToolUse group preserved"
 
 echo
 echo "passed: $PASS  failed: $FAIL"


### PR DESCRIPTION
## Summary
- Replace doc-level worktree-scoping rules (fix-011 recurring) with enforcement — agents kept landing Edit/Write and git mutations in the shared main clone instead of their own worktree.
- **`fleet-guard-worktree-edit`** gains an assignment-derived mode: when `FLEET_ASSIGNED_WORKTREE` is set (baked per-worktree by `fleet-up`), scope is the *assignment*, not the drift-prone session cwd — a main-clone or sibling-worktree edit is denied even after cwd drifts. Allowlist: own worktree (engine **and** game, by basename), `$HOME/.fleet`, `/tmp`, `/private/tmp`, auto-memory. Env unset ⇒ the legacy cwd-derived behavior, byte-for-byte.
- **`fleet-up write_worktree_settings`** emits the `FLEET_ASSIGNED_WORKTREE` env key and a `PreToolUse` `Edit|Write|MultiEdit` guard hook (engine-clone path baked at generation time, wrapped to fail open), both carrying #2284 hand-edit preservation.
- **Assert wrappers:** `fleet-assert-worktree` fronts `fleet-pr-amend-push` (before the push) and `fleet-review-verdict --agent` (the #2153/#2326 misroute lane); `fleet-edit` applies the same allowlist under assignment; `fleet-build` warns (never fails) from a main-clone cwd. Scout / ingest / claim / rebase run from the main clone by design and are deliberately **not** asserted.
- No role-doc / SKILL.md / `.claude/commands` edits — enforcement side only (the doc rules #1332 added are exactly what kept failing). The gated `role-*.md` mirror is out of scope for this PR.

## Test plan
- [x] `test_guard_worktree_edit.sh` (17), `test_worktree_settings_hooks.sh` (20), `test_fleet_edit_scope.sh` (9), `test_fleet_amend_push_scope.sh` (6), `test_fleet_review_verdict.sh` (32) — all green, hermetic
- [x] `ruff check scripts/` clean
- [x] Grep-verified: no gated self-config in the diff

Closes #2402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
