### PR TITLE
crash: macOS/Metal segfault at yaw-state transitions in IRPerfGrid + IRShapeDebug (#2412)

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -941,3 +941,13 @@ parity with voxel-pool primary shapes.
   namespaces), so a GL-only smoke will not catch it. Any compute kernel that
   mixes a sampler read with images bound elsewhere in the pipeline is exposed;
   the #1294 chunk cull's fine Hi-Z levels are the known other victim.
+  The same stickiness makes resource **destruction** a hazard: the tables hold
+  non-owning pointers, so destroying a bound resource leaves a dangling entry
+  the next dispatch's flush re-binds — `objc_retain` on the freed handle
+  segfaults (#2412: a rotation-lifecycle buffer bound at a slot no
+  cardinal-path pass re-binds, freed at the yaw→0 per-axis release). The
+  backend therefore scrubs its tables on destruction — `untrackMetalTexture` /
+  `untrackMetalBuffer` in the Metal texture/buffer destructors
+  (`metal_runtime.cpp`) — mirroring GL's delete-unbinds semantics. A new
+  resource type that lands in any sticky table must untrack itself the same
+  way.

--- a/engine/render/include/irreden/render/metal/metal_runtime.hpp
+++ b/engine/render/include/irreden/render/metal/metal_runtime.hpp
@@ -121,6 +121,19 @@ void deferReleaseMetalBuffer(MTL::Buffer *buffer);
 void releaseDeferredMetalBuffers();
 void replaceMetalBufferInBindings(MTL::Buffer *oldBuffer, MTL::Buffer *newBuffer);
 
+// Null every sticky uniform/storage bind slot (and the active vertex-layout
+// slots) that still points at @p buffer, and drop it from the encoded-set.
+// The buffer twin of untrackMetalTexture: bindings are sticky, so a destroyed
+// buffer otherwise lingers as a dangling pointer that bindRenderResources /
+// bindComputeResources re-binds on a later dispatch — setBuffer objc_retains
+// the freed handle and EXC_BAD_ACCESSes. Realized by a rotation-lifecycle
+// buffer bound at a slot no cardinal-path pass re-binds (#2412: the #2334
+// overflow relight's slot-8 bind survived the per-axis release and crashed
+// STAGE_1's next dispatch at the yaw→0 transition). GL needs no equivalent —
+// deleting a GL buffer detaches it from every binding point. Call from the
+// Metal buffer destructor before releasing the handle.
+void untrackMetalBuffer(MTL::Buffer *buffer);
+
 void markMetalBufferEncoded(MTL::Buffer *buffer);
 bool wasMetalBufferEncoded(MTL::Buffer *buffer);
 

--- a/engine/render/src/metal/metal_buffer.cpp
+++ b/engine/render/src/metal/metal_buffer.cpp
@@ -31,6 +31,10 @@ class MetalBufferImpl final : public BufferImpl {
     }
 
     ~MetalBufferImpl() override {
+        // Drop any sticky bind slot that still references this handle so a
+        // later dispatch's bind pass can't re-bind the freed buffer (#2412 —
+        // the buffer twin of the texture dtor's untrackMetalTexture call).
+        untrackMetalBuffer(m_buffer);
         if (m_buffer != nullptr) {
             m_buffer->release();
             m_buffer = nullptr;

--- a/engine/render/src/metal/metal_runtime.cpp
+++ b/engine/render/src/metal/metal_runtime.cpp
@@ -384,6 +384,20 @@ void replaceMetalBufferInBindings(MTL::Buffer *oldBuffer, MTL::Buffer *newBuffer
     }
 }
 
+void untrackMetalBuffer(MTL::Buffer *buffer) {
+    if (buffer == nullptr) {
+        return;
+    }
+    // Null-out every sticky table entry via the orphan-retarget helper. A
+    // cleared binding keeps its stale offset, which is benign — the flush
+    // loops gate on buffer_ != nullptr.
+    replaceMetalBufferInBindings(buffer, nullptr);
+    // Also drop it from the encoded-since-last-wait set: a future buffer
+    // allocated at the same address would otherwise false-positive
+    // wasMetalBufferEncoded and orphan on its first subData for no reason.
+    g_runtime().encodedBuffers_.erase(buffer);
+}
+
 MTL::Buffer *ensureImageAtomicScratchBuffer(MTL::Texture *texture) {
     if (texture == nullptr) {
         return nullptr;
@@ -426,6 +440,12 @@ void releaseImageAtomicScratchBuffer(MTL::Texture *texture) {
         return;
     }
     if (it->second != nullptr) {
+        // Same dangling-rebind hazard as untrackMetalBuffer: the sticky
+        // current-scratch pointer would re-bind the freed buffer on the next
+        // scratch-consumer dispatch if no R32I bindAsImage refreshed it first.
+        if (g_runtime().currentImageAtomicScratch_ == it->second) {
+            g_runtime().currentImageAtomicScratch_ = nullptr;
+        }
         it->second->release();
     }
     cache.erase(it);


### PR DESCRIPTION
## Summary
- Fixes the 100%-repro macOS/Metal segfault at yaw-state transitions (`IRPerfGrid` shot 6 `zoom4_pan`, `IRShapeDebug` shot 17 `zoom8_yaw180`).
- **Bisected** the e13421ba..20837602 window (5 probes, deterministic repro): first bad commit is 14631b79 — overflow-face lighting (C2, #2334, PR #2388).
- **Root cause** (lldb backtrace, `EXC_BAD_ACCESS` in `objc_retain` ← `bindComputeResources` `setBuffer(index=8)` ← `VOXEL_TO_TRIXEL_STAGE_1` tick): the Metal sticky binding tables hold non-owning pointers and are never cleared, and the C2 relight pass binds the per-axis `winnerIds_` scratch at `kBufferIndex_OverflowLightingScratch` (= slot 8, aliasing `kBufferIndex_VoxelActiveMask`) — a slot **no cardinal-path pass re-binds**. At the yaw→0 transition the per-axis release destroys that buffer, the dangling entry survives in the table, and the next compute dispatch's flush `objc_retain`s the freed handle. Textures never hit this because `~MetalTexture2DImpl` already calls `untrackMetalTexture` (#1961); buffers had no equivalent.
- **Fix**: add `untrackMetalBuffer` (the buffer twin — nulls table entries via `replaceMetalBufferInBindings(buffer, nullptr)` + drops the encoded-set entry), called from `~MetalBufferImpl`; also clear the sticky `currentImageAtomicScratch_` pointer when its buffer is released (same hazard class). This mirrors GL's delete-unbinds semantics, so any future rotation-lifecycle resource is covered by construction rather than by per-slot discipline.
- Documents the destruction contract in the `engine/render/CLAUDE.md` sticky-binding gotcha (#1812 block).

## Test plan
- [x] `IRPerfGrid --grid-size 16 --zoom 8 --wave-amplitude 0 --auto-screenshot 10`: crashed 100% at shot 6 pre-fix (reproduced on this host, master head) → completes 7/7, exit 0.
- [x] `IRShapeDebug --auto-screenshot 10`: crashed at shot 17/21 pre-fix → completes 21/21, exit 0.
- [x] Zero visual delta: pre-fix vs post-fix same-shot (`zoom4_rot`) `img_diff` — drift confined to the live perf-HUD timing digits; world pixels identical. (Screenshot pairs are inapplicable here: "before" has no frames past the crash point, and all completing frames are pixel-identical by construction — the fix only runs at resource destruction.)
- [x] Run-to-run determinism post-fix: two runs, all 7 shots world-content identical (HUD digits only).
- [x] Good-endpoint sanity: parent commit fea3ffbb completes the repro (bisect probe).
- [ ] Cross-host smoke (GL hosts): Metal-only C++ surface (`metal_runtime.{hpp,cpp}`, `metal_buffer.cpp`); GL builds don't compile these files — smoke is a build/run sanity only.

Closes #2412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
