### PR TITLE
fleet: clean-exit policy + fix-forward — ir-run RESULT verdicts, doc wiring

### DIFF
--- a/.claude/commands/role-smoke-worker.md
+++ b/.claude/commands/role-smoke-worker.md
@@ -151,7 +151,13 @@ Do **not** add `--timeout` — `fleet-run --timeout` reports "alive at
 deadline" as success, which masks an `--auto-screenshot` hang.
 
 If `fleet-run` exits nonzero or crashes, jump to **step 5 — failure
-verdict** with the run log.
+verdict** with the run log. Key off the `ir-run: RESULT=` line
+(`RESULT=CLEAN` required; `RESULT=CRASH` = failure even if every
+screenshot saved before the crash) rather than shell exit alone — a
+trailing pipe or `; echo` can mask the wrapper's status. This is the
+clean-exit policy
+([`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) §"Clean-exit
+policy"); a crash verdict must never be reported as green.
 
 ### Step 5 — verdict
 

--- a/.claude/skills/platform-catchup/SKILL.md
+++ b/.claude/skills/platform-catchup/SKILL.md
@@ -8,8 +8,8 @@ description: >-
   merged PR. On red (build break), files / opens a fix PR for the offender
   and holds labels on PRs that touch the implicated source paths until
   the fix lands. On partial (per-demo runtime hang or crash but build
-  green), sweeps the rest and files a follow-up perf / functional issue
-  for the offending demo. Runs on Linux, macOS, AND native Windows (MSYS2
+  green), sweeps the rest, then fix-forwards the offending demo this
+  session (issue only as the documented fallback). Runs on Linux, macOS, AND native Windows (MSYS2
   mingw64) — Windows is now the primary validation host. Use when the human
   cues "platform-catchup", "catch up smoke tests", or "catch up Windows
   builds". Skill is **cue-only**, never auto-run — multi-target builds and
@@ -332,6 +332,12 @@ Per-target pass criteria:
 
 ### 7. Decide outcome
 
+"Pass" for a run means the wrapper's `ir-run: RESULT=CLEAN` verdict — a
+`RESULT=CRASH` (teardown crashes included, even with all screenshots
+saved) is a per-demo crash for this table, per
+[`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) §"Clean-exit
+policy".
+
 | Build result                       | Run result                                  | Outcome    |
 |------------------------------------|---------------------------------------------|------------|
 | All targets build                  | All pass                                    | **green**  |
@@ -375,7 +381,13 @@ touches the offending demo's source tree:
 For each held-back PR, do NOT edit the labels. Note them in the
 report's `held_prs` field.
 
-File a follow-up issue for the offending demo:
+Then apply fix-forward
+([`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) §"Fix-forward"):
+after the sweep, attempt the offender's fix **this session** — bisect
+the deterministic repro, root-cause, and open a fix PR — regardless of
+which merged change introduced it. Fall back to filing only when the
+fix genuinely exceeds the session (design escalation, other-host-only
+repro), and then with full forensics:
 
 ```bash
 gh issue create --repo <repo> \
@@ -383,9 +395,9 @@ gh issue create --repo <repo> \
   --body "<...>" --label "fleet:task"
 ```
 
-Body covers: which demo, what symptom, log excerpt, suspected root
-cause (e.g. "perf_grid runs ~1 FPS — likely an OpenGL lighting stage
-regression; `/optimize` flow needed").
+Body covers: which demo, the exact repro command and its
+`ir-run: RESULT=` line, log excerpt, the bisect window or suspected
+root cause, and what was already ruled out.
 
 Update marker: `last_outcome = "partial"`,
 `skipped_targets = [<failed-targets>]`,

--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -69,6 +69,13 @@ The demo renders warmup frames, cycles through its configured shots,
 captures one screenshot per shot, and closes the window. `fleet-run`
 handles the working-directory requirement automatically.
 
+**Gate on the run's `ir-run: RESULT=` verdict line, not on screenshots
+existing.** `RESULT=CRASH` (any signal death, teardown included) fails
+this step even when every shot saved — treat the crash as a finding of
+the current iteration and fix it per
+[`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) §"Clean-exit
+policy". The saved shots remain usable as diagnosis evidence.
+
 ### 4. Read the screenshots
 
 Use the **Glob** tool against

--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -80,7 +80,11 @@ The driver:
 4. Clears `<exe_dir>/save_files/screenshots/`.
 5. Runs `fleet-run IRShapeDebug --auto-screenshot 10`.
 6. For each shot, runs `scripts/render-compare.py` against the reference.
-7. Prints a pass/fail table and exits non-zero on any failure.
+7. Prints a pass/fail table and exits non-zero on any failure. A crashed
+   demo run (`ir-run: RESULT=CRASH`, teardown crashes included) fails the
+   harness regardless of how many shots saved — see
+   [`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) §"Clean-exit
+   policy".
 
 ### Typical pass output
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -146,6 +146,19 @@ any `c_compute_*shadow*.glsl` / `.metal`)
   explicitly said "no tests").
 - Build or format-check not run before opening the PR (check the commit
   message, or run `fleet-build --target format-changed` yourself if cheap).
+- Verification claims green over an unclean exit: a PR body or run log that
+  reports a crash / `RESULT=CRASH` (teardown included) but presents the
+  verification as passing — needs-fix per
+  [`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) §"Clean-exit
+  policy". A crash observed but out of reach must be filed with forensics
+  AND the lane reported failed.
+
+**Opportunistic fixes (fix-forward covenant)**
+- A clearly-sectioned `## Opportunistic fixes` block in the PR body is the
+  expected shape under FLEET.md §"Fix-forward", not scope creep — review the
+  bundled fixes on their merits. Ask for a split only when a bundled fix
+  materially raises the PR's risk (schema changes, cross-module refactors,
+  behavior changes beyond what the section claims).
 
 **Opus-only items** (Sonnet should not attempt these — escalate via the
 verdict footer if any of these surfaces are touched)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ working inside such a subdirectory, always read that subdirectory's own
 | Module-specific patterns (ECS, prefabs, render, math, system, etc.) | the nearest `CLAUDE.md` (loaded automatically when you open a file in that subtree) |
 | Long-form architecture reference (ECS internals, render pipeline, coordinate systems, Lua integration) | [`docs/agents/AGENTS-ARCHITECTURE.md`](docs/agents/AGENTS-ARCHITECTURE.md) |
 | Build commands and environment setup (Linux/WSL, Windows, macOS) | [`docs/agents/BUILD.md`](docs/agents/BUILD.md) |
-| Fleet workflow (parallel agents, PRs, cursor cues, design escalation, model split, labels, feedback) | [`docs/agents/FLEET.md`](docs/agents/FLEET.md) |
+| Fleet workflow (parallel agents, PRs, cursor cues, design escalation, model split, labels, clean-exit policy, fix-forward, feedback) | [`docs/agents/FLEET.md`](docs/agents/FLEET.md) |
 | Skills (named workflows like `simplify`, `commit-and-push`, `review-pr`) | [`.claude/skills/`](.claude/skills/) — each has its own `SKILL.md` |
 | Shared skill flows (fleet skills factored for cross-repo reuse) | [`docs/agents/skills/`](docs/agents/skills/) — canonical flows; each repo's `SKILL.md` is a thin wrapper (mechanism: [`docs/design/skill-sharing.md`](docs/design/skill-sharing.md)) |
 | Roles (autonomous personas — worker, reviewer, merger, architect) | [`.claude/commands/role-*.md`](.claude/commands/) |

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -546,6 +546,69 @@ The skill drives any creation that supports `--auto-screenshot` (today:
 SDF shapes, lighting, and backend parity. See `engine/render/CLAUDE.md`
 "Verifying render changes" for the exceptions list.
 
+### Clean-exit policy
+
+Every scripted run of a demo, test, or tool through `fleet-run` / `ir-run`
+must end with the wrapper's `RESULT=CLEAN` verdict. A `RESULT=CRASH` —
+any signal death or non-zero exit, **including a teardown crash after the
+run's outputs (screenshots, profiles, logs) were already saved** — fails
+the verification step that ran it. Outputs existing is never evidence of
+green; parse the RESULT line or the propagated exit code, not the log
+prose. (`RESULT=ALIVE-TIMEOUT` — the watchdog killing a still-healthy
+process at `--timeout` — is healthy for smoke purposes but says nothing
+about shutdown-path health, since teardown never ran.)
+
+What the observing agent does with a CRASH:
+
+1. **Fix it, this session** — the fix-forward policy below applies in
+   full: ownership of the change that introduced the crash is
+   irrelevant. Bisect if needed (a deterministic crash plus incremental
+   builds makes the window cheap), root-cause, fix, and ship it with
+   your PR or as an immediate sibling PR.
+2. **Only if genuinely out of reach** (needs another host or hardware,
+   needs design escalation, exceeds the session): file an issue carrying
+   the exact repro command, the RESULT line, and the bisect window — AND
+   mark your own verification lane failed. A smoke verdict, PR body, or
+   `fleet:verified-<host>` label must never report green over a crash
+   you observed; say "N/M shots captured, run FAILED clean-exit
+   (issue #X)".
+
+A crashed run's partial outputs may still be *used* for diagnosis (the
+shots that saved before the crash are real data) — the policy is about
+the verdict you report, not about discarding evidence.
+
+### Fix-forward: opportunistic fixes ship with the finder
+
+When work on a task surfaces an adjacent defect — a bug, a crash, dead
+code, a duplication, a stale doc, a missing test — the default is that
+the agent who found it **fixes it in the same session**, not "file a
+follow-up and move on". You found it, you fix it; whether your change or
+someone else's introduced it does not matter.
+
+Choose the vehicle by review impact:
+
+- **Same PR** — small or mechanical fixes that a reviewer can absorb
+  without re-scoping (a wrong comment, an off-by-one, a missed rename, a
+  dead branch, a missing guard): include them in the PR that found them,
+  in their **own commit**, called out under an `## Opportunistic fixes`
+  section in the PR body.
+- **Immediate sibling PR** — separable fixes, or anything that would
+  balloon the primary PR's risk or review surface: finish the primary
+  PR, `start-next-task`, and ship the fix as the very next PR in the
+  same session (stacked when it depends on the primary).
+- **Issue, as the exception** — only when the fix needs design
+  escalation (`fleet:design-blocked` / `fleet:needs-plan`), another
+  host/hardware, or genuinely exceeds the session budget. The issue must
+  carry full forensics: repro command, observed output, suspected
+  window/commit, and what was already ruled out — enough that the next
+  agent starts at the root cause, not at reproduction.
+
+Reviewer covenant: a clearly-sectioned `## Opportunistic fixes` block in
+a PR body is the *expected* shape, not scope creep — reviewers review it
+on its merits and only ask for a split when the bundled fix materially
+raises the PR's risk (schema changes, cross-module refactors, behavior
+changes outside the section's claims).
+
 ### Resource coordination
 
 `ir-acquire` gates CPU-heavy builds and GPU-heavy bench runs so parallel

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -243,7 +243,14 @@ PR that touches:
 - anything affecting pipeline ordering, canvas textures, or the voxel pool
 
 must run the **`render-debug-loop`** skill after the change and attach
-the following to the PR body:
+the following to the PR body.
+
+Every verification run must also end `ir-run: RESULT=CLEAN` — a
+teardown crash after the screenshots saved still fails the run (see
+[`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) §"Clean-exit
+policy").
+
+Attach:
 
 1. At least one full-frame before/after screenshot pair.
 2. **At least one ROI crop pair** (current + baseline) covering a

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -285,9 +285,16 @@ fi
 # Decode an exit code into a signal name for the RESULT line (128+N =
 # died on signal N; e.g. 139 = SIGSEGV, 134 = SIGABRT). Prints "none"
 # for plain non-zero exits.
+#
+# Upper bound 193: 128+64=192 is the highest signal-death code any host
+# emits — standard signals are ≤31 (rc ≤159), Linux realtime signals run
+# 34–64 (rc ≤192). rc ≥193 can only be a plain exit status, so it reports
+# signal=none rather than mis-decoding a large exit code as a signal.
+# kill -l falls back to the raw number when the host can't name N (macOS
+# has no realtime signals).
 ir_exit_signal_name() {
     local rc="$1"
-    if (( rc > 128 && rc < 165 )); then
+    if (( rc > 128 && rc < 193 )); then
         local name
         name="$(kill -l $((rc - 128)) 2>/dev/null || true)"
         echo "SIG${name:-$((rc - 128))}"

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -155,6 +155,17 @@ Run mode
                                 Set in ~/.fleet/fleet-up.conf or shell init
                                 to catch fleet agents that forgot --timeout.
 
+  Result reporting (self-terminating runs — auto verbs and --timeout):
+    ir-run: RESULT=CLEAN exe=<name> exit=0
+        The program ran to completion and exited 0, teardown included.
+    ir-run: RESULT=CRASH exe=<name> exit=<rc> signal=<SIGNAME|none>
+        FAILED run, exit code propagated. Saved outputs (screenshots,
+        profiles) do not make a crashed run green — see
+        docs/agents/FLEET.md "Clean-exit policy".
+    ir-run: RESULT=ALIVE-TIMEOUT exe=<name> ...
+        Watchdog killed a still-healthy process at --timeout. Says
+        nothing about shutdown-path health (teardown never ran).
+
   Build directory (when not using --build-dir):
     1. $IRREDEN_BUILD_DIR if set
     2. <git-worktree-root>/build from git rev-parse
@@ -271,17 +282,52 @@ if [[ -n "$acquire_verb" ]]; then
     acquire_prefix=("$IR_ACQUIRE" "$acquire_verb" "--")
 fi
 
+# Decode an exit code into a signal name for the RESULT line (128+N =
+# died on signal N; e.g. 139 = SIGSEGV, 134 = SIGABRT). Prints "none"
+# for plain non-zero exits.
+ir_exit_signal_name() {
+    local rc="$1"
+    if (( rc > 128 && rc < 165 )); then
+        local name
+        name="$(kill -l $((rc - 128)) 2>/dev/null || true)"
+        echo "SIG${name:-$((rc - 128))}"
+    else
+        echo "none"
+    fi
+}
+
+# One-line, machine-greppable verdict + the clean-exit directive. Every
+# self-terminating run (auto-screenshot, auto-profile, timeout mode)
+# reports through this so harnesses and agents key off a single stable
+# token instead of re-deriving "did it really pass" from log prose.
+# Policy: docs/agents/FLEET.md §"Clean-exit policy" — a signal exit is a
+# FAILED run even when outputs (screenshots, profiles) were saved before
+# the crash, teardown included.
+ir_report_result() {
+    local rc="$1"
+    if [[ $rc -eq 0 ]]; then
+        echo "ir-run: RESULT=CLEAN exe=$EXE_NAME exit=0"
+        return
+    fi
+    local sig
+    sig="$(ir_exit_signal_name "$rc")"
+    echo "ir-run: RESULT=CRASH exe=$EXE_NAME exit=$rc signal=$sig" >&2
+    echo "ir-run: this run FAILED the clean-exit policy — outputs saved" \
+         "before the crash do not make it green. Fix the crash before" \
+         "shipping, whoever introduced it (docs/agents/FLEET.md" \
+         "§\"Clean-exit policy\")." >&2
+}
+
 # --- No timeout: interactive mode, exec replaces this process --------------
-# Exception: `--auto-screenshot` is a self-terminating verb. The demo is
-# expected to call `closeWindow()` and exit 0 after its last shot — any
-# non-zero return is a crash on shutdown (e.g. T-336's Metal static-
-# destruction segfault that lands AFTER screenshots are saved). We still
-# need to surface that distinction at the script level, so swap exec for
-# a run-and-validate path when the verb is gpu/screenshot. Interactive
+# Exception: `--auto-screenshot` / `--auto-profile` are self-terminating
+# verbs. The program is expected to close its window and exit 0 after its
+# last shot / profile dump — any non-zero return is a crash (teardown
+# crashes included). Swap exec for a run-and-validate path for those verbs
+# so the verdict is surfaced and the exit code propagates. Interactive
 # mode (no verb, no timeout) keeps the exec path so signals and stdin
-# pass straight through.
+# pass straight through to the human-supervised process.
 if [[ -z "$TIMEOUT" ]]; then
-    if [[ "$acquire_verb" == "gpu" ]]; then
+    if [[ -n "$acquire_verb" ]]; then
         echo "ir-run: ${acquire_prefix[*]} $EXE_PATH $*"
         cd "$EXE_DIR"
         # Disarm `set -e` around the run so we can inspect the exit code
@@ -291,21 +337,12 @@ if [[ -z "$TIMEOUT" ]]; then
         "${acquire_prefix[@]}" "./$EXE_RUN" "$@"
         rc=$?
         set -e
-        if [[ $rc -ne 0 ]]; then
-            echo "ir-run: $EXE_NAME crashed on shutdown (exit code $rc) — " \
-                 "screenshots may have been saved before the crash, but the " \
-                 "process did not exit cleanly. See engine/render/CLAUDE.md " \
-                 "and T-336 for the canonical static-destruction symptom." >&2
-        fi
+        ir_report_result "$rc"
         exit "$rc"
     fi
-    if (( ${#acquire_prefix[@]} > 0 )); then
-        echo "ir-run: ${acquire_prefix[*]} $EXE_PATH $*"
-    else
-        echo "ir-run: $EXE_PATH $*"
-    fi
+    echo "ir-run: $EXE_PATH $*"
     cd "$EXE_DIR"
-    exec "${acquire_prefix[@]}" "./$EXE_RUN" "$@"
+    exec "./$EXE_RUN" "$@"
 fi
 
 # --- Timeout mode: launch, wait, kill, report ------------------------------
@@ -327,18 +364,20 @@ while [[ $elapsed -lt $TIMEOUT ]]; do
         wait "$PID" 2>/dev/null || exit_code=$?
         if [[ $exit_code -eq 0 ]]; then
             echo "ir-run: $EXE_NAME exited cleanly after ${elapsed}s"
-            exit 0
         else
-            echo "ir-run: $EXE_NAME crashed after ${elapsed}s (exit code $exit_code)"
-            exit 1
+            echo "ir-run: $EXE_NAME crashed after ${elapsed}s"
         fi
+        ir_report_result "$exit_code"
+        [[ $exit_code -eq 0 ]] && exit 0 || exit 1
     fi
     sleep 1
     elapsed=$((elapsed + 1))
 done
 
-# Process survived the timeout — it's healthy. Kill it.
+# Process survived the timeout — it's healthy for smoke purposes. Kill it.
+# RESULT=ALIVE-TIMEOUT is deliberately distinct from CLEAN: the run never
+# reached teardown, so it says nothing about shutdown-path health.
 kill "$PID" 2>/dev/null
 wait "$PID" 2>/dev/null || true
-echo "ir-run: $EXE_NAME ran for ${TIMEOUT}s without crashing — killed"
+echo "ir-run: RESULT=ALIVE-TIMEOUT exe=$EXE_NAME — ran for ${TIMEOUT}s without crashing, killed by watchdog"
 exit 0

--- a/scripts/fleet/tests/test_ir_run_result_reporting.sh
+++ b/scripts/fleet/tests/test_ir_run_result_reporting.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tests for ir-run's clean-exit RESULT reporting (engine/tools/bin/ir-run).
+#
+# The fleet's clean-exit policy (docs/agents/FLEET.md §"Clean-exit policy")
+# keys off ir-run's one-line verdicts, so their shape and exit-code
+# propagation are contract, not cosmetics:
+#
+#   RESULT=CLEAN exe=<name> exit=0                — ran + exited 0
+#   RESULT=CRASH exe=<name> exit=<rc> signal=<..> — FAILED, code propagated
+#   RESULT=ALIVE-TIMEOUT exe=<name> ...           — watchdog kill, healthy
+#
+# Hermetic: a fake build dir with tiny scripts stands in for real demos;
+# the --timeout path is exercised so no ir-acquire lock is taken.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+IR_RUN="$REPO_ROOT/engine/tools/bin/ir-run"
+
+# shellcheck source=lib_assert.sh
+source "$SCRIPT_DIR/lib_assert.sh"
+
+if [[ ! -x "$IR_RUN" ]]; then
+    echo "test setup: ir-run not found at $IR_RUN" >&2
+    exit 1
+fi
+
+FAKE_BUILD="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BUILD"' EXIT
+
+make_exe() {
+    local name="$1" body="$2"
+    printf '#!/usr/bin/env bash\n%s\n' "$body" > "$FAKE_BUILD/$name"
+    chmod +x "$FAKE_BUILD/$name"
+}
+
+make_exe clean-exit 'exit 0'
+make_exe plain-fail 'exit 3'
+# Real signal death (not `exit 139`): the reporter decodes 128+N.
+make_exe segfaulter 'kill -SEGV $$'
+make_exe sleeper 'sleep 30'
+
+run_ir() {
+    # Runs ir-run with the fake build dir; captures combined output and rc.
+    OUT="$("$IR_RUN" --build-dir "$FAKE_BUILD" "$@" 2>&1)"
+    RC=$?
+}
+
+echo "clean exit before timeout:"
+run_ir --timeout 10 clean-exit
+assert_eq "$RC" "0" "clean exit propagates rc 0"
+assert_contains "$OUT" "RESULT=CLEAN exe=clean-exit exit=0" "CLEAN verdict line"
+
+echo "plain non-zero exit:"
+run_ir --timeout 10 plain-fail
+assert_eq "$RC" "1" "crash exits 1 in timeout mode"
+assert_contains "$OUT" "RESULT=CRASH exe=plain-fail exit=3 signal=none" \
+    "CRASH verdict names the code, signal=none"
+assert_contains "$OUT" "clean-exit policy" "failure text cites the policy"
+
+echo "signal death:"
+run_ir --timeout 10 segfaulter
+assert_eq "$RC" "1" "signal death exits 1 in timeout mode"
+assert_contains "$OUT" "RESULT=CRASH exe=segfaulter exit=139 signal=SIGSEGV" \
+    "CRASH verdict decodes SIGSEGV from 139"
+
+echo "watchdog kill of a healthy process:"
+run_ir --timeout 1 sleeper
+assert_eq "$RC" "0" "watchdog kill stays exit 0 (healthy for smoke)"
+assert_contains "$OUT" "RESULT=ALIVE-TIMEOUT exe=sleeper" "ALIVE-TIMEOUT verdict"
+
+summarize "ir-run result-reporting tests"

--- a/scripts/gui-verify.py
+++ b/scripts/gui-verify.py
@@ -90,6 +90,15 @@ def main() -> None:
     ]
     run_rc, output = _run_capture(run_cmd)
 
+    # An --auto-screenshot GUI-test run must self-terminate. The fleet-run
+    # watchdog reports a process still alive at --timeout as exit 0
+    # ("healthy" for generic smoke), which would mask a hung GUI test as a
+    # zero-assertion success — treat the watchdog kill as a failure here.
+    hung = "RESULT=ALIVE-TIMEOUT" in output
+    if hung:
+        print(f"[gui-verify] run hung: watchdog killed it at --timeout "
+              f"{args.timeout}s before the shot table completed")
+
     assertions = []
     for m in _GUI_ASSERT_RE.finditer(output):
         shot, label, kind, target, name, result, actual = m.groups()
@@ -102,7 +111,7 @@ def main() -> None:
 
     if not assertions:
         msg = "[gui-verify] no GUI-ASSERT lines found in output"
-        if run_rc != 0:
+        if run_rc != 0 or hung:
             print(msg)
             raise SystemExit(1)
         print(msg + " (run exited 0 — target may have no assertion tables)")
@@ -131,7 +140,7 @@ def main() -> None:
         for a in failures:
             print(f"  shot={a['shot']} name={a['name']} kind={a['kind']} actual={a['actual']}")
 
-    if failures or run_rc != 0:
+    if failures or run_rc != 0 or hung:
         raise SystemExit(1)
 
 

--- a/test/tools/ir_run_exit_code_test.sh
+++ b/test/tools/ir_run_exit_code_test.sh
@@ -6,9 +6,12 @@
 # screenshots were written, so the per-shot comparator passed while the
 # process crashed. ir-run's `--auto-screenshot` path now refuses to
 # exec'-replace (which would hide the signal behind a bash builtin); it
-# runs as a child and prints a "crashed on shutdown" diagnostic on
-# non-zero. This test pins that behavior so a future revert doesn't
-# silently re-open the gap.
+# runs as a child and reports the clean-exit verdict (RESULT=CRASH … +
+# the clean-exit-policy failure text) on non-zero, propagating the code.
+# This test pins that behavior on the --auto-screenshot path — the
+# GPU-lock path, distinct from the --timeout coverage in
+# scripts/fleet/tests/test_ir_run_result_reporting.sh — so a future
+# revert doesn't silently re-open the gap.
 
 set -euo pipefail
 
@@ -68,10 +71,10 @@ set +e
 rc=$?
 set -e
 check "exit code matches binary (139)" "[[ $rc -eq 139 ]]"
-check "diagnostic mentions 'crashed on shutdown'" \
-    "grep -q 'crashed on shutdown' /tmp/ir-run-crash.log"
-check "diagnostic mentions T-336" \
-    "grep -q 'T-336' /tmp/ir-run-crash.log"
+check "RESULT=CRASH verdict names the propagated code + decoded signal" \
+    "grep -q 'RESULT=CRASH exe=IRFakeCrash exit=139 signal=SIGSEGV' /tmp/ir-run-crash.log"
+check "diagnostic cites the clean-exit policy" \
+    "grep -q 'clean-exit policy' /tmp/ir-run-crash.log"
 
 echo
 echo "ir_run_exit_code_test.sh: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

Human-cued fleet policy change, two halves:

**Clean-exit enforcement (tooling).** `ir-run` now emits a stable one-line verdict on every self-terminating run (`--auto-screenshot` / `--auto-profile` / `--timeout`):

- `RESULT=CLEAN exe=<name> exit=0` — ran to completion, teardown included
- `RESULT=CRASH exe=<name> exit=<rc> signal=<SIGNAME|none>` — exit code propagated; the old softening "screenshots may have been saved… (T-336)" message (which cited a doc section that never existed) is replaced with a directive citing the policy
- `RESULT=ALIVE-TIMEOUT` — watchdog kill of a healthy process; explicitly says nothing about teardown health

`--auto-profile` moves from bare `exec` to the same run-and-validate path. Hermetic test (`scripts/fleet/tests/test_ir_run_result_reporting.sh`, 9 assertions) pins verdict shape, SIGSEGV decode from 139, and exit-code propagation. Verified live on the #2412 crash repro (CRASH verdict + directive) and a clean IRCanvasStress run (CLEAN).

**Policy (docs).** `FLEET.md` gains:

- **§Clean-exit policy** — a signal exit fails the verification step that ran it, even when outputs saved before the crash; the observing agent fixes it regardless of who introduced it; a crash observed is never reported green (file-with-forensics + mark the lane failed is the only fallback).
- **§Fix-forward** — opportunistic fixes (bugs, crashes, dead code, duplication, stale docs) ship with the finder: same PR (own commit, `## Opportunistic fixes` section) or an immediate sibling PR; follow-up issues become the documented exception. Includes the reviewer covenant so sectioned bundles aren't flagged as scope creep.

Pointers wired: `engine/render/CLAUDE.md` (verify section), `render-debug-loop`, `render-verify`, `platform-catchup` (partial-runtime path now fix-forwards instead of filing), `role-smoke-worker` (verdict keys off the RESULT line, not maskable shell status), `review-pr` checklist (+ green-over-crash flag), top-level `CLAUDE.md` index row.

## Opportunistic fixes

- `scripts/gui-verify.py` — a hung GUI-test run killed by the fleet-run watchdog returned exit 0 with zero assertions and read as success; it now detects `RESULT=ALIVE-TIMEOUT` and fails. (Found while auditing consumers for this PR.)

## Test plan

- [x] `bash scripts/fleet/tests/test_ir_run_result_reporting.sh` — 9/9
- [x] Live gpu-path CRASH verdict on the #2412 IRPerfGrid repro (exit 139 → `signal=SIGSEGV`)
- [x] Live gpu-path CLEAN verdict on IRCanvasStress (rc=0)
- [x] `ruff check scripts/gui-verify.py` clean
- [x] `bash -n engine/tools/bin/ir-run`

## Notes

- The smoke/verify harness `scripts/render-verify.py` already failed on fleet-run crashes; this PR aligns the agent-driven flows and the messaging with it.
- Next PR this session (fix-forward in action): root-cause + fix for #2412, the macOS yaw-transition segfault this policy would have caught as red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3td6Ct8PwkJY7q6J3YSYo