### PR TITLE
render/metal: scrub sticky bindings on buffer destruction (fixes #2412)

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -940,7 +940,7 @@ parity with voxel-pool primary shapes.
   that a stale image shadows. GL is immune (separate image/texture-unit
   namespaces), so a GL-only smoke will not catch it. Any compute kernel that
   mixes a sampler read with images bound elsewhere in the pipeline is exposed;
-   the #1294 chunk cull's fine Hi-Z levels are the known other victim.
+  the #1294 chunk cull's fine Hi-Z levels are the known other victim.
 - **Destroying a Metal resource must scrub the sticky binding tables
   (#2412).** `bindComputeResources`/`bindRenderResources` re-encode every
   non-null sticky table entry on each dispatch, so a released `MTL::Buffer`

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -940,4 +940,16 @@ parity with voxel-pool primary shapes.
   that a stale image shadows. GL is immune (separate image/texture-unit
   namespaces), so a GL-only smoke will not catch it. Any compute kernel that
   mixes a sampler read with images bound elsewhere in the pipeline is exposed;
-  the #1294 chunk cull's fine Hi-Z levels are the known other victim.
+   the #1294 chunk cull's fine Hi-Z levels are the known other victim.
+- **Destroying a Metal resource must scrub the sticky binding tables
+  (#2412).** `bindComputeResources`/`bindRenderResources` re-encode every
+  non-null sticky table entry on each dispatch, so a released `MTL::Buffer`
+  / `MTL::Texture` left in a table is an `objc_retain` on a dangling
+  pointer — a segfault on the NEXT dispatch after the owner died (the
+  #2412 yaw-transition crash: the overflow-lighting scratch, transiently
+  bound at slot 8, died when the per-axis canvases released at a cardinal
+  return). The impl destructors now scrub (`replaceMetalBufferInBindings`
+  in `~MetalBufferImpl`, `untrackMetalTexture` in the texture dtor, and
+  `releaseImageAtomicScratchBuffer` nulls the sticky current-scratch
+  pointer). If you add a NEW sticky cache of a raw MTL object pointer,
+  wire the owner's destruction to scrub it the same way.

--- a/engine/render/src/metal/metal_buffer.cpp
+++ b/engine/render/src/metal/metal_buffer.cpp
@@ -32,7 +32,21 @@ class MetalBufferImpl final : public BufferImpl {
 
     ~MetalBufferImpl() override {
         if (m_buffer != nullptr) {
-            m_buffer->release();
+            // Scrub the sticky binding tables first: bindRenderResources /
+            // bindComputeResources re-encode every non-null table entry on
+            // the next dispatch, so a released buffer left behind is an
+            // objc_retain on a dangling pointer (the #2412 yaw-transition
+            // segfault — a transiently-bound SSBO whose owner died when the
+            // per-axis canvases released). Mirrors untrackMetalTexture.
+            replaceMetalBufferInBindings(m_buffer, nullptr);
+            // If an in-flight command buffer may still read it, defer the
+            // release to the post-wait drain (same contract as the subData
+            // orphan path); otherwise release immediately.
+            if (wasMetalBufferEncoded(m_buffer)) {
+                deferReleaseMetalBuffer(m_buffer);
+            } else {
+                m_buffer->release();
+            }
             m_buffer = nullptr;
         }
     }

--- a/engine/render/src/metal/metal_runtime.cpp
+++ b/engine/render/src/metal/metal_runtime.cpp
@@ -426,7 +426,20 @@ void releaseImageAtomicScratchBuffer(MTL::Texture *texture) {
         return;
     }
     if (it->second != nullptr) {
-        it->second->release();
+        // The sticky current-scratch pointer ("set by every R32I
+        // bindAsImage, never cleared") may still name this buffer;
+        // bindComputeResources re-encodes it for every scratch-consumer
+        // kernel, so leaving it behind is the same dangling-retain class
+        // as an unscrubbed binding-table entry (#2412). Null it, and defer
+        // the release when an in-flight command buffer may still read it.
+        if (currentImageAtomicScratch() == it->second) {
+            setCurrentImageAtomicScratch(nullptr);
+        }
+        if (wasMetalBufferEncoded(it->second)) {
+            deferReleaseMetalBuffer(it->second);
+        } else {
+            it->second->release();
+        }
     }
     cache.erase(it);
 }


### PR DESCRIPTION
## Summary

Fixes the macOS/Metal segfault at yaw-state transitions (#2412) — the crash this session's clean-exit policy work (PR #2416) is designed to make impossible to ship past. Fix-forward in action: found during the #2410 investigation, root-caused and fixed by the finder.

**Root cause** (lldb: `EXC_BAD_ACCESS` in `objc_retain` ← `MTL::ComputeCommandEncoder::setBuffer(index=8)` ← `bindComputeResources` ← `VOXEL_TO_TRIXEL` dispatch):

- `bindComputeResources`/`bindRenderResources` re-encode every non-null **sticky binding-table** entry on each dispatch.
- `~MetalBufferImpl` released its `MTL::Buffer` **without scrubbing those tables** — textures have had this scrub (`untrackMetalTexture`) since #1812-era work; buffers never did.
- Exposure: the overflow-lighting lane (#2357/#2388) transiently binds the per-axis resolve scratch at slot 8 (`kBufferIndex_OverflowLightingScratch`, aliasing `VoxelActiveMask`). That scratch dies when the per-axis canvases release at a cardinal return — the next compute dispatch retained the freed object. Hence the exact crash points: IRPerfGrid `zoom4_pan` (yaw 0.35 → 0) and IRShapeDebug `zoom8_yaw180` (yaw 45° → 180°).

**Fix** (mirrors the existing texture precedent):
- `~MetalBufferImpl`: `replaceMetalBufferInBindings(m_buffer, nullptr)` + defer-release when the buffer was encoded into an in-flight command buffer (same contract as the `subData` orphan path).
- Same-class sibling in `releaseImageAtomicScratchBuffer`: destroying a distance texture whose scratch is the sticky current-scratch pointer now nulls that pointer and defer-releases when encoded.
- Gotcha documented in `engine/render/CLAUDE.md` next to the #1812 stale-image-bind sibling: any new sticky cache of a raw MTL pointer must wire owner-destruction scrubbing.

## Test plan

- [x] IRPerfGrid repro (`--grid-size 16 --zoom 8 --wave-amplitude 0 --auto-screenshot 10`): was 100%-repro SIGSEGV at shot 6/7 → now exit 0, 7/7 shots, across 4 repeat runs
- [x] IRPerfGrid default config (64³ wave): exit 0 (previously crashed at the same transition)
- [x] IRShapeDebug full 21-shot table: was SIGSEGV at shot 17 (`zoom8_yaw180`) → exit 0, all shots
- [x] IRCanvasStress: exit 0, shots byte-identical pre/post fix (img_diff drift 0 on sampled shots) — destruction-path change is visually inert
- [x] `fleet-build --target format-changed` clean
- [ ] Linux/OpenGL smoke (change is Metal-backend-only; GL unaffected by construction)

Closes #2412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3td6Ct8PwkJY7q6J3YSYo