### PR TITLE
fleet: semantic-conflict PRs generate opus dispatch pressure

### DIFF
--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -263,6 +263,16 @@ Specifically, **never pass these via `--label` when filing**:
   `IRREDEN_USER_PROJECTS` build-verify) — or escalated to
   `human:needs-fix` if even Opus can't resolve (or, for a game PR, can't
   build-verify the resolution).
+  **Dispatch pressure:** the scout surfaces claimable conflicts in the
+  worker projection + slice (`semantic_conflict_prs[]`), and the class
+  election counts each as one **opus** item ranked between feedback and
+  task pickup — so a conflicted PR launches an opus iteration even when
+  the opus queue is empty or host-locked, instead of starving behind
+  sonnet no-op iterations (engine #2417). Claimable means: live
+  `mergeable == CONFLICTING` (a stale label on a MERGEABLE PR — the
+  #1654 race — generates no dispatch), none of step 1c's own exclusion
+  labels, no active `fleet:resolving-*` claim, and stacked children
+  defer to their conflicted base.
 - `fleet:fork-of-other-pr` — owned by the **merger** (sets when it
   detects this PR's branch was forked from another open PR's branch
   rather than from master, meaning the diff carries inherited commits

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1082,6 +1082,15 @@ FEEDBACK_LABELS = frozenset({
 # (and only there) so the worker iteration picks it up like any other
 # feedback PR; reviewers do not act on it.
 DESIGN_RESUME_LABELS = frozenset({"fleet:design-unblocked"})
+# role-worker step 1c's own pickup exclusions: a fleet:semantic-conflict PR
+# also carrying any of these is not resolvable right now — wip/human-held,
+# or not yet rebaseable against master (awaiting-*, fork-of-other-pr). Keep
+# in lockstep with the step-1c filter list in role-worker.md.
+SEMANTIC_CONFLICT_EXCLUDE_LABELS = frozenset({
+    "fleet:wip", "human:wip", "human:needs-fix", "human:blocker",
+    "fleet:awaiting-base", "fleet:awaiting-upstream-review",
+    "fleet:fork-of-other-pr",
+})
 REVIEW_VERDICT_LABELS = frozenset({
     "fleet:approved", "fleet:needs-fix", "fleet:blocker", "fleet:has-nits",
 })
@@ -1633,12 +1642,53 @@ def enrich_inflight_pr_tasks(state):
 # fleet:needs-linux-smoke), waking the role to find nothing actionable.
 # Same anti-pattern project_merger already documents and avoids — keep
 # only the labels each role's own decision logic actually keys on.
-# fleet:semantic-conflict is intentionally NOT in this set. A stale
-# fleet:semantic-conflict on a MERGEABLE PR (fail-then-succeed race, #1654)
-# must not trigger a false step-1c resolution pass — the structural exclusion
-# here is the guarantee. The label is cleared by fleet-rebase's stale-conflict
-# cleanup sweep (#1654) before the worker ever sees the PR.
+# fleet:semantic-conflict is intentionally NOT in this set — a plain label
+# match cannot tell a real conflict from a stale label on a MERGEABLE PR
+# (fail-then-succeed race, #1654), and a stale label must not trigger a
+# false step-1c resolution pass. Conflicted PRs still generate dispatch
+# pressure, but via _semantic_conflict_claimable, which gates on the
+# cached mergeable == CONFLICTING (the same live-state signal
+# _merger_action_signal keys on), so the #1654 shape stays structurally
+# excluded. fleet-rebase's stale-conflict cleanup sweep (#1654) still
+# clears the stale label itself.
 _WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
+
+
+def _semantic_conflict_claimable(pr, labels, head_labels):
+    """True when role-worker step 1c would pick this PR up right now, so it
+    must count as opus-class claimable work in the worker projection + slice.
+
+    Without this, fleet:semantic-conflict has no dispatch pressure at all:
+    its only consumer is step 1c, which runs inside opus+-class worker
+    iterations, and the class election (fleet_task_class.py) elects from
+    feedback/tasks/needs-plan only — so when the opus queue is dry or
+    host-locked, conflicted PRs starve behind sonnet no-op iterations
+    (engine #2417 sat unclaimed while worker panes idled).
+
+    `head_labels` maps the repo's open-PR head refs to their label sets,
+    for the stacked-child check.
+    """
+    if "fleet:semantic-conflict" not in labels:
+        return False
+    # #1654 guard: only a live CONFLICTING PR is real step-1c work. A stale
+    # label on a MERGEABLE PR (fail-then-succeed race) generates no dispatch;
+    # UNKNOWN (GitHub still computing) fails closed until the next tick.
+    if pr.get("mergeable") != "CONFLICTING":
+        return False
+    if labels & SEMANTIC_CONFLICT_EXCLUDE_LABELS:
+        return False
+    # An active fleet:resolving-<host>-<agent> claim means a worker is
+    # already mid-resolution — covered, not claimable. Stale claims are
+    # swept by `fleet-claim cleanup --gh`, so this can't strand a PR.
+    if any(label.startswith("fleet:resolving-") for label in labels):
+        return False
+    # Stack-aware (role-worker step 1c): a stacked child whose base PR is
+    # itself semantic-conflicted is skipped — the base resolves first, and
+    # the base is the claimable item that carries the dispatch pressure.
+    base_labels = head_labels.get(pr.get("baseRefName"))
+    if base_labels and "fleet:semantic-conflict" in base_labels:
+        return False
+    return True
 
 
 def project_worker(state):
@@ -1646,9 +1696,10 @@ def project_worker(state):
     # sonnet-author split was vestigial once model class became a
     # property of the task (#1691), so this projector is the union of
     # the two — every open task regardless of class, every needs-plan
-    # issue, and every feedback/design-resume PR. The dispatcher picks
-    # the concrete model per dispatch from the slice (resolve_worker_class
-    # / fleet_task_class.py); the lane no longer pins a model.
+    # issue, every feedback/design-resume PR, and every claimable
+    # semantic-conflict PR. The dispatcher picks the concrete model per
+    # dispatch from the slice (resolve_worker_class / fleet_task_class.py);
+    # the lane no longer pins a model.
     items = []
     for repo, repo_state in state["repos"].items():
         for task in repo_state.get("tasks", {}).get("open", []):
@@ -1677,7 +1728,11 @@ def project_worker(state):
                 continue
             items.append({"kind": "needs_plan", "repo": repo,
                           "issue": issue["number"]})
-        for pr in repo_state.get("prs", []):
+        prs = repo_state.get("prs", [])
+        head_labels = {
+            p.get("headRefName"): set(p.get("labels", [])) for p in prs
+        }
+        for pr in prs:
             labels = set(pr["labels"])
             if "human:wip" in labels:
                 continue
@@ -1699,6 +1754,12 @@ def project_worker(state):
             if labels & _WORKER_RELEVANT_LABELS:
                 items.append({"kind": "pr", "repo": repo, "pr": pr["number"],
                               "labels": sorted(labels & _WORKER_RELEVANT_LABELS)})
+            # Distinct kind so the hash keys on presence only — resolution
+            # (label removed / PR merged) or a fleet:resolving-* claim drops
+            # the item; transient label churn on the PR doesn't re-flip it.
+            if _semantic_conflict_claimable(pr, labels, head_labels):
+                items.append({"kind": "semantic_conflict", "repo": repo,
+                              "pr": pr["number"]})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
@@ -2140,11 +2201,12 @@ def _slice_issue_with_repo(repo_key, issue):
 
 def slice_worker(state):
     # Unified worker slice (P2): all open tasks of every class, all
-    # needs-plan issues, and all feedback/design-resume PRs. The
-    # dispatcher's per-task class resolution (fleet_task_class.py)
-    # already handles a mixed-class tasks_open list, so a single slice
-    # serves fable / opus / sonnet work.
-    out = {"tasks_open": [], "needs_plan": [], "feedback_prs": []}
+    # needs-plan issues, all feedback/design-resume PRs, and all claimable
+    # semantic-conflict PRs. The dispatcher's per-task class resolution
+    # (fleet_task_class.py) already handles a mixed-class tasks_open list,
+    # so a single slice serves fable / opus / sonnet work.
+    out = {"tasks_open": [], "needs_plan": [], "feedback_prs": [],
+           "semantic_conflict_prs": []}
     for repo_key, repo_state in state["repos"].items():
         for task in repo_state.get("tasks", {}).get("open", []):
             if model_tags(task) & {"opus", "fable", "sonnet"}:
@@ -2166,7 +2228,11 @@ def slice_worker(state):
             if issue.get("blocked"):
                 continue
             out["needs_plan"].append(_slice_issue_with_repo(repo_key, issue))
-        for pr in repo_state.get("prs", []):
+        prs = repo_state.get("prs", [])
+        head_labels = {
+            p.get("headRefName"): set(p.get("labels", [])) for p in prs
+        }
+        for pr in prs:
             labels = set(pr["labels"])
             if "human:wip" in labels:
                 continue
@@ -2176,6 +2242,9 @@ def slice_worker(state):
                 continue
             if labels & (FEEDBACK_LABELS | DESIGN_RESUME_LABELS):
                 out["feedback_prs"].append(_slice_pr_with_repo(repo_key, pr))
+            if _semantic_conflict_claimable(pr, labels, head_labels):
+                out["semantic_conflict_prs"].append(
+                    _slice_pr_with_repo(repo_key, pr))
     return out
 
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1677,6 +1677,19 @@ def _semantic_conflict_claimable(pr, labels, head_labels):
         return False
     if labels & SEMANTIC_CONFLICT_EXCLUDE_LABELS:
         return False
+    # A PR that also owes worker feedback/design-resume work
+    # (fleet:needs-fix / fleet:has-nits / fleet:design-unblocked — plus
+    # human:needs-fix/blocker, already in SEMANTIC_CONFLICT_EXCLUDE_LABELS)
+    # is routed to the feedback lane. That lane's fleet:amending-* claim
+    # namespace is disjoint from this lane's fleet:resolving-*, so minting an
+    # opus conflict item in parallel lets a (sonnet) feedback pane and an opus
+    # resolver pane force-push the SAME head branch on one tick — a
+    # last-writer-wins race that silently drops the conflict resolution or the
+    # feedback fix. Feedback comes first (this PR's own stated priority), so a
+    # conflicted PR generates no conflict-resolution pressure until the
+    # feedback/design-resume label clears. Mirror in role-worker.md step 1c.
+    if labels & _WORKER_RELEVANT_LABELS:
+        return False
     # An active fleet:resolving-<host>-<agent> claim means a worker is
     # already mid-resolution — covered, not claimable. Stale claims are
     # swept by `fleet-claim cleanup --gh`, so this can't strand a PR.

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -17,10 +17,23 @@ Resolution order mirrors the worker role docs' pickup priority:
                       (``fleet:needs-fix`` / ``human:needs-fix`` /
                       ``human:blocker``) routes to opus; nits-only feedback
                       routes to sonnet.
-  2. open tasks     — the oldest claimable task's class (slices are sorted
+  2. semantic-conflict PRs — always opus: role-worker step 1c ("judging two
+                      sides' intent in a conflicted rebase is opus-tier
+                      work") runs between feedback and task pickup, and only
+                      inside opus+-class iterations, so each claimable
+                      conflict is one opus item. Without this tier the label
+                      has no dispatch pressure at all — conflicts only
+                      resolve as a ride-along when opus queue work happens
+                      to be flowing, and starve when it isn't (engine
+                      #2417). The scout pre-filters the slice's
+                      ``semantic_conflict_prs[]`` (CONFLICTING-gated per
+                      #1654, step-1c label exclusions, fleet:resolving-*
+                      unclaimed, stacked-child-deferred), so every entry
+                      counts.
+  3. open tasks     — the oldest claimable task's class (slices are sorted
                       by issue number; ``model`` comes from the
                       fleet:fable/opus/sonnet labels via the scout).
-  3. needs_plan     — a `fleet:sonnet`-tagged needs-plan issue is a MECHANICAL
+  4. needs_plan     — a `fleet:sonnet`-tagged needs-plan issue is a MECHANICAL
                       task the sonnet lane light-plans and self-queues (see
                       `_plan_class`); every other needs-plan issue is
                       architect-tier design work that prefers the fable class
@@ -233,14 +246,15 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
     """Yield (class, effort, kind) per actionable item, pickup-priority order.
 
     Feedback PRs come first (the worker fixes review feedback before new work),
-    then unblocked open tasks, then stackable `blocked` tasks (a fallback tier,
-    claimable only as a stack on the blocker's PR), then needs_plan. This
-    mirrors the worker role docs so the *elected* class matches what the worker
-    actually picks up, and one yield per item lets the caller count claimable
-    work per class for the dispatcher's fan-out cap. ``kind`` is "plan" for a
-    needs_plan yield and "work" for everything else — `resolve` uses it to flag
-    the elected class's planning candidate so the dispatcher pre-claims a
-    specific issue for the dispatch (#2197).
+    then semantic-conflict PRs (role-worker step 1c sits between feedback and
+    task pickup), then unblocked open tasks, then stackable `blocked` tasks (a
+    fallback tier, claimable only as a stack on the blocker's PR), then
+    needs_plan. This mirrors the worker role docs so the *elected* class
+    matches what the worker actually picks up, and one yield per item lets the
+    caller count claimable work per class for the dispatcher's fan-out cap.
+    ``kind`` is "plan" for a needs_plan yield and "work" for everything else —
+    `resolve` uses it to flag the elected class's planning candidate so the
+    dispatcher pre-claims a specific issue for the dispatch (#2197).
 
     needs_plan yields once PER PLANNING CLASS, not once per issue: one planning
     assignment per class per tick is a deliberate serialization — planning is
@@ -268,6 +282,14 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
     for pr in slice_data.get("feedback_prs", []) or []:
         cls = feedback_pr_class(pr.get("labels", []))
         yield cls, CLASS_DEFAULT_EFFORT[cls], "work"
+    # Step-1c work is opus+-only, so each conflict is one opus claimable item.
+    # The scout already filtered the slice (CONFLICTING-gated per #1654,
+    # step-1c label exclusions, no fleet:resolving-* claim, stacked children
+    # deferred to their base), so no re-filtering here. No host gate either:
+    # step 1c build-verifies IRShapeDebug, which every fleet host builds
+    # natively, unlike the GL-locked tasks below.
+    for _pr in slice_data.get("semantic_conflict_prs", []) or []:
+        yield "opus", CLASS_DEFAULT_EFFORT["opus"], "work"
     tasks = slice_data.get("tasks_open", []) or []
     for task in tasks:
         if _task_claimable(task, host) and not task.get("blocked"):

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -8,6 +8,7 @@
 #   - only cap-blocked fable work -> defer (keep trigger, no dispatch)
 #   - per-task Effort: override threads through to the dispatch
 #   - feedback severity routing (nits-only -> sonnet beats queued tasks)
+#   - semantic-conflict-only slice -> opus dispatch (step-1c pressure, #2417)
 #   - empty slice -> lane-default fallthrough (class empty)
 #   - non-worker role is a no-op (class empty)
 #   - planning pre-claim (#2197): plan=1 election, --plan-assign claim walk
@@ -229,6 +230,17 @@ case "$out" in
     *" plan="*) FAIL=$((FAIL+1)); echo "  FAIL: unassigned dispatch carries plan=: $out" ;;
     *) PASS=$((PASS+1)); echo "  ok: unassigned dispatch has no plan= arg" ;;
 esac
+
+# --- T18: semantic-conflict-only slice dispatches opus -----------------------
+# The #2417 starvation shape end-to-end: no feedback, no claimable tasks, no
+# needs-plan — just a conflicted PR the scout surfaced. The lane must elect
+# opus (role-worker step 1c is opus+-only), not defer and not fall through to
+# the lane default (a sonnet iteration skips step 1c by design).
+echo "T18: semantic-conflict-only slice dispatches opus (step-1c pressure)"
+write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[],"semantic_conflict_prs":[{"number":2417,"repo":"engine","labels":["fleet:semantic-conflict"]}]}'
+assert_eq "$(resolve worker)" \
+    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0 count=1 plan=0" \
+    "conflicted PR alone elects opus with count=1"
 
 echo
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -5,9 +5,15 @@ work it's serving (a claude process can't change model/effort after
 launch), so this resolution IS the per-task model routing. The invariants
 that matter:
 
-  - pickup priority mirrors the role docs: feedback PRs, then unblocked open
-    tasks (oldest first — slices arrive sorted), then stackable `blocked`
-    tasks, then needs_plan;
+  - pickup priority mirrors the role docs: feedback PRs, then
+    semantic-conflict PRs, then unblocked open tasks (oldest first — slices
+    arrive sorted), then stackable `blocked` tasks, then needs_plan;
+  - a semantic-conflict PR is one opus claimable item (role-worker step 1c is
+    opus+-only; the scout pre-filters the slice's semantic_conflict_prs[]),
+    so a conflicted PR generates opus dispatch pressure even when the task
+    queue is empty or host-locked — before this tier the label had no
+    dispatch pressure at all and conflicts starved behind sonnet no-op
+    iterations (engine #2417);
   - feedback class derives from review severity labels (fable opt-in via
     fleet:fable on the PR, blocking labels -> opus, nits-only -> sonnet);
   - the fable concurrency cap skips fable items rather than idling the
@@ -380,6 +386,93 @@ class GlHostGate(unittest.TestCase):
         out = self._resolve_on(
             "unknown", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
         self.assertEqual(out, "defer")
+
+
+class SemanticConflictDispatchPressure(unittest.TestCase):
+    """Semantic-conflict PRs are opus-class claimable work slotted between
+    feedback and task pickup (role-worker step 1c, opus+-classes-only). This
+    tier is what gives the label dispatch pressure at all: before it, a
+    conflicted PR was only resolved as a ride-along when opus queue work
+    happened to be flowing, and starved when the opus lane was dry or
+    host-locked (engine #2417 sat unclaimed while sonnet iterations
+    no-op'd). The scout pre-filters the slice (CONFLICTING-gated per #1654,
+    step-1c exclusions, resolving-claims, stacked children), so the resolver
+    counts every entry as-is."""
+
+    def setUp(self):
+        self._saved_host = os.environ.get("FLEET_TEST_HOST")
+
+    def tearDown(self):
+        if self._saved_host is None:
+            os.environ.pop("FLEET_TEST_HOST", None)
+        else:
+            os.environ["FLEET_TEST_HOST"] = self._saved_host
+
+    @staticmethod
+    def _sc(num):
+        return {"number": num, "repo": "engine",
+                "labels": ["fleet:semantic-conflict"]}
+
+    def test_conflict_alone_elects_opus(self):
+        out = resolve({"semantic_conflict_prs": [self._sc(2417)]},
+                      "sonnet", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 1 0")
+
+    def test_conflict_dispatches_when_all_tasks_host_locked(self):
+        # The #2417 starvation shape: every open task is GL-locked on a
+        # Metal-only host, so tasks alone would defer and no opus iteration
+        # ever launches — the conflict must still dispatch opus.
+        os.environ["FLEET_TEST_HOST"] = "mac"
+        out = resolve({
+            "tasks_open": [_task("#1938", "opus", needs_gl_host=True)],
+            "semantic_conflict_prs": [self._sc(2417)],
+        }, "sonnet", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 1 0")
+
+    def test_feedback_still_elected_before_conflict(self):
+        # Pickup priority mirrors the worker loop: feedback (step 1) before
+        # conflicts (step 1c). The conflict stays servable -> more=1 so the
+        # next tick serves the opus lane.
+        out = resolve({
+            "feedback_prs": [{"number": 11, "labels": ["fleet:has-nits"]}],
+            "semantic_conflict_prs": [self._sc(2417)],
+        }, "sonnet", fable_blocked=False)
+        self.assertEqual(out, "sonnet high 1 1 0")
+
+    def test_conflict_elected_before_open_tasks(self):
+        # Step 1c runs before task pickup (step 2), so the conflict outranks
+        # a claimable sonnet task; the task holds more=1.
+        out = resolve({
+            "semantic_conflict_prs": [self._sc(2417)],
+            "tasks_open": [_task("#10", "sonnet")],
+        }, "sonnet", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 1 1 0")
+
+    def test_conflicts_and_opus_feedback_share_the_count(self):
+        # Each conflict is one claimable opus item alongside opus feedback:
+        # the fan-out cap must cover both, one worker per item.
+        out = resolve({
+            "feedback_prs": [{"number": 11, "labels": ["fleet:needs-fix"]}],
+            "semantic_conflict_prs": [self._sc(2417), self._sc(2420)],
+        }, "sonnet", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 3 0")
+
+    def test_exclude_opus_defers_not_lane_default(self):
+        # Cap-covered opus with only conflict work left -> defer (real work
+        # exists, none servable now), never '' — a lane-default dispatch
+        # would launch a sonnet iteration that skips step 1c by design.
+        out = resolve({"semantic_conflict_prs": [self._sc(2417)]},
+                      "sonnet", fable_blocked=False, exclude=["opus"])
+        self.assertEqual(out, "defer")
+
+    def test_no_host_gate_on_conflicts(self):
+        # Unlike needs_gl_host tasks, a conflict resolves on any host — step
+        # 1c build-verifies IRShapeDebug, which every fleet host builds
+        # natively. mac included.
+        os.environ["FLEET_TEST_HOST"] = "mac"
+        out = resolve({"semantic_conflict_prs": [self._sc(2417)]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
 
 class ExcludeClasses(unittest.TestCase):

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -38,6 +38,8 @@ that matter:
   - an empty/unroutable slice falls through to the lane default (covers
     reservation resumes and missing slices).
 """
+import importlib.machinery
+import importlib.util
 import os
 import sys
 import unittest
@@ -45,6 +47,18 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from fleet_task_class import feedback_pr_class, plan_pick, resolve  # noqa: E402
+
+# The scout's slice_worker is the pre-filter that feeds resolve(). Loaded here
+# (not only in test_worker_projection.py) to assert the cross-module contract:
+# a fleet:semantic-conflict PR that ALSO carries a worker feedback label is
+# dropped from semantic_conflict_prs[] so it reaches resolve() as feedback-only.
+_SCOUT = Path(__file__).parent.parent / "fleet-state-scout"
+_scout_loader = importlib.machinery.SourceFileLoader(
+    "fleet_state_scout", str(_SCOUT))
+_scout_spec = importlib.util.spec_from_loader("fleet_state_scout", _scout_loader)
+_scout_mod = importlib.util.module_from_spec(_scout_spec)
+_scout_loader.exec_module(_scout_mod)
+slice_worker = _scout_mod.slice_worker
 
 
 def _task(issue, model=None, effort=None, owner="free", blocked=False,
@@ -565,6 +579,44 @@ class PlanPick(unittest.TestCase):
 
     def test_empty_slice_yields_no_picks(self):
         self.assertEqual(plan_pick({}, "fable", False), [])
+
+
+class SemanticConflictFeedbackExclusionIntegration(unittest.TestCase):
+    """End-to-end (slice_worker -> resolve): a fleet:semantic-conflict PR that
+    ALSO owes a worker feedback fix must reach resolve() as feedback-only. The
+    scout drops it from semantic_conflict_prs[], so no parallel opus conflict
+    item is minted alongside the feedback item. Without this, a feedback pane
+    and an opus resolver pane can force-push the same head branch on one tick
+    (disjoint fleet:amending-* vs fleet:resolving-* claims give no mutual
+    exclusion), silently dropping the conflict resolution or the fix."""
+
+    @staticmethod
+    def _state(pr):
+        return {"repos": {"engine": {
+            "prs": [pr], "tasks": {"open": []}, "needs_plan": []}}}
+
+    @staticmethod
+    def _pr(labels, mergeable):
+        return {"number": 2422, "title": "T: feat",
+                "headRefName": "claude/feat", "baseRefName": "master",
+                "labels": sorted(labels), "isDraft": False,
+                "mergeable": mergeable, "author": "bot"}
+
+    def test_conflict_plus_feedback_dispatches_feedback_only(self):
+        # Every worker feedback / design-resume label suppresses the parallel
+        # conflict item, regardless of which class the feedback itself routes
+        # to (nits -> sonnet, needs-fix / design-unblocked -> opus). Assert the
+        # dispatch is identical to the same PR with no conflict label at all —
+        # the conflict adds zero pressure while the feedback is pending.
+        for label in ("fleet:has-nits", "fleet:needs-fix",
+                      "fleet:design-unblocked"):
+            combined = slice_worker(self._state(self._pr(
+                ["fleet:semantic-conflict", label], "CONFLICTING")))
+            self.assertEqual(combined["semantic_conflict_prs"], [], label)
+            self.assertEqual(len(combined["feedback_prs"]), 1, label)
+            plain = slice_worker(self._state(self._pr([label], "MERGEABLE")))
+            self.assertEqual(resolve(combined, "sonnet", False),
+                             resolve(plain, "sonnet", False), label)
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -52,15 +52,16 @@ def _state(prs, tasks=None, needs_plan=None):
     }
 
 
-def _pr(num, *, labels=None, head="claude/feat", is_draft=False):
+def _pr(num, *, labels=None, head="claude/feat", is_draft=False,
+        base="master", mergeable="MERGEABLE"):
     return {
         "number": num,
         "title": f"T-{num}: feat",
         "headRefName": head,
-        "baseRefName": "master",
+        "baseRefName": base,
         "labels": sorted(labels or []),
         "isDraft": is_draft,
-        "mergeable": "MERGEABLE",
+        "mergeable": mergeable,
         "author": "bot",
     }
 
@@ -84,10 +85,12 @@ class WorkerStableAcrossIrrelevantLabels(unittest.TestCase):
         self.assertEqual(before, after,
                          "merger-cooldown toggle must not re-fire the worker")
 
-    def test_semantic_conflict_does_not_flip_hash(self):
-        # The worker handles semantic-conflict (step 1c), but the projector
-        # includes a PR via FEEDBACK_LABELS, not semantic-conflict. Flipping
-        # that label while the feedback label is unchanged must not re-fire.
+    def test_stale_semantic_conflict_does_not_flip_hash(self):
+        # A fleet:semantic-conflict label on a MERGEABLE PR is the #1654
+        # fail-then-succeed race shape — stale, awaiting fleet-rebase's
+        # cleanup sweep. It must not re-fire the worker; only a live
+        # CONFLICTING PR is dispatch pressure (the SemanticConflictDispatch
+        # tests). `_pr` defaults to mergeable=MERGEABLE.
         before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
         after = self._hash([_pr(101, labels=[
             "fleet:needs-fix", "fleet:semantic-conflict",
@@ -210,6 +213,119 @@ class WorkerSkipLabelsDropPR(unittest.TestCase):
             project_worker(_state([_pr(101, labels=["fleet:needs-fix", "fleet:gated"])])),
             [],
         )
+
+
+def _sc_pr(num, **kwargs):
+    kwargs.setdefault("labels", ["fleet:semantic-conflict"])
+    kwargs.setdefault("mergeable", "CONFLICTING")
+    return _pr(num, **kwargs)
+
+
+class SemanticConflictDispatch(unittest.TestCase):
+    """A claimable fleet:semantic-conflict PR IS worker dispatch pressure:
+    it enters project_worker (so its appearance/resolution flips the hash and
+    wakes the lane) and slice_worker's semantic_conflict_prs[] (so the class
+    election counts it as one opus item). Its only consumer, role-worker step
+    1c, runs exclusively in opus+-class iterations — without a projection
+    item, no opus iteration ever launches when the opus queue is dry or
+    host-locked, and conflicted PRs starve behind sonnet no-ops (engine
+    #2417). Only a live CONFLICTING PR counts: the #1654 stale-label shape
+    (label on a MERGEABLE PR) stays structurally excluded via the cached
+    mergeable field, preserving what the old blanket label exclusion
+    guaranteed."""
+
+    def _items(self, prs):
+        return [i for i in project_worker(_state(prs))
+                if i["kind"] == "semantic_conflict"]
+
+    def _slice(self, prs):
+        return slice_worker(_state(prs))["semantic_conflict_prs"]
+
+    def test_conflicting_pr_enters_projection_and_slice(self):
+        prs = [_sc_pr(2417)]
+        self.assertEqual(self._items(prs),
+                         [{"kind": "semantic_conflict", "repo": "engine",
+                           "pr": 2417}])
+        slice_prs = self._slice(prs)
+        self.assertEqual(len(slice_prs), 1)
+        self.assertEqual(slice_prs[0]["number"], 2417)
+        self.assertEqual(slice_prs[0]["repo"], "engine")
+
+    def test_appearance_and_resolution_flip_hash(self):
+        # Label lands (merger) -> wake; label cleared (worker resolved) ->
+        # the item leaves. Both edges are real dispatch-relevant transitions.
+        without = stable_hash(project_worker(_state([_pr(2417,
+            mergeable="CONFLICTING")])))
+        with_sc = stable_hash(project_worker(_state([_sc_pr(2417)])))
+        self.assertNotEqual(without, with_sc)
+
+    def test_stale_label_on_mergeable_pr_is_not_pressure(self):
+        # #1654: fail-then-succeed race leaves the label on a MERGEABLE PR.
+        # No projection item, no slice entry — the dispatch side must stay
+        # blind to it until fleet-rebase's cleanup sweep clears the label.
+        prs = [_sc_pr(2417, mergeable="MERGEABLE")]
+        self.assertEqual(self._items(prs), [])
+        self.assertEqual(self._slice(prs), [])
+
+    def test_unknown_mergeable_fails_closed(self):
+        # GitHub still computing mergeability -> not (yet) claimable; the
+        # next scout tick picks it up once CONFLICTING is confirmed.
+        prs = [_sc_pr(2417, mergeable="UNKNOWN")]
+        self.assertEqual(self._items(prs), [])
+        self.assertEqual(self._slice(prs), [])
+
+    def test_resolving_claim_covers_the_pr(self):
+        # A worker mid-resolution holds fleet:resolving-<host>-<agent>; the
+        # PR is covered, not claimable — no second opus dispatch for it.
+        prs = [_sc_pr(2417, labels=["fleet:semantic-conflict",
+                                    "fleet:resolving-mac-worker-1"])]
+        self.assertEqual(self._items(prs), [])
+        self.assertEqual(self._slice(prs), [])
+
+    def test_step1c_exclusion_labels_drop_the_pr(self):
+        # role-worker step 1c's own pickup filter: wip/human-held or not yet
+        # rebaseable against master. Mirror it exactly so a dispatched opus
+        # worker never wakes to a conflict it would refuse on sight.
+        for label in ("fleet:wip", "human:wip", "human:needs-fix",
+                      "human:blocker", "fleet:awaiting-base",
+                      "fleet:awaiting-upstream-review",
+                      "fleet:fork-of-other-pr"):
+            prs = [_sc_pr(2417, labels=["fleet:semantic-conflict", label])]
+            self.assertEqual(self._items(prs), [], label)
+            self.assertEqual(self._slice(prs), [], label)
+
+    def test_gated_pr_stays_human_only(self):
+        # fleet:gated wins unconditionally (loop-level exclusion shared with
+        # the feedback path): the conflict sits in a file no agent can push.
+        prs = [_sc_pr(2417, labels=["fleet:semantic-conflict", "fleet:gated"])]
+        self.assertEqual(self._items(prs), [])
+        self.assertEqual(self._slice(prs), [])
+
+    def test_stacked_child_defers_to_conflicted_base(self):
+        # Step 1c resolves the base first; the child is skipped until then,
+        # and the base is the (single) item carrying the dispatch pressure.
+        base = _sc_pr(2417, head="claude/base-feat")
+        child = _sc_pr(2418, head="claude/child-feat", base="claude/base-feat")
+        items = self._items([base, child])
+        self.assertEqual([i["pr"] for i in items], [2417])
+        self.assertEqual([p["number"] for p in self._slice([base, child])],
+                         [2417])
+
+    def test_stacked_child_with_clean_base_is_claimable(self):
+        # A conflicted child whose base PR is NOT semantic-conflicted is
+        # resolvable now — step 1c picks it up, so it counts.
+        base = _pr(2417, head="claude/base-feat")
+        child = _sc_pr(2418, head="claude/child-feat", base="claude/base-feat")
+        self.assertEqual([i["pr"] for i in self._items([base, child])], [2418])
+
+    def test_feedback_and_conflict_are_distinct_items(self):
+        # A PR can owe both a feedback fix and a conflict resolution; each is
+        # its own projection item (kinds "pr" and "semantic_conflict"), so
+        # clearing one edge still flips the hash for the other.
+        prs = [_sc_pr(2417, labels=["fleet:semantic-conflict",
+                                    "fleet:has-nits"])]
+        kinds = sorted(i["kind"] for i in project_worker(_state(prs)))
+        self.assertEqual(kinds, ["pr", "semantic_conflict"])
 
 
 class SliceWorkerSkipLabelsDropPR(unittest.TestCase):

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -318,14 +318,29 @@ class SemanticConflictDispatch(unittest.TestCase):
         child = _sc_pr(2418, head="claude/child-feat", base="claude/base-feat")
         self.assertEqual([i["pr"] for i in self._items([base, child])], [2418])
 
-    def test_feedback_and_conflict_are_distinct_items(self):
-        # A PR can owe both a feedback fix and a conflict resolution; each is
-        # its own projection item (kinds "pr" and "semantic_conflict"), so
-        # clearing one edge still flips the hash for the other.
-        prs = [_sc_pr(2417, labels=["fleet:semantic-conflict",
-                                    "fleet:has-nits"])]
-        kinds = sorted(i["kind"] for i in project_worker(_state(prs)))
-        self.assertEqual(kinds, ["pr", "semantic_conflict"])
+    def test_feedback_label_suppresses_conflict_pressure(self):
+        # A conflicted PR that ALSO owes worker feedback/design-resume work
+        # routes to the feedback lane ONLY — it must NOT also mint a
+        # semantic_conflict item. The two lanes hold disjoint claim
+        # namespaces (fleet:amending-* for the feedback fix vs
+        # fleet:resolving-* for the rebase), so surfacing both lets a
+        # (sonnet) nit-fix pane and an opus resolver pane force-push the same
+        # head branch on one tick — a last-writer-wins race that silently
+        # drops the conflict resolution or the feedback fix. Feedback comes
+        # first (the PR's own stated priority); conflict pressure holds until
+        # the feedback/design-resume label clears.
+        for label in ("fleet:needs-fix", "fleet:has-nits",
+                      "fleet:design-unblocked"):
+            prs = [_sc_pr(2417, labels=["fleet:semantic-conflict", label])]
+            # No semantic_conflict projection item or slice entry ...
+            self.assertEqual(self._items(prs), [], label)
+            self.assertEqual(self._slice(prs), [], label)
+            # ... but the PR still surfaces in the feedback lane, so the fix
+            # itself is not lost — only the parallel conflict dispatch is.
+            kinds = sorted(i["kind"] for i in project_worker(_state(prs)))
+            self.assertEqual(kinds, ["pr"], label)
+            feedback = slice_worker(_state(prs))["feedback_prs"]
+            self.assertEqual([p["number"] for p in feedback], [2417], label)
 
 
 class SliceWorkerSkipLabelsDropPR(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `fleet:semantic-conflict` PRs now generate their own dispatch pressure. Previously the label's only consumer was role-worker step 1c (opus+-class iterations only), but the dispatcher's class election never saw conflicted PRs — so when the opus queue was dry or host-locked, conflicts starved behind sonnet no-op iterations. Observed live on #2417: flagged 21:14, sat unclaimed while worker-1 logged 15 consecutive sonnet no-ops, and was only resolved when #2407 turning needs-plan happened to launch an opus iteration an hour later.
- `fleet-state-scout`: new `_semantic_conflict_claimable` gate shared by `project_worker` (hash item kind `semantic_conflict`) and `slice_worker` (new `semantic_conflict_prs[]` slice field). Claimable = live `mergeable == CONFLICTING` + step 1c's own label exclusions + no active `fleet:resolving-*` claim + stacked children defer to a conflicted base.
- `fleet_task_class.py`: each slice entry counts as one **opus** claimable item, ranked between feedback and task pickup (mirrors role-worker step order). Feeds `count` for the fan-out cap; `exclude=opus` defers instead of falling through to a lane default that would skip step 1c.
- **#1654 guard preserved**: the old design deliberately excluded the label from the worker projection because a fail-then-succeed race can leave a stale label on a MERGEABLE PR. The mergeable gate keeps that shape structurally excluded (same live-state signal `_merger_action_signal` keys on); the stale-label hash-stability test is updated to say so and still passes.
- Docs: `fleet-labels-reference.md` label entry gains the dispatch-pressure semantics. No dispatcher changes needed — it consumes the election output generically (verified end-to-end by the new T18).

## Test plan
- [x] `python3 -m unittest discover -s tests` — 639 tests green (includes 9 new projection/slice tests and 7 new election tests)
- [x] `tests/test_dispatcher_class_dispatch.sh` — new T18 drives the real dispatcher `--resolve-class` on a conflict-only slice → `class=opus … count=1` (25/25 green)
- [x] `tests/test_dispatcher_rearm.sh` — 6/6 green
- [x] `ruff check scripts/` clean
- [x] Modified scout run read-only against live `~/.fleet/state/state.json` — no false positives (no claimable conflicts exist right now, correctly empty)

## Notes for reviewer
The worker side needs no changes: step 1c already reads the full cached PR set and re-verifies `mergeable` live (step b'') before spending on a rebase. This PR only makes the *dispatcher* aware that step-1c work exists. Loop-pattern scan flagged pre-existing per-tick linear scans in `enrich_stackable_blocker_prs` — untouched here, candidates for a follow-up perf ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)