### PR TITLE
system: per-system update cadence in the pipeline scheduler (#2404)

### DIFF
--- a/.fleet/plans/issue-2404.md
+++ b/.fleet/plans/issue-2404.md
@@ -1,0 +1,71 @@
+## Plan: SystemManager: per-system update cadence (run-every-N-ticks + dt-scaled reduced-rate execution)
+
+- **Issue:** #2404
+- **Model:** opus — the approach below is committed; implementation is a bounded single-module scheduler change + tests, but it touches the core pipeline dispatch path so it stays above sonnet.
+- **Date:** 2026-07-14
+
+### Scope
+
+A per-system execution-cadence facility in the SystemManager pipeline: a system declares (at registration) or sets (at runtime) "run every N phase ticks"; off-cadence ticks skip the system's entire dispatch (no `beginTick`, no node query, no per-entity iteration); on-cadence executions can read how many phase ticks — and how much fixed-step time — elapsed since their previous execution. Generic engine capability only; throttle policy stays in consuming creations.
+
+### Verified current state (master `5374cf78`, 2026-07-14)
+
+- `SystemManager::executePipeline` (`engine/system/src/system_manager.cpp:334`) runs every group and every member unconditionally; the only per-system dispatch knobs are `Concurrency` + `grainSize` (parallel vectors `m_concurrency` / `m_grainSize` emplaced in `createSystem`). **No cadence/throttle mechanism exists in the scheduler** — verified by grep across `engine/` for cadence/throttle/every-N/sub-rate shapes: the only hits are in-body counters private to individual systems (`system_perf_stats_overlay.hpp` text-refresh throttle, `system_voxel_to_trixel.hpp` log throttles), which still pay full dispatch + iteration — exactly the pattern this issue replaces with real dispatch savings.
+- Phase ticks: `World::gameLoop` calls `executePipeline(INPUT)` once per frame, `executePipeline(UPDATE)` once per `shouldUpdate()` fixed step (0..maxTicks catch-up per frame), `executePipeline(RENDER)` once per frame. `IRTime::tick()` (= `EventProfiler<UPDATE>::fixedStepCount`) counts UPDATE ticks only; SystemManager has no per-event execution counter today.
+- `IRTime::deltaTime(UPDATE)` is the constant fixed step (1/kFPS, const-after-ctor, worker-readable). For UPDATE-phase systems, "accumulated fixed-step delta since previous execution" ≡ elapsedPhaseTicks × `deltaTime(UPDATE)` exactly — no new accumulator infrastructure needed in `engine/time`; this reuses the existing `IRTime` fixed-step contract as the issue asks.
+- Registration-metadata pattern to mirror: `registerSystem<N>` detects `static constexpr Concurrency kConcurrency` / `int kGrainSize` via concepts (`HasConcurrencyMember` / `HasGrainSizeMember`, `ir_system.hpp`); the free-function `createSystem` takes trailing `concurrency, grainSize` params.
+- Per-system timing (`TimingAccum.callCount_` / `totalEntityCount_`, gated on `setTimingEnabled`) already provides the measurement surface for "executed K times over M ticks" and "iteration scales with 1/N".
+- Sibling / in-flight reconciliation: no open PR touches `engine/system` (checked all 7 open engine PRs — render/docs/fleet/math surfaces). #226 (threading epic) is complementary by design — T-224 groups parallelize *within* a tick; cadence decides whether a system dispatches at all on a given tick. The gate below runs on the main thread before group fan-out, so there is no interaction with the group validator (a throttled member validates identically for the ticks it does run). Render LOD (`LOD_UPDATE` / `C_ActiveLodLevel`) is orthogonal per the issue. The pausable sim clock (`IRSim::tick()`) is deliberately NOT the cadence timebase — cadence counts pipeline executions; sim-time-aware policies compose on top via the runtime setter.
+
+### Approach
+
+Committed design: **integer divisor is the stored primitive; elapsed-ticks comparison (not modulo); gating lives in `executePipeline` only.**
+
+1. **State (`system_manager.hpp`).** Parallel vectors emplaced in `createSystem` / `createSystemDynamic` alongside `m_concurrency`: `m_cadence` (`uint32_t`, 1 = every tick, 0 normalized to 1), `m_cadenceOffset` (`uint32_t`, initial phase 0..cadence-1), `m_lastRunTick` (`uint64_t`), `m_accumulatedTicks` (`uint64_t`). Plus `std::array<uint64_t, IRTime::END + 1> m_eventTickCounts{}` — SystemManager-owned per-event execution counters (self-contained; works for INPUT/RENDER phases too; unit-testable without a TimeManager). Plus a reusable `std::vector<SystemId> m_dueScratch` for multi-system group filtering (reserved once; no per-frame allocation).
+2. **Gate (`system_manager.cpp` `executePipeline`).** Increment `m_eventTickCounts[event]` once at entry → `now`. A system is *due* iff `cadence <= 1 || now >= m_lastRunTick[id] + cadence` (addition, not `now % N` and not `now - lastRun` — the additive form is underflow-safe with a nonzero offset seed and re-phases correctly when the cadence changes at runtime, so call count over M ticks is ⌊M/N⌋ ±1). Singleton group: if not due, skip the observer fires + `executeSystem` (the per-group `flushStructuralChanges` still runs unconditionally). Multi-system group: filter due members into `m_dueScratch` on the main thread before fan-out; skip the `IRJob::parallelFor` entirely when none are due. For each due system, before dispatch (main thread): `m_accumulatedTicks[id] = now - m_lastRunTick[id]`, then `m_lastRunTick[id] = now`. Workers never write cadence state; tick bodies may read it (written-before-dispatch, read-only during execution — same thread-safety argument as the fixed dt).
+3. **Late-join stamping.** `registerPipelineGroups` / `appendToPipeline` / `insertSingletonGroupRelativeTo` stamp each newly-listed system's `m_lastRunTick = m_eventTickCounts[event] + offset`, so a system joining a live pipeline measures elapsed from its join point — not from counter zero (otherwise its first accumulated delta spans the pipeline's whole lifetime) — and its offset staggers the initial phase relative to co-registered siblings.
+4. **Runtime API (`system_manager.hpp` + `ir_system.hpp` free functions).** `setSystemCadence(SystemId, uint32_t)` (normalizes 0→1; takes effect next phase tick, no re-registration, re-phases from the last run) and `getSystemCadence(SystemId)`. `setSystemCadenceOffset(SystemId, uint32_t)` / `getSystemCadenceOffset(SystemId)` (amendment 1: honor offset from the runtime setter). `getAccumulatedTicks(SystemId)` — phase ticks covered by the current/most-recent execution (≥1 once it has run). Convenience `IRSystem::accumulatedDeltaTime(SystemId)` = `getAccumulatedTicks(id) * IRTime::deltaTime(IRTime::UPDATE)` — exact for UPDATE-phase systems (fixed step); documented UPDATE-phase-only (RENDER dt is wall-clock-variable; RENDER-phase consumers use raw ticks). The issue's "or a target sub-rate" is satisfied as sugar, not a second scheduling mode: `IRSystem::cadenceFromRate(targetHz)` returns `max(1, round(kFPS / targetHz))`.
+5. **Registration metadata (`ir_system.hpp`).** Trailing `uint32_t cadence = 1, uint32_t offset = 0` params on the free-function `createSystem` (after `grainSize`) and on `SystemManager::createSystem` (before `accessDescriptor`; the wrapper is its only positional caller). `registerSystem<N>` detects `static constexpr uint32_t kCadence` / `kCadenceOffset` via `HasCadenceMember` / `HasCadenceOffsetMember` concepts + `cadenceOf<T>()` / `cadenceOffsetOf<T>()`, mirroring `kGrainSize`. `createSystemDynamic` gains trailing `cadence = 1, offset = 0` for symmetry.
+6. **Lua binding (`lua_pipeline_bindings.hpp`).** `IRSystem.setSystemCadence(sysId, n)` / `IRSystem.getSystemCadence(sysId)` / `IRSystem.setSystemCadenceOffset(sysId, o)` / `IRSystem.getSystemCadenceOffset(sysId)` alongside the pipeline-composition bindings — the surface consuming creations build dynamic throttle policies on. Amendment 2: also bind `IRSystem.getAccumulatedTicks(sysId)` and `IRSystem.accumulatedDeltaTime(sysId)` so a Lua-registered throttled system (EVAL/CODEGEN) can read the numerically-correct-at-reduced-rate delta (issue deliverable 3), same UPDATE-phase-only caveat as the C++ convenience.
+7. **`executeSystem` stays ungated.** Cadence is a pipeline-scheduling property; direct `executeSystem` / `executeQuery` calls always run. Keeps "unset = unchanged" airtight and manual-invocation semantics intact.
+8. **Docs.** `engine/system/CLAUDE.md` gains a "Per-system cadence" section: declaration forms, the accumulated-delta contract, and skip semantics (`beginTick`/`endTick` also skip; observers don't fire on skipped ticks, so GPU-stage timing rows hold stale samples on skip frames).
+
+One task, one PR — core + tests + Lua binding + CLAUDE.md are one bounded surface; no carve-offs.
+
+### Amendments (accepted in-thread, folded into this plan)
+
+1. **Phase offset.** Optional `offset` (initial phase, 0..cadence-1) alongside the cadence — registration metadata (`kCadenceOffset` / `createSystem` trailing param) + honored by the runtime setter (`setSystemCadenceOffset`). K sibling cold-tier buckets at cadence K registered together now stagger across K consecutive ticks instead of spiking on the same tick.
+2. **Lua exposure of the accumulated delta.** Bind `IRSystem.getAccumulatedTicks(sysId)` and `IRSystem.accumulatedDeltaTime(sysId)` in addition to the cadence getter/setter, so a Lua-registered throttled system can read the accumulated delta and stay numerically correct at the reduced rate.
+
+Explicitly NOT this issue: deferred component add/remove from an EVAL Lua tick (tier-migration systems) — a separate #2286-adjacent gap, filed by the consumer if confirmed.
+
+### Affected files
+
+- `engine/system/include/irreden/system/system_manager.hpp` — cadence/offset/lastRun/accumulated vectors, per-event counters, due-scratch, `createSystem` params, runtime API
+- `engine/system/src/system_manager.cpp` — `executePipeline` gate + bookkeeping, late-join stamping, `createSystemDynamic` params, runtime-API impls
+- `engine/system/include/irreden/ir_system.hpp` — `createSystem` trailing params, `kCadence`/`kCadenceOffset` detection, free functions (`setSystemCadence` / `getSystemCadence` / `setSystemCadenceOffset` / `getSystemCadenceOffset` / `getAccumulatedTicks` / `accumulatedDeltaTime` / `cadenceFromRate`)
+- `engine/script/include/irreden/script/lua_pipeline_bindings.hpp` — Lua setter/getter + accumulated-delta bindings
+- `test/system/system_cadence_test.cpp` — new; fixture pattern per `test/system/pipeline_groups_test.cpp`
+- `test/CMakeLists.txt` — register the new test
+- `engine/system/CLAUDE.md` — cadence section
+
+### Acceptance criteria
+
+Concrete versions of the issue's five:
+
+1. A cadence-N system executes ⌊M/N⌋ (±1) times over M `executePipeline` calls (counting tick body; cross-checked against `TimingAccum.callCount_` with timing enabled).
+2. The sum of per-execution `getAccumulatedTicks` across a mid-run `setSystemCadence` change equals total elapsed phase ticks, and each execution's value matches its actual gap (e.g. 3,3,3 → change to 5 → 5,5); `accumulatedDeltaTime` = that × fixed dt.
+3. Off-cadence ticks fire no `beginTick`/`tick`/`endTick`, and per-entity visits scale ~1/N (`totalEntityCount_` or a visit counter).
+4. Default path unchanged: full existing suite green (`pipeline_groups_test`, `system_concurrency_test`, `register_system_test` untouched); the cadence-1 fast path is one load + compare.
+5. Mixed-cadence multi-system group: only due members dispatch on a given tick (use the `g_jobManager == nullptr` serial fallback for a deterministic unit test); runtime mutability covered by 2.
+
+### Gotchas
+
+- Stamp `m_lastRunTick` when a system joins a live pipeline (step 3) — without it, the first accumulated delta after a late `appendToPipeline` spans the whole run.
+- Skips must NOT skip the per-group `flushStructuralChanges` — deferred structural changes queued by other systems still flush on the existing cadence.
+- The due-filter for parallel groups runs on the main thread (reused scratch vector, no allocation in the frame loop); do not move the check inside the worker lambda.
+- The due comparison is `now >= lastRun + cadence` (addition), NOT `now - lastRun >= cadence` — the offset seed makes `lastRun > now` on early ticks, and the subtraction form underflows `uint64_t` there. Accumulated (`now - lastRun`) is computed only at fire time, where `now >= lastRun` holds.
+- `IRTime::Events` is a C-style enum (`UPDATE, RENDER, INPUT, START, END`) — size the counter array `END + 1`; no hashing.
+- `kCadence` goes on the `System<N>` specialization as a constexpr member (like `kGrainSize`), NOT in the component pack — tag types in the `registerSystem` pack have a known filtering gap.
+- Perf overlay / GPU-stage rows show stale samples for throttled systems on skip frames — expected; note it in CLAUDE.md rather than special-casing the observer.
+- Purely additive public surface — no engine API removals.

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -832,6 +832,17 @@ IRSystem.registerPipeline(IRTime.UPDATE, {
   release a bad anchor silently front-inserts.
   Underlying semantics: `engine/system/CLAUDE.md` "Appending to a live
   pipeline".
+- **`IRSystem.setSystemCadence(sysId, n)`** / **`getSystemCadence(sysId)`**
+  (#2404) — throttle a system to run 1-in-`n` phase ticks (n ≥ 1; 1 = every
+  tick). Off-cadence ticks skip its entire dispatch. Paired with
+  **`setSystemCadenceOffset(sysId, o)`** / **`getSystemCadenceOffset(sysId)`**
+  — an initial phase stagger (`0..n-1`) so sibling throttled systems don't
+  spike on the same tick. A throttled Lua system that integrates at the
+  reduced rate reads **`getAccumulatedTicks(sysId)`** (phase ticks this run
+  covers) or **`accumulatedDeltaTime(sysId)`** (that × the fixed UPDATE dt,
+  UPDATE-phase-only) to stay numerically correct. `sysId` is any SystemId
+  (from `IRSystem.systemId` or `IRSystem.registerSystem`). Underlying
+  semantics: `engine/system/CLAUDE.md` "Per-system update cadence".
 - **Game-side enums** (e.g. `IRGameSystem.GameSystemName`) extend the
   same pattern — bind the game's own enum table at game-side init via
   `LuaScript::registerEnum<...>()` plus `registerPrefabSystemId` for each

--- a/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
@@ -34,6 +34,7 @@
 #include <irreden/ir_time.hpp>
 #include <irreden/script/lua_script.hpp>
 
+#include <cstdint>
 #include <list>
 #include <string>
 #include <unordered_map>
@@ -343,6 +344,51 @@ inline void bindRegisterPipelineAndSystemId(
                 static_cast<IRSystem::SystemId>(anchorId)
             );
         };
+
+    // #2404: per-system update cadence. A Lua throttle policy sets a
+    // system to run 1-in-N phase ticks (`setSystemCadence`), staggers its
+    // initial phase (`setSystemCadenceOffset`), and — for a throttled
+    // Lua-registered system that must stay numerically correct at the
+    // reduced rate — reads how many phase ticks / how much fixed-step
+    // time its current execution covers (`getAccumulatedTicks` /
+    // `accumulatedDeltaTime`, amendment 2). `sysId` is any SystemId (from
+    // IRSystem.systemId or IRSystem.registerSystem).
+    lua["IRSystem"]["setSystemCadence"] = [](lua_Integer sysId, lua_Integer cadence) {
+        if (cadence < 1) {
+            throw sol::error{"IRSystem.setSystemCadence: cadence must be >= 1 (1 = every tick)"};
+        }
+        IRSystem::setSystemCadence(
+            static_cast<IRSystem::SystemId>(sysId),
+            static_cast<std::uint32_t>(cadence)
+        );
+    };
+    lua["IRSystem"]["getSystemCadence"] = [](lua_Integer sysId) -> lua_Integer {
+        return static_cast<lua_Integer>(
+            IRSystem::getSystemCadence(static_cast<IRSystem::SystemId>(sysId))
+        );
+    };
+    lua["IRSystem"]["setSystemCadenceOffset"] = [](lua_Integer sysId, lua_Integer offset) {
+        if (offset < 0) {
+            throw sol::error{"IRSystem.setSystemCadenceOffset: offset must be >= 0"};
+        }
+        IRSystem::setSystemCadenceOffset(
+            static_cast<IRSystem::SystemId>(sysId),
+            static_cast<std::uint32_t>(offset)
+        );
+    };
+    lua["IRSystem"]["getSystemCadenceOffset"] = [](lua_Integer sysId) -> lua_Integer {
+        return static_cast<lua_Integer>(
+            IRSystem::getSystemCadenceOffset(static_cast<IRSystem::SystemId>(sysId))
+        );
+    };
+    lua["IRSystem"]["getAccumulatedTicks"] = [](lua_Integer sysId) -> lua_Integer {
+        return static_cast<lua_Integer>(
+            IRSystem::getAccumulatedTicks(static_cast<IRSystem::SystemId>(sysId))
+        );
+    };
+    lua["IRSystem"]["accumulatedDeltaTime"] = [](lua_Integer sysId) -> double {
+        return IRSystem::accumulatedDeltaTime(static_cast<IRSystem::SystemId>(sysId));
+    };
 }
 
 } // namespace IRScript::detail

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -530,6 +530,99 @@ in `IR_RELEASE` builds and safe to call when `g_jobManager ==
 nullptr` (unit tests / pre-`World` startup return `true` as the
 default).
 
+## Per-system update cadence (#2404)
+
+A system can declare — or set at runtime — a **cadence**: run on 1-in-N
+phase ticks of the pipeline it belongs to, instead of every tick. This is
+a *generic scheduling throttle*; which systems (or entities) get throttled
+is policy the consuming creation owns, not the engine. It is orthogonal to
+render LOD (`LOD_UPDATE` / `C_ActiveLodLevel`, which derives mesh detail
+from zoom) and to the T-224 threading groups (which parallelize *within* a
+tick): cadence decides whether a system dispatches *at all* on a given tick.
+
+Off-cadence ticks skip the system's **entire** dispatch — no `beginTick`,
+no archetype-node query, no per-entity iteration, no `endTick`, no observer
+fires. The saving is real dispatch/iteration cost, not an in-body early
+return. The per-group `flushStructuralChanges` still runs on every tick, so
+deferred changes queued by *other* systems keep flushing on schedule.
+
+### Declaring a cadence
+
+```cpp
+// registerSystem<N> form: constexpr members on the System<N> spec,
+// mirroring kConcurrency / kGrainSize. Absent → cadence 1 / offset 0.
+template <> struct System<BACKGROUND_DECAY> {
+    static constexpr std::uint32_t kCadence = 4;        // run every 4th tick
+    static constexpr std::uint32_t kCadenceOffset = 1;  // initial phase stagger
+    void tick(C_Foo &f) {
+        // integrate over the ticks this run covers so the reduced rate
+        // stays numerically correct — see accumulatedDeltaTime below.
+    }
+    static SystemId create() { return registerSystem<BACKGROUND_DECAY, C_Foo>("BgDecay"); }
+};
+
+// createSystem<Cs...> free function: trailing (cadence, offset) after grainSize.
+auto id = IRSystem::createSystem<C_Foo>(
+    "BgDecay", tickFn, beginFn, endFn, {}, relFn,
+    IRSystem::Concurrency::SERIAL, IRSystem::kDefaultGrainSize, /*cadence=*/4, /*offset=*/1);
+```
+
+`cadence == 1` (the default, unset) is every tick — legacy behavior, one
+load + compare on the hot path. `0` normalizes to `1`.
+
+### Runtime API (`IRSystem::` free functions + SystemManager methods)
+
+- `setSystemCadence(id, n)` / `getSystemCadence(id)` — change the divisor with
+  no re-registration; takes effect next tick and **re-phases from the last
+  run** (a shorter cadence fires sooner, a longer one later).
+- `setSystemCadenceOffset(id, o)` / `getSystemCadenceOffset(id)` — the initial
+  phase, `0..cadence-1`. K sibling cold-tier systems registered together at
+  cadence K with distinct offsets fire on K consecutive ticks (smoothed
+  load) instead of spiking on the same tick. Setting it at runtime re-staggers
+  from the current phase tick.
+- `getAccumulatedTicks(id)` — phase ticks the current/most-recent execution
+  covers (`>= 1` once it has run).
+- `accumulatedDeltaTime(id)` — **UPDATE-phase-only** convenience:
+  `getAccumulatedTicks(id) * IRTime::deltaTime(UPDATE)`. For an integrator or
+  accumulator running at a reduced rate, multiply your per-tick delta by this
+  so the math stays correct. RENDER-phase throttled consumers must use raw
+  `getAccumulatedTicks` — RENDER dt is wall-clock-variable.
+- `cadenceFromRate(hz)` — sugar mapping a target sub-rate to the nearest
+  integer divisor of the fixed UPDATE rate (`round(kFPS / hz)`, min 1). The
+  issue's "target sub-rate" is this helper, not a second scheduling mode.
+
+Lua mirrors the whole surface: `IRSystem.setSystemCadence(sysId, n)` /
+`getSystemCadence` / `setSystemCadenceOffset` / `getSystemCadenceOffset` /
+`getAccumulatedTicks` / `accumulatedDeltaTime` (see `engine/script/CLAUDE.md`).
+
+### How the gate works
+
+`executePipeline` bumps a SystemManager-owned per-event tick counter
+(`m_eventTickCounts`, sized `IRTime::END + 1` — self-contained, no
+TimeManager dependency, so cadence works for INPUT/RENDER and is unit-
+testable in isolation) once at entry to `now`, then gates each system with
+`now >= m_lastRunTick[id] + cadence`. The comparison is **additive, not
+`now - lastRun >= cadence`** — a nonzero offset seeds `lastRun > now` on the
+first ticks, where the unsigned subtraction would underflow; `now - lastRun`
+(the accumulated delta) is computed only at fire time, where `now >= lastRun`
+holds. A due system stamps `m_accumulatedTicks[id] = now - lastRun`, then
+`m_lastRunTick[id] = now`, on the main thread **before** any worker fan-out
+(a multi-system group filters its due members into a reused scratch vector
+first), so a tick body reading the accumulated delta from a worker never
+races the write. Joining a pipeline (`registerPipelineGroups` /
+`appendToPipeline` / insert) seeds `lastRun` from the current event counter
+(+ offset), so a system's first accumulated delta measures from its join
+point — not the pipeline's whole lifetime.
+
+`executeSystem` / `executeQuery` are **ungated** — cadence is a pipeline-
+scheduling property, so direct/manual invocation always runs.
+
+**Skip semantics on observers.** The `TickObserver` bracket (GPU-stage
+timing) fires only on ticks a singleton system actually runs, so the perf
+overlay / GPU-stage rows hold *stale* samples for a throttled system on its
+skip frames. That is expected — it's the honest picture of "this system
+didn't run this frame" — not a bug to special-case.
+
 ## Gotchas
 
 - **Archetype mutations in a TICK will skip or revisit entities.** If you

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -372,6 +372,12 @@ IRSystem::insertIntoPipelineAfter(IRTime::Events::UPDATE, sysId, anchor);
 - All three assert (debug; no-op in release) if `sysId` is already in
   the event's pipeline (a double-add would tick it twice), and the
   insert forms assert if `anchor` isn't found.
+- Joining a system into a **different** event's pipeline while it's
+  still listed in its prior one trips a matching debug assert in
+  `stampCadenceJoin` — a system's cadence clock binds to one event, so
+  being live in two pipelines at once would thrash `m_lastRunTick`
+  between two counters that advance at different rates. Clear the old
+  pipeline (or the group containing it) first.
 - Lua surface: `IRSystem.appendSystem(event, sysId)`,
   `IRSystem.insertSystemBefore(event, sysId, anchor)`,
   `IRSystem.insertSystemAfter(event, sysId, anchor)` — see

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -9,6 +9,7 @@
 #include <irreden/system/system_access.hpp>
 #include <irreden/system/system_manager.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <tuple>
@@ -118,6 +119,12 @@ validateConcurrencyForAccess(const std::string &name, Concurrency c, SystemAcces
 // the worker-pool dispatch path. `Concurrency::SERIAL` (default)
 // matches the legacy behavior; `PARALLEL_FOR` requires the tick body
 // to satisfy the validator (`detail::validateConcurrencyForAccess`).
+//
+// #2404: trailing `cadence` / `offset` opt the system into throttled
+// dispatch — run 1-in-`cadence` phase ticks (1 = every tick), staggered
+// by `offset` (0..cadence-1) against co-registered siblings. Off-cadence
+// ticks skip the whole dispatch; the runtime setters live on
+// SystemManager / the free functions below.
 template <
     typename... TickComponents,
     typename... TickRelationComponents,
@@ -133,7 +140,9 @@ constexpr SystemId createSystem(
     RelationParams<TickRelationComponents...> extraParams = {},
     FunctionRelationTick functionRelationTick = nullptr,
     Concurrency concurrency = Concurrency::SERIAL,
-    int grainSize = kDefaultGrainSize
+    int grainSize = kDefaultGrainSize,
+    std::uint32_t cadence = 1,
+    std::uint32_t offset = 0
 ) {
     using Partition = detail::PartitionExcludes<TickComponents...>;
     auto excludeArchetype = detail::ArchetypeFromList<typename Partition::Excluded>::value();
@@ -195,6 +204,8 @@ constexpr SystemId createSystem(
         std::move(excludeArchetype),
         concurrency,
         grainSize,
+        cadence,
+        offset,
         accessDescriptor
     );
 }
@@ -311,6 +322,36 @@ template <typename T> constexpr int grainSizeOf() {
     }
 }
 
+// #2404: detect `static constexpr std::uint32_t kCadence` / `kCadenceOffset`
+// members on a System<N> specialization, mirroring kConcurrency / kGrainSize.
+// Absent → cadence 1 (every tick) / offset 0, so every legacy spec is
+// unchanged.
+template <typename T>
+concept HasCadenceMember = requires {
+    { T::kCadence } -> std::convertible_to<std::uint32_t>;
+};
+
+template <typename T>
+concept HasCadenceOffsetMember = requires {
+    { T::kCadenceOffset } -> std::convertible_to<std::uint32_t>;
+};
+
+template <typename T> constexpr std::uint32_t cadenceOf() {
+    if constexpr (HasCadenceMember<T>) {
+        return T::kCadence;
+    } else {
+        return 1u;
+    }
+}
+
+template <typename T> constexpr std::uint32_t cadenceOffsetOf() {
+    if constexpr (HasCadenceOffsetMember<T>) {
+        return T::kCadenceOffset;
+    } else {
+        return 0u;
+    }
+}
+
 } // namespace detail
 
 // Register a system whose state lives as **member fields on the
@@ -373,6 +414,13 @@ registerSystem(std::string name, RelationParams<RelationComponents...> relationP
     constexpr Concurrency concurrency = detail::concurrencyOf<SystemT>();
     constexpr int grainSize = detail::grainSizeOf<SystemT>();
 
+    // #2404: a System<N> spec opts into throttled dispatch by declaring
+    // `static constexpr std::uint32_t kCadence = ...;` (and optionally
+    // `kCadenceOffset`). Detectors default to cadence 1 / offset 0, so
+    // legacy specs are unchanged.
+    constexpr std::uint32_t cadence = detail::cadenceOf<SystemT>();
+    constexpr std::uint32_t cadenceOffset = detail::cadenceOffsetOf<SystemT>();
+
     SystemId id = createSystem<Components...>(
         std::move(name),
         std::move(tickFn),
@@ -381,7 +429,9 @@ registerSystem(std::string name, RelationParams<RelationComponents...> relationP
         std::move(relationParams),
         std::move(relationFn),
         concurrency,
-        grainSize
+        grainSize,
+        cadence,
+        cadenceOffset
     );
     setSystemParams(id, std::move(instance));
     return id;
@@ -588,6 +638,57 @@ void validateAllPipelineGroups();
 void clearPipeline(IRTime::Events event);
 
 void executePipeline(IRTime::Events event);
+
+// #2404: per-system update cadence. Run a system on 1-in-`cadence` phase
+// ticks (1 = every tick, the default); off-cadence ticks skip the entire
+// dispatch. `offset` (0..cadence-1) staggers the initial phase so sibling
+// systems don't spike on the same tick. Both are settable at runtime with
+// no re-registration; a cadence change re-phases from the last run, an
+// offset change re-staggers from the current phase tick.
+inline void setSystemCadence(SystemId system, std::uint32_t cadence) {
+    getSystemManager().setSystemCadence(system, cadence);
+}
+inline std::uint32_t getSystemCadence(SystemId system) {
+    return getSystemManager().getSystemCadence(system);
+}
+inline void setSystemCadenceOffset(SystemId system, std::uint32_t offset) {
+    getSystemManager().setSystemCadenceOffset(system, offset);
+}
+inline std::uint32_t getSystemCadenceOffset(SystemId system) {
+    return getSystemManager().getSystemCadenceOffset(system);
+}
+
+// #2404: phase ticks covered by the system's current / most-recent
+// execution — the multiplier a throttled integrator reads to stay
+// numerically correct at the reduced rate (>= 1 once it has run).
+inline std::uint64_t getAccumulatedTicks(SystemId system) {
+    return getSystemManager().getAccumulatedTicks(system);
+}
+
+// #2404: accumulated fixed-step delta since the system's previous
+// execution. UPDATE-phase-only: `IRTime::deltaTime(UPDATE)` is the constant
+// fixed step. A RENDER-phase throttled consumer must use raw
+// `getAccumulatedTicks` — RENDER dt is wall-clock-variable, so a scaled
+// value would be meaningless. Asserts if the TimeManager is not
+// initialised (the fixed dt has no meaning without the running loop);
+// use `getAccumulatedTicks` in a pure-scheduler unit test.
+inline double accumulatedDeltaTime(SystemId system) {
+    return static_cast<double>(getSystemManager().getAccumulatedTicks(system)) *
+           IRTime::deltaTime(IRTime::UPDATE);
+}
+
+// #2404: convert a target sub-rate (Hz) to the nearest integer cadence
+// divisor of the engine's fixed UPDATE rate. `targetHz <= 0` clamps to 1
+// (every tick). Sugar over the integer-divisor primitive — not a second
+// scheduling mode.
+inline std::uint32_t cadenceFromRate(double targetHz) {
+    if (targetHz <= 0.0) {
+        return 1u;
+    }
+    const double divisor = static_cast<double>(IRConstants::kFPS) / targetHz;
+    const long rounded = static_cast<long>(divisor + 0.5); // round-half-up (divisor > 0)
+    return rounded < 1 ? 1u : static_cast<std::uint32_t>(rounded);
+}
 
 inline void setTimingEnabled(bool enabled) {
     getSystemManager().setTimingEnabled(enabled);

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -385,11 +385,18 @@ class SystemManager {
     //                     counter — the events advance at different rates
     //                     (RENDER is uncapped, UPDATE is fixed-step), so
     //                     mixing clocks seeds `lastRun` far ahead of `now`.
+    //   m_cadenceJoined   whether `m_cadenceEvent` holds a real join (true)
+    //                     or is still the inert placeholder from
+    //                     emplaceCadenceState (false) — lets stampCadenceJoin
+    //                     tell "never joined" apart from "joined to UPDATE",
+    //                     so it can assert against a system still listed in
+    //                     a different event's pipeline when re-joined.
     std::vector<std::uint32_t> m_cadence;
     std::vector<std::uint32_t> m_cadenceOffset;
     std::vector<std::uint64_t> m_lastRunTick;
     std::vector<std::uint64_t> m_accumulatedTicks;
     std::vector<IRTime::Events> m_cadenceEvent;
+    std::vector<bool> m_cadenceJoined;
 
     // #2404: SystemManager-owned per-event execution counter, bumped once
     // at the top of executePipeline so every cadence gate in a pass sees

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -12,7 +12,9 @@
 #include <irreden/system/components/component_system_event.hpp>
 #include <irreden/system/components/component_system_relation.hpp>
 
+#include <array>
 #include <chrono>
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 #include <memory>
@@ -95,6 +97,8 @@ class SystemManager {
         Archetype excludeArchetype = {},
         Concurrency concurrency = Concurrency::SERIAL,
         int grainSize = kDefaultGrainSize,
+        std::uint32_t cadence = 1,
+        std::uint32_t offset = 0,
         SystemAccess accessDescriptor = {}
     ) {
         m_systemNames.emplace_back(C_Name{name});
@@ -111,6 +115,7 @@ class SystemManager {
         m_concurrency.emplace_back(concurrency);
         m_grainSize.emplace_back(grainSize > 0 ? grainSize : 1);
         m_systemAccess.emplace_back(accessDescriptor);
+        emplaceCadenceState(cadence, offset);
         return newSystemId;
     }
 
@@ -135,6 +140,39 @@ class SystemManager {
     const SystemAccess &getSystemAccess(SystemId system) const {
         static const SystemAccess kEmpty{};
         return system < m_systemAccess.size() ? m_systemAccess[system] : kEmpty;
+    }
+
+    /// #2404: per-system update cadence — run the system on 1-in-N phase
+    /// ticks of the pipeline it belongs to. `cadence == 1` (default) is
+    /// every tick (0 is normalized to 1). Takes effect on the next phase
+    /// tick with no re-registration; the change re-phases from the
+    /// system's last run (a shorter cadence fires sooner, a longer one
+    /// later). Off-cadence ticks skip the ENTIRE dispatch — no
+    /// `beginTick`, no archetype query, no per-entity iteration — so the
+    /// saving is real, not an in-body early return.
+    void setSystemCadence(SystemId system, std::uint32_t cadence);
+    std::uint32_t getSystemCadence(SystemId system) const {
+        return system < m_cadence.size() ? m_cadence[system] : 1u;
+    }
+
+    /// #2404 (amendment 1): initial phase stagger, `0..cadence-1`. Sibling
+    /// systems registered together at cadence N with distinct offsets fire
+    /// on distinct ticks (smoothed load) instead of spiking on the same
+    /// tick. Setting it at runtime re-phases the system so the offset takes
+    /// effect as a fresh stagger from the current phase tick.
+    void setSystemCadenceOffset(SystemId system, std::uint32_t offset);
+    std::uint32_t getSystemCadenceOffset(SystemId system) const {
+        return system < m_cadenceOffset.size() ? m_cadenceOffset[system] : 0u;
+    }
+
+    /// #2404: phase ticks covered by the system's current / most-recent
+    /// execution — the multiplier a throttled integrator reads so its
+    /// per-tick-rate math stays correct at the reduced rate. `>= 1` once
+    /// the system has run; `0` before its first execution. For UPDATE-
+    /// phase systems the accumulated fixed-step delta is this value times
+    /// `IRTime::deltaTime(UPDATE)` (see `IRSystem::accumulatedDeltaTime`).
+    std::uint64_t getAccumulatedTicks(SystemId system) const {
+        return system < m_accumulatedTicks.size() ? m_accumulatedTicks[system] : 0u;
     }
 
     template <typename Tag> void addSystemTag(SystemId system) {
@@ -170,7 +208,9 @@ class SystemManager {
         Archetype includeArchetype,
         Archetype excludeArchetype,
         std::function<void(ArchetypeNode *)> body,
-        Concurrency concurrency = Concurrency::SERIAL
+        Concurrency concurrency = Concurrency::SERIAL,
+        std::uint32_t cadence = 1,
+        std::uint32_t offset = 0
     );
 
     /// Replace the per-archetype tick body of an existing system in place.
@@ -326,6 +366,54 @@ class SystemManager {
     std::vector<Concurrency> m_concurrency;
     std::vector<int> m_grainSize;
     std::vector<SystemAccess> m_systemAccess;
+
+    // #2404: per-system update cadence. Parallel to m_ticks; emplaced in
+    // both system-creation paths via emplaceCadenceState.
+    //   m_cadence         run 1-in-N phase ticks (1 = every tick).
+    //   m_cadenceOffset   initial phase stagger, 0..cadence-1.
+    //   m_lastRunTick     per-event tick counter at this system's last run,
+    //                     seeded at pipeline-join (stampCadenceJoin) so the
+    //                     first accumulated delta measures from the join
+    //                     point, not counter zero.
+    //   m_accumulatedTicks  phase ticks covered by the current/most-recent
+    //                     execution (getAccumulatedTicks).
+    std::vector<std::uint32_t> m_cadence;
+    std::vector<std::uint32_t> m_cadenceOffset;
+    std::vector<std::uint64_t> m_lastRunTick;
+    std::vector<std::uint64_t> m_accumulatedTicks;
+
+    // #2404: SystemManager-owned per-event execution counter, bumped once
+    // at the top of executePipeline so every cadence gate in a pass sees
+    // the same `now`. Self-contained (no TimeManager dependency), so
+    // cadence works for INPUT/RENDER phases and is unit-testable in
+    // isolation. IRTime::Events is a C-style enum ending at END; size the
+    // array END + 1.
+    std::array<std::uint64_t, IRTime::END + 1> m_eventTickCounts{};
+
+    // #2404: reused scratch for filtering the due members of a multi-
+    // system group on the main thread before fan-out; reserved lazily,
+    // never reallocated per frame in steady state.
+    std::vector<SystemId> m_dueScratch;
+
+    // #2404: emplace the four cadence vectors for a newly-created system.
+    // Called by both createSystem and createSystemDynamic to keep the
+    // parallel vectors in lockstep with m_ticks. cadence 0 -> 1; offset is
+    // clamped into [0, cadence-1].
+    void emplaceCadenceState(std::uint32_t cadence, std::uint32_t offset);
+
+    // #2404: main-thread cadence gate. Returns true and advances the
+    // bookkeeping (accumulated ticks + last-run tick) when `system` is due
+    // to run at phase tick `now`; returns false to skip the whole dispatch.
+    bool pollCadenceDue(SystemId system, std::uint64_t now);
+
+    // #2404: seed a system's phase when it joins `event`'s pipeline, so its
+    // first accumulated delta measures from the join tick (plus its offset
+    // stagger), not from counter zero.
+    void stampCadenceJoin(IRTime::Events event, SystemId system);
+
+    // #2404: the largest per-event tick counter — the reference clock for a
+    // runtime offset re-phase (which is event-agnostic).
+    std::uint64_t maxEventTickCount() const;
 
     // Begin tick functions happen once per system before tick function(s)
     template <typename FunctionBeginTick>

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -377,10 +377,19 @@ class SystemManager {
     //                     point, not counter zero.
     //   m_accumulatedTicks  phase ticks covered by the current/most-recent
     //                     execution (getAccumulatedTicks).
+    //   m_cadenceEvent    the event whose tick counter `m_lastRunTick` is
+    //                     measured against, bound at pipeline-join
+    //                     (stampCadenceJoin). A runtime re-phase
+    //                     (setSystemCadenceOffset) must seed from this
+    //                     system's own event clock, not some other event's
+    //                     counter — the events advance at different rates
+    //                     (RENDER is uncapped, UPDATE is fixed-step), so
+    //                     mixing clocks seeds `lastRun` far ahead of `now`.
     std::vector<std::uint32_t> m_cadence;
     std::vector<std::uint32_t> m_cadenceOffset;
     std::vector<std::uint64_t> m_lastRunTick;
     std::vector<std::uint64_t> m_accumulatedTicks;
+    std::vector<IRTime::Events> m_cadenceEvent;
 
     // #2404: SystemManager-owned per-event execution counter, bumped once
     // at the top of executePipeline so every cadence gate in a pass sees
@@ -408,12 +417,10 @@ class SystemManager {
 
     // #2404: seed a system's phase when it joins `event`'s pipeline, so its
     // first accumulated delta measures from the join tick (plus its offset
-    // stagger), not from counter zero.
+    // stagger), not from counter zero. Also records `event` into
+    // m_cadenceEvent so a later runtime re-phase (setSystemCadenceOffset)
+    // binds to the same clock.
     void stampCadenceJoin(IRTime::Events event, SystemId system);
-
-    // #2404: the largest per-event tick counter — the reference clock for a
-    // runtime offset re-phase (which is event-agnostic).
-    std::uint64_t maxEventTickCount() const;
 
     // Begin tick functions happen once per system before tick function(s)
     template <typename FunctionBeginTick>

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -385,18 +385,11 @@ class SystemManager {
     //                     counter — the events advance at different rates
     //                     (RENDER is uncapped, UPDATE is fixed-step), so
     //                     mixing clocks seeds `lastRun` far ahead of `now`.
-    //   m_cadenceJoined   whether `m_cadenceEvent` holds a real join (true)
-    //                     or is still the inert placeholder from
-    //                     emplaceCadenceState (false) — lets stampCadenceJoin
-    //                     tell "never joined" apart from "joined to UPDATE",
-    //                     so it can assert against a system still listed in
-    //                     a different event's pipeline when re-joined.
     std::vector<std::uint32_t> m_cadence;
     std::vector<std::uint32_t> m_cadenceOffset;
     std::vector<std::uint64_t> m_lastRunTick;
     std::vector<std::uint64_t> m_accumulatedTicks;
     std::vector<IRTime::Events> m_cadenceEvent;
-    std::vector<bool> m_cadenceJoined;
 
     // #2404: SystemManager-owned per-event execution counter, bumped once
     // at the top of executePipeline so every cadence gate in a pass sees
@@ -428,6 +421,13 @@ class SystemManager {
     // m_cadenceEvent so a later runtime re-phase (setSystemCadenceOffset)
     // binds to the same clock.
     void stampCadenceJoin(IRTime::Events event, SystemId system);
+
+    // #2404: true if `system` is still listed in `priorEvent`'s pipeline
+    // groups. Pure lookup (no side effects), so it's safe to call from an
+    // IR_ASSERT condition — used by stampCadenceJoin to guard against a
+    // system live in two event pipelines at once, which would thrash its
+    // cadence clock between two counters that advance at different rates.
+    bool isStillLiveInPriorPipeline(IRTime::Events priorEvent, SystemId system) const;
 
     // Begin tick functions happen once per system before tick function(s)
     template <typename FunctionBeginTick>

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -122,7 +122,6 @@ void SystemManager::emplaceCadenceState(std::uint32_t cadence, std::uint32_t off
     // event; a system never listed in any pipeline is unreachable by
     // executePipeline, so the placeholder is inert.
     m_cadenceEvent.emplace_back(IRTime::UPDATE);
-    m_cadenceJoined.emplace_back(false);
 }
 
 bool SystemManager::pollCadenceDue(SystemId system, std::uint64_t now) {
@@ -146,20 +145,28 @@ bool SystemManager::pollCadenceDue(SystemId system, std::uint64_t now) {
     return true;
 }
 
+bool SystemManager::isStillLiveInPriorPipeline(IRTime::Events priorEvent, SystemId system) const {
+    const auto it = m_systemPipelineGroups.find(priorEvent);
+    return it != m_systemPipelineGroups.end() && pipelineGroupsContain(it->second, system);
+}
+
 void SystemManager::stampCadenceJoin(IRTime::Events event, SystemId system) {
     if (system >= m_lastRunTick.size()) {
         return;
     }
-    if (m_cadenceJoined[system] && m_cadenceEvent[system] != event) {
+    if (m_cadenceEvent[system] != event) {
         // Re-joining to a different event is fine on its own (e.g. a scene
         // transition re-purposes the SystemId after clearing its old
-        // pipeline) — only assert if the system is STILL listed in the old
-        // event's pipeline, i.e. it would be live in two pipelines at once
-        // and thrash m_lastRunTick between two counters that advance at
-        // different rates (the same clock-mixing bug amendment 2 fixed).
-        const auto it = m_systemPipelineGroups.find(m_cadenceEvent[system]);
+        // pipeline, or this is the system's first-ever join to an event
+        // other than the inert UPDATE placeholder) — only assert if the
+        // system is STILL listed in the old event's pipeline, i.e. it would
+        // be live in two pipelines at once and thrash m_lastRunTick between
+        // two counters that advance at different rates (the same
+        // clock-mixing bug amendment 2 fixed). A never-joined system isn't
+        // listed in any pipeline yet, so isStillLiveInPriorPipeline is false
+        // and this never false-fires on a genuine first join.
         IR_ASSERT(
-            it == m_systemPipelineGroups.end() || !pipelineGroupsContain(it->second, system),
+            !isStillLiveInPriorPipeline(m_cadenceEvent[system], system),
             "stampCadenceJoin: system '{}' is still registered in its prior event's pipeline "
             "and is now being joined to a different event — listing the same system in two "
             "pipelines simultaneously thrashes its cadence clock between two counters that "
@@ -167,7 +174,6 @@ void SystemManager::stampCadenceJoin(IRTime::Events event, SystemId system) {
             getSystemName(system)
         );
     }
-    m_cadenceJoined[system] = true;
     m_cadenceEvent[system] = event; // bind the runtime re-phase clock to this event.
     const std::uint64_t now = m_eventTickCounts[event];
     const std::uint32_t offset = system < m_cadenceOffset.size() ? m_cadenceOffset[system] : 0u;

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -93,6 +93,22 @@ SystemId SystemManager::createSystemDynamic(
 
 // #2404 — per-system update cadence -------------------------------------
 
+namespace {
+// True if `system` appears in any group of `groups`. Used to reject a
+// double-add: appending / inserting a system already in the pipeline
+// would tick it twice per frame.
+bool pipelineGroupsContain(const std::vector<std::vector<SystemId>> &groups, SystemId system) {
+    for (const auto &group : groups) {
+        for (SystemId id : group) {
+            if (id == system) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+} // namespace
+
 void SystemManager::emplaceCadenceState(std::uint32_t cadence, std::uint32_t offset) {
     const std::uint32_t normCadence = cadence == 0 ? 1u : cadence;
     m_cadence.emplace_back(normCadence);
@@ -106,6 +122,7 @@ void SystemManager::emplaceCadenceState(std::uint32_t cadence, std::uint32_t off
     // event; a system never listed in any pipeline is unreachable by
     // executePipeline, so the placeholder is inert.
     m_cadenceEvent.emplace_back(IRTime::UPDATE);
+    m_cadenceJoined.emplace_back(false);
 }
 
 bool SystemManager::pollCadenceDue(SystemId system, std::uint64_t now) {
@@ -133,6 +150,24 @@ void SystemManager::stampCadenceJoin(IRTime::Events event, SystemId system) {
     if (system >= m_lastRunTick.size()) {
         return;
     }
+    if (m_cadenceJoined[system] && m_cadenceEvent[system] != event) {
+        // Re-joining to a different event is fine on its own (e.g. a scene
+        // transition re-purposes the SystemId after clearing its old
+        // pipeline) — only assert if the system is STILL listed in the old
+        // event's pipeline, i.e. it would be live in two pipelines at once
+        // and thrash m_lastRunTick between two counters that advance at
+        // different rates (the same clock-mixing bug amendment 2 fixed).
+        const auto it = m_systemPipelineGroups.find(m_cadenceEvent[system]);
+        IR_ASSERT(
+            it == m_systemPipelineGroups.end() || !pipelineGroupsContain(it->second, system),
+            "stampCadenceJoin: system '{}' is still registered in its prior event's pipeline "
+            "and is now being joined to a different event — listing the same system in two "
+            "pipelines simultaneously thrashes its cadence clock between two counters that "
+            "advance at different rates. Remove it from the old pipeline first.",
+            getSystemName(system)
+        );
+    }
+    m_cadenceJoined[system] = true;
     m_cadenceEvent[system] = event; // bind the runtime re-phase clock to this event.
     const std::uint64_t now = m_eventTickCounts[event];
     const std::uint32_t offset = system < m_cadenceOffset.size() ? m_cadenceOffset[system] : 0u;
@@ -225,22 +260,6 @@ void SystemManager::registerPipelineGroups(
         }
     }
 }
-
-namespace {
-// True if `system` appears in any group of `groups`. Used to reject a
-// double-add: appending / inserting a system already in the pipeline
-// would tick it twice per frame.
-bool pipelineGroupsContain(const std::vector<std::vector<SystemId>> &groups, SystemId system) {
-    for (const auto &group : groups) {
-        for (SystemId id : group) {
-            if (id == system) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-} // namespace
 
 void SystemManager::appendToPipeline(IRTime::Events event, SystemId system) {
     // operator[] default-constructs an empty group sequence when the

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -50,7 +50,9 @@ SystemId SystemManager::createSystemDynamic(
     Archetype includeArchetype,
     Archetype excludeArchetype,
     std::function<void(ArchetypeNode *)> body,
-    Concurrency concurrency
+    Concurrency concurrency,
+    std::uint32_t cadence,
+    std::uint32_t offset
 ) {
     m_systemNames.emplace_back(C_Name{std::move(name)});
     SystemId newSystemId = m_nextSystemId++;
@@ -85,7 +87,91 @@ SystemId SystemManager::createSystemDynamic(
     m_concurrency.emplace_back(concurrency);
     m_grainSize.emplace_back(kDefaultGrainSize);
     m_systemAccess.emplace_back();
+    emplaceCadenceState(cadence, offset);
     return newSystemId;
+}
+
+// #2404 — per-system update cadence -------------------------------------
+
+void SystemManager::emplaceCadenceState(std::uint32_t cadence, std::uint32_t offset) {
+    const std::uint32_t normCadence = cadence == 0 ? 1u : cadence;
+    m_cadence.emplace_back(normCadence);
+    m_cadenceOffset.emplace_back(normCadence <= 1 ? 0u : offset % normCadence);
+    // Seeded to 0 here; stampCadenceJoin re-seeds to the join tick (+offset)
+    // when the system is listed in a pipeline. A system never listed in any
+    // pipeline is unreachable by executePipeline, so the 0 seed is inert.
+    m_lastRunTick.emplace_back(0);
+    m_accumulatedTicks.emplace_back(0);
+}
+
+bool SystemManager::pollCadenceDue(SystemId system, std::uint64_t now) {
+    if (system >= m_cadence.size()) {
+        return true; // no cadence state recorded — always run (defensive).
+    }
+    const std::uint32_t cadence = m_cadence[system];
+    // Additive comparison (`now >= lastRun + cadence`), NOT `now - lastRun >=
+    // cadence`: a nonzero offset seeds `lastRun > now` on the first few ticks,
+    // where the unsigned subtraction would underflow and read as "hugely due".
+    if (cadence > 1 && now < m_lastRunTick[system] + cadence) {
+        return false; // off-cadence — skip the whole dispatch.
+    }
+    // Due: `now >= lastRun` holds here, so the subtraction is safe.
+    m_accumulatedTicks[system] = now - m_lastRunTick[system];
+    m_lastRunTick[system] = now;
+    return true;
+}
+
+void SystemManager::stampCadenceJoin(IRTime::Events event, SystemId system) {
+    if (system >= m_lastRunTick.size()) {
+        return;
+    }
+    const std::uint64_t now = m_eventTickCounts[event];
+    const std::uint32_t offset = system < m_cadenceOffset.size() ? m_cadenceOffset[system] : 0u;
+    // Seed `lastRun = now + offset`. The additive due check then first fires
+    // at `now + offset + cadence`, so siblings with distinct offsets stagger
+    // across consecutive ticks; the first accumulated delta is exactly the
+    // cadence regardless of offset.
+    m_lastRunTick[system] = now + offset;
+    m_accumulatedTicks[system] = 0;
+}
+
+std::uint64_t SystemManager::maxEventTickCount() const {
+    std::uint64_t maxCount = 0;
+    for (std::uint64_t count : m_eventTickCounts) {
+        if (count > maxCount) {
+            maxCount = count;
+        }
+    }
+    return maxCount;
+}
+
+void SystemManager::setSystemCadence(SystemId system, std::uint32_t cadence) {
+    if (system >= m_cadence.size()) {
+        return;
+    }
+    const std::uint32_t normCadence = cadence == 0 ? 1u : cadence;
+    m_cadence[system] = normCadence;
+    // Keep the stored offset in range if the cadence shrank below it. No
+    // re-seed of lastRunTick: the additive due check re-phases from the last
+    // run automatically on the next tick (a shorter cadence fires sooner).
+    if (m_cadenceOffset[system] >= normCadence) {
+        m_cadenceOffset[system] = normCadence <= 1 ? 0u : m_cadenceOffset[system] % normCadence;
+    }
+}
+
+void SystemManager::setSystemCadenceOffset(SystemId system, std::uint32_t offset) {
+    if (system >= m_cadenceOffset.size()) {
+        return;
+    }
+    const std::uint32_t cadence = m_cadence[system];
+    const std::uint32_t normOffset = cadence <= 1 ? 0u : offset % cadence;
+    m_cadenceOffset[system] = normOffset;
+    // Re-phase against a reference clock so the offset takes effect as a
+    // fresh stagger (the runtime setter is event-agnostic; the largest
+    // per-event counter is the monotonic reference). Mirrors the stamp-time
+    // seed: next fire lands at reference + offset + cadence.
+    m_lastRunTick[system] = maxEventTickCount() + normOffset;
+    m_accumulatedTicks[system] = 0;
 }
 
 void SystemManager::replaceSystemBody(SystemId system, std::function<void(ArchetypeNode *)> body) {
@@ -129,6 +215,14 @@ void SystemManager::registerPipelineGroups(
 ) {
     m_systemPipelineGroups[event] = std::move(groups);
     m_flattenedPipelinesDirty = true;
+    // #2404: seed each listed system's cadence phase from the current event
+    // tick (+ its offset), so a mid-run re-registration measures elapsed
+    // from here rather than from counter zero.
+    for (const auto &group : m_systemPipelineGroups[event]) {
+        for (SystemId system : group) {
+            stampCadenceJoin(event, system);
+        }
+    }
 }
 
 namespace {
@@ -160,6 +254,7 @@ void SystemManager::appendToPipeline(IRTime::Events event, SystemId system) {
     );
     groups.push_back({system});
     m_flattenedPipelinesDirty = true;
+    stampCadenceJoin(event, system); // #2404: seed phase from the join tick.
 }
 
 void SystemManager::insertIntoPipelineBefore(
@@ -213,6 +308,7 @@ void SystemManager::insertSingletonGroupRelativeTo(
     const std::size_t pos = after ? anchorGroup + 1 : anchorGroup;
     groups.insert(groups.begin() + static_cast<std::ptrdiff_t>(pos), std::vector<SystemId>{system});
     m_flattenedPipelinesDirty = true;
+    stampCadenceJoin(event, system); // #2404: seed phase from the join tick.
 }
 
 void SystemManager::refreshFlattenedPipelines() const {
@@ -337,6 +433,9 @@ void SystemManager::executePipeline(IRTime::Events event) {
     if (it == m_systemPipelineGroups.end()) {
         return;
     }
+    // #2404: bump this event's phase-tick counter once, so every cadence
+    // gate in this pass compares against the same `now`.
+    const std::uint64_t now = ++m_eventTickCounts[event];
     const auto &groups = it->second;
     for (const auto &group : groups) {
         if (group.size() == 1) {
@@ -349,13 +448,20 @@ void SystemManager::executePipeline(IRTime::Events event) {
             // + drives main-thread-only GPU APIs (device()->finish(),
             // writeTimestamp). See registerTickObserver doc + the
             // multi-system note below.
+            //
+            // #2404: a throttled system skips its entire dispatch
+            // (observers + executeSystem) on off-cadence ticks; the
+            // per-group flushStructuralChanges still runs, so deferred
+            // changes queued by other systems keep flushing on schedule.
             const SystemId id = group[0];
-            for (auto &entry : m_observers) {
-                entry.second->onBeforeTick(id);
-            }
-            executeSystem(id);
-            for (auto &entry : m_observers) {
-                entry.second->onAfterTick(id);
+            if (pollCadenceDue(id, now)) {
+                for (auto &entry : m_observers) {
+                    entry.second->onBeforeTick(id);
+                }
+                executeSystem(id);
+                for (auto &entry : m_observers) {
+                    entry.second->onAfterTick(id);
+                }
             }
         } else if (!group.empty()) {
             // T-224: parallel group — fan out across the worker pool.
@@ -379,23 +485,38 @@ void SystemManager::executePipeline(IRTime::Events event) {
             // single worker, killing the parallelism. It shares only the
             // null-pool serial guard with the helper, not the
             // chunk-planning boilerplate the helper consolidates.
-            if (g_jobManager != nullptr) {
-                IRJob::parallelFor(
-                    0,
-                    static_cast<int>(group.size()),
-                    1,
-                    [&group, this](int begin, int end) {
-                        for (int k = begin; k < end; ++k) {
-                            executeSystem(group[k]);
+            // #2404: filter the due members on the main thread before
+            // fan-out — a throttled member simply doesn't dispatch on its
+            // off-cadence ticks. The gate MUST run here, not inside the
+            // worker lambda: pollCadenceDue writes m_accumulatedTicks /
+            // m_lastRunTick, and those must be resolved before any worker
+            // (or a tick body) reads them. m_dueScratch is main-thread-
+            // owned and read-only during the fan-out.
+            m_dueScratch.clear();
+            for (SystemId id : group) {
+                if (pollCadenceDue(id, now)) {
+                    m_dueScratch.push_back(id);
+                }
+            }
+            if (!m_dueScratch.empty()) {
+                if (g_jobManager != nullptr) {
+                    IRJob::parallelFor(
+                        0,
+                        static_cast<int>(m_dueScratch.size()),
+                        1,
+                        [this](int begin, int end) {
+                            for (int k = begin; k < end; ++k) {
+                                executeSystem(m_dueScratch[k]);
+                            }
                         }
+                    );
+                } else {
+                    // No worker pool (unit tests, pre-World init) — fall
+                    // back to serial dispatch in declaration order so the
+                    // pipeline still runs.
+                    for (SystemId id : m_dueScratch) {
+                        executeSystem(id);
                     }
-                );
-            } else {
-                // No worker pool (unit tests, pre-World init) — fall
-                // back to serial dispatch in declaration order so the
-                // pipeline still runs.
-                for (SystemId id : group) {
-                    executeSystem(id);
                 }
             }
         }

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -102,6 +102,10 @@ void SystemManager::emplaceCadenceState(std::uint32_t cadence, std::uint32_t off
     // pipeline is unreachable by executePipeline, so the 0 seed is inert.
     m_lastRunTick.emplace_back(0);
     m_accumulatedTicks.emplace_back(0);
+    // Placeholder until stampCadenceJoin records the system's real pipeline
+    // event; a system never listed in any pipeline is unreachable by
+    // executePipeline, so the placeholder is inert.
+    m_cadenceEvent.emplace_back(IRTime::UPDATE);
 }
 
 bool SystemManager::pollCadenceDue(SystemId system, std::uint64_t now) {
@@ -112,7 +116,11 @@ bool SystemManager::pollCadenceDue(SystemId system, std::uint64_t now) {
     // Additive comparison (`now >= lastRun + cadence`), NOT `now - lastRun >=
     // cadence`: a nonzero offset seeds `lastRun > now` on the first few ticks,
     // where the unsigned subtraction would underflow and read as "hugely due".
-    if (cadence > 1 && now < m_lastRunTick[system] + cadence) {
+    // Applies uniformly at cadence 1 too — no special-case short-circuit: for
+    // an un-offset cadence-1 system `lastRun == now - 1`, so the check is
+    // false and it fires every tick, same as before this held only for
+    // cadence > 1.
+    if (now < m_lastRunTick[system] + cadence) {
         return false; // off-cadence — skip the whole dispatch.
     }
     // Due: `now >= lastRun` holds here, so the subtraction is safe.
@@ -125,6 +133,7 @@ void SystemManager::stampCadenceJoin(IRTime::Events event, SystemId system) {
     if (system >= m_lastRunTick.size()) {
         return;
     }
+    m_cadenceEvent[system] = event; // bind the runtime re-phase clock to this event.
     const std::uint64_t now = m_eventTickCounts[event];
     const std::uint32_t offset = system < m_cadenceOffset.size() ? m_cadenceOffset[system] : 0u;
     // Seed `lastRun = now + offset`. The additive due check then first fires
@@ -133,16 +142,6 @@ void SystemManager::stampCadenceJoin(IRTime::Events event, SystemId system) {
     // cadence regardless of offset.
     m_lastRunTick[system] = now + offset;
     m_accumulatedTicks[system] = 0;
-}
-
-std::uint64_t SystemManager::maxEventTickCount() const {
-    std::uint64_t maxCount = 0;
-    for (std::uint64_t count : m_eventTickCounts) {
-        if (count > maxCount) {
-            maxCount = count;
-        }
-    }
-    return maxCount;
 }
 
 void SystemManager::setSystemCadence(SystemId system, std::uint32_t cadence) {
@@ -166,11 +165,13 @@ void SystemManager::setSystemCadenceOffset(SystemId system, std::uint32_t offset
     const std::uint32_t cadence = m_cadence[system];
     const std::uint32_t normOffset = cadence <= 1 ? 0u : offset % cadence;
     m_cadenceOffset[system] = normOffset;
-    // Re-phase against a reference clock so the offset takes effect as a
-    // fresh stagger (the runtime setter is event-agnostic; the largest
-    // per-event counter is the monotonic reference). Mirrors the stamp-time
-    // seed: next fire lands at reference + offset + cadence.
-    m_lastRunTick[system] = maxEventTickCount() + normOffset;
+    // Re-phase against the system's OWN event clock (bound at pipeline-join
+    // by stampCadenceJoin), not some other event's counter — events advance
+    // at different rates (e.g. RENDER is uncapped, UPDATE is fixed-step), so
+    // seeding from a foreign clock can put `lastRun` far ahead of this
+    // system's `now` and silently stall it until its own counter catches up.
+    // Mirrors the stamp-time seed: next fire lands at now + offset + cadence.
+    m_lastRunTick[system] = m_eventTickCounts[m_cadenceEvent[system]] + normOffset;
     m_accumulatedTicks[system] = 0;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(IrredenEngineTest
   system/pipeline_groups_test.cpp
   system/register_system_test.cpp
   system/system_access_test.cpp
+  system/system_cadence_test.cpp
   system/system_concurrency_test.cpp
   time/sim_clock_test.cpp
   time/cycle_test.cpp

--- a/test/system/system_cadence_test.cpp
+++ b/test/system/system_cadence_test.cpp
@@ -7,6 +7,7 @@
 #include <irreden/entity/entity_manager.hpp>
 
 #include <cstdint>
+#include <stdexcept>
 #include <vector>
 
 // #2404 — per-system update cadence. Exercises the SystemManager cadence
@@ -343,6 +344,52 @@ TEST_F(SystemCadenceTest, OffsetRephaseUsesOwnEventClock) {
         m_system_manager.executePipeline(IRTime::UPDATE);
     }
     EXPECT_EQ(exec, 1);
+}
+
+// A system's cadence clock is bound to one event (stampCadenceJoin). Joining
+// it to a second event while it is STILL listed in the first one would leave
+// it live in two pipelines, thrashing m_lastRunTick between two counters that
+// advance at different rates. stampCadenceJoin IR_ASSERTs on that; the assert
+// throws std::runtime_error via engAssert, as in pipeline_groups_test.cpp.
+TEST_F(SystemCadenceTest, JoinToSecondEventWhileLiveInFirstAsserts) {
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "TwoPipelinesLive",
+        [](C_CadA &) {},
+        nullptr,
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+
+    // UPDATE's pipeline still lists sys — joining RENDER must be rejected.
+    EXPECT_THROW(m_system_manager.appendToPipeline(IRTime::RENDER, sys), std::runtime_error);
+}
+
+// The counterpart success path: clearing the old event's pipeline first makes
+// the re-join legitimate (a scene transition re-purposing the SystemId), so
+// the guard must stay silent rather than false-assert on any re-join.
+TEST_F(SystemCadenceTest, RejoinAfterClearingPriorPipelineIsSilent) {
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "RejoinAfterClear",
+        [](C_CadA &) {},
+        nullptr,
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+    m_system_manager.clearPipeline(IRTime::UPDATE); // no longer live in UPDATE.
+
+    EXPECT_NO_THROW(m_system_manager.appendToPipeline(IRTime::RENDER, sys));
 }
 
 } // namespace

--- a/test/system/system_cadence_test.cpp
+++ b/test/system/system_cadence_test.cpp
@@ -271,4 +271,78 @@ TEST_F(SystemCadenceTest, RuntimeSettersNormalizeAndCadenceFromRate) {
     ); // half rate → 2
 }
 
+// A runtime drop to cadence 1 while `lastRunTick` is still ahead of `now`
+// (from a nonzero offset seed a prior, larger cadence hadn't yet caught up
+// to) must keep waiting for `now` to catch up, not fire immediately — firing
+// early would compute `now - lastRunTick` as an underflowed uint64_t. See
+// #2425.
+TEST_F(SystemCadenceTest, CadenceDropToOneDoesNotUnderflow) {
+    int exec = 0;
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "DropToOne",
+        [](C_CadA &) {},
+        [&exec]() { ++exec; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/4,
+        /*offset=*/3
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys}); // stamp: lastRun = 0 + 3 = 3
+
+    m_system_manager.executePipeline(IRTime::UPDATE); // now=1: off-cadence, no fire.
+    EXPECT_EQ(exec, 0);
+
+    m_system_manager.setSystemCadence(sys, 1); // cadence=1, offset clamps to 0; lastRun stays 3.
+
+    // now=2, now=3: still off-cadence — due at now >= lastRun(3) + cadence(1) = 4.
+    m_system_manager.executePipeline(IRTime::UPDATE);
+    m_system_manager.executePipeline(IRTime::UPDATE);
+    EXPECT_EQ(exec, 0);
+
+    m_system_manager.executePipeline(IRTime::UPDATE); // now=4: due.
+    EXPECT_EQ(exec, 1);
+    EXPECT_EQ(m_system_manager.getAccumulatedTicks(sys), 1u); // not ~1.8e19 (UINT64_MAX underflow).
+}
+
+// setSystemCadenceOffset must re-phase against the system's own pipeline
+// event clock, not another event's counter — events advance at different
+// rates (RENDER is uncapped, UPDATE is fixed-step), so seeding from a
+// foreign clock can put `lastRunTick` far ahead of this system's `now` and
+// silently stall it. See #2425.
+TEST_F(SystemCadenceTest, OffsetRephaseUsesOwnEventClock) {
+    int exec = 0;
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "OwnClock",
+        [](C_CadA &) {},
+        [&exec]() { ++exec; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/4,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+    m_system_manager.registerPipelineGroups(IRTime::RENDER, {}); // establish RENDER's counter.
+
+    // Advance RENDER far past UPDATE — representative of a real World,
+    // where RENDER is uncapped and UPDATE is pinned to the fixed step.
+    for (int i = 0; i < 50; ++i) {
+        m_system_manager.executePipeline(IRTime::RENDER);
+    }
+
+    m_system_manager.setSystemCadenceOffset(sys, 1); // must re-phase against UPDATE's own clock.
+
+    // Fires within offset + cadence UPDATE ticks (5) — not stalled for
+    // ~50 ticks waiting for UPDATE to catch up to RENDER's counter.
+    for (int i = 0; i < 5; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+    EXPECT_EQ(exec, 1);
+}
+
 } // namespace

--- a/test/system/system_cadence_test.cpp
+++ b/test/system/system_cadence_test.cpp
@@ -392,4 +392,66 @@ TEST_F(SystemCadenceTest, RejoinAfterClearingPriorPipelineIsSilent) {
     EXPECT_NO_THROW(m_system_manager.appendToPipeline(IRTime::RENDER, sys));
 }
 
+// A system whose FIRST-EVER join is to a non-UPDATE event: m_cadenceEvent still
+// holds the inert UPDATE placeholder from emplaceCadenceState, so the guard's
+// `m_cadenceEvent[system] != event` arm is true and the isStillLiveInPriorPipeline
+// lookup is the only thing keeping it silent. Here UPDATE has no pipeline at all,
+// so the lookup returns via the map-miss arm. A render-only system is a
+// legitimate usage pattern and must never false-assert on its first join.
+TEST_F(SystemCadenceTest, FirstEverJoinToRenderIsSilent) {
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "FirstJoinRender",
+        [](C_CadA &) {},
+        nullptr,
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/0
+    );
+
+    // No UPDATE registration whatsoever — RENDER is this system's first join.
+    EXPECT_NO_THROW(m_system_manager.appendToPipeline(IRTime::RENDER, sys));
+}
+
+// The same first-ever-join-to-RENDER case, but with UPDATE's pipeline populated
+// by an unrelated system. find(UPDATE) now succeeds, so the guard falls through
+// to the pipelineGroupsContain arm — which must report sys absent — instead of
+// short-circuiting on a map miss. This is the arm that distinguishes "someone
+// else is in the placeholder event" from "I am still live there".
+TEST_F(SystemCadenceTest, FirstEverJoinToRenderIsSilentWhenUpdateHostsAnotherSystem) {
+    auto resident = IRSystem::createSystem<C_CadB>(
+        "UpdateResident",
+        [](C_CadB &) {},
+        nullptr,
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/1,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {resident});
+
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "FirstJoinRenderForeignUpdate",
+        [](C_CadA &) {},
+        nullptr,
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/0
+    );
+
+    // UPDATE's pipeline exists but lists only `resident` — sys has never joined
+    // anything, so the prior-pipeline lookup must find it absent.
+    EXPECT_NO_THROW(m_system_manager.appendToPipeline(IRTime::RENDER, sys));
+}
+
 } // namespace

--- a/test/system/system_cadence_test.cpp
+++ b/test/system/system_cadence_test.cpp
@@ -1,0 +1,274 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_constants.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+#include <irreden/entity/entity_manager.hpp>
+
+#include <cstdint>
+#include <vector>
+
+// #2404 — per-system update cadence. Exercises the SystemManager cadence
+// gate end-to-end through IRSystem::createSystem + registerPipeline(Groups),
+// using the g_jobManager == nullptr serial fallback (no worker pool in a
+// unit test) for deterministic dispatch. The five acceptance criteria from
+// the issue map onto the tests below; execution counting rides beginTick
+// (fires once per due execution, even with zero matched entities), and
+// per-entity iteration counting rides the per-entity tick body.
+
+namespace {
+
+struct C_CadA {
+    int n_ = 0;
+};
+struct C_CadB {
+    int m_ = 0;
+};
+
+class SystemCadenceTest : public testing::Test {
+  protected:
+    SystemCadenceTest()
+        : m_entity_manager{}
+        , m_system_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+// Acceptance 1: a cadence-N system fires on exactly 1-in-N phase ticks.
+TEST_F(SystemCadenceTest, RunsOneInNTicks) {
+    int exec = 0;
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "Cad3",
+        [](C_CadA &) {},
+        [&exec]() { ++exec; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/3,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+
+    for (int i = 0; i < 30; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+    // Fires on ticks 3, 6, ..., 30 = 10 executions = floor(30/3).
+    EXPECT_EQ(exec, 10);
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 3u);
+}
+
+// Acceptance 4: the default (unset) cadence runs every tick, unchanged.
+TEST_F(SystemCadenceTest, DefaultCadenceRunsEveryTick) {
+    int exec = 0;
+    auto sys = IRSystem::createSystem<C_CadA>("Every", [](C_CadA &) {}, [&exec]() { ++exec; });
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+
+    for (int i = 0; i < 12; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+    EXPECT_EQ(exec, 12);
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 1u);
+    // A cadence-1 system covers exactly one phase tick per execution.
+    EXPECT_EQ(m_system_manager.getAccumulatedTicks(sys), 1u);
+}
+
+// Acceptance 3: off-cadence ticks incur no per-entity iteration — the
+// visit count scales with 1/N, not with the tick count.
+TEST_F(SystemCadenceTest, OffCadenceTicksSkipIteration) {
+    int exec = 0;
+    int visits = 0;
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "Skip",
+        [&visits](C_CadA &) { ++visits; },
+        [&exec]() { ++exec; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/4,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+    IREntity::createEntity(C_CadA{});
+    IREntity::createEntity(C_CadA{});
+
+    for (int i = 0; i < 20; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+    EXPECT_EQ(exec, 5);       // fires on 4, 8, 12, 16, 20
+    EXPECT_EQ(visits, 5 * 2); // two entities iterated only on due ticks
+}
+
+// Acceptance 2: getAccumulatedTicks reports the phase-tick gap each
+// execution covers, re-phasing correctly across a mid-run cadence change,
+// and the per-execution values sum to the total elapsed phase ticks.
+TEST_F(SystemCadenceTest, AccumulatedTicksRephaseOnCadenceChange) {
+    int exec = 0;
+    int prevExec = 0;
+    std::vector<std::uint64_t> accs;
+    auto sys = IRSystem::createSystem<C_CadA>(
+        "Acc",
+        [](C_CadA &) {},
+        [&exec]() { ++exec; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/3,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+
+    auto tickAndRecord = [&]() {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+        if (exec != prevExec) {
+            accs.push_back(m_system_manager.getAccumulatedTicks(sys));
+            prevExec = exec;
+        }
+    };
+
+    for (int i = 0; i < 9; ++i) { // fires at 3, 6, 9 — each covering 3 ticks
+        tickAndRecord();
+    }
+    m_system_manager.setSystemCadence(sys, 5); // re-phase from last run (tick 9)
+    for (int i = 0; i < 10; ++i) {             // ticks 10..19 — fires at 14, 19 — 5 ticks each
+        tickAndRecord();
+    }
+
+    ASSERT_EQ(accs.size(), 5u);
+    EXPECT_EQ(accs[0], 3u);
+    EXPECT_EQ(accs[1], 3u);
+    EXPECT_EQ(accs[2], 3u);
+    EXPECT_EQ(accs[3], 5u);
+    EXPECT_EQ(accs[4], 5u);
+
+    std::uint64_t sum = 0;
+    for (std::uint64_t a : accs) {
+        sum += a;
+    }
+    EXPECT_EQ(sum, 19u); // last fire landed on phase tick 19
+}
+
+// Acceptance 5: in a mixed-cadence multi-system group, only the due
+// members dispatch on a given tick (serial fallback, no worker pool).
+TEST_F(SystemCadenceTest, MultiSystemGroupFiltersDueMembers) {
+    int execA = 0;
+    int execB = 0;
+    auto a = IRSystem::createSystem<C_CadA>(
+        "GroupA",
+        [](C_CadA &) {},
+        [&execA]() { ++execA; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/0
+    );
+    auto b = IRSystem::createSystem<C_CadB>(
+        "GroupB",
+        [](C_CadB &) {},
+        [&execB]() { ++execB; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/3,
+        /*offset=*/0
+    );
+    m_system_manager.registerPipelineGroups(IRTime::UPDATE, {{a, b}});
+
+    for (int i = 0; i < 6; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+    EXPECT_EQ(execA, 3); // 2, 4, 6
+    EXPECT_EQ(execB, 2); // 3, 6
+}
+
+// Amendment 1: an initial-phase offset staggers sibling systems registered
+// together so they fire on distinct ticks instead of spiking together.
+TEST_F(SystemCadenceTest, OffsetStaggersSiblings) {
+    int exec0 = 0;
+    int exec1 = 0;
+    auto s0 = IRSystem::createSystem<C_CadA>(
+        "Off0",
+        [](C_CadA &) {},
+        [&exec0]() { ++exec0; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/0
+    );
+    auto s1 = IRSystem::createSystem<C_CadB>(
+        "Off1",
+        [](C_CadB &) {},
+        [&exec1]() { ++exec1; },
+        nullptr,
+        {},
+        nullptr,
+        IRSystem::Concurrency::SERIAL,
+        IRSystem::kDefaultGrainSize,
+        /*cadence=*/2,
+        /*offset=*/1
+    );
+    m_system_manager.registerPipeline(IRTime::UPDATE, {s0, s1});
+
+    std::vector<int> fires0;
+    std::vector<int> fires1;
+    for (int t = 1; t <= 6; ++t) {
+        const int p0 = exec0;
+        const int p1 = exec1;
+        m_system_manager.executePipeline(IRTime::UPDATE);
+        if (exec0 != p0) {
+            fires0.push_back(t);
+        }
+        if (exec1 != p1) {
+            fires1.push_back(t);
+        }
+        // Staggered: the two never fire on the same tick.
+        EXPECT_FALSE(exec0 != p0 && exec1 != p1);
+    }
+    EXPECT_EQ(fires0, (std::vector<int>{2, 4, 6}));
+    EXPECT_EQ(fires1, (std::vector<int>{3, 5}));
+    EXPECT_EQ(m_system_manager.getSystemCadenceOffset(s1), 1u);
+}
+
+// Runtime setters normalize their inputs; cadenceFromRate maps a target
+// sub-rate onto the integer divisor primitive.
+TEST_F(SystemCadenceTest, RuntimeSettersNormalizeAndCadenceFromRate) {
+    auto sys = IRSystem::createSystem<C_CadA>("Setters", [](C_CadA &) {});
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 1u);
+    EXPECT_EQ(m_system_manager.getSystemCadenceOffset(sys), 0u);
+
+    m_system_manager.setSystemCadence(sys, 0); // 0 normalizes to 1
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 1u);
+
+    m_system_manager.setSystemCadence(sys, 5);
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 5u);
+
+    m_system_manager.setSystemCadenceOffset(sys, 7); // clamps into [0, 5) → 2
+    EXPECT_EQ(m_system_manager.getSystemCadenceOffset(sys), 2u);
+
+    EXPECT_EQ(IRSystem::cadenceFromRate(0.0), 1u); // non-positive → every tick
+    EXPECT_EQ(
+        IRSystem::cadenceFromRate(static_cast<double>(IRConstants::kFPS)),
+        1u
+    ); // full rate → 1
+    EXPECT_EQ(
+        IRSystem::cadenceFromRate(static_cast<double>(IRConstants::kFPS) / 2.0),
+        2u
+    ); // half rate → 2
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds a **per-system update cadence** to `SystemManager`: a system runs on 1-in-N phase ticks instead of every tick, declared at registration (`kCadence` / `kCadenceOffset` on the `System<N>` spec, or the trailing `createSystem` params) or set at runtime.
- Off-cadence ticks skip the system's **entire** dispatch — `beginTick`, archetype query, per-entity iteration, `endTick`, observer fires — so the saving is real dispatch/iteration cost, not an in-body early return. The per-group `flushStructuralChanges` still runs every tick, so deferred changes queued by other systems keep flushing.
- The gate lives in `executePipeline` behind a SystemManager-owned per-event tick counter (self-contained, no `TimeManager` dependency — works for INPUT/RENDER too and is unit-testable in isolation). The due check is additive (`now >= lastRun + cadence`) to stay underflow-safe with a nonzero offset seed, and re-phases from the last run on a runtime cadence change.
- **Offset** (amendment 1) staggers sibling systems so cold-tier buckets fire on consecutive ticks instead of spiking on the same tick. Multi-system parallel groups filter due members into a reused scratch vector on the main thread before fan-out, so a worker never races the accumulated-delta write.
- `getAccumulatedTicks` / `accumulatedDeltaTime` (UPDATE-phase-only) let a throttled integrator stay numerically correct at the reduced rate; `cadenceFromRate(hz)` maps a target sub-rate onto the divisor. Full C++ + Lua surface (amendment 2 binds the accumulated-delta getters for Lua-registered throttled systems).
- **Generic engine throttle only** — throttle *policy* (which systems/entities) stays in the consuming creation, per the issue. Orthogonal to render LOD and to the T-224 threading groups.

## Acceptance criteria (#2404)
- [x] A cadence-N system executes floor(M/N) (+/-1) times over M `executePipeline` calls
- [x] Correct accumulated fixed-step delta each execution, verified across a mid-run cadence change (`3,3,3 -> 5,5`, summing to total elapsed ticks)
- [x] Off-cadence ticks incur no per-entity iteration (visits scale ~1/N)
- [x] Unset cadence = unchanged behavior; existing suite green
- [x] Cadence runtime-mutable; a mixed-cadence multi-system group dispatches only due members

## Plan
The approved `## Plan` comment (+ the two accepted in-thread amendments) rides as the first commit at `.fleet/plans/issue-2404.md`.

## Test plan
- [x] `test/system/system_cadence_test.cpp` — 7 tests covering all five acceptance criteria + offset stagger + setter normalization / `cadenceFromRate` (`build/IrredenEngineTest --gtest_filter='SystemCadenceTest.*'` -> **7 passed**)
- [x] No regression: existing system suite (PipelineGroups / Concurrency / RegisterSystem / SystemAccess = **55 tests**) green; full non-MIDI suite **1320 tests** green
- [x] `fleet-build --target IrredenEngineTest` clean on macOS (Metal)

Note: the full-suite run aborts in a MIDI test on `MidiInCore::initialize: error creating OS-X MIDI client object (-10833)` — a pre-existing macOS-headless CoreMIDI environment failure, unrelated to `engine/system`; the non-MIDI subset is fully green.

Perf: no render surface touched. The cadence-1 fast path is a bounds-check + short-circuited `cadence > 1` compare + a couple of integer stores per system per tick — negligible next to the `std::vector<ArchetypeNode*>` allocation + hash-lookup `executeSystem` already does every tick, which throttled systems now skip entirely. No per-frame allocation added (the multi-system due-filter reuses `m_dueScratch`).

Closes #2404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
