### PR TITLE
fleet: fleet-net-doctor + github ssh multiplexing — ephemeral-port exhaustion defenses

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -68,3 +68,7 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   fleet-net.sh` — it shadows `git()`/`gh()` with a `timeout` and bounds every
   current and future call site by construction — rather than adding per-site
   guards. Python fetchers use their own subprocess/urllib timeouts instead.
+  The escalated form of the same failure is host-wide: leaked/hung
+  connections exhaust the ephemeral port range and every network call dies
+  instantly with EADDRNOTAVAIL ("Can't assign requested address") — that is
+  not GitHub being down; run `fleet-net-doctor` (exit 2 ⇒ reboot the host).

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -116,7 +116,7 @@ Example:
 See scripts/fleet/fleet-edit header.
 EOF
             ;;
-        fleet-run | fleet-run-targets | fleet-down | fleet-claim | fleet-labels | fleet-gate-status)
+        fleet-run | fleet-run-targets | fleet-down | fleet-claim | fleet-labels | fleet-gate-status | fleet-net-doctor)
             bash "$path" --help
             ;;
         fleet-claude-stream | fleet-state-scout | fleet-feedback)
@@ -237,6 +237,9 @@ Parallel-agent fleet (tmux + Claude)
                                  the LLM merger pass
   fleet-gate-status [--json]     show usage gate (Anthropic + GitHub API
                                  pools) + per-pane cooldown state
+  fleet-net-doctor [--kill-hung] TCP socket / ephemeral-port pressure report
+                                 (EADDRNOTAVAIL forensics) + hung git/ssh/gh
+                                 reaper; exit 0 OK / 1 WARN / 2 CRITICAL
   fleet-claude-stream            format claude stream-json for tmux
   fleet-heartbeat <agent>        bump heartbeat mtime
   fleet-iteration-summary <agent> "<text>"

--- a/scripts/fleet/fleet-net-doctor
+++ b/scripts/fleet/fleet-net-doctor
@@ -42,7 +42,7 @@ HOST_OS="${FLEET_NET_DOCTOR_OS:-$(uname -s)}"
 kill_hung=0
 case "${1:-}" in
     --kill-hung) kill_hung=1 ;;
-    -h|--help) sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     "") ;;
     *) echo "fleet-net-doctor: unknown option: $1 (try --help)" >&2; exit 64 ;;
 esac
@@ -132,7 +132,7 @@ while IFS= read -r line; do
     # zero-padded field ("08") is otherwise parsed as (invalid) octal.
     case "$etime" in
         *-*)   mins=99999 ;;
-        *:*:*) mins=$(( 10#${etime%%:*} * 60 )) ;;
+        *:*:*) IFS=: read -r hh mm _ <<<"$etime"; mins=$(( 10#$hh * 60 + 10#$mm )) ;;
         *)     mins=$(( 10#${etime%%:*} )) ;;
     esac
     if (( mins >= HUNG_MINUTES )); then

--- a/scripts/fleet/fleet-net-doctor
+++ b/scripts/fleet/fleet-net-doctor
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# fleet-net-doctor — diagnose TCP socket / ephemeral-port pressure on a fleet
+# host, and reap hung git/ssh/gh processes.
+#
+# Why this exists (incident 2026-07-15, macOS host): heavy fleet connection
+# churn (gh CLI + git-over-ssh to GitHub, API traffic) combined with a wedged
+# kernel PCB reaper (85-day uptime) left ~30k sockets frozen in
+# TIME_WAIT/FIN_WAIT_1/LAST_ACK. All 16,384 ephemeral ports were consumed and
+# every new outbound connection failed instantly with EADDRNOTAVAIL ("Can't
+# assign requested address") — git, gh, and ssh were all dead host-wide. Only
+# a reboot reclaims frozen sockets; the point of this tool is to see the
+# pressure building BEFORE that cliff, and to reap the hung network processes
+# that accumulate along the way (the same class fleet-net.sh's timeout guard
+# bounds inside daemons, but that guard can't cover ad-hoc/human sessions).
+#
+# Usage:
+#   fleet-net-doctor              report socket/port pressure + hung processes
+#   fleet-net-doctor --kill-hung  also kill git/ssh-to-github/gh processes
+#                                 older than HUNG_MINUTES (default 30)
+#
+# Exit codes:
+#   0 = OK        1 = WARN (zombie pressure building)
+#   2 = CRITICAL  (ports nearly/fully exhausted or reaper wedged — reboot)
+#
+# Env (all optional; the FLEET_NET_DOCTOR_* ones are test seams):
+#   HUNG_MINUTES                  age threshold for the hung-process scan (30)
+#   FLEET_NET_DOCTOR_WARN_ZOMBIES zombie-socket WARN threshold (4000)
+#   FLEET_NET_DOCTOR_CRIT_FREE    free-ephemeral-port CRITICAL floor (1000)
+#   FLEET_NET_DOCTOR_PROBE_SECS   reaper-probe wait; TIME_WAIT drains in
+#                                 2*MSL=30s on macOS, so 12s shows movement (12)
+#   FLEET_NET_DOCTOR_OS           override `uname -s` (test seam)
+#   FLEET_NET_DOCTOR_PORT_RANGE   override the range as "first last" (test seam)
+
+set -u
+
+HUNG_MINUTES="${HUNG_MINUTES:-30}"
+WARN_ZOMBIES="${FLEET_NET_DOCTOR_WARN_ZOMBIES:-4000}"
+CRIT_FREE="${FLEET_NET_DOCTOR_CRIT_FREE:-1000}"
+PROBE_SECS="${FLEET_NET_DOCTOR_PROBE_SECS:-12}"
+HOST_OS="${FLEET_NET_DOCTOR_OS:-$(uname -s)}"
+
+kill_hung=0
+case "${1:-}" in
+    --kill-hung) kill_hung=1 ;;
+    -h|--help) sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    "") ;;
+    *) echo "fleet-net-doctor: unknown option: $1 (try --help)" >&2; exit 64 ;;
+esac
+
+# Normalized socket census: one "STATE PORT" line per TCP socket, where PORT
+# is the local port. State spellings are canonicalized to the BSD names
+# (TIME_WAIT, FIN_WAIT_1, LAST_ACK) on every OS.
+socket_dump() {
+    case "$HOST_OS" in
+        Darwin)
+            netstat -an -p tcp 2>/dev/null \
+                | awk '$1 ~ /^tcp/ {n=split($4,a,"."); print $6, a[n]}'
+            ;;
+        Linux)
+            ss -H -tan 2>/dev/null \
+                | awk '{st=toupper($1); gsub("-","_",st);
+                        if (st=="ESTAB") st="ESTABLISHED";
+                        n=split($4,a,":"); print st, a[n]}'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Ephemeral port range as "first last".
+port_range() {
+    if [[ -n "${FLEET_NET_DOCTOR_PORT_RANGE:-}" ]]; then
+        echo "$FLEET_NET_DOCTOR_PORT_RANGE"
+        return 0
+    fi
+    case "$HOST_OS" in
+        Darwin)
+            echo "$(sysctl -n net.inet.ip.portrange.first 2>/dev/null || echo 49152)" \
+                 "$(sysctl -n net.inet.ip.portrange.last 2>/dev/null || echo 65535)"
+            ;;
+        Linux)
+            awk '{print $1, $2}' /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null \
+                || echo "32768 60999"
+            ;;
+    esac
+}
+
+echo "== fleet-net-doctor $(date '+%Y-%m-%d %H:%M:%S') =="
+
+dump=$(socket_dump) || { echo "unsupported host OS '$HOST_OS' — nothing to check"; exit 0; }
+read -r range_first range_last <<<"$(port_range)"
+range_size=$((range_last - range_first + 1))
+
+count_state() { printf '%s\n' "$dump" | grep -c "^$1 " || true; }
+tw=$(count_state TIME_WAIT)
+fw=$(count_state FIN_WAIT_1)
+la=$(count_state LAST_ACK)
+zombies=$((tw + fw + la))
+ports_used=$(printf '%s\n' "$dump" \
+    | awk -v lo="$range_first" '{if ($2+0>=lo) print $2}' | sort -u | wc -l | tr -d ' ')
+ports_free=$((range_size - ports_used))
+
+echo "zombie sockets:      $zombies (TIME_WAIT=$tw FIN_WAIT_1=$fw LAST_ACK=$la)"
+echo "ephemeral ports use: $ports_used / $range_size ($range_first-$range_last)"
+
+# Reaper probe — TIME_WAIT should visibly drain within 2*MSL when the kernel
+# is healthy. A count that does not drop while pressure is high means the PCB
+# reaper is wedged and the zombies will never expire on their own.
+frozen=""
+if (( tw > WARN_ZOMBIES )); then
+    sleep "$PROBE_SECS"
+    tw2=$(socket_dump | grep -c '^TIME_WAIT ' || true)
+    if (( tw2 >= tw )); then
+        frozen=yes
+        echo "REAPER: TIME_WAIT not draining ($tw -> $tw2 over ${PROBE_SECS}s) — kernel PCB reaper looks wedged; only a reboot reclaims these sockets."
+    else
+        echo "REAPER: draining ($tw -> $tw2 over ${PROBE_SECS}s) — churn is high but the kernel is keeping up."
+    fi
+fi
+
+# Hung network processes: git network verbs, ssh sessions to github.com, and
+# gh CLI calls older than HUNG_MINUTES. The gh alternative deliberately
+# matches "<sep>gh <subcommand> " so bare `gh issue list …` from ps (where the
+# command column follows pid/etime, i.e. mid-line) is caught — an anchored
+# `^gh` never fires there.
+hung_pids=()
+while IFS= read -r line; do
+    pid=$(printf '%s' "$line" | awk '{print $1}')
+    etime=$(printf '%s' "$line" | awk '{print $2}')
+    # ps etime formats: MM:SS, HH:MM:SS, D-HH:MM:SS. Force base 10 — a
+    # zero-padded field ("08") is otherwise parsed as (invalid) octal.
+    case "$etime" in
+        *-*)   mins=99999 ;;
+        *:*:*) mins=$(( 10#${etime%%:*} * 60 )) ;;
+        *)     mins=$(( 10#${etime%%:*} )) ;;
+    esac
+    if (( mins >= HUNG_MINUTES )); then
+        hung_pids+=("$pid")
+        echo "HUNG (${etime}): $(printf '%s' "$line" | cut -c1-160)"
+    fi
+done < <(ps -axo pid=,etime=,command= 2>/dev/null \
+    | grep -E '(git (fetch|push|pull|ls-remote|index-pack|upload-pack)|ssh .*git@github\.com|( |/)gh (pr|issue|api|repo|search) )' \
+    | grep -vE 'grep|fleet-net-doctor')
+
+if (( ${#hung_pids[@]} == 0 )); then
+    echo "hung processes:      none older than ${HUNG_MINUTES}m"
+elif (( kill_hung )); then
+    echo "killing ${#hung_pids[@]} hung process(es): ${hung_pids[*]}"
+    kill "${hung_pids[@]}" 2>/dev/null
+    sleep 3
+    for p in "${hung_pids[@]}"; do
+        kill -0 "$p" 2>/dev/null && kill -9 "$p" 2>/dev/null
+    done
+else
+    echo "hung processes:      ${#hung_pids[@]} found — rerun with --kill-hung to reap"
+fi
+
+if (( ports_free < CRIT_FREE )) || [[ -n "$frozen" ]]; then
+    echo "VERDICT: CRITICAL — ephemeral ports at $ports_used/$range_size${frozen:+, reaper wedged}. New outbound connections fail with EADDRNOTAVAIL; reboot to reclaim."
+    exit 2
+elif (( zombies > WARN_ZOMBIES )); then
+    echo "VERDICT: WARN — zombie-socket pressure building ($zombies). Watch for growth; consider pausing fleet polling loops."
+    exit 1
+fi
+echo "VERDICT: OK"
+exit 0

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -165,6 +165,8 @@ FLEET_CLONE_FRESHNESS_SRC="$SCRIPT_DIR/fleet-clone-freshness.sh"
 FLEET_CLONE_FRESHNESS_DEST="$HOME/bin/fleet-clone-freshness.sh"
 FLEET_NET_SRC="$SCRIPT_DIR/fleet-net.sh"
 FLEET_NET_DEST="$HOME/bin/fleet-net.sh"
+FLEET_NET_DOCTOR_SRC="$SCRIPT_DIR/fleet-net-doctor"
+FLEET_NET_DOCTOR_DEST="$HOME/bin/fleet-net-doctor"
 # timeout-shim.py installs as ~/bin/timeout ONLY when the host has no coreutils
 # timeout/gtimeout (host-protection section, step c) — declared here so the
 # chmod loop keeps it executable; its symlink is conditional, not in Step 1.
@@ -263,7 +265,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_COMMON_SRC" "$FLEET_CLONE_FRESHNESS_SRC" "$FLEET_NET_SRC" "$TIMEOUT_SHIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_TRANSITION_SRC" "$FLEET_REVIEW_VERDICT_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_PR_CLEAR_SRC" "$FLEET_PR_CLAIM_FEEDBACK_SRC" "$FLEET_PR_DETACH_SRC" "$FLEET_PR_AMEND_SRC" "$FLEET_ISSUE_SRC" "$FLEET_GH_POLL_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_GATE_STATUS_SRC" "$FLEET_QUEUE_INGEST_SRC" "$FLEET_PLAN_LINT_SRC" "$FLEET_QUEUE_LIST_SRC" "$FLEET_RECONCILE_AMENDMENTS_SRC" "$FLEET_ITERATION_SUMMARY_SRC" "$FLEET_EDIT_SRC" "$FLEET_NIT_CLOSE_SRC" "$FLEET_VALIDATE_STACK_SRC" "$FLEET_EPIC_STATUS_SRC" "$FLEET_VALIDATE_ROLES_SRC" "$FLEET_ASSERT_WT_SRC" "$WITNESS_SRC" "$SOLO_ARCHITECT_SRC" "$FLEET_REBASE_SRC" "$FLEET_GH_TOKEN_SRC" "$FLEET_SESSION_TRACK_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_COMMON_SRC" "$FLEET_CLONE_FRESHNESS_SRC" "$FLEET_NET_SRC" "$FLEET_NET_DOCTOR_SRC" "$TIMEOUT_SHIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_TRANSITION_SRC" "$FLEET_REVIEW_VERDICT_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_PR_CLEAR_SRC" "$FLEET_PR_CLAIM_FEEDBACK_SRC" "$FLEET_PR_DETACH_SRC" "$FLEET_PR_AMEND_SRC" "$FLEET_ISSUE_SRC" "$FLEET_GH_POLL_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_GATE_STATUS_SRC" "$FLEET_QUEUE_INGEST_SRC" "$FLEET_PLAN_LINT_SRC" "$FLEET_QUEUE_LIST_SRC" "$FLEET_RECONCILE_AMENDMENTS_SRC" "$FLEET_ITERATION_SUMMARY_SRC" "$FLEET_EDIT_SRC" "$FLEET_NIT_CLOSE_SRC" "$FLEET_VALIDATE_STACK_SRC" "$FLEET_EPIC_STATUS_SRC" "$FLEET_VALIDATE_ROLES_SRC" "$FLEET_ASSERT_WT_SRC" "$WITNESS_SRC" "$SOLO_ARCHITECT_SRC" "$FLEET_REBASE_SRC" "$FLEET_GH_TOKEN_SRC" "$FLEET_SESSION_TRACK_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -306,6 +308,11 @@ fi
 if [[ -f "$FLEET_NET_SRC" ]]; then
     ln -sf "$FLEET_NET_SRC" "$FLEET_NET_DEST"
     echo "symlinked $FLEET_NET_DEST -> $FLEET_NET_SRC"
+fi
+
+if [[ -f "$FLEET_NET_DOCTOR_SRC" ]]; then
+    ln -sf "$FLEET_NET_DOCTOR_SRC" "$FLEET_NET_DOCTOR_DEST"
+    echo "symlinked $FLEET_NET_DOCTOR_DEST -> $FLEET_NET_DOCTOR_SRC"
 fi
 
 if [[ -f "$FLEET_BUILD_SRC" ]]; then
@@ -733,6 +740,40 @@ if ((INSTALL_APPEND_SSH_CONFIG)); then
     fi
 else
     echo "note: skipped ~/.ssh/config (--no-ssh-config or IRREDEN_INSTALL_SKIP_SSH_CONFIG)."
+fi
+
+# (a2) ssh connection multiplexing for github.com — the fleet's git-over-ssh
+# churn (a fresh TCP dial per operation, thousands/day) leaks a TIME_WAIT
+# socket per dial; on a host whose kernel PCB reaper wedges (2026-07-15
+# incident: macOS, 85-day uptime) the leak exhausts the entire ephemeral port
+# range and EVERY new outbound connection fails with EADDRNOTAVAIL. One
+# persistent master connection drops that churn to ~zero. Appended as its own
+# marked block: ssh config is first-match-wins PER PARAMETER, so this composes
+# with any earlier github.com block — options the user (or stanza (a)) already
+# set win, and only the unset Control* options are picked up from here. If the
+# master itself black-holes, stanza (a)'s keepalives kill it in ~60s and the
+# next git op re-dials. Diagnose pressure anytime with `fleet-net-doctor`.
+SSH_MUX_MARKER="# IRREDEN_ENGINE: github.com ssh connection multiplexing (install.sh)"
+if ((INSTALL_APPEND_SSH_CONFIG)); then
+    if [[ -f "$SSH_CONFIG" ]] && grep -qF "$SSH_MUX_MARKER" "$SSH_CONFIG" 2>/dev/null; then
+        echo "note: github.com ssh multiplexing already present in $SSH_CONFIG (marker unchanged)."
+    elif ssh -G github.com 2>/dev/null | grep -qi '^controlmaster auto'; then
+        echo "note: github.com already resolves ControlMaster auto (user-owned config) — leaving it alone."
+    else
+        ( umask 077; mkdir -p "$HOME/.ssh"; [[ -e "$SSH_CONFIG" ]] || : > "$SSH_CONFIG" ) 2>/dev/null || true
+        if {
+            echo ""
+            echo "$SSH_MUX_MARKER"
+            echo "Host github.com"
+            echo "    ControlMaster auto"
+            echo "    ControlPath ~/.ssh/cm-%r@%h:%p"
+            echo "    ControlPersist 10m"
+        } >>"$SSH_CONFIG" 2>/dev/null; then
+            echo "appended github.com ssh connection multiplexing to $SSH_CONFIG"
+        else
+            echo "install.sh: could not write $SSH_CONFIG — add ControlMaster auto / ControlPersist 10m for Host github.com manually." >&2
+        fi
+    fi
 fi
 
 # (b) Bound git-over-HTTPS: abort a transfer stalled below 1000 B/s for 60s.

--- a/scripts/fleet/tests/test_fleet_net_doctor.sh
+++ b/scripts/fleet/tests/test_fleet_net_doctor.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Tests for fleet-net-doctor (socket/ephemeral-port pressure diagnostics).
+#
+# Hermetic: netstat / ss / sysctl / ps / sleep are PATH-shimmed to fixture
+# readers — no live socket tables, no live processes, no real waiting. The
+# netstat shim counts invocations so the reaper probe's second census can
+# serve a different fixture (draining vs frozen).
+#
+# Covers:
+#   - healthy census → VERDICT: OK, exit 0
+#   - high zombies + draining second census → WARN, exit 1
+#   - high zombies + frozen second census → CRITICAL (reaper wedged), exit 2
+#   - free ephemeral ports below the floor → CRITICAL, exit 2
+#   - hung-process scan: day-old etime + mid-line `gh issue` match (the
+#     anchored-^gh regression), fresh process NOT flagged, zero-padded etime
+#     ("08:23") parsed as base 10
+#   - Linux ss spelling normalization (TIME-WAIT → TIME_WAIT)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DOCTOR="$SCRIPT_DIR/fleet-net-doctor"
+source "$(dirname "$0")/lib_assert.sh"
+
+if [[ ! -x "$DOCTOR" ]]; then
+    echo "test setup: fleet-net-doctor not found at $DOCTOR" >&2
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+SHIM="$TMP/bin"
+FIX="$TMP/fix"
+mkdir -p "$SHIM" "$FIX"
+
+# --- PATH shims ---------------------------------------------------------------
+# netstat: serves $FIX/netstat.out; from the 2nd call on, serves
+# $FIX/netstat2.out when present (reaper-probe recount).
+cat >"$SHIM/netstat" <<EOF
+#!/usr/bin/env bash
+count_file="$FIX/.netstat-calls"
+n=\$(cat "\$count_file" 2>/dev/null || echo 0)
+echo \$((n + 1)) >"\$count_file"
+if (( n + 1 >= 2 )) && [[ -f "$FIX/netstat2.out" ]]; then
+    cat "$FIX/netstat2.out"
+else
+    cat "$FIX/netstat.out"
+fi
+EOF
+cat >"$SHIM/ss" <<EOF
+#!/usr/bin/env bash
+cat "$FIX/ss.out"
+EOF
+cat >"$SHIM/ps" <<EOF
+#!/usr/bin/env bash
+cat "$FIX/ps.out"
+EOF
+printf '#!/usr/bin/env bash\nexit 0\n' >"$SHIM/sleep"
+printf '#!/usr/bin/env bash\necho 0\n' >"$SHIM/sysctl"
+chmod +x "$SHIM"/*
+export PATH="$SHIM:$PATH"
+
+# Deterministic knobs for every case; individual tests override as needed.
+export FLEET_NET_DOCTOR_OS=Darwin
+export FLEET_NET_DOCTOR_PORT_RANGE="49152 65535"
+export FLEET_NET_DOCTOR_PROBE_SECS=0
+export FLEET_NET_DOCTOR_WARN_ZOMBIES=4000
+export FLEET_NET_DOCTOR_CRIT_FREE=1000
+export HUNG_MINUTES=30
+
+# macOS netstat line for a local socket in STATE with local port PORT.
+ns_line() {
+    printf 'tcp4       0      0  192.168.1.5.%s      140.82.116.3.443       %s\n' "$2" "$1"
+}
+
+reset_calls() { rm -f "$FIX/.netstat-calls" "$FIX/netstat2.out"; }
+
+# --- T1: healthy census → OK -------------------------------------------------
+echo "T1: healthy census"
+reset_calls
+{
+    echo "Active Internet connections (including servers)"
+    echo "Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)"
+    ns_line ESTABLISHED 50001
+    ns_line TIME_WAIT 50002
+} >"$FIX/netstat.out"
+: >"$FIX/ps.out"
+rc=0; out=$("$DOCTOR") || rc=$?
+assert_eq "$rc" "0" "exit 0 when healthy"
+assert_contains "$out" "VERDICT: OK" "verdict OK"
+assert_contains "$out" "zombie sockets:      1 (TIME_WAIT=1 FIN_WAIT_1=0 LAST_ACK=0)" "state census"
+assert_contains "$out" "none older than 30m" "no hung processes"
+
+# --- T2: high zombies, second census drains → WARN ---------------------------
+echo "T2: zombie pressure, reaper draining"
+reset_calls
+{ ns_line TIME_WAIT 50001; ns_line TIME_WAIT 50002; ns_line TIME_WAIT 50003; } >"$FIX/netstat.out"
+{ ns_line TIME_WAIT 50001; } >"$FIX/netstat2.out"
+rc=0; out=$(FLEET_NET_DOCTOR_WARN_ZOMBIES=2 "$DOCTOR") || rc=$?
+assert_eq "$rc" "1" "exit 1 on WARN"
+assert_contains "$out" "REAPER: draining (3 -> 1" "probe sees the drain"
+assert_contains "$out" "VERDICT: WARN" "verdict WARN"
+
+# --- T3: high zombies, second census frozen → CRITICAL ------------------------
+echo "T3: zombie pressure, reaper wedged"
+reset_calls
+{ ns_line TIME_WAIT 50001; ns_line TIME_WAIT 50002; ns_line TIME_WAIT 50003; } >"$FIX/netstat.out"
+cp "$FIX/netstat.out" "$FIX/netstat2.out"
+rc=0; out=$(FLEET_NET_DOCTOR_WARN_ZOMBIES=2 "$DOCTOR") || rc=$?
+assert_eq "$rc" "2" "exit 2 when reaper is wedged"
+assert_contains "$out" "REAPER: TIME_WAIT not draining (3 -> 3" "probe sees the freeze"
+assert_contains "$out" "reaper wedged" "critical verdict names the wedge"
+
+# --- T4: free ports below the floor → CRITICAL --------------------------------
+echo "T4: ephemeral ports nearly exhausted"
+reset_calls
+{ ns_line ESTABLISHED 49152; ns_line ESTABLISHED 49153; ns_line ESTABLISHED 49154; } >"$FIX/netstat.out"
+# Range of 5 ports, 3 used, floor of 3 → free (2) < floor → CRITICAL.
+rc=0; out=$(FLEET_NET_DOCTOR_PORT_RANGE="49152 49156" FLEET_NET_DOCTOR_CRIT_FREE=3 "$DOCTOR") || rc=$?
+assert_eq "$rc" "2" "exit 2 on port exhaustion"
+assert_contains "$out" "ephemeral ports use: 3 / 5" "port census"
+assert_contains "$out" "EADDRNOTAVAIL" "verdict names the failure signature"
+
+# --- T5: hung-process scan ----------------------------------------------------
+echo "T5: hung git/ssh/gh processes"
+reset_calls
+{ ns_line ESTABLISHED 50001; } >"$FIX/netstat.out"
+cat >"$FIX/ps.out" <<'EOF'
+67734 05-18:38:42 /opt/homebrew/opt/git/libexec/git-core/git fetch --update-head-ok origin HEAD
+92844 02-20:30:56 /usr/bin/ssh -o SendEnv=GIT_PROTOCOL git@github.com git-upload-pack 'jakildev/IrredenEngine.git'
+71980 08:23:00 gh issue list --repo jakildev/IrredenEngine --state open --label fleet:needs-plan
+50000 00:29 git fetch origin master
+EOF
+rc=0; out=$("$DOCTOR") || rc=$?
+assert_eq "$rc" "0" "hung processes alone do not change the verdict"
+assert_contains "$out" "HUNG (05-18:38:42): 67734" "day-old git fetch flagged"
+assert_contains "$out" "HUNG (02-20:30:56): 92844" "old ssh-to-github flagged"
+assert_contains "$out" "HUNG (08:23:00): 71980" "mid-line gh call flagged (zero-padded etime)"
+assert_absent "$out" "HUNG (00:29)" "fresh process not flagged"
+assert_contains "$out" "3 found — rerun with --kill-hung to reap" "reap hint with count"
+
+# --- T6: Linux ss spelling normalization ---------------------------------------
+echo "T6: Linux census via ss"
+reset_calls
+: >"$FIX/ps.out"
+cat >"$FIX/ss.out" <<'EOF'
+TIME-WAIT  0 0 10.0.0.2:50001 140.82.116.3:443
+FIN-WAIT-1 0 0 10.0.0.2:50002 140.82.116.3:443
+LAST-ACK   0 0 10.0.0.2:50003 140.82.116.3:443
+ESTAB      0 0 10.0.0.2:50004 140.82.116.3:443
+EOF
+rc=0; out=$(FLEET_NET_DOCTOR_OS=Linux "$DOCTOR") || rc=$?
+assert_eq "$rc" "0" "exit 0 (below thresholds)"
+assert_contains "$out" "(TIME_WAIT=1 FIN_WAIT_1=1 LAST_ACK=1)" "ss states normalized to BSD names"
+
+summarize "fleet-net-doctor tests"

--- a/scripts/fleet/tests/test_fleet_net_doctor.sh
+++ b/scripts/fleet/tests/test_fleet_net_doctor.sh
@@ -153,4 +153,22 @@ rc=0; out=$(FLEET_NET_DOCTOR_OS=Linux "$DOCTOR") || rc=$?
 assert_eq "$rc" "0" "exit 0 (below thresholds)"
 assert_contains "$out" "(TIME_WAIT=1 FIN_WAIT_1=1 LAST_ACK=1)" "ss states normalized to BSD names"
 
+# --- T7: --help prints only the usage/env doc block, no code lines --------------
+echo "T7: --help output range"
+help_out=$("$DOCTOR" --help)
+assert_absent "$help_out" "set -u" "help text excludes the code that follows the header"
+assert_absent "$help_out" "HUNG_MINUTES=\"" "help text excludes the HUNG_MINUTES assignment"
+assert_contains "$help_out" "FLEET_NET_DOCTOR_PORT_RANGE" "help text still includes the last env doc line"
+
+# --- T8: HUNG_MINUTES above 60 crosses an HH:MM:SS threshold --------------------
+echo "T8: hung-process scan with HUNG_MINUTES raised past an hour"
+reset_calls
+{ ns_line ESTABLISHED 50001; } >"$FIX/netstat.out"
+cat >"$FIX/ps.out" <<'EOF'
+71980 01:45:00 gh issue list --repo jakildev/IrredenEngine --state open --label fleet:needs-plan
+EOF
+rc=0; out=$(HUNG_MINUTES=90 "$DOCTOR") || rc=$?
+assert_eq "$rc" "0" "hung processes alone do not change the verdict"
+assert_contains "$out" "HUNG (01:45:00): 71980" "01:45:00 (105m) crosses a 90m threshold"
+
 summarize "fleet-net-doctor tests"


### PR DESCRIPTION
## Summary
- New `scripts/fleet/fleet-net-doctor`: TCP socket / ephemeral-port pressure report with a reaper-drain probe, hung git/ssh-to-github/gh process scan (`--kill-hung` to reap), and OK/WARN/CRITICAL exit codes (0/1/2) for use in fleet loops. Darwin (`netstat`) and Linux (`ss`) censuses normalized to one format.
- `install.sh`: registry wiring for the new tool (var pair + chmod + symlink), plus a new host-protection stanza (a2) that appends a marked `ControlMaster auto` / `ControlPersist 10m` block for `Host github.com` — one persistent ssh master drops the fleet's per-git-op TCP dial churn to ~zero. Marker- and `ssh -G`-guarded so user-owned multiplexing is left alone; composes per-parameter with the existing keepalive stanza (a), whose keepalives bound a black-holed master to ~60s.
- `fleet-help`: index entry + `--help` passthrough arm.
- `scripts/fleet/CLAUDE.md`: documents the escalated form of #2362 — host-wide `EADDRNOTAVAIL` is ephemeral-port exhaustion, not GitHub downtime; run `fleet-net-doctor`.
- Hermetic test suite `tests/test_fleet_net_doctor.sh` (21 assertions).

## Why
Incident 2026-07-15 (macOS fleet host, 85-day uptime): the kernel PCB reaper wedged, ~30k sockets froze in TIME_WAIT/FIN_WAIT_1/LAST_ACK, and all 16,384 ephemeral ports were consumed — every new outbound connection (git, gh, ssh) failed instantly with `EADDRNOTAVAIL` until a reboot. The feeder was the fleet's own connection churn (a fresh TCP dial per git-over-ssh op and per gh call); the recurring GitHub "black-hole" hangs (#2362) were early symptoms of the same progressive exhaustion. This PR reduces the churn at the source and makes the pressure visible long before the cliff.

## Test plan
- [x] `scripts/fleet/tests/test_fleet_net_doctor.sh` — 21/21 pass (netstat/ss/ps/sleep PATH-shimmed; covers OK / WARN-draining / CRITICAL-frozen / CRITICAL-ports verdicts, hung-process scan incl. mid-line `gh issue` match + zero-padded etime, Linux `ss` state normalization)
- [x] `bash -n` on `fleet-net-doctor` + `install.sh`
- [x] Live validation on the incident host: correctly reported CRITICAL (16,383/16,384 ports, frozen reaper, 15 hung processes) pre-reboot and OK (196/16,384) post-reboot
- [x] `ssh -G github.com` resolves `controlmaster auto` / `controlpersist 600` with the appended block
- [ ] Reviewer: sanity-check the install.sh (a2) guard ordering (marker → `ssh -G` probe → append)

## Notes for reviewer
gh CLI churn (HTTPS, one connection per invocation) cannot be multiplexed — the doctor's WARN threshold is the guard for that side. Nothing here can unwedge a stuck kernel reaper; exit 2 means reboot the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)