### PR TITLE
docs: test/CLAUDE.md — suite layout + per-surface coverage bar (#2444)

### DIFF
--- a/.fleet/plans/issue-2444.md
+++ b/.fleet/plans/issue-2444.md
@@ -1,0 +1,152 @@
+## Plan: review/test policy — per-new-public-surface coverage + test/CLAUDE.md
+
+- **Issue:** #2444
+- **Model:** sonnet — docs/checklist work, fully bounded: the exact checklist
+  replacement text is supplied below and the doc's content spec is enumerated.
+- **Date:** 2026-07-15
+
+### Scope
+
+Two deliverables, split by the self-config gate:
+
+1. `test/CLAUDE.md` (new) — suite layout + per-surface authoring expectation.
+   **Worker-executable**; ships as the PR.
+2. The `review-pr` SKILL.md §Tests/build reword. `.claude/skills/**/SKILL.md`
+   is gated self-config — the auto-mode gate physically blocks every worker
+   class from pushing it (fleet-labels-reference § `fleet:gated`; all prior
+   checklist edits landed via human-cued batches: #2399, #2268, #1733).
+   **Human-applied**: the worker posts the exact edit (verbatim from
+   § Gated half below) as an issue comment and parks this issue
+   `fleet:needs-human`.
+
+### Verified current state (master @ b622bb54)
+
+- `.claude/skills/review-pr/SKILL.md:145` still reads "New feature with no
+  new test at all (flag as needs-fix unless the user explicitly said 'no
+  tests')" — the per-PR wording the issue targets.
+- `test/CLAUDE.md` is absent.
+- The #2425 worked example **still holds post-merge**:
+  `test/system/system_cadence_test.cpp` has 13 tests and zero
+  `kCadence`/`kCadenceOffset` references, so the `System<N>` spec-member
+  detection path (`engine/system/include/irreden/ir_system.hpp:325-336`) is
+  uncovered; the four Lua bindings `IRSystem.setSystemCadence` /
+  `getSystemCadence` / `setSystemCadenceOffset` / `getSystemCadenceOffset`
+  (`engine/script/include/irreden/script/lua_pipeline_bindings.hpp:356-382`)
+  have no coverage anywhere under `test/script/`.
+- **Count correction:** the issue body says 19 precedent files; master has
+  **17** `test/script/lua_*_test.cpp`. Use 17.
+- Suite mechanics (for the doc): single `add_executable(IrredenEngineTest …)`
+  in `test/CMakeLists.txt` with an explicit per-area source list (a new test
+  file does not build until registered there); `gtest_discover_tests`
+  registers per-test CTest entries; Lua fixtures live at `test/script/*.lua`
+  and are wired through `irreden_lua_codegen(IrredenEngineTest …)` blocks.
+- Sibling/in-flight check: the only open engine PR (#2393) is render-only —
+  no overlap with `test/` or the skill file.
+- No phase-0 probe needed: every premise above is a static source fact,
+  verified against master at planning time (no measurable-mechanism claim).
+
+### Approach
+
+1. Branch off master; commit this plan as `.fleet/plans/issue-2444.md`
+   (first commit, per #1932).
+2. Author `test/CLAUDE.md` covering, in order:
+   - **Target**: all tests compile into the single `IrredenEngineTest`
+     executable; `gtest_discover_tests` handles CTest registration.
+   - **Layout**: per-area subdirectories mirroring engine modules (asset,
+     audio, common, ecs, job, math, render, script, system, time, tools,
+     utility, world); new engine functionality lands with tests in the
+     matching subdirectory.
+   - **Registration**: add the new `.cpp` to the explicit source list in
+     `test/CMakeLists.txt` (grouped by area) — unregistered files silently
+     don't build.
+   - **Lua fixture pattern**: `test/script/*.lua` fixtures +
+     `lua_*_test.cpp` exercising the sol2 seam (17 precedent files);
+     codegen fixtures wired via `irreden_lua_codegen`.
+   - **Filtered runs**: build with `fleet-build --target IrredenEngineTest`,
+     run a subset with `--gtest_filter=<pattern>` through `fleet-run`.
+     Verify the documented command by running it once; paste the output
+     line in the PR body.
+   - **Authoring expectation**: coverage is per new public surface — each
+     new Lua binding, each registration path when a facility has two
+     (free-function params AND `System<N>` spec-member detection), each new
+     public API — with the #2425 cadence gap as the worked example.
+   Keep it tight (aim under ~100 lines) per CLAUDE-BASELINE's rules for
+   what belongs in a `CLAUDE.md`.
+3. Open the PR via `commit-and-push`. PR body says **"Part of #2444"** —
+   NOT `Closes` — the gated half stays open behind it.
+4. After the PR is open: post the § Gated half block below verbatim as a
+   comment on #2444, then park the issue for the human:
+   `gh issue edit 2444 --remove-label fleet:queued --add-label fleet:needs-human`
+   (keep `human:approved`), and release the claim. The human pastes the
+   edit, lands it through their own lane, and closes the issue.
+
+### Gated half — ready-to-apply §Tests/build edit (human applies)
+
+In `.claude/skills/review-pr/SKILL.md`, replace this bullet (lines 145-146):
+
+```
+- New feature with no new test at all (flag as needs-fix unless the user
+  explicitly said "no tests").
+```
+
+with:
+
+```
+- New public surface with no covering test — coverage is per **new public
+  surface**, not per PR. "A new test exists" does not satisfy this: a PR
+  that tests one surface while shipping others uncovered gets needs-fix on
+  the uncovered surfaces. Per surface the diff adds, expect:
+  - a new Lua binding → a `test/script/lua_*_test.cpp` exercising the sol2
+    seam (17 existing files set the precedent);
+  - a facility with two registration paths (e.g. free-function params AND
+    `System<N>` spec-member detection) → a test through **each** path;
+  - other new public surface (`ir_*.hpp` API, component/system, serialized
+    format) → a test in the matching `test/<area>/` subdirectory.
+  Worked example (#2425, per-system cadence): 13 SystemManager tests
+  shipped, but the `IRSystem.*Cadence*` Lua bindings and the
+  `kCadence`/`kCadenceOffset` spec-member detection path shipped with zero
+  coverage — under this wording each uncovered surface is mechanically
+  flaggable even though "a new test" existed. Suite layout + authoring
+  expectations: `test/CLAUDE.md`.
+  The "no tests" waiver stays human-explicit (the user literally said "no
+  tests"); never infer it.
+```
+
+### Affected files
+
+- `test/CLAUDE.md` — new; suite doc per Approach step 2.
+- `.fleet/plans/issue-2444.md` — new; this plan, first commit of the PR.
+- `.claude/skills/review-pr/SKILL.md` — §Tests/build bullet swap;
+  **human-applied, never part of the worker PR** (gated self-config).
+
+### Acceptance criteria
+
+- [ ] `test/CLAUDE.md` merged covering target / layout / CMake registration /
+      Lua fixture pattern / filtered-run command / per-surface authoring
+      expectation, with the #2425 gap cited as the worked example.
+- [ ] The documented filtered-run command was actually executed once and its
+      output shown in the PR body (positive-fire: the named check runs and
+      reports tests, not just "docs look right").
+- [ ] The § Gated half block posted verbatim as a comment on #2444; issue
+      parked `fleet:needs-human` (with `human:approved` kept) after the PR
+      opened; claim released.
+- [ ] PR body uses "Part of #2444", not "Closes" — the issue closes only
+      when the human lands the SKILL.md edit (acceptance box 1 of the issue
+      body is theirs).
+- [ ] Under the new wording, both #2425 gaps (Lua cadence bindings;
+      spec-member path) are mechanically flaggable — the worked example in
+      the checklist text names them explicitly.
+
+### Gotchas
+
+- **Do not attempt to edit or commit `.claude/skills/review-pr/SKILL.md`.**
+  The self-modification gate blocks the write for every worker class —
+  attempting it burns the iteration (role-worker step 8b). The comment +
+  `fleet:needs-human` park is the sanctioned handoff.
+- Park the issue only **after** the PR is open, or ingest/scope-shipped
+  churn can re-queue a half-done state.
+- Keep `human:approved` when parking — it is the human's durable signal.
+- Use the verified count (17), not the issue body's 19.
+- The plan and PR are engine-public: engine terminology only.
+- New test files need explicit registration in `test/CMakeLists.txt` —
+  document that in the CLAUDE.md; it is the most common authoring miss.

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -1,0 +1,112 @@
+# test/ — the engine's GoogleTest suite
+
+Every test in this tree compiles into a **single** `IrredenEngineTest`
+executable that links the whole `IrredenEngine` library plus `gtest_main`.
+There is no per-module test target: a test can reach any engine header, and
+`gtest_discover_tests` registers each test individually with CTest.
+
+## New test files must be registered by hand
+
+`test/CMakeLists.txt` lists every source explicitly in the
+`add_executable(IrredenEngineTest ...)` block — there is no glob. **A new
+`.cpp` that isn't added to that list silently does not build**: no error, no
+warning, and your tests simply never run. This is the most common authoring
+miss in this tree; it looks exactly like a passing suite.
+
+Add the file to the list under the group matching its directory.
+
+## Where a test goes
+
+Tests live in `test/<area>/`, where `<area>` mirrors the engine module under
+test (`engine/math/` → `test/math/`, `engine/script/` → `test/script/`, and
+so on). New engine functionality lands with its tests in the matching
+subdirectory — reach for `Glob` to see the current set rather than trusting a
+list here.
+
+## Build and run
+
+```bash
+fleet-build --target IrredenEngineTest
+fleet-run IrredenEngineTest                                  # whole suite
+fleet-run IrredenEngineTest --gtest_filter='SystemCadenceTest.*'   # one suite
+```
+
+`--gtest_filter` takes a `Suite.Test` glob, so `--gtest_filter='*Cadence*'`
+narrows by substring across suites. Prefer a filtered run while iterating —
+the full suite links and boots every engine subsystem.
+
+## Coverage is per new public surface, not per PR
+
+Author coverage **per new public surface the diff adds**, not per PR. "The PR
+has a test" is not the bar: a change that covers one surface while shipping
+others bare is expected back with `needs-fix` on the uncovered ones (the
+`Tests / build` checklist in `.claude/skills/review-pr/SKILL.md` is where this
+is enforced at review). Per surface, that means:
+
+- a new Lua binding → a `test/script/lua_*_test.cpp` exercising the sol2 seam;
+- a facility with two registration paths → a test through **each** path;
+- other new public surface (`ir_*.hpp` API, component, system, serialized
+  format) → a test in the matching `test/<area>/`.
+
+The waiver is human-explicit — someone literally says "no tests". Never infer
+it.
+
+**Worked example (#2425, per-system cadence).** The change shipped 13 solid
+`SystemManager` tests, and still left two surfaces uncovered: the
+`IRSystem.*Cadence*` Lua bindings, and the `kCadence` / `kCadenceOffset`
+spec-member detection path on `System<N>`. Both are public, both are how
+downstream code actually consumes the feature, and "a new test exists" hid
+them. Count surfaces, not tests.
+
+## Lua seam tests
+
+The C++ API and the Lua binding are **separate surfaces** — a test that drives
+`SystemManager` directly proves nothing about the sol2 seam in front of it.
+Cover the binding by driving Lua:
+
+```cpp
+class MyLuaTest : public testing::Test {
+  protected:
+    MyLuaTest() { m_lua.bindLuaDrivenEcs(); }
+
+    IRScript::LuaScript m_lua;          // declared FIRST → destroyed LAST
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(MyLuaTest, BindingIsReachable) {
+    auto result = m_lua.lua().safe_script(R"lua(
+        return IRSystem.getSystemCadence(0)
+    )lua");
+    ASSERT_TRUE(result.valid());
+}
+```
+
+**Member order is load-bearing.** `LuaScript` must be declared before the
+managers so it is destroyed *last*: `sol::function` references captured in
+dynamic-system bodies call `lua_unref` during manager teardown, which requires
+a still-open `lua_State`. Get the order backwards and you get a crash at
+fixture teardown, not at the assertion.
+
+Scripts run inline via `safe_script` — assert on `result.valid()`, since a Lua
+error otherwise surfaces as a confusing value rather than a failed test. The
+`.lua` files in `test/script/` are **not** the general pattern; they are
+codegen fixtures (see below).
+
+## Codegen fixtures
+
+`test/script/*.lua` fixtures feed the build-time codegen path and are wired
+through `irreden_lua_codegen(IrredenEngineTest SOURCES ... DEFAULT_MODE
+CODEGEN)` blocks in `CMakeLists.txt`. Two constraints there are deliberate:
+
+- **`DEFAULT_MODE CODEGEN` is pinned explicitly**, overriding the
+  `IR_LUA_ECS_DEFAULT_MODE` cache variable. These tests exist to verify the
+  typed-emission path; if the global flag flipped them to EVAL they would
+  silently pass while testing nothing.
+- **Fixture paths reach the test through compile definitions**, never a
+  relative path. The engine `chdir`s to the executable directory at boot but
+  the test binary does not, so a relative fixture path resolves differently
+  under CTest than under a direct run.
+
+See [`engine/script/CLAUDE.md`](../engine/script/CLAUDE.md) for the binding
+surface itself and the CODEGEN-vs-EVAL split.


### PR DESCRIPTION
## Summary
- Adds `test/CLAUDE.md`, documenting the suite's non-obvious contracts: the single `IrredenEngineTest` target, the **explicit** source list (a new `.cpp` that isn't registered in `test/CMakeLists.txt` silently does not build — it reads exactly like a passing suite), where a test goes, the filtered-run command, and the sol2 Lua-seam fixture pattern.
- States the authoring bar as **per new public surface**, not per PR, with #2425 as the worked example.
- Layout is stated as a *rule* (`test/<area>/` mirrors the engine module) rather than a directory listing, per CLAUDE-BASELINE §"What belongs in agent-facing docs" — a listing would go stale and agents can `Glob`.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean.
- [x] Documented filtered-run command executed (acceptance criterion — positive fire, not just "docs look right"):
  ```
  $ fleet-run IrredenEngineTest --gtest_filter='SystemCadenceTest.*'
  [----------] 13 tests from SystemCadenceTest (47 ms total)
  [==========] 13 tests from 1 test suite ran. (47 ms total)
  [  PASSED  ] 13 tests.
  ```
- [x] **The documented Lua fixture example was compiled and run**, not just written: added it verbatim as a scratch test, built, ran (`[ OK ] MyLuaTest.BindingIsReachable`), then removed it. `test/CMakeLists.txt` is untouched in this PR — confirmed identical to master.
- [x] All cited symbols verified to exist: `System<N>` spec-member detection, `IR_LUA_ECS_DEFAULT_MODE`, `irreden_lua_codegen`'s `DEFAULT_MODE`, and the `Tests / build` checklist label.

## Notes for reviewer
**This is `Part of #2444`, not `Closes` — deliberately.** The issue has two halves; only one is worker-executable:

1. **This PR** — `test/CLAUDE.md` (not gated).
2. **The `review-pr` SKILL.md §Tests/build reword** — `.claude/skills/**/SKILL.md` is gated self-config that the auto-mode gate blocks for every worker class. The ready-to-apply edit is posted verbatim as a comment on #2444 and the issue is parked `fleet:needs-human`. The issue closes when the human lands that half.

Consequence worth knowing while reviewing: until the human applies the gated half, the checklist still carries the old per-PR wording. The doc is therefore written to **own** the per-surface rule rather than to assert wording that isn't in the checklist yet.

Two corrections made against the plan/issue during execution, both verified:
- The issue body claims **19** precedent `test/script/lua_*_test.cpp` files; master has **17**. Used 17 (the plan had already caught this).
- The plan describes a "`test/script/*.lua` fixture pattern" for Lua tests. Measured: **16 of 17** Lua tests drive the seam inline via `lua().safe_script(...)`, and only 1 loads a `.lua` file. The 5 `.lua` files are *codegen* fixtures specifically. The doc documents what's actually true, so a worker adding a binding test doesn't think a `.lua` file is required.

Part of #2444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
