### PR TITLE
fleet: derive PR closes-refs at fetch so 304-reuse keeps stack offers

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -238,6 +238,19 @@ def _is_pull_request(issue):
     return "pull_request" in issue
 
 
+# Closes/Fixes/Resolves #N refs parsed from a PR body at fetch time — where the
+# body is still live — into pr["closes_issues"], a bounded sorted int list.
+# enrich_stackable_blocker_prs matches its blocker union's body half on this
+# derived field rather than re-parsing pr["body"], which it may never receive:
+# bodies are popped after enrichment and fetch_prs's 304 fast path reuses the
+# body-stripped prior records, so the live parse was dead on every reuse tick
+# (#2442). Deriving once here keeps the offer and this grammar from drifting.
+CLOSES_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
 def _fetch_prs_graphql(repo):
     out = run_capture([
         "gh", "pr", "list", "--repo", repo, "--state", "open",
@@ -264,6 +277,12 @@ def _fetch_prs_graphql(repo):
             }
             for rev in pr.get("reviews", [])
         ]
+        # Derive here, while body is live, so the signal survives both the
+        # post-enrich body-pop and fetch_prs's 304 reuse of body-stripped
+        # records (#2442). Its presence is also fetch_prs's cache-desync marker.
+        pr["closes_issues"] = sorted(
+            {int(n) for n in CLOSES_RE.findall(pr.get("body", "") or "")}
+        )
     # gh's PR ordering is not stable run-to-run; sort by number so the
     # projection hash stays quiescent when nothing has actually changed.
     prs.sort(key=lambda pr: pr.get("number", 0))
@@ -290,7 +309,14 @@ def fetch_prs(repo, prev=None):
     changed, _body = conditional_get(repo, "pulls", params={
         "state": "open", "sort": "updated", "direction": "desc", "per_page": "100",
     })
-    if not changed and prev is not None:
+    # Reuse the prior list only when it carries the derived closes_issues field
+    # (added by _fetch_prs_graphql). On the first tick after a deploy that
+    # introduced the field, prev predates it — reusing it would re-strand every
+    # Closes-only stack base until an unrelated ETag flip, re-creating #2442. A
+    # missing key ⇒ cache desync ⇒ fall through to a fresh fetch. all() on an
+    # empty prev is True (an empty open-PR set needs no refetch).
+    if (not changed and prev is not None
+            and all("closes_issues" in p for p in prev)):
         return prev
     return _fetch_prs_graphql(repo)
 
@@ -1548,10 +1574,12 @@ def enrich_stackable_blocker_prs(state):
     # `#NNN` by resolve_blocked_by() (runs first), so it reaches here eligible.
     #
     # A PR "matches" the blocker when its head branch is `claude/<NNN>-…` OR its
-    # body Closes/Fixes/Resolves #NNN — the same union fleet-claim's
+    # derived closes_issues (Closes/Fixes/Resolves #NNN, parsed at fetch time —
+    # see CLOSES_RE) contains NNN — the same union fleet-claim's
     # find-stackable-blockers uses, so the scout offers every base the live
     # finder would (the Closes-#N form catches blocker PRs on non-standard /
-    # human branches).
+    # human branches). The Closes half reads the derived field, not pr["body"],
+    # which is body-stripped on 304 reuse ticks (#2442).
     #
     # The field is always omitted when:
     #   - blocked_by doesn't reference exactly one issue (multi-blocker,
@@ -1576,15 +1604,13 @@ def enrich_stackable_blocker_prs(state):
             issue_num = _single_blocker_issue(blocked_by)
             if not issue_num:
                 continue
-            closes_re = re.compile(
-                r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#"
-                + re.escape(issue_num) + r"\b",
-                re.IGNORECASE,
-            )
+            # _single_blocker_issue returns a digit string; closes_issues holds
+            # ints — compare as int so "255" in [255] doesn't silently miss.
+            issue_num_int = int(issue_num)
             matches = [
                 pr for pr in prs
                 if branch_matches_issue(pr.get("headRefName", ""), issue_num, repo_key)
-                or closes_re.search(pr.get("body", "") or "")
+                or issue_num_int in (pr.get("closes_issues") or [])
             ]
             if len(matches) != 1:
                 continue
@@ -2817,10 +2843,12 @@ def tick_once():
         resolve_needs_plan_blocked_by(state)
         resolve_epic_children(state)
         enrich_stackable_blocker_prs(state)
-        # Drop PR bodies now the only consumer (the Closes-#N stack-base match
-        # above) has run, so they don't bloat state.json or the per-role slices
-        # — mirrors resolve_human_approved_blockers popping issue bodies. No
-        # projector or slice needs pr body.
+        # Drop PR bodies so they don't bloat state.json or the per-role slices
+        # — mirrors resolve_human_approved_blockers popping issue bodies. Safe
+        # because the Closes-#N stack-base signal was already derived into
+        # pr["closes_issues"] at fetch time (see CLOSES_RE); nothing downstream
+        # reads pr["body"]. Popping here after deriving there is what lets the
+        # signal survive the 304-reuse of these stripped records (#2442).
         for _repo_state in state["repos"].values():
             for _pr in _repo_state.get("prs", []):
                 _pr.pop("body", None)

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -48,11 +48,27 @@ def _task(id_, blocked_by):
 
 
 def _pr(number, head_ref, author="bot", labels=None, body=""):
+    # Mirror _fetch_prs_graphql: derive closes_issues from the live body at
+    # "fetch" time via the module's own CLOSES_RE, so the record matches the
+    # shape enrichment actually consumes. enrich_stackable_blocker_prs reads
+    # closes_issues, not body (#2442) — deriving here (not hardcoding) keeps the
+    # test's derivation from drifting off production's.
     pr = {"number": number, "headRefName": head_ref, "author": author,
-          "body": body}
+          "body": body,
+          "closes_issues": sorted({int(n) for n in _mod.CLOSES_RE.findall(body)})}
     if labels is not None:
         pr["labels"] = labels
     return pr
+
+
+def _strip_bodies(prs):
+    """Pop `body` from each PR, reproducing the state.json round-trip that the
+    304-reuse fast path serves back as `prev`: bodies are dropped after
+    enrichment (fleet-state-scout tick_once), so a reused record carries only
+    the derived closes_issues field, never body."""
+    for pr in prs:
+        pr.pop("body", None)
+    return prs
 
 
 # ---------------------------------------------------------------------------
@@ -371,6 +387,72 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         enrich_stackable_blocker_prs(state)
         self.assertIn("stackable_blocker_pr",
                       state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_closes_n_offer_survives_304_reuse(self):
+        """#2442: the Closes-#N offer must survive the 304-reuse path. The
+        prev list fetch_prs serves on a 304 is body-stripped (exactly what
+        state.json holds after the post-enrich body pop), retaining only the
+        derived closes_issues field. A blocker PR on a non-standard branch that
+        Closes the issue must still be offered off that shape. Fails on master,
+        whose enrich re-reads the now-absent body and finds no match."""
+        tasks = [_task("#1112", "#1111")]
+        prs = _strip_bodies([
+            _pr(540, "feature/manual-fix", body="Implements it.\nCloses #1111"),
+        ])
+        # Round-trip shape: no body survives, only the derived signal.
+        self.assertNotIn("body", prs[0])
+        self.assertEqual(prs[0]["closes_issues"], [1111])
+        self._write_pr_cache("engine", 540, ["engine/render/x.cpp"])
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 540)
+
+
+class TestFetchPrs304Reuse(unittest.TestCase):
+    """#2442 Phase 3: fetch_prs's 304 fast path must not reuse a prev whose
+    records predate the closes_issues field (the first tick after the deploy
+    that added it) — that would re-strand every Closes-only stack base until an
+    unrelated ETag flip, re-creating the exact defect. A missing key ⇒ cache
+    desync ⇒ fall through to a fresh fetch.
+
+    Hermetic: both network seams (conditional_get, _fetch_prs_graphql) are
+    stubbed so no live GitHub call fires (scripts/fleet/CLAUDE.md)."""
+
+    def setUp(self):
+        self._orig_cget = _mod.conditional_get
+        self._orig_graphql = _mod._fetch_prs_graphql
+        # (False, None) = the change-detector reports the open-PR set unchanged
+        # (a 304), so fetch_prs takes its reuse branch.
+        _mod.conditional_get = lambda *a, **k: (False, None)
+        # Sentinel identifies a fall-through to the fresh GraphQL fetch.
+        self._sentinel = [{"number": 1, "headRefName": "claude/1-x",
+                           "closes_issues": []}]
+        _mod._fetch_prs_graphql = lambda repo: self._sentinel
+
+    def tearDown(self):
+        _mod.conditional_get = self._orig_cget
+        _mod._fetch_prs_graphql = self._orig_graphql
+
+    def test_reuses_prev_that_has_closes_issues(self):
+        """A prev whose records already carry closes_issues is reused verbatim
+        on a 304 — the fast path still works, no needless refetch."""
+        prev = [{"number": 9, "headRefName": "claude/9-x", "closes_issues": [9]}]
+        self.assertIs(_mod.fetch_prs("repo", prev=prev), prev)
+
+    def test_refetches_when_prev_lacks_closes_issues(self):
+        """A prev predating the field (no closes_issues key) is cache desync:
+        fetch_prs ignores it and fires the fresh fetch despite the 304. Fails on
+        master, which returns prev unconditionally on a 304."""
+        prev = [{"number": 9, "headRefName": "claude/9-x"}]  # pre-field record
+        self.assertIs(_mod.fetch_prs("repo", prev=prev), self._sentinel)
+
+    def test_empty_prev_is_reused(self):
+        """all() over an empty prev is True — an empty open-PR set needs no
+        refetch, so the empty list is reused rather than triggering a fetch."""
+        prev = []
+        self.assertIs(_mod.fetch_prs("repo", prev=prev), prev)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- The scout's stackable-blocker enrichment matched a blocker PR to its
  blocked issue by branch prefix **OR** a `Closes/Fixes/Resolves #N`
  reference in the PR body. The body half was dead on every tick that
  reused the cached PR list: bodies are popped after enrichment, and
  `fetch_prs`'s conditional-REST **304** fast path returns the prior
  **body-stripped** records verbatim, so enrichment only ever matched the
  branch-prefix half. Each half (304-reuse, body-pop) is correct alone;
  the defect is their interaction across ticks — intermittent
  stackable-offer starvation.
- **Fix:** derive the Closes-refs once at fetch time
  (`_fetch_prs_graphql`), where the body is still live, into a bounded
  `pr["closes_issues"]` int list that survives both the strip and the 304
  reuse. Enrichment matches on the derived field instead of re-parsing a
  body it may never receive; the grammar is hoisted to one module-level
  `CLOSES_RE` so the offer and the derivation can't drift.
- **Deploy-boundary self-heal:** `fetch_prs` treats a `prev` whose records
  predate the field as cache desync and refetches, so the fix is live on
  the first tick after deploy rather than waiting for an unrelated ETag
  flip. Bodies are still popped — no `state.json` size regression.

## Test plan
- [x] New `test_closes_n_offer_survives_304_reuse` (enrichment offers off a
  body-stripped record) and `TestFetchPrs304Reuse.test_refetches_when_prev_lacks_closes_issues`
  (refetch on missing field) — **both fail against master**, pass after.
- [x] `test_enrich_stackable_blocker_prs.py` green (29 tests); the full
  `scripts/fleet/tests` suite green (648 tests).
- [x] `ruff check scripts/` clean.

## Notes
- Deploying the scout requires a `fleet-down` / `fleet-up` bounce (the
  in-proc-vs-subprocess activation gap) for the change to take effect.
- Follow-up candidate (out of scope here): `fleet-claim` defines a
  byte-identical `CLOSES_RE`; a shared helper module would keep the offer
  and accept sides from drifting.

Closes #2442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
