### PR TITLE
docs: gated self-config batch — role docs + review checklist

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -168,21 +168,21 @@ cheap-first / Opus-for-judgment split the PR path uses):
    verified** (did they read the real code path, not the issue's guess; were
    negative/gap claims checked across the full candidate set), is the **single
    approach actually correct** (not merely present), is the **sibling + in-flight
-   reconciliation** right, and is the **cross-system audit** complete where one
-   is required.
+   reconciliation** right, is the **cross-system audit** complete where one
+   is required, does any phase **assume an unmeasured mechanism** (a cited
+   measurement or phase-0 probe is required), and are the named acceptance
+   tests **positive-fire**?
 
 - **Sound →** remove the label: `gh issue edit <N> --repo <repo> --remove-label
   "fleet:plan-review"`. The scout queues it on its next pass.
-- **Not sound →** delete the existing `## Plan` comment **first**, then requeue.
-  `fleet-claim planning-claim` exit-3's on `## Plan` *comment presence* (not on
-  the `fleet:needs-plan` label), so swapping the label back while the stale plan
-  comment remains leaves the issue **un-plannable** — the next planning pass can't
-  re-claim it. Get the comment id from `fleet-issue view <N>` and delete it
-  (`gh api -X DELETE repos/<owner>/<repo>/issues/comments/<comment-id>`), then
-  swap the label: `gh issue edit <N> --repo <repo> --remove-label
-  "fleet:plan-review" --add-label "fleet:needs-plan"`, and comment the specific
-  gaps. The next planning pass can then claim afresh and post a corrected
-  `## Plan` comment.
+- **Not sound →** swap the label back: `gh issue edit <N> --repo <repo>
+  --remove-label "fleet:plan-review" --add-label "fleet:needs-plan"`, and
+  comment the specific gaps. Leave the stale `## Plan` comment in place as
+  audit trail — the dispatcher's planning-claim walk retries the exit-3
+  ("`## Plan` comment already present") with `--replan`, gated on the live
+  `fleet:needs-plan` label your swap just set (#2197/#2295), so the next
+  assigned planner revises the plan in place. Do NOT delete the old
+  `## Plan` comment (the pre-#2295 delete-first workaround is obsolete).
 
 This is a review of the **plan**, distinct from the PR code review — and it's
 cheap (no build, no diff), so do it every iteration even when there are no PR

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -41,7 +41,7 @@ Class-conditional duties at a glance ("opus+" = opus or fable):
 | 1 — feedback tiers | `human:needs-fix` / `human:blocker` / `fleet:needs-fix` / `fleet:has-nits` | those + `fleet:design-unblocked` |
 | 1b — cross-host smoke | exit-code half (escalate visual judgment) | judgment half (inspect screenshots) |
 | 1c — semantic conflicts | skip | resolve one per iteration |
-| 2 — planning needs-plan | light-plan the oldest `fleet:sonnet`-tagged entry | plan the oldest entry |
+| 2 — planning needs-plan | light-plan the assigned `FLEET_PLAN_ISSUE` (if set) | plan the assigned `FLEET_PLAN_ISSUE` (if set) |
 | 3 — task pickup | `model` == `sonnet` | `model` == your class |
 | 8 — escalation | re-tag one class up | design-blocked flow / re-tag to fable |
 | 10 — optimize | only hot-path changes | almost always |
@@ -70,11 +70,13 @@ See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNT
   issue queue. There is no separate game-side worker; you cover both
   queues. (game-architect is interactive only and does not autonomously
   claim tasks.)
-- **[opus+ classes]** Plan issues flagged with `fleet:needs-plan` on
-  either repo — claim it (`fleet-claim planning-claim`), read the thread,
+- **[opus+ classes]** Plan the needs-plan issue the dispatcher assigned
+  this iteration (`FLEET_PLAN_ISSUE=<repo>:<N>`, pre-claimed via
+  `fleet-claim planning-claim` before launch — #2197): read the thread,
   post the structured plan as a `## Plan` comment, then swap
   `fleet:needs-plan` → `fleet:plan-review` for a reviewer to vet, and release
-  (`fleet-claim planning-release`). The plan lands in `.fleet/plans/` as the
+  (`fleet-claim planning-release`). With `FLEET_PLAN_ISSUE` unset, do no
+  planning. The plan lands in `.fleet/plans/` as the
   first commit of the implementer's PR — not a separate plan-doc PR (#1932).
 - Handle tasks escalated from a lower class (look for an `escalated
   from <class>` note in the issue body or a recent issue comment).
@@ -104,8 +106,8 @@ body suggests:
   `fleet:no-plan` or a filed `## Plan` + `fleet:plan-review`) and
   queues with no human triage; anything else files with no labels and
   waits for the human's `human:approved`. Do not edit other issues'
-  bodies or labels to retitle / re-scope them. (The one sanctioned
-  label edit on issues you don't own is the class re-tag on **your own
+  bodies or labels to retitle / re-scope them. (The one exception to
+  "don't edit issues you don't own" is the class re-tag on **your own
   claimed task** — step 8.)
 - **Pre-applying STATE labels at filing time.** When you file an issue
   for follow-up work, apply only the labels the agent-approved lane
@@ -154,7 +156,7 @@ fleet-claim --repo game claim 45 worker-1
 ## Startup actions (do these immediately, in order)
 
 0. Print your role banner:
-   `[worker] Executes <class>-class tasks from engine + game issue queues; plans fleet:needs-plan issues at opus class+. This iteration: class=$FLEET_ROLE_MODEL. Transient — re-fires when scout sees actionable state (each iteration runs in fresh context).`
+   `[worker] Executes <class>-class tasks from engine + game issue queues; plans fleet:needs-plan issues at opus class+. This iteration: class=$FLEET_ROLE_MODEL, plan-assignment=${FLEET_PLAN_ISSUE:-none}. Transient — re-fires when scout sees actionable state (each iteration runs in fresh context).`
 1. `pwd` and confirm you are in an engine `worker-*` worktree (not
    the architect's, not a reviewer worktree). The directory basename
    (`worker-1` … `worker-4`) is your **agent name** — pass it as the
@@ -205,8 +207,8 @@ fleet-claim --repo game claim 45 worker-1
    in flight under another agent (the live "is this task already
    being worked" signal).
 5. Print a one-line summary: count of `fleet:needs-plan` entries
-   across both repos (all `fleet:sonnet`-tagged for the sonnet class; all
-   entries for opus+), count of unblocked
+   across both repos (informational only — you plan solely the
+   dispatcher-assigned `FLEET_PLAN_ISSUE`, step 2), count of unblocked
    unclaimed tasks of your class per repo (filter `tasks.open[]`
    where `model` contains your class, `owner == "free"`, and
    `blocked_by` resolves to merged work or `(none)`).
@@ -519,34 +521,34 @@ Do the work, then exit cleanly:
     push) and force-push retriggers CI — keep this step bounded to
     one PR per iteration.
 
-2. **Plan `fleet:needs-plan` issues on either repo.** Which entries you plan
-   depends on your class:
-   - **[opus+ classes]** Plan the oldest unprocessed entry (smallest `number`)
-     across both repos — the default, architect-tier path. Planning sets the
-     approach every downstream class executes, so it runs at opus class or
-     higher (`FLEET_ROLE_MODEL` is the signal; the dispatcher routes untagged
-     needs-plan dispatches to the fable/opus class).
-   - **[sonnet class]** Plan only the oldest entry that carries `fleet:sonnet`
-     (a **mechanical** task the human/architect judged bounded enough for a
-     lightweight plan). Write a thin `## Plan` comment, run `fleet-plan-lint
-     <N>`, and on pass **remove `fleet:needs-plan`** to self-queue (no
-     plan-review); on fail swap to `fleet:plan-review` for the opus safety net.
-     If no needs-plan issue is `fleet:sonnet`-tagged, skip to step 3. Full flow:
+2. **Plan the dispatcher-assigned needs-plan issue (if any).** Planning
+   dispatches are **assignment-based** (#2197): the dispatcher pre-claims one
+   needs-plan issue via `fleet-claim planning-claim` and hands it to this
+   iteration as `FLEET_PLAN_ISSUE=<repo>:<N>`. You never self-select an issue
+   to plan and never make `planning-claim` calls at this step — see
+   [PLANNING-PROTOCOL.md §"The flow" step 0](../../docs/agents/PLANNING-PROTOCOL.md).
+   - **`FLEET_PLAN_ISSUE` set** — the issue is yours, already locked. Verify
+     `fleet:needs-plan` is still live on it (release + skip to step 3 if
+     not), read the full thread (`fleet-issue view <N>`, add `--repo game`
+     for game), post the structured `## Plan` comment per
+     [docs/agents/PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md),
+     swap `fleet:needs-plan` → `fleet:plan-review` (leaving `human:approved`;
+     add `human:review-plan` when the plan is high-stakes), and release
+     (`fleet-claim planning-release`). Sonnet light-plan mechanics are
+     unchanged past the claim step: thin `## Plan` comment, `fleet-plan-lint
+     <N>`, on pass **remove `fleet:needs-plan`** to self-queue (no
+     plan-review), on fail swap to `fleet:plan-review` for the opus safety
+     net — full flow:
      [PLANNING-PROTOCOL.md § Lightweight plan for mechanical (`fleet:sonnet`)
      tasks](../../docs/agents/PLANNING-PROTOCOL.md#lightweight-plan-for-mechanical-fleetsonnet-tasks).
+   - **`FLEET_PLAN_ISSUE` unset** — skip planning entirely (no claim
+     attempts, no needs-plan scanning) and move on to step 3.
 
-   For the opus+ path, the cached `repos.engine.needs_plan[]` and
-   `repos.game.needs_plan[]` arrays hold the open needs-plan issues. Follow
-   [docs/agents/PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md)
-   — read the full thread (`fleet-issue view <N>`, add `--repo game`
-   for game), acquire the planning claim (`fleet-claim planning-claim <N>
-   <agent>` — exit 3 means a `## Plan` comment already exists, so skip it),
-   post the structured `## Plan` comment, swap `fleet:needs-plan` →
-   `fleet:plan-review` (leaving `human:approved`) for a reviewer to vet, and
-   release (`fleet-claim planning-release`). The plan file is committed by the
+   The plan file is committed by the
    implementer as the first commit of its PR (#1932). If the work decomposes
    into a stack,
-   that doc routes you to `file-epic` via
+   [PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md) routes you
+   to `file-epic` via
    [docs/agents/TASK-FILING.md](../../docs/agents/TASK-FILING.md).
 
 3. **Resume an active molecule first, then pick the next task.**

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -142,8 +142,22 @@ any `c_compute_*shadow*.glsl` / `.metal`)
 
 **Tests / build**
 - Code change with no corresponding test change where a test existed.
-- New feature with no new test at all (flag as needs-fix unless the user
-  explicitly said "no tests").
+- New **public surface** with no covering test — judge per *surface*, not
+  per PR: a PR that tests one surface while shipping others uncovered still
+  fails this check; flag each uncovered surface as needs-fix unless the
+  human explicitly waived tests ("no tests" stays a human-explicit waiver).
+  Specifically call out:
+  - a new **Lua binding** needs a `test/script/lua_*_test.cpp` exercising
+    the sol2 seam (the existing `lua_*_test.cpp` files there are the
+    precedent);
+  - a facility with **two registration paths** (free-function params AND
+    `System<N>` spec-member detection) needs both paths covered.
+  Worked example (#2425): the per-system cadence gate shipped 13 solid
+  SystemManager tests, but the new `IRSystem.*` cadence Lua surface and the
+  `kCadence`/`kCadenceOffset` spec-member path shipped with zero coverage —
+  under the old "a new test exists" wording that was unflaggable; under
+  per-surface wording each gap is a needs-fix hook. Suite layout and
+  authoring conventions: [`test/CLAUDE.md`](../../../test/CLAUDE.md).
 - Build or format-check not run before opening the PR (check the commit
   message, or run `fleet-build --target format-changed` yourself if cheap).
 - Verification claims green over an unclean exit: a PR body or run log that


### PR DESCRIPTION
## Summary
- Gated self-config batch, applied in the human-cued lane (human approved these edits in-session; the autonomous commit gate blocks every worker class from touching `role-*.md` / `skills/**/SKILL.md`).
- **#2300** — role-doc half of dispatcher-assigned planning (#2197): `role-worker.md` step 2 now keys entirely off `FLEET_PLAN_ISSUE` (verify-live → plan → swap to `fleet:plan-review` → release; unset ⇒ no planning, zero `planning-claim` calls), the startup banner echoes the assignment, and the class table / step-5 summary are aligned. `role-opus-reviewer.md`'s "Not sound" bounce no longer deletes the `## Plan` comment — it swaps to `fleet:needs-plan` and the dispatcher's `--replan` retry revises in place.
- **#2407** — the plan-review judgment enumeration in `role-opus-reviewer.md` gains the two lines already mirrored in PLANNING-PROTOCOL.md step 4: unmeasured-mechanism premises and positive-fire acceptance tests.
- **#2434** — reworded the self-contradictory "sanctioned label edit on issues you don't own" phrasing to "the one exception to 'don't edit issues you don't own'".
- **#2444** (remaining half; `test/CLAUDE.md` landed in #2445) — `review-pr` SKILL.md Tests/build rule tightened from per-PR to **per-new-public-surface**, with the Lua-binding and dual-registration-path callouts and #2425 as the worked example.

## Test plan
- [ ] Doc-only diff — no build surface. Cross-refs verified: `test/CLAUDE.md` exists on master, PLANNING-PROTOCOL.md anchors resolve, remaining `planning-claim` mentions in role-worker.md are descriptive of the dispatcher only.
- [ ] #2300 deployment-order precondition met: PR #2295 merged 2026-07-08 and the fleet has been bounced since (2026-07-15), so the role-doc half can land without a planning outage.

## Notes for reviewer
#2300's third listed edit ("stale-queued-plan discovery: replace the `planning-claim --replan` contract with flip-and-move-on") had no matching text left in role-worker.md — that contract is already absent, so the item is satisfied vacuously. The issue-body claim of "19 existing" Lua test files is 17 on master; the checklist edit cites the directory precedent without a count.

Closes #2300
Closes #2407
Closes #2434
Closes #2444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
