### PR TITLE
fleet: #2419 residual — matcher precedence gate + Closes-regex DRY + branch-check mint guard

### DIFF
--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -121,8 +121,9 @@ claim-liveness matcher can't tie your open PR back to the issue — the sweep
 then judges the claim abandoned and a second worker files a duplicate PR
 (#2419: a `claude/<worktree>-issue-<N>`-shaped branch was invisible to it).
 Validate here, **before pushing** (the check is network-free — it can't hang
-the flow), immediately beside the `claim-base <issue#>` lookup that already
-threads the issue number:
+the flow). The `<issue#>` comes from your active fleet claim, not from any
+step-2 lookup — `claim-base <issue#>` doesn't run until PR-open (step 8), and
+stack mode's step-2 `stack-base` lookup is keyed by task-id:
 
 ```bash
 <claim-tool> [--repo <ns>] branch-check <issue#>   # exit 0 = ok, 1 = mismatch

--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -115,6 +115,29 @@ default branch for the first task, else the previous task's branch). See the
 
 If you're already on a feature branch, use it — don't rename mid-session.
 
+**Fleet-lane branch validation (mint-time guard).** When you hold a fleet
+claim, the branch name must encode the claimed issue number, or the
+claim-liveness matcher can't tie your open PR back to the issue — the sweep
+then judges the claim abandoned and a second worker files a duplicate PR
+(#2419: a `claude/<worktree>-issue-<N>`-shaped branch was invisible to it).
+Validate here, **before pushing** (the check is network-free — it can't hang
+the flow), immediately beside the `claim-base <issue#>` lookup that already
+threads the issue number:
+
+```bash
+<claim-tool> [--repo <ns>] branch-check <issue#>   # exit 0 = ok, 1 = mismatch
+```
+
+On a non-zero exit it prints the expected form; rename to it before the push
+in step 7:
+
+```bash
+git branch -m claude/<issue#>-<short-topic>
+```
+
+Skip this for a plain human PR with no claimed issue (`Issue:` field
+`(none)`) — there's no issue number to validate against.
+
 ### 3. Pre-commit checks and `simplify`
 
 **First**, run the **rebase guard** (**procedures** `rebase-guard.md`): if

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1300,6 +1300,52 @@ cmd_claim_base() {
     echo "master"
 }
 
+cmd_branch_check() {
+    # Validate that a branch name encodes its claimed issue number, so the
+    # fleet PR-open flow never mints an untrackable branch. The #2419
+    # incident: `claude/game-worker-3-issue-255` was invisible to the claim
+    # matcher, the liveness sweep judged the claim abandoned, and a duplicate
+    # PR followed. Enforcing at mint time (right beside claim-base, which
+    # already has the issue number in hand) is the durable fix.
+    #
+    # Purely LOCAL — no network — so it can never hang the PR-open path.
+    #
+    # Usage: fleet-claim [--repo <ns>] branch-check <issue-number> [branch]
+    #   <branch> defaults to the current git branch. Exit 0 on match, 1 on
+    #   mismatch (printing the observed branch + expected form), 2 on bad args.
+    local issue_num
+    if ! issue_num=$(require_issue_number "$1"); then
+        return 2
+    fi
+    local branch="${2:-}"
+    if [[ -z "$branch" ]]; then
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    fi
+    if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
+        echo "fleet-claim branch-check: no branch given and not on a named git branch" >&2
+        return 2
+    fi
+    # The matcher (and the expected-form message on mismatch) live in the
+    # shared module so the accepted grammar can't drift from the claim gate.
+    BRANCH="$branch" ISSUE_NUM="$issue_num" REPO_NS="$REPO_NS" python3 -c '
+import os, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import branch_matches_issue, issue_branch_prefixes
+branch = os.environ["BRANCH"]
+issue = os.environ["ISSUE_NUM"]
+repo = os.environ.get("REPO_NS", "")
+if branch_matches_issue(branch, issue, repo):
+    sys.exit(0)
+forms = ["%s<topic>" % p for p in issue_branch_prefixes(repo, issue)]
+sys.stderr.write(
+    "fleet-claim branch-check: branch %r does not encode issue #%s; expected "
+    "one of: %s (or a claude/... branch carrying an issue-%s token)\n"
+    % (branch, issue, ", ".join(forms), issue)
+)
+sys.exit(1)
+'
+}
+
 cmd_find_stackable_blockers() {
     # If the task's **Blocked by:** field resolves to exactly one unresolved
     # blocker with exactly one matching open PR (head-branch `claude/<N>-*`
@@ -1407,9 +1453,9 @@ PYEOF
     # qualifies; zero or multiple → empty output.
 
     BLOCKER="$blocker" REPO="$repo" python3 <<'PYEOF'
-import json, os, re, subprocess, sys
+import json, os, subprocess, sys
 sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
-from fleet_branch_match import branch_matches_issue
+from fleet_branch_match import body_closes_issue, branch_matches_issue
 # Same reject-state predicate the scout's offer and the claim gate use (#1751),
 # so the finder doesn't advertise a base the gate would then refuse — a worker
 # would otherwise burn an iteration claiming a WIP/design-unblocked base only to
@@ -1433,13 +1479,11 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
-closes_re = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#" + re.escape(blocker) + r"\b", re.IGNORECASE)
-
 matches = []
 for pr in prs:
     head = pr.get("headRefName", "") or ""
     body = pr.get("body", "") or ""
-    if branch_matches_issue(head, blocker, repo) or closes_re.search(body):
+    if branch_matches_issue(head, blocker, repo) or body_closes_issue(body, blocker):
         matches.append(pr)
 if len(matches) != 1:
     sys.exit(0)
@@ -3893,6 +3937,15 @@ cmd_molecule_rebase_downstream() {
         elif [[ "$current_branch" =~ ^claude/[Tt]-([0-9]+) ]]; then
             echo "auto-detect: legacy claude/T-NNN branch ($current_branch) — pass the issue number explicitly" >&2
             return 0
+        elif [[ "$current_branch" == claude/* && "$current_branch" =~ (^|[/-])issue-([0-9]+)(-|$) ]]; then
+            # Token fallback mirrors _token_issue in fleet_branch_match.py: a
+            # word-bounded issue-<N> token, reached only when the branch has no
+            # leading-number form (the first arm) and isn't a legacy T-NNN one,
+            # so the documented mirror doesn't drift from the widened shared
+            # matcher (#2419). bash ERE has no lookahead, so the `(-|$)` right
+            # boundary is spelled out; greedy `[0-9]+` captures the full number.
+            upstream_id="${BASH_REMATCH[2]}"
+            echo "auto-detected upstream issue: #${upstream_id} (from issue-<N> token in branch $current_branch)"
         else
             echo "could not auto-detect upstream issue from branch '$current_branch' (not on a claude/<N>-… branch); skipping" >&2
             return 0
@@ -4299,6 +4352,13 @@ case "${1:-}" in
         fi
         cmd_find_stackable_blockers "$2"
         ;;
+    branch-check)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] branch-check <issue-number> [branch]" >&2
+            exit 2
+        fi
+        cmd_branch_check "$2" "${3:-}"
+        ;;
     release)
         if [[ -z "${2:-}" ]]; then
             echo "usage: fleet-claim release <issue-number>" >&2
@@ -4573,6 +4633,13 @@ commands:
                                 PR — "master" for normal claims, the
                                 recorded stackable_base_branch for a
                                 --stackable-on claim.
+  branch-check <issue-number> [branch]
+                                validate that <branch> (default: the current
+                                git branch) encodes <issue-number> via the
+                                shared matcher — the mint-time guard against
+                                an untrackable branch the liveness sweep would
+                                free (#2419). Network-free. Exit 0=match,
+                                1=mismatch (prints the expected form).
   find-stackable-blockers <issue-number>
                                 if exactly one #N blocker has exactly
                                 one open PR (matched via head-branch

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -55,6 +55,7 @@ import fleet_poll_topology
 from fleet_blocked_by import is_no_blocker_value, parse_blocked_by
 from fleet_branch_match import (
     PARKED_PR_LABELS,
+    body_closed_issue_numbers,
     branch_matches_issue,
     issue_from_branch,
 )
@@ -254,11 +255,9 @@ def _is_pull_request(issue):
 # derived field rather than re-parsing pr["body"], which it may never receive:
 # bodies are popped after enrichment and fetch_prs's 304 fast path reuses the
 # body-stripped prior records, so the live parse was dead on every reuse tick
-# (#2442). Deriving once here keeps the offer and this grammar from drifting.
-CLOSES_RE = re.compile(
-    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
-    re.IGNORECASE,
-)
+# (#2442). Deriving once here keeps the offer live; the closing-keyword grammar
+# itself lives in fleet_branch_match.body_closed_issue_numbers so it can't
+# drift from the claim/sweep side that shares it (#2419).
 
 
 def _fetch_prs_graphql(repo):
@@ -294,7 +293,7 @@ def _fetch_prs_graphql(repo):
         # post-enrich body-pop and fetch_prs's 304 reuse of body-stripped
         # records (#2442). Its presence is also fetch_prs's cache-desync marker.
         pr["closes_issues"] = sorted(
-            {int(n) for n in CLOSES_RE.findall(pr.get("body", "") or "")}
+            set(body_closed_issue_numbers(pr.get("body", "") or ""))
         )
     # gh's PR ordering is not stable run-to-run; sort by number so the
     # projection hash stays quiescent when nothing has actually changed.
@@ -1730,7 +1729,7 @@ def enrich_stackable_blocker_prs(state):
     #
     # A PR "matches" the blocker when its head branch is `claude/<NNN>-…` OR its
     # derived closes_issues (Closes/Fixes/Resolves #NNN, parsed at fetch time —
-    # see CLOSES_RE) contains NNN — the same union fleet-claim's
+    # see body_closed_issue_numbers) contains NNN — the same union fleet-claim's
     # find-stackable-blockers uses, so the scout offers every base the live
     # finder would (the Closes-#N form catches blocker PRs on non-standard /
     # human branches). The Closes half reads the derived field, not pr["body"],
@@ -3034,9 +3033,10 @@ def tick_once():
         # Drop PR bodies so they don't bloat state.json or the per-role slices
         # — mirrors resolve_human_approved_blockers popping issue bodies. Safe
         # because the Closes-#N stack-base signal was already derived into
-        # pr["closes_issues"] at fetch time (see CLOSES_RE); nothing downstream
-        # reads pr["body"]. Popping here after deriving there is what lets the
-        # signal survive the 304-reuse of these stripped records (#2442).
+        # pr["closes_issues"] at fetch time (see body_closed_issue_numbers);
+        # nothing downstream reads pr["body"]. Popping here after deriving
+        # there is what lets the signal survive the 304-reuse of these
+        # stripped records (#2442).
         for _repo_state in state["repos"].values():
             for _pr in _repo_state.get("prs", []):
                 _pr.pop("body", None)

--- a/scripts/fleet/fleet_branch_match.py
+++ b/scripts/fleet/fleet_branch_match.py
@@ -18,12 +18,20 @@ The matcher accepts BOTH forms for the game repo, so in-flight
 `claude/game-<N>-*` branches keep resolving while the convention migrates
 to the prefix-less form. Engine accepts only `claude/<N>-`.
 
-It also recognizes the improvised `issue-<N>` token form
-(`claude/<worktree>-issue-<N>`) that a worker minted in the #2419 incident,
-plus a `Closes/Fixes/Resolves #N` body reference as a second liveness
-signal — so a live PR under a non-standard branch name is no longer read
-as an abandoned claim and swept into a duplicate.
+Beyond the prefix forms, the matcher also recognizes a word-bounded
+`issue-<N>` token anywhere in a `claude/...` branch
+(`claude/game-worker-3-issue-255` -> #255) as a *fallback*: it fires only
+when the branch carries no leading-number form, so the leading-number form
+stays authoritative and `claude/2419-fix-issue-1425-recurrence` resolves to
+#2419 alone, never also to #1425. That token shape is the #2419 recurrence
+of the same #1425 duplicate-PR incident — workers improvised
+`claude/game-<worktree>-issue-<N>` branches the prefix-only matcher could not
+tie back to the issue, so the liveness sweep judged the live claim abandoned
+and a duplicate PR followed. The token boundaries are explicit
+(`(?:^|[-/])issue-(\\d+)(?=-|$)`) so the `fleet-claim` bash mirror can copy
+the spelling exactly.
 """
+
 import re
 
 
@@ -49,33 +57,48 @@ def _norm_issue(issue):
     return str(issue).strip().lstrip("#")
 
 
-# An `issue-<N>` segment anywhere in the branch. `(?:^|[-/])` pins it to a
-# `-`/`/`-delimited token start (so `reissue-1` is not a match), and the
-# greedy `\d+` consumes the whole digit run so an `issue-25` token yields
-# "25", never a prefix of #255 (#2419).
-_ISSUE_TOKEN_RE = re.compile(r"(?:^|[-/])issue-(\d+)")
+def _leading_issue(head_ref):
+    """Leading-number issue from a `claude/...` branch, or None.
 
-# Same close-keyword set as find-stackable-blockers' `closes_re` (fleet-claim);
-# this is the importable copy the other hand-rolled inlines can converge on.
-_CLOSES_RE_TMPL = r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#%s\b"
-
-
-def _issue_token_numbers(head_ref):
-    """Issue numbers carried by word-bounded `issue-<N>` tokens in a branch."""
-    return [m.group(1) for m in _ISSUE_TOKEN_RE.finditer(head_ref or "")]
-
-
-def body_closes_issue(body, issue):
-    """True when `body` carries a `Closes/Fixes/Resolves #<issue>` reference.
-
-    The #2419 second liveness signal: a PR whose branch shape the matcher
-    can't tie to `issue` is still live work for it when its body closes the
-    issue (the same dual-match find-stackable-blockers already uses).
+    The authoritative form: strip `claude/` + an optional `game-` infix, then
+    read leading digits. `claude/game-worker-3-issue-255` yields None (the
+    remainder after the strip starts with `w`), which is exactly why the token
+    fallback below exists.
     """
-    n = _norm_issue(issue)
-    if not body or not n:
-        return False
-    return re.search(_CLOSES_RE_TMPL % re.escape(n), body, re.IGNORECASE) is not None
+    head = head_ref or ""
+    if not head.startswith("claude/"):
+        return None
+    rest = head[len("claude/"):]
+    if rest.startswith("game-"):
+        rest = rest[len("game-"):]
+    num = ""
+    for ch in rest:
+        if ch.isdigit():
+            num += ch
+        else:
+            break
+    return int(num) if num else None
+
+
+# Word-bounded `issue-<N>` token: starts at a segment boundary (start, '/',
+# or '-') and the digits end at '-' or end-of-string, so `issue-25` does not
+# match #255 and `issue-255` does not match #25. The bash mirror in
+# `fleet-claim`'s stack-rebase auto-detect copies this spelling verbatim —
+# keep the two in sync.
+_TOKEN_ISSUE_RE = re.compile(r"(?:^|[-/])issue-(\d+)(?=-|$)")
+
+
+def _token_issue(head_ref):
+    """First `issue-<N>` token issue in a `claude/...` branch, or None.
+
+    A *fallback* only — see `issue_from_branch` / `branch_matches_issue` for
+    the leading-number-is-authoritative precedence that gates when this fires.
+    """
+    head = head_ref or ""
+    if not head.startswith("claude/"):
+        return None
+    m = _TOKEN_ISSUE_RE.search(head)
+    return int(m.group(1)) if m else None
 
 
 def issue_branch_prefixes(repo, issue):
@@ -95,17 +118,53 @@ def issue_branch_prefixes(repo, issue):
 def branch_matches_issue(head_ref, issue, repo):
     """True when `head_ref` is the working branch for `issue` in `repo`.
 
-    Matches the number-first fleet forms (`claude/<N>-`, game
-    `claude/game-<N>-`) and — for any `claude/…` branch — the improvised
-    `issue-<N>` token form (`claude/<worktree>-issue-<N>`) that the #2419
-    sweep read as an abandoned claim and duplicated.
+    Two arms, prefix authoritative:
+      1. Prefix `claude/<N>-` (game also `claude/game-<N>-`) — unchanged.
+      2. Fallback: a word-bounded `issue-<N>` token, but ONLY when the branch
+         carries no leading-number form. So `claude/2419-fix-issue-1425-*`
+         matches #2419 (prefix) and NOT #1425 (token suppressed), while
+         `claude/game-worker-3-issue-255` matches #255 via the token. The
+         token arm is repo-agnostic (no prefix shape to namespace).
     """
     head = head_ref or ""
     if any(head.startswith(p) for p in issue_branch_prefixes(repo, issue)):
         return True
-    if head.startswith("claude/"):
-        return _norm_issue(issue) in _issue_token_numbers(head)
+    if _leading_issue(head) is None:
+        tok = _token_issue(head)
+        if tok is not None and str(tok) == _norm_issue(issue):
+            return True
     return False
+
+
+# GitHub closing-keyword prefix, shared by the single-issue and all-refs
+# forms below (case-insensitive `close/closes/closed`, `fix/fixes/fixed`,
+# `resolve/resolves/resolved` + `#`). Kept as one string so the two regex
+# shapes can't drift — the same centralization argument as the branch matcher.
+_CLOSES_KEYWORD = r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#"
+_CLOSES_ANY_RE = re.compile(_CLOSES_KEYWORD + r"(\d+)\b", re.IGNORECASE)
+
+
+def body_closes_issue(body, issue):
+    """True when `body` declares it closes `issue` via a GitHub closing keyword.
+
+    The second liveness signal: an open PR referencing the issue in its body
+    counts as live work even when its branch name doesn't match. Matches
+    `close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`
+    followed by `#<N>`, case-insensitive and word-bounded so `#25` does not
+    match `#255`. A missing/empty body simply never fires (backward compatible
+    with any caller that hasn't started fetching `body`).
+    """
+    if not body:
+        return False
+    pat = _CLOSES_KEYWORD + re.escape(_norm_issue(issue)) + r"\b"
+    return re.search(pat, body, re.IGNORECASE) is not None
+
+
+def body_closed_issue_numbers(body):
+    """All issue numbers a closing keyword references in `body`, as ints."""
+    if not body:
+        return []
+    return [int(m) for m in _CLOSES_ANY_RE.findall(body)]
 
 
 # A PR carrying any of these is *parked*: a worker hit a design wall and
@@ -134,17 +193,20 @@ def issue_pr_state(prs, issue, repo):
                  stale and safe to clear/sweep (#1488 Fix A/B).
       "none"   — no open PR branch matches the issue.
 
-    `prs` is a list of `gh pr list --json headRefName,labels[,body]` records
-    (any extra keys are ignored). A record whose branch the matcher can't tie
-    to the issue but whose `body` closes it counts as a match too (#2419); a
-    caller that omits `body` from its fetch simply forgoes that second signal.
+    A PR matches `issue` by EITHER signal: its branch (`branch_matches_issue`)
+    or a body `Closes #N` reference (`body_closes_issue`). `prs` is a list of
+    `gh pr list --json headRefName,labels[,body]` records (any extra keys are
+    ignored); a record without `body` simply can't fire the second signal.
     Callers that only distinguish "keep the claim" from "release the claim"
     treat "parked" and "none" identically.
     """
     saw_parked = False
     for pr in (prs or []):
-        if not (branch_matches_issue(pr.get("headRefName") or "", issue, repo)
-                or body_closes_issue(pr.get("body") or "", issue)):
+        matched = (
+            branch_matches_issue(pr.get("headRefName") or "", issue, repo)
+            or body_closes_issue(pr.get("body") or "", issue)
+        )
+        if not matched:
             continue
         names = {
             (lbl or {}).get("name", "")
@@ -161,27 +223,12 @@ def issue_pr_state(prs, issue, repo):
 def issue_from_branch(head_ref):
     """Extract the issue number from a `claude/...` branch, or None.
 
-    Repo-agnostic inverse of `branch_matches_issue`: handles both
-    `claude/<N>-...` (engine / new game) and `claude/game-<N>-...` (legacy
-    game) by stripping the optional `game-` infix before reading the digits,
-    and falls back to an explicit `issue-<N>` token (#2419) when the
-    number-first form is absent.
+    Repo-agnostic inverse of `branch_matches_issue`, same precedence: prefer
+    the authoritative leading-number form (`claude/<N>-...`, legacy
+    `claude/game-<N>-...`); fall back to a word-bounded `issue-<N>` token
+    (`claude/game-worker-3-issue-255` -> 255) only when there is none.
     """
-    head = head_ref or ""
-    if not head.startswith("claude/"):
-        return None
-    rest = head[len("claude/"):]
-    if rest.startswith("game-"):
-        rest = rest[len("game-"):]
-    num = ""
-    for ch in rest:
-        if ch.isdigit():
-            num += ch
-        else:
-            break
-    if num:
-        return int(num)
-    # Number-first form absent — read an explicit `issue-<N>` token
-    # (`claude/<worktree>-issue-<N>`), the shape behind the #2419 sweep miss.
-    tokens = _issue_token_numbers(head)
-    return int(tokens[0]) if tokens else None
+    lead = _leading_issue(head_ref)
+    if lead is not None:
+        return lead
+    return _token_issue(head_ref)

--- a/scripts/fleet/tests/test_branch_matches_issue.py
+++ b/scripts/fleet/tests/test_branch_matches_issue.py
@@ -7,6 +7,8 @@ Pins the contract both fleet-claim and fleet-state-scout rely on:
   - issue_from_branch is the repo-agnostic inverse (strips optional game-)
   - (#2419) an improvised `issue-<N>` token branch, or a `Closes #N` body,
     resolves to the issue so a live PR is not swept into a duplicate claim
+  - the token is a *fallback*: a leading-number form suppresses it, so a
+    branch naming `issue-<M>` in its topic never dual-attributes to #M
 """
 import sys
 import unittest
@@ -15,6 +17,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from fleet_branch_match import (
     _is_game,
+    body_closed_issue_numbers,
     body_closes_issue,
     branch_matches_issue,
     issue_branch_prefixes,
@@ -93,10 +96,12 @@ class BranchMatchesIssue(unittest.TestCase):
 
     def test_issue_token_word_bounded(self):
         # `issue-25` must NOT satisfy #255 (word-bounded digit run), and the
-        # right boundary rejects a longer number too.
+        # right boundary rejects a longer number too — in both directions:
+        # `issue-255` must not satisfy #25 either.
         self.assertFalse(branch_matches_issue("claude/w-3-issue-25", 255, "engine"))
         self.assertTrue(branch_matches_issue("claude/w-3-issue-25", 25, "engine"))
         self.assertFalse(branch_matches_issue("claude/w-3-issue-2550", 255, "engine"))
+        self.assertFalse(branch_matches_issue("claude/w-3-issue-255", 25, "engine"))
 
     def test_issue_token_left_boundary(self):
         # `reissue-255` is not an `issue-<N>` token (must open a -/ segment).
@@ -113,6 +118,16 @@ class BranchMatchesIssue(unittest.TestCase):
         # Regression guard: widening the matcher didn't break the primary form.
         self.assertTrue(branch_matches_issue("claude/255-topic", 255, "engine"))
         self.assertFalse(branch_matches_issue("claude/1050-x", 105, "engine"))
+
+    def test_leading_number_is_authoritative_over_token(self):
+        # The dual-attribution lock: a branch carrying BOTH a leading number
+        # and an `issue-<N>` token resolves to the leading number ONLY — the
+        # token arm is a fallback, not an additional match. Without the gate,
+        # `cmd_claim`'s open-PR guard falsely refuses a fresh claim on #1425
+        # because an unrelated branch names `issue-1425` in its topic.
+        b = "claude/2419-fix-issue-1425-recurrence"
+        self.assertTrue(branch_matches_issue(b, 2419, "engine"))
+        self.assertFalse(branch_matches_issue(b, 1425, "engine"))
 
 
 class IssueFromBranch(unittest.TestCase):
@@ -147,6 +162,8 @@ class IssueFromBranch(unittest.TestCase):
         # the leading number, not the token.
         self.assertEqual(issue_from_branch("claude/255-issue-tracker"), 255)
         self.assertEqual(issue_from_branch("claude/game-105-issue-99-fix"), 105)
+        self.assertEqual(
+            issue_from_branch("claude/2419-fix-issue-1425-recurrence"), 2419)
 
 
 class IssuePrState(unittest.TestCase):
@@ -258,6 +275,14 @@ class BodyClosesIssue(unittest.TestCase):
             self.assertTrue(body_closes_issue("Closes #255", issue), issue)
         self.assertFalse(body_closes_issue("", 255))
         self.assertFalse(body_closes_issue(None, 255))
+
+    def test_closed_issue_numbers_extraction(self):
+        # The all-refs form the scout's closes_issues derivation rides on:
+        # keyword-gated (a bare `#99` mention is not a close) and int-typed.
+        body = "Closes #10, fixes #20 and resolves #255. Mentions #99 too."
+        self.assertEqual(sorted(body_closed_issue_numbers(body)), [10, 20, 255])
+        self.assertEqual(body_closed_issue_numbers(""), [])
+        self.assertEqual(body_closed_issue_numbers(None), [])
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -49,13 +49,14 @@ def _task(id_, blocked_by):
 
 def _pr(number, head_ref, author="bot", labels=None, body=""):
     # Mirror _fetch_prs_graphql: derive closes_issues from the live body at
-    # "fetch" time via the module's own CLOSES_RE, so the record matches the
-    # shape enrichment actually consumes. enrich_stackable_blocker_prs reads
-    # closes_issues, not body (#2442) — deriving here (not hardcoding) keeps the
-    # test's derivation from drifting off production's.
+    # "fetch" time via the shared helper (body_closed_issue_numbers, centralized
+    # in fleet_branch_match — #2419), so the record matches the shape enrichment
+    # actually consumes. enrich_stackable_blocker_prs reads closes_issues, not
+    # body (#2442) — deriving here (not hardcoding) keeps the test's derivation
+    # from drifting off production's.
     pr = {"number": number, "headRefName": head_ref, "author": author,
           "body": body,
-          "closes_issues": sorted({int(n) for n in _mod.CLOSES_RE.findall(body)})}
+          "closes_issues": sorted(set(_mod.body_closed_issue_numbers(body)))}
     if labels is not None:
         pr["labels"] = labels
     return pr

--- a/scripts/fleet/tests/test_fleet_claim_branch_check.sh
+++ b/scripts/fleet/tests/test_fleet_claim_branch_check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for `fleet-claim branch-check` (#2419) — the mint-time guard that
+# validates a branch encodes its claimed issue number, so the fleet PR-open
+# flow never pushes a branch the claim-liveness matcher can't tie back to the
+# issue (the incident: `claude/game-worker-3-issue-255` was invisible to the
+# sweep, freeing the claim and spawning a duplicate PR).
+#
+# The subcommand is purely LOCAL — no network — so this test needs no gh stub;
+# it only exercises the shared matcher via fleet-claim and, for the default
+# path, a throwaway git repo. Hermetic per scripts/fleet/CLAUDE.md.
+#
+# Covers:
+#   - prefix-form match (engine) and token-form match (repo-agnostic)
+#   - mismatch → exit 1 with the observed branch + expected form
+#   - game namespace: prefix match + game-form in the expected-form message
+#   - leading-number precedence (a token is suppressed when a number leads)
+#   - default-to-current-branch (matching and mismatching) + detached HEAD
+#   - legacy T-NNN issue arg is rejected (exit 2)
+
+set -euo pipefail
+
+# branch-check is a pure local subcommand, but disable the clone-freshness gate
+# defensively so nothing in fleet-claim startup can mask an exit code.
+export FLEET_SKIP_CLONE_FRESHNESS=1
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+assert_exit() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" -eq "$expected" ]]; then
+        ok "$msg"
+    else
+        bad "$msg"
+        echo "        expected exit: $expected"
+        echo "        actual exit:   $actual"
+    fi
+}
+
+# --- explicit-branch forms --------------------------------------------------
+
+echo "T1: prefix-form branch matches its issue (engine)"
+actual=0; "$FLEET_CLAIM" branch-check 2419 claude/2419-widen-matcher >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 0 "branch-check 2419 claude/2419-… → exit 0"
+
+echo "T2: issue-<N> token branch matches (repo-agnostic)"
+actual=0; "$FLEET_CLAIM" branch-check 255 claude/game-worker-3-issue-255 >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 0 "branch-check 255 claude/game-worker-3-issue-255 → exit 0"
+
+echo "T3: mismatch → exit 1 with observed branch + expected form"
+err=$("$FLEET_CLAIM" branch-check 255 claude/some-unrelated-topic 2>&1 1>/dev/null) && actual=0 || actual=$?
+assert_exit "$actual" 1 "branch-check 255 claude/some-unrelated-topic → exit 1"
+assert_contains "$err" "does not encode issue #255" "mismatch names the issue"
+assert_contains "$err" "claude/255-" "mismatch prints the expected prefix form"
+
+echo "T4: game namespace — prefix form matches"
+actual=0; "$FLEET_CLAIM" --repo game branch-check 255 claude/game-255-topic >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 0 "--repo game branch-check 255 claude/game-255-topic → exit 0"
+
+echo "T5: game namespace — expected-form message lists the game prefix"
+err=$("$FLEET_CLAIM" --repo game branch-check 255 claude/nope 2>&1 1>/dev/null) && actual=0 || actual=$?
+assert_exit "$actual" 1 "--repo game branch-check 255 claude/nope → exit 1"
+assert_contains "$err" "claude/game-255-" "game mismatch prints the game prefix form"
+
+echo "T6: leading-number precedence — a trailing token does NOT match"
+# claude/2419-fix-issue-1425-recurrence resolves to #2419 only, never #1425.
+actual=0; "$FLEET_CLAIM" branch-check 1425 claude/2419-fix-issue-1425-recurrence >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 1 "branch-check 1425 on a #2419-leading branch → exit 1 (token suppressed)"
+actual=0; "$FLEET_CLAIM" branch-check 2419 claude/2419-fix-issue-1425-recurrence >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 0 "branch-check 2419 on the same branch → exit 0 (leading number wins)"
+
+# --- default-to-current-branch (needs a throwaway git repo) -----------------
+
+REPO="$TMPROOT/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$REPO" checkout -q -b claude/700-default-branch-topic
+
+echo "T7: default branch (current) matches the issue"
+actual=0; ( cd "$REPO" && "$FLEET_CLAIM" branch-check 700 ) >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 0 "branch-check 700 on branch claude/700-… → exit 0"
+
+echo "T8: default branch mismatch → exit 1"
+actual=0; ( cd "$REPO" && "$FLEET_CLAIM" branch-check 701 ) >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 1 "branch-check 701 on branch claude/700-… → exit 1"
+
+echo "T9: detached HEAD (no named branch) → exit 2"
+git -C "$REPO" checkout -q --detach HEAD
+actual=0; ( cd "$REPO" && "$FLEET_CLAIM" branch-check 700 ) >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 2 "branch-check with no named branch → exit 2"
+
+# --- arg validation ---------------------------------------------------------
+
+echo "T10: legacy T-NNN issue arg is rejected"
+actual=0; "$FLEET_CLAIM" branch-check T-255 claude/255-x >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 2 "branch-check T-255 … → exit 2 (legacy form rejected)"
+
+summarize "fleet-claim branch-check tests"


### PR DESCRIPTION
## Summary

Residual of the #2419 duplicate-implementation collision: this PR raced #2456
on the same issue (a live instance of the very claim-liveness hole #2419
describes) and #2456 merged first. Re-scoped by the architect on the human's
`human:needs-fix` cue to exactly what #2456 did **not** cover — each piece
verified against current master rather than taken from the thread's summary
(which understated the residual):

1. **Matcher precedence + boundary fix — a live defect on master.** The merged
   token arm fires even when the branch carries a leading-number form:
   `branch_matches_issue("claude/2419-fix-issue-1425-recurrence", 1425)` is
   True on master, so `cmd_claim`'s open-PR guard falsely refuses a fresh
   claim on #1425 whenever an unrelated branch names `issue-1425` in its
   topic (and the TTL sweep over-retains the same way). This PR's
   `fleet_branch_match.py` makes the leading-number form authoritative — the
   word-bounded `issue-<N>` token (explicit `(?=-|$)` right boundary) is
   strictly a fallback — and locks it with a regression test that fails
   against master's module. The test file is the **union** of master's #2456
   suite (all kept, all still passing) and this PR's precedence/boundary/
   `body_closed_issue_numbers` locks.

2. **Closes-regex centralization** (#2456 explicitly left this out of scope;
   three copies of the grammar existed). `_CLOSES_KEYWORD` in
   `fleet_branch_match` is now the single spelling; `body_closes_issue`
   derives from it and a new `body_closed_issue_numbers` covers the all-refs
   form. Converted onto the shared helpers: the scout's `CLOSES_RE`
   (`closes_issues` derivation at fetch time) and
   `cmd_find_stackable_blockers`' inline `closes_re` in `fleet-claim`.
   `test_enrich_stackable_blocker_prs.py`'s fixture derivation follows.

3. **Mint-time enforcement — entirely absent from master.** New network-free
   `fleet-claim [--repo <ns>] branch-check <issue#> [branch]` (exit 0 match /
   1 mismatch-with-expected-form / 2 bad args) validating through the same
   shared matcher; the `rebase-downstream` bash auto-detect learns the
   token-form mirror (kept in sync with the Python spelling, no-lookahead ERE
   noted inline); `test_fleet_claim_branch_check.sh` (14 cases); and the
   commit-and-push flow doc wires the check in **before the push**, beside
   the `claim-base` lookup that already threads the issue number.

**Deliberately not carried over from the original diff:** the sweep-survival
and claim-guard test additions (master's `test_fleet_claim_issue_token_liveness.sh`
from #2456 already locks both contracts — double-covering the same contract
at two seams is maintenance surface, not coverage); the
`.fleet/plans/issue-2419.md` plan file (#2419 is closed; #2456 was the
canonical implementation); everything else was superseded by #2456.

No `Closes` line — #2419 is already closed by the merged #2456.

## Test plan

- [x] `test_branch_matches_issue.py` — 41 tests green (union file); the
      precedence lock verified to FAIL against master's module
- [x] `test_fleet_claim_branch_check.sh` — 14/14
- [x] Full hermetic fleet suite: every `tests/*.sh` green (0 failures),
      695-test Python suite green
- [x] `bash -n` fleet-claim; `py_compile` scout + matcher module;
      `ruff check scripts/` clean; `lint_state_mtime.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6v8rYcLosaHJghwGqBCRp
