### PR TITLE
fleet: issue-<N> token branch + Closes-#N body keep claims live (#2419)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1034,11 +1034,11 @@ sys.stdout.write(unsafe_base_reason(labels, files) or "")
         if [[ -n "$repo_for_pr_check" ]]; then
             local existing_pr
             existing_pr=$(gh pr list --repo "$repo_for_pr_check" --state open \
-                --json number,headRefName 2>/dev/null \
+                --json number,headRefName,body 2>/dev/null \
                 | ISSUE_NUM="$issue_num" REPO_NS="$REPO_NS" python3 -c '
 import json, os, sys
 sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
-from fleet_branch_match import branch_matches_issue
+from fleet_branch_match import body_closes_issue, branch_matches_issue
 issue = os.environ["ISSUE_NUM"]
 repo = os.environ.get("REPO_NS", "")
 try:
@@ -1046,12 +1046,15 @@ try:
 except Exception:
     prs = []
 for pr in prs:
-    if branch_matches_issue(pr.get("headRefName") or "", issue, repo):
+    # Second liveness signal (#2419): an untrackable branch name still
+    # blocks a duplicate claim when its body closes the issue.
+    if (branch_matches_issue(pr.get("headRefName") or "", issue, repo)
+            or body_closes_issue(pr.get("body") or "", issue)):
         print(pr.get("number"))
         break
 ' 2>/dev/null | head -1)
             if [[ -n "$existing_pr" ]]; then
-                echo "fleet-claim claim: #${issue_num} already has open PR #${existing_pr} (head claude/[game-]${issue_num}-…); refusing duplicate claim" >&2
+                echo "fleet-claim claim: #${issue_num} already has open PR #${existing_pr} (branch or Closes #${issue_num}); refusing duplicate claim" >&2
                 return 1
             fi
         fi
@@ -1347,7 +1350,7 @@ _release_parked_issue_labels() {
 
     local prs_json
     prs_json=$(gh pr list --repo "$repo" --state open \
-        --json number,headRefName,labels --limit 300 2>/dev/null || echo "[]")
+        --json number,headRefName,labels,body --limit 300 2>/dev/null || echo "[]")
 
     [[ "$(_issue_pr_state_from "$prs_json" "$issue_num" "$repo")" == "parked" ]] || return 1
 
@@ -1887,8 +1890,11 @@ for issue in issues:
 
         [[ -z "$open_claim_plan" ]] && continue
 
+        # `body` feeds the #2419 second liveness signal: issue_pr_state()
+        # keeps a claim whose PR closes the issue even under a branch name
+        # the head-prefix/token matcher can't tie to it.
         open_pr_branches_json=$(gh pr list --repo "$repo" --state open \
-            --json headRefName,labels --limit 300 2>/dev/null || echo "[]")
+            --json headRefName,labels,body --limit 300 2>/dev/null || echo "[]")
 
         while IFS=$'\t' read -r issue_num label_name; do
             [[ -z "$issue_num" || -z "$label_name" ]] && continue
@@ -2107,7 +2113,7 @@ for issue in issues:
         [[ -z "$open_claim_plan" ]] && continue
 
         open_pr_branches_json=$(gh pr list --repo "$repo" --state open \
-            --json headRefName --limit 300 2>/dev/null || echo "[]")
+            --json headRefName,body --limit 300 2>/dev/null || echo "[]")
 
         while IFS=$'\t' read -r issue_num label_name; do
             [[ -z "$issue_num" || -z "$label_name" ]] && continue
@@ -2116,7 +2122,7 @@ for issue in issues:
             has_wip_pr=$(echo "$open_pr_branches_json" | ISSUE_NUM="$issue_num" REPO="$repo" python3 -c '
 import json, os, sys
 sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
-from fleet_branch_match import branch_matches_issue
+from fleet_branch_match import body_closes_issue, branch_matches_issue
 try:
     prs = json.load(sys.stdin)
 except Exception:
@@ -2124,7 +2130,10 @@ except Exception:
 issue = os.environ["ISSUE_NUM"]
 repo = os.environ.get("REPO", "")
 for pr in prs:
-    if branch_matches_issue(pr.get("headRefName") or "", issue, repo):
+    # #2419 second liveness signal: a Closes #N body keeps the claim even
+    # when the branch name is untrackable by the matcher.
+    if (branch_matches_issue(pr.get("headRefName") or "", issue, repo)
+            or body_closes_issue(pr.get("body") or "", issue)):
         print(1)
         sys.exit(0)
 print(0)

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1314,7 +1314,7 @@ PYEOF
 
 # _issue_pr_state_from <prs-json> <issue-num> <repo>
 #   Echo the shared issue_pr_state() classification ("active" / "parked" /
-#   "none") for <issue-num> over a `gh pr list --json headRefName,labels` blob.
+#   "none") for <issue-num> over a `gh pr list --json headRefName,labels[,body]` blob.
 #   Defaults to "none" on any parse/import failure so callers fail safe (treat
 #   the claim as abandoned rather than wedged-active).
 _issue_pr_state_from() {

--- a/scripts/fleet/fleet_branch_match.py
+++ b/scripts/fleet/fleet_branch_match.py
@@ -17,7 +17,14 @@ matcher so they can't drift, and fixes every inference at once.
 The matcher accepts BOTH forms for the game repo, so in-flight
 `claude/game-<N>-*` branches keep resolving while the convention migrates
 to the prefix-less form. Engine accepts only `claude/<N>-`.
+
+It also recognizes the improvised `issue-<N>` token form
+(`claude/<worktree>-issue-<N>`) that a worker minted in the #2419 incident,
+plus a `Closes/Fixes/Resolves #N` body reference as a second liveness
+signal — so a live PR under a non-standard branch name is no longer read
+as an abandoned claim and swept into a duplicate.
 """
+import re
 
 
 def _is_game(repo):
@@ -42,6 +49,35 @@ def _norm_issue(issue):
     return str(issue).strip().lstrip("#")
 
 
+# An `issue-<N>` segment anywhere in the branch. `(?:^|[-/])` pins it to a
+# `-`/`/`-delimited token start (so `reissue-1` is not a match), and the
+# greedy `\d+` consumes the whole digit run so an `issue-25` token yields
+# "25", never a prefix of #255 (#2419).
+_ISSUE_TOKEN_RE = re.compile(r"(?:^|[-/])issue-(\d+)")
+
+# Same close-keyword set as find-stackable-blockers' `closes_re` (fleet-claim);
+# this is the importable copy the other hand-rolled inlines can converge on.
+_CLOSES_RE_TMPL = r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#%s\b"
+
+
+def _issue_token_numbers(head_ref):
+    """Issue numbers carried by word-bounded `issue-<N>` tokens in a branch."""
+    return [m.group(1) for m in _ISSUE_TOKEN_RE.finditer(head_ref or "")]
+
+
+def body_closes_issue(body, issue):
+    """True when `body` carries a `Closes/Fixes/Resolves #<issue>` reference.
+
+    The #2419 second liveness signal: a PR whose branch shape the matcher
+    can't tie to `issue` is still live work for it when its body closes the
+    issue (the same dual-match find-stackable-blockers already uses).
+    """
+    n = _norm_issue(issue)
+    if not body or not n:
+        return False
+    return re.search(_CLOSES_RE_TMPL % re.escape(n), body, re.IGNORECASE) is not None
+
+
 def issue_branch_prefixes(repo, issue):
     """Accepted `claude/...` branch prefixes for `issue` in `repo`.
 
@@ -57,9 +93,19 @@ def issue_branch_prefixes(repo, issue):
 
 
 def branch_matches_issue(head_ref, issue, repo):
-    """True when `head_ref` is the working branch for `issue` in `repo`."""
+    """True when `head_ref` is the working branch for `issue` in `repo`.
+
+    Matches the number-first fleet forms (`claude/<N>-`, game
+    `claude/game-<N>-`) and — for any `claude/…` branch — the improvised
+    `issue-<N>` token form (`claude/<worktree>-issue-<N>`) that the #2419
+    sweep read as an abandoned claim and duplicated.
+    """
     head = head_ref or ""
-    return any(head.startswith(p) for p in issue_branch_prefixes(repo, issue))
+    if any(head.startswith(p) for p in issue_branch_prefixes(repo, issue)):
+        return True
+    if head.startswith("claude/"):
+        return _norm_issue(issue) in _issue_token_numbers(head)
+    return False
 
 
 # A PR carrying any of these is *parked*: a worker hit a design wall and
@@ -88,13 +134,17 @@ def issue_pr_state(prs, issue, repo):
                  stale and safe to clear/sweep (#1488 Fix A/B).
       "none"   — no open PR branch matches the issue.
 
-    `prs` is a list of `gh pr list --json headRefName,labels` records (any
-    extra keys are ignored). Callers that only distinguish "keep the claim"
-    from "release the claim" treat "parked" and "none" identically.
+    `prs` is a list of `gh pr list --json headRefName,labels[,body]` records
+    (any extra keys are ignored). A record whose branch the matcher can't tie
+    to the issue but whose `body` closes it counts as a match too (#2419); a
+    caller that omits `body` from its fetch simply forgoes that second signal.
+    Callers that only distinguish "keep the claim" from "release the claim"
+    treat "parked" and "none" identically.
     """
     saw_parked = False
     for pr in (prs or []):
-        if not branch_matches_issue(pr.get("headRefName") or "", issue, repo):
+        if not (branch_matches_issue(pr.get("headRefName") or "", issue, repo)
+                or body_closes_issue(pr.get("body") or "", issue)):
             continue
         names = {
             (lbl or {}).get("name", "")
@@ -113,7 +163,9 @@ def issue_from_branch(head_ref):
 
     Repo-agnostic inverse of `branch_matches_issue`: handles both
     `claude/<N>-...` (engine / new game) and `claude/game-<N>-...` (legacy
-    game) by stripping the optional `game-` infix before reading the digits.
+    game) by stripping the optional `game-` infix before reading the digits,
+    and falls back to an explicit `issue-<N>` token (#2419) when the
+    number-first form is absent.
     """
     head = head_ref or ""
     if not head.startswith("claude/"):
@@ -127,4 +179,9 @@ def issue_from_branch(head_ref):
             num += ch
         else:
             break
-    return int(num) if num else None
+    if num:
+        return int(num)
+    # Number-first form absent — read an explicit `issue-<N>` token
+    # (`claude/<worktree>-issue-<N>`), the shape behind the #2419 sweep miss.
+    tokens = _issue_token_numbers(head)
+    return int(tokens[0]) if tokens else None

--- a/scripts/fleet/tests/test_branch_matches_issue.py
+++ b/scripts/fleet/tests/test_branch_matches_issue.py
@@ -5,6 +5,8 @@ Pins the contract both fleet-claim and fleet-state-scout rely on:
   - game accepts both `claude/<N>-` and `claude/game-<N>-`
   - cross-repo and wrong-issue branches do not match
   - issue_from_branch is the repo-agnostic inverse (strips optional game-)
+  - (#2419) an improvised `issue-<N>` token branch, or a `Closes #N` body,
+    resolves to the issue so a live PR is not swept into a duplicate claim
 """
 import sys
 import unittest
@@ -13,6 +15,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from fleet_branch_match import (
     _is_game,
+    body_closes_issue,
     branch_matches_issue,
     issue_branch_prefixes,
     issue_from_branch,
@@ -75,6 +78,42 @@ class BranchMatchesIssue(unittest.TestCase):
             ["claude/105-", "claude/game-105-"],
         )
 
+    # --- #2419: the improvised `issue-<N>` token form --------------------
+    def test_issue_token_form_matches(self):
+        # The exact branch shapes from the #2419 duplicate-PR incident.
+        self.assertTrue(
+            branch_matches_issue("claude/game-worker-3-issue-255", 255, "game"))
+        self.assertTrue(
+            branch_matches_issue("claude/worker-4-issue-255", 255, "engine"))
+        # game token branch is repo-agnostic for the token, but a game- infix
+        # branch checked as engine still resolves via the token (the number is
+        # what the sweep needs; the head-prefix cross-repo guard is separate).
+        self.assertTrue(
+            branch_matches_issue("claude/game-worker-3-issue-255", 255, "engine"))
+
+    def test_issue_token_word_bounded(self):
+        # `issue-25` must NOT satisfy #255 (word-bounded digit run), and the
+        # right boundary rejects a longer number too.
+        self.assertFalse(branch_matches_issue("claude/w-3-issue-25", 255, "engine"))
+        self.assertTrue(branch_matches_issue("claude/w-3-issue-25", 25, "engine"))
+        self.assertFalse(branch_matches_issue("claude/w-3-issue-2550", 255, "engine"))
+
+    def test_issue_token_left_boundary(self):
+        # `reissue-255` is not an `issue-<N>` token (must open a -/ segment).
+        self.assertFalse(branch_matches_issue("claude/reissue-255", 255, "engine"))
+        # `claude/issue-255-topic` (token right after the slash) does match.
+        self.assertTrue(branch_matches_issue("claude/issue-255-topic", 255, "engine"))
+
+    def test_issue_token_requires_claude_prefix(self):
+        # A non-fleet branch with an issue- token is not a working branch.
+        self.assertFalse(branch_matches_issue("feature/issue-255", 255, "engine"))
+        self.assertFalse(branch_matches_issue("issue-255", 255, "engine"))
+
+    def test_number_first_form_still_wins(self):
+        # Regression guard: widening the matcher didn't break the primary form.
+        self.assertTrue(branch_matches_issue("claude/255-topic", 255, "engine"))
+        self.assertFalse(branch_matches_issue("claude/1050-x", 105, "engine"))
+
 
 class IssueFromBranch(unittest.TestCase):
     def test_engine_branch(self):
@@ -95,6 +134,19 @@ class IssueFromBranch(unittest.TestCase):
     def test_empty_and_none(self):
         self.assertIsNone(issue_from_branch(""))
         self.assertIsNone(issue_from_branch(None))
+
+    # --- #2419: fall back to an `issue-<N>` token ------------------------
+    def test_issue_token_fallback(self):
+        self.assertEqual(
+            issue_from_branch("claude/game-worker-3-issue-255"), 255)
+        self.assertEqual(issue_from_branch("claude/worker-4-issue-255"), 255)
+        self.assertEqual(issue_from_branch("claude/issue-42-topic"), 42)
+
+    def test_number_first_wins_over_token(self):
+        # A number-first branch whose topic merely contains 'issue-<M>' reads
+        # the leading number, not the token.
+        self.assertEqual(issue_from_branch("claude/255-issue-tracker"), 255)
+        self.assertEqual(issue_from_branch("claude/game-105-issue-99-fix"), 105)
 
 
 class IssuePrState(unittest.TestCase):
@@ -147,6 +199,65 @@ class IssuePrState(unittest.TestCase):
         ]
         # None are parked, all match -> first match is active.
         self.assertEqual(issue_pr_state(prs, 1488, "engine"), "active")
+
+    # --- #2419: an `issue-<N>` token branch survives the sweep -----------
+    def test_active_via_issue_token_branch(self):
+        # Acceptance (b): the exact incident branch is live work, so the
+        # cleanup sweep (which keeps a claim only on "active") won't free it.
+        prs = [{"headRefName": "claude/game-worker-3-issue-255",
+                "labels": [{"name": "fleet:wip"}]}]
+        self.assertEqual(issue_pr_state(prs, 255, "game"), "active")
+
+    # --- #2419: body `Closes #N` is a second liveness signal -------------
+    def test_active_via_closes_body_untrackable_branch(self):
+        # Branch name the matcher can't tie to #1488, but the body closes it:
+        # still live work, so the claim must stay (not swept -> no duplicate).
+        prs = [{"headRefName": "claude/some-weird-branch",
+                "body": "Closes #1488", "labels": []}]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "active")
+
+    def test_parked_via_closes_body(self):
+        # The body signal is classified the same as a branch match: a parked
+        # PR that closes the issue is parked, not active.
+        prs = [{"headRefName": "claude/weird",
+                "body": "Fixes #1488", "labels": [{"name": "fleet:design-blocked"}]}]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "parked")
+
+    def test_closes_body_word_bounded(self):
+        # `Closes #14` must not keep the claim on #1488.
+        prs = [{"headRefName": "claude/weird", "body": "Closes #14", "labels": []}]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "none")
+
+    def test_missing_body_is_backward_compatible(self):
+        # A caller that fetches only headRefName+labels (no body) simply
+        # forgoes the second signal — an untrackable branch is "none".
+        prs = [{"headRefName": "claude/weird", "labels": [{"name": "fleet:wip"}]}]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "none")
+
+
+class BodyClosesIssue(unittest.TestCase):
+    def test_close_keywords(self):
+        for verb in ("Closes", "close", "closed", "Fixes", "fix", "fixed",
+                     "Resolves", "resolve", "resolved"):
+            self.assertTrue(body_closes_issue("%s #255" % verb, 255), verb)
+
+    def test_case_insensitive_and_embedded(self):
+        self.assertTrue(body_closes_issue("...work here.\n\nCLOSES #255\n", 255))
+        self.assertTrue(body_closes_issue("this fixes #255 fully", 255))
+
+    def test_word_bounded_number(self):
+        self.assertFalse(body_closes_issue("Closes #2550", 255))
+        self.assertFalse(body_closes_issue("Closes #25", 255))
+
+    def test_requires_a_close_keyword(self):
+        self.assertFalse(body_closes_issue("see #255", 255))
+        self.assertFalse(body_closes_issue("relates to #255", 255))
+
+    def test_issue_arg_forms_and_empty(self):
+        for issue in (255, "255", "#255"):
+            self.assertTrue(body_closes_issue("Closes #255", issue), issue)
+        self.assertFalse(body_closes_issue("", 255))
+        self.assertFalse(body_closes_issue(None, 255))
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_fleet_claim_issue_token_liveness.sh
+++ b/scripts/fleet/tests/test_fleet_claim_issue_token_liveness.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# #2419: an improvised `issue-<N>` token branch (or a `Closes #N` body) is
+# recognized as live work by fleet-claim's two liveness surfaces:
+#   - the cleanup sweep, via _issue_pr_state_from -> issue_pr_state (keeps the
+#     claim while the PR is open, so it is not swept into a duplicate), and
+#   - cmd_claim's open-PR guard (refuses a second claim on the same issue).
+# The #1425 matcher recognized only claude/<N>- / claude/game-<N>- prefixes;
+# the incident branch claude/game-worker-3-issue-255 slipped both surfaces,
+# so the TTL sweep freed the live claim and a duplicate PR followed.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+source "$(dirname "$0")/lib_assert.sh"
+
+# Source fleet-claim as a library (helpers only, no dispatch). Clear args so
+# the top-level --repo parse is a no-op.
+set --
+FLEET_CLAIM_LIB=1 source "$FLEET_CLAIM"
+
+TOKEN_BRANCH="claude/game-worker-3-issue-255"
+
+echo "== cleanup-sweep liveness (_issue_pr_state_from, the real helper) =="
+
+# (b) A live token-branch PR classifies "active" -> the sweep keeps the claim.
+prs='[{"headRefName":"'"$TOKEN_BRANCH"'","labels":[{"name":"fleet:wip"}]}]'
+assert_eq "$(_issue_pr_state_from "$prs" 255 game)" "active" \
+    "token branch PR keeps the claim (survives sweep)"
+
+# A `Closes #N` body under an untrackable branch is the second signal.
+prs='[{"headRefName":"claude/some-odd-branch","body":"Closes #255","labels":[]}]'
+assert_eq "$(_issue_pr_state_from "$prs" 255 game)" "active" \
+    "Closes #255 body keeps the claim (survives sweep)"
+
+# Control: an unrelated open PR is not live -> the claim would be swept.
+prs='[{"headRefName":"claude/999-unrelated","labels":[]}]'
+assert_eq "$(_issue_pr_state_from "$prs" 255 game)" "none" \
+    "unrelated branch is not live for #255"
+
+echo "== cmd_claim open-PR guard (refuses a duplicate) =="
+
+# Isolate the guard: neutralize the gates that run before it (each hits
+# gh / git / FS and is covered by its own test).
+_refuse_if_closed()            { return 0; }
+assert_clone_fresh()           { return 0; }
+check_blockers()               { return 0; }
+check_model_tag()              { return 0; }
+check_host_capability()        { return 0; }
+reservation_holder_for_task()  { :; }
+repo_from_ns()                 { echo "jakildev/IrredenEngine"; }
+
+CLAIMS_DIR=$(mktemp -d)/claims
+
+# gh stub: pr list returns an open token-branch PR for #255. The guard only
+# consults pr list; any other call returns empty.
+gh() {
+    if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+        printf '%s' '[{"number":900,"headRefName":"'"$TOKEN_BRANCH"'","body":""}]'
+    fi
+}
+
+set +e
+out=$(cmd_claim 255 worker-4 2>&1); rc=$?
+set -e
+assert_eq "$rc" "1" "cmd_claim refuses a duplicate on a token branch (exit 1)"
+assert_contains "$out" "refusing duplicate claim" \
+    "cmd_claim names the duplicate refusal"
+assert_contains "$out" "900" "cmd_claim reports the existing PR number"
+
+# The `Closes #N` body also blocks the claim under an untrackable branch.
+gh() {
+    if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+        printf '%s' '[{"number":901,"headRefName":"claude/odd","body":"Closes #255"}]'
+    fi
+}
+CLAIMS_DIR=$(mktemp -d)/claims
+set +e
+out=$(cmd_claim 255 worker-4 2>&1); rc=$?
+set -e
+assert_eq "$rc" "1" "cmd_claim refuses a duplicate on a Closes #N body (exit 1)"
+
+# Control: an unrelated open PR must NOT fire the guard (no over-refusal). The
+# claim may fail later (label path), but the duplicate refusal must be absent.
+gh() {
+    if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+        printf '%s' '[{"number":902,"headRefName":"claude/999-unrelated","body":""}]'
+    fi
+    return 0
+}
+CLAIMS_DIR=$(mktemp -d)/claims
+set +e
+out=$(cmd_claim 255 worker-4 2>&1)
+set -e
+assert_absent "$out" "refusing duplicate claim" \
+    "no duplicate refusal for an unrelated open PR"
+
+summarize "fleet-claim issue-token liveness (#2419)"


### PR DESCRIPTION
## Summary
- The #1425 branch↔issue matcher recognized only `claude/<N>-` / `claude/game-<N>-` prefixes. The improvised `claude/game-worker-3-issue-255` branch (issue number as a trailing `issue-<N>` token) slipped it, so the TTL cleanup sweep judged the live claim abandoned, freed it, and a second worker opened a duplicate PR — the #1425 signature via an uncovered branch shape.
- **Part 1 — widen the shared matcher** (`fleet_branch_match.py`): `branch_matches_issue` and `issue_from_branch` now recognize a word-bounded `issue-<N>` token in any `claude/` branch (`issue-25` never satisfies #255). Centralized, so the claim guard, both cleanup sweeps, the scout projection, and `reconcile` are fixed at once.
- **Part 2 — second liveness signal**: an open PR whose body carries `Closes/Fixes/Resolves #N` is live work for #N (`body_closes_issue`), the same dual-match `find-stackable-blockers` already uses. `issue_pr_state`, `cmd_claim`'s open-PR guard, and both host-claim sweeps now consult the PR body too. The fleet PR template always emits `Closes #N`, so this covers any non-standard branch name — **either signal alone keeps the claim**.
- **Part 4 — tests**: token matching (engine + game), word-boundedness, `issue_from_branch` fallback, `body_closes_issue`, and `issue_pr_state`'s body signal in `test_branch_matches_issue.py`; a hermetic `test_fleet_claim_issue_token_liveness.sh` drives the real `_issue_pr_state_from` sweep helper and `cmd_claim`'s guard end-to-end (survives sweep + blocks a second claim).

## Deferred — acceptance item 3 (mint-time enforcement)
Item 3 ("the durable fix": the PR-open flow refuses an untrackable branch) is **not** in this PR; a tracked follow-up is filed as #2457. Rationale:
- **No mechanical choke point.** The fleet PR-open flow is agent *prose* (`commit-and-push` SKILL.md + `procedures/*.md`), not executable code. SKILL.md is gated self-config no worker class can push; the procedure `.md` files are prose, not a hard gate. True mint-time *refusal* wants an enforcement seam (a committed git `pre-push` hook, a mandatory `fleet-claim assert-branch` call, or claim-time branch capture) — a design choice, not settled here.
- **Low residual risk after this PR.** Every fleet PR body already carries `Closes #N`, which Part 2 now treats as a liveness signal, so untrackable branches are already caught on the sweep and the claim guard. Mint-time enforcement only adds value for a branch that is *both* untrackable-by-token *and* missing a `Closes #N` body — which the template never produces.

## Test plan
- [x] `python3 -m unittest tests.test_branch_matches_issue` — 39 pass (22 pre-existing + 17 new)
- [x] `bash tests/test_fleet_claim_issue_token_liveness.sh` — 8 pass
- [x] `ruff check scripts/` clean; `bash -n scripts/fleet/fleet-claim` clean
- [x] Regression: `test_fleet_claim_{parked_release,orphan_sweep,prlabel_orphan_sweep,reconcile,acquire}.sh`, `test_enrich_stackable_blocker_prs.py` pass

## Notes for reviewer
The close-keyword regex now lives in `fleet_branch_match` (`_CLOSES_RE_TMPL` / `body_closes_issue`) as the first importable copy; three pre-existing hand-rolled inlines (`fleet-claim` `closes_re` at find-stackable, `CLOSES_RE` at reconcile, and the scout) still duplicate it and could converge here in a later consolidation — left out of scope for #2419.

Closes #2419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
