### PR TITLE
fleet: stack-base ancestry guard — reject a base missing a merged ancestor

### DIFF
--- a/.fleet/plans/issue-2447.md
+++ b/.fleet/plans/issue-2447.md
@@ -1,0 +1,210 @@
+## Plan: fleet/scout: stack-base guard validates base ancestry (offer + accept)
+
+- **Issue:** #2447
+- **Model:** opus
+- **Date:** 2026-07-19
+
+### Scope
+
+Extend the shared stack-base predicate so both surfaces — the scout's offer
+(`enrich_stackable_blocker_prs`) and `fleet-claim claim --stackable-on`'s
+accept — reject a base whose head is missing the squash commit of a merged
+blocker anywhere in the base's blocker ancestry, with a reason naming the
+missing ancestor. Fixes the churn loop where a provably-unbuildable base is
+offered, claimed, released, and re-offered every tick, defeating the
+dispatcher's go-quiet gate (`_only_unclaimable_tasks`).
+
+### Verified current state (all premises measured, 2026-07-19)
+
+**Code (read this session):**
+
+- `fleet_stack_base.unsafe_base_reason()` (`scripts/fleet/fleet_stack_base.py:68`)
+  checks labels + empty-diff only. No ancestry input exists in the signature.
+- `enrich_stackable_blocker_prs` (`fleet-state-scout:1541`) runs **after**
+  `resolve_blocked_by` (`:1324`), which **mutates** `task["blocked_by"]`,
+  dropping merged refs. The merged-ancestor identity the check needs is
+  destroyed before the enrich runs — this is the "collapsed" data loss and it
+  also means `resolve_blocked_by` is the natural place to stash the removed
+  refs. Note `resolve_blocked_by` iterates `tasks.open` **only**; ancestor
+  records sitting in `tasks.in_progress` keep their raw (uncollapsed)
+  `blocked_by`.
+- `fetch_recent_merged_prs` (`fleet-state-scout:529`) pulls REST `/pulls`
+  (state=closed) and projects number/title/headRefName/baseRefName/mergedAt.
+  The raw payload already carries `merge_commit_sha` — **verified live**:
+  `gh api 'repos/jakildev/IrredenEngine/pulls?state=closed&…&per_page=3'`
+  returns e.g. PR #2445 → `merge_commit_sha: 2200a82…`, which is the current
+  master tip commit. Projecting it costs zero extra API calls.
+- The scout's open-PR list projection (`prs[]`) carries no `headRefOid`; the
+  per-PR detail cache does (`fleet-state-scout:850`). The list poll's raw
+  payload includes the head oid, so projecting it into `prs[]` is also free.
+- `fleet-claim`'s blocker check already fetches merged PRs live
+  (`fleet-claim:1210`: `gh pr list --state merged --limit 30 --json
+  headRefName` + `branch_matches_issue`). Adding `number,mergeCommit` to that
+  same `--json` list yields the accept-side sha in the existing single call.
+
+**Live repro (the downstream private repo's active instance, anonymized per
+cross-repo isolation — chain T1→T2→T3→T4, T4 offered T3's head as base):**
+
+- `git merge-base --is-ancestor <T1-squash> origin/<T3-head>` → **false**;
+  same sha vs `origin/master` → **true**. The hole is real and live today.
+- GitHub compare API on the same pair:
+  `compare/<T3-head-oid>...<T1-squash>` → `status: diverged, ahead_by: 6`.
+  Positive control (the base's fork-point sha, known-contained) →
+  `status: behind, ahead_by: 0`. So the API verdict rule is
+  **contained ⇔ `ahead_by == 0`** (status `behind` or `identical`), and it
+  agrees with local `git merge-base --is-ancestor` on both the negative and
+  the positive case. The compare route needs no local refs, which matters
+  because the scout never fetches.
+- T3's issue's raw `Blocked by:` names two entries (T1 merged, T2 open); the
+  cached task record shows it collapsed to the single open one — confirming
+  the walk must recover merged refs from the pre-collapse parse.
+
+**Cost (measured on the live queue):** engine has 0 candidate offers this
+tick, the downstream repo has 1 (the churn instance) with 1 merged frontier
+ancestor, whose PR is inside the 30-entry `recent_merged_prs` window (sha
+free). Cold cost = 1 compare call per new (offer × merged ancestor) pair,
+memoizable forever on the immutable `(base-head-oid, sha)` key → steady-state
+**0 added API calls per tick**. No per-offer `git fetch` is needed anywhere.
+
+### Approach
+
+**1. Pure logic in `fleet_stack_base.py` (shared, injected callables).**
+Add `missing_ancestor_reason(base_issue, get_blocker_refs, ref_merged,
+merged_sha, contains, max_depth=8)`:
+
+- Walk same-repo blocker refs from the base PR's issue: recurse through
+  **open** ancestors, collect refs classified **merged** (the frontier).
+  Merged nodes are checked, never recursed: squash-merge history on master is
+  linear, so if frontier ancestor C's squash is contained in the base head,
+  everything merged before C is too — a deeper hole cannot exist without a
+  frontier miss.
+- For each frontier ancestor C: `merged_sha(C)` then `contains(sha)`.
+  `False` → return `"missing merged ancestor #C"`.
+- Fail closed: any `None` from a callable (record unknown, cross-repo ref,
+  sha unresolvable, verdict unavailable), a depth-cap hit, or a cycle
+  (visited set) → return an `"ancestry undeterminable (<why>)"` reason.
+  Rationale: a suppressed offer degrades to the safe pre-stackable status quo
+  (task waits for the merge), while fail-open reproduces the guaranteed-no-op
+  dispatch loop this issue exists to kill. The #2442-style silent-withholding
+  hazard is handled by logging, not by failing open (below).
+
+**2. Scout (offer side).**
+
+- `resolve_blocked_by`: before collapsing, stash the removed refs as
+  `task["collapsed_blockers"]`. Shared helper for "is this ref merged"
+  (closed-issue window ∪ merged-head branch match — the exact sets resolve
+  already uses) so the walk can classify raw refs on `in_progress` records
+  that resolve never visited.
+- `fetch_recent_merged_prs`: project `mergeCommitSha` (only when `merged_at`
+  is set — REST's `merge_commit_sha` on an unmerged PR is a test-merge sha,
+  not usable).
+- Open-PR list projection: add `headRefOid`.
+- `enrich_stackable_blocker_prs`: after the existing `unsafe_base_reason`
+  filter, run `missing_ancestor_reason` with in-memory callables; `contains`
+  goes through the compare API via the scout's conditional-fetch layer, with
+  a persistent memo (JSON beside the existing scout caches) keyed
+  `(base_head_oid, sha) → bool` — immutable, so it never invalidates; a base
+  rebase changes the oid and naturally re-keys. On a reason: skip the offer
+  **and `log()` it** (task, base PR#, reason) — suppressions must be
+  observable, never silent (the #2442 lesson).
+
+**3. `fleet-claim` (accept side).** In the `--stackable-on` block after the
+label/diff check: rebuild the walk live in an inline `python3` block
+(imports `fleet_stack_base` + `fleet_blocked_by` via `FLEET_LIB_DIR`) —
+`gh issue view` per open ancestor for raw `Blocked by:`, the existing merged
+`gh pr list` call extended with `number,mergeCommit` for the frontier shas,
+and `git fetch origin <base-branch>` + `git merge-base --is-ancestor` for
+containment (claim has a repo checkout; measured agreement with the compare
+API above). Refusal mirrors the existing message:
+`"<pr> is not a stackable base (missing merged ancestor #C) — refusing claim"`.
+Offer and accept agree by construction — both route the decision through the
+same pure function.
+
+**4. Tests (hermetic, per `scripts/fleet/CLAUDE.md` — mock misses raise,
+tempfile cache dirs, no live GitHub, no live `~/.fleet`).**
+
+- `tests/test_stack_base_guard.py`: unit tests for
+  `missing_ancestor_reason` — the acceptance pair (base whose *parent's*
+  collapsed blocker merged after the fork → rejected naming the ancestor;
+  same base with `contains=True` → offered); hole two levels up (the
+  T5-shape); candidate's own collapsed set empty while the hole is upstream
+  (the #2447 signature); undeterminable inputs fail closed; cycle + depth
+  cap terminate.
+- `tests/test_enrich_stackable_blocker_prs.py`: existing cases stay green
+  (fixtures gain the new windows/fields as needed); new: offer suppressed +
+  log line emitted on a not-contained verdict; warm memo → zero fetcher
+  calls (pins the steady-state-0 cost); missing `headRefOid`/sha →
+  suppressed as undeterminable, logged.
+- `tests/test_fleet_task_class.py` (integration, the addendum's A/B): run the
+  enrichment over a slice shaped like the forensics (sole non-terminal entry
+  rides the invalid base) and assert the resolver returns **`defer`**; flip
+  the verdict to contained and assert it dispatches. Positive-fire in both
+  directions; pins the observable go-quiet behavior (#1726/#1998 lineage).
+- `tests/test_fleet_claim_stackable_live_resolve.sh`: mocked `gh`/`git` —
+  refusal message names the ancestor; contained case proceeds to claim.
+
+### Affected files
+
+- `scripts/fleet/fleet_stack_base.py` — `missing_ancestor_reason` + walk
+  (pure, injected callables)
+- `scripts/fleet/fleet-state-scout` — resolve stash + merged-ref helper;
+  `mergeCommitSha` + `headRefOid` projections; enrich integration; persistent
+  compare-verdict memo; suppression `log()`
+- `scripts/fleet/fleet-claim` — `--stackable-on` ancestry gate
+- `scripts/fleet/tests/test_stack_base_guard.py`
+- `scripts/fleet/tests/test_enrich_stackable_blocker_prs.py`
+- `scripts/fleet/tests/test_fleet_task_class.py`
+- `scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh`
+
+One task, one PR (the offer and accept must land together — that is the
+module's contract). No epic.
+
+### Acceptance criteria (positive-fire)
+
+1. Unit: a base missing a transitively-merged ancestor (hole ≥1 level above
+   the candidate's own blocker list) is rejected with a reason naming the
+   ancestor; the same base containing that squash is offered.
+2. Agreement: both surfaces call `missing_ancestor_reason`; the claim-side
+   test refuses the same fixture base the scout declines to offer.
+3. `resolve(slice) == "defer"` when the slice's only claimable entry rode the
+   invalid base — and dispatches when the base is valid (the A/B fires both
+   ways).
+4. Enrich test proves a suppression **logs** (count > 0 in captured output) —
+   no silent withholding.
+5. Warm-memo enrich performs zero network-fetch calls (steady-state cost
+   pinned at 0 per tick).
+6. `tests/test_enrich_stackable_blocker_prs.py` fully green.
+
+### Gotchas
+
+- Compare-API verdict is **`ahead_by == 0`** (`behind` *or* `identical`) —
+  do not test `status == "behind"` alone or read `behind_by`.
+- `merge_commit_sha` is only meaningful when `merged_at` is set.
+- `resolve_blocked_by` visits `tasks.open` only — never assume the
+  `collapsed_blockers` stash exists on an `in_progress` record; classify raw
+  refs on demand there.
+- The ancestry inputs deliberately avoid PR **bodies** (issue-side graph +
+  branch-match + oids only) so #2442's 304-body-stripping cannot corrupt this
+  check.
+- Keep downstream-repo identifiers out of code comments and commit text —
+  reference #2447 itself for the incident (public-repo isolation).
+- New `gh`/`git` call sites in `fleet-claim` are covered by the sourced
+  `fleet-net.sh` timeout shadows — do not add raw unguarded calls.
+- Cross-repo blocker refs in the walk: classify as undeterminable (fail
+  closed + log), matching `resolve_blocked_by`'s same-repo-only window.
+
+### Sibling / in-flight reconciliation
+
+- **#2442** (open, unclaimed): same function, different stage (the
+  Closes-#N *match*; this plan filters *after* the match). Merge-order
+  agnostic; this plan's body-independence note above is the interaction
+  guard.
+- **#1531**: multi-blocker stacking stays deferred (v1 Q3) — this plan
+  implements transitive ancestry for the single-blocker eligible set only.
+  The 2026-07-15 transitive-closure comment there is subsumed for that set.
+- **#1726 / #1998**: the defer A/B test pins the go-quiet gate those issues
+  established; no dispatcher-side change (the addendum's resolver audit
+  already ruled the dispatcher correct).
+- No open PRs touch `scripts/fleet/` (checked both repos' open-PR lists this
+  session).
+

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -978,6 +978,134 @@ sys.stdout.write(unsafe_base_reason(labels, files) or "")
                     echo "fleet-claim claim: $stackable_pr is not a stackable base ($stack_reject) — refusing claim" >&2
                     return 1
                 fi
+                # Ancestry gate (#2447): the label/diff check above never checks
+                # whether the base head actually CONTAINS the work of a blocker
+                # that merged after the base forked. Route the same walk the
+                # scout's offer filter uses (fleet_stack_base.missing_ancestor_reason)
+                # through live gh (base issue's blocker graph, merged-frontier
+                # shas) + git merge-base --is-ancestor (containment against the
+                # fetched base head), so offer and accept can't disagree. Fails
+                # CLOSED (refuse) on any unresolvable input — the safe direction
+                # for a claim, mirroring the base-safety check above.
+                local stack_anc_reject
+                if ! stack_anc_reject=$(BASE_PR="$stackable_pr" BASE_BRANCH="$pr_head" \
+                    REPO="$(repo_from_ns)" python3 <<'PYEOF'
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_blocked_by import blocker_refs
+from fleet_branch_match import branch_matches_issue, issue_from_branch
+from fleet_stack_base import missing_ancestor_reason
+
+repo = os.environ["REPO"]
+base_branch = os.environ["BASE_BRANCH"]
+base_pr = os.environ["BASE_PR"]
+
+
+def _run(cmd, timeout=15):
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return r if r.returncode == 0 else None
+
+
+# Base issue: the base PR's own issue, whose Blocked-by is the ancestry root.
+base_issue = issue_from_branch(base_branch)
+if base_issue is None:
+    r = _run(["gh", "pr", "view", base_pr, "--repo", repo, "--json",
+              "closingIssuesReferences", "--jq",
+              ".closingIssuesReferences[0].number"])
+    if r and r.stdout.strip().isdigit():
+        base_issue = int(r.stdout.strip())
+if base_issue is None:
+    sys.stdout.write("ancestry undeterminable (base issue unresolvable)")
+    sys.exit(0)
+
+r = _run(["gh", "pr", "view", base_pr, "--repo", repo, "--json", "headRefOid",
+          "--jq", ".headRefOid"])
+base_oid = r.stdout.strip() if r else ""
+
+merged_prs = []
+r = _run(["gh", "pr", "list", "--repo", repo, "--state", "merged", "--limit",
+          "50", "--json", "number,headRefName,mergeCommit"])
+if r:
+    try:
+        merged_prs = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        merged_prs = []
+
+_merged_sha = {}
+
+
+def get_blocker_refs(issue):
+    # gh failure → None (fail closed → refuse the claim on an unverifiable base).
+    # Cross-repo refs are dropped, not failed on: same-repo git containment can't
+    # evaluate them and a cross-repo dependency is never in this repo's git head.
+    r = _run(["gh", "issue", "view", str(issue), "--repo", repo, "--json",
+              "body", "--jq", ".body"])
+    if r is None:
+        return None
+    return [num for slug, num in blocker_refs(r.stdout, repo) if slug == repo]
+
+
+def ref_merged(ref):
+    for pr in merged_prs:
+        if branch_matches_issue(pr.get("headRefName", ""), ref, repo):
+            _merged_sha[ref] = (pr.get("mergeCommit") or {}).get("oid", "")
+            return True
+    r = _run(["gh", "issue", "view", ref, "--repo", repo, "--json", "state",
+              "--jq", ".state"])
+    if r is None:
+        return None
+    state = r.stdout.strip()
+    if state in ("CLOSED", "MERGED"):
+        return True   # merged but its PR fell outside the window → sha None → fail closed
+    if state == "OPEN":
+        return False
+    return None
+
+
+def merged_sha(ref):
+    return _merged_sha.get(ref) or None
+
+
+if base_oid:
+    _run(["git", "fetch", "origin", base_branch], timeout=30)
+_contains = {}
+
+
+def contains(sha):
+    if not base_oid or not sha:
+        return None
+    if sha in _contains:
+        return _contains[sha]
+    try:
+        r = subprocess.run(["git", "merge-base", "--is-ancestor", sha, base_oid],
+                           capture_output=True, text=True, timeout=15)
+    except (subprocess.SubprocessError, OSError):
+        _contains[sha] = None
+        return None
+    v = True if r.returncode == 0 else (False if r.returncode == 1 else None)
+    _contains[sha] = v
+    return v
+
+
+reason = missing_ancestor_reason(base_issue, get_blocker_refs, ref_merged,
+                                 merged_sha, contains)
+sys.stdout.write(reason or "")
+PYEOF
+                ); then
+                    echo "fleet-claim claim: base-ancestry check failed (Python error) — refusing to stack on an unverifiable base" >&2
+                    return 1
+                fi
+                if [[ -n "$stack_anc_reject" ]]; then
+                    echo "fleet-claim claim: $stackable_pr is not a stackable base ($stack_anc_reject) — refusing claim" >&2
+                    return 1
+                fi
                 stackable_branch="$pr_head"
                 ;;
             "")

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1638,7 +1638,11 @@ def _load_ancestry_memo():
 
 def _save_ancestry_memo(memo):
     try:
-        ANCESTRY_MEMO_FILE.write_text(json.dumps(memo))
+        # write_atomic (unique-temp + os.replace) so a concurrent scout reader
+        # under a leader/follower dual-poll tick only ever sees the complete
+        # prior or new memo, never a torn splice — matches every other writer in
+        # this file (state.json, the PR/diff/issue caches, the seen-file hashes).
+        write_atomic(ANCESTRY_MEMO_FILE, json.dumps(memo))
     except OSError:
         pass
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -53,14 +53,18 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import fleet_poll_topology
 from fleet_blocked_by import is_no_blocker_value, parse_blocked_by
-from fleet_branch_match import PARKED_PR_LABELS, branch_matches_issue
+from fleet_branch_match import (
+    PARKED_PR_LABELS,
+    branch_matches_issue,
+    issue_from_branch,
+)
 
 # Conditional-REST polling core (#1394 Q1) — see the fetcher section below.
 # ETAG_DIR aliases the module's shared etag-cache default so the two never
 # drift; it's mkdir'd in main() and the fetchers rely on that default cache_dir.
 from fleet_gh_poll import DEFAULT_CACHE_DIR as ETAG_DIR
 from fleet_gh_poll import conditional_get
-from fleet_stack_base import unsafe_base_reason
+from fleet_stack_base import missing_ancestor_reason, unsafe_base_reason
 
 
 def _fleet_script_argv(cmd):
@@ -87,6 +91,12 @@ PROJECTIONS_DIR = STATE_DIR / "projections"
 PRS_DIR = STATE_DIR / "prs"
 DIFFS_DIR = STATE_DIR / "diffs"
 ISSUES_DIR = STATE_DIR / "issues"
+# Persistent memo for the stack-base ancestry guard (#2447): a compare-API
+# containment verdict keyed on `(base_head_oid, sha)`. Both keys are immutable
+# commit shas, so a cached verdict never invalidates — a base rebase changes
+# the head oid and naturally re-keys. Warm entries make the steady-state
+# per-tick cost of the guard zero network calls.
+ANCESTRY_MEMO_FILE = STATE_DIR / "stack-ancestry-memo.json"
 PID_FILE = STATE_DIR / "scout.pid"
 STATE_FILE = STATE_DIR / "state.json"
 SHUTDOWN_FLAG = Path.home() / ".fleet" / "shutdown-in-progress"
@@ -255,7 +265,10 @@ def _fetch_prs_graphql(repo):
     out = run_capture([
         "gh", "pr", "list", "--repo", repo, "--state", "open",
         "--json",
-        "number,title,headRefName,baseRefName,author,labels,mergeable,"
+        # headRefOid feeds the stack-base ancestry guard (#2447): the compare-API
+        # containment check is keyed on the base head oid. It rides the same list
+        # poll, so requesting it costs no extra call.
+        "number,title,headRefName,headRefOid,baseRefName,author,labels,mergeable,"
         "isDraft,reviews,updatedAt,body",
     ])
     if out is None:
@@ -595,6 +608,13 @@ def fetch_recent_merged_prs(repo, limit=30):
             "headRefName": (pr.get("head") or {}).get("ref", ""),
             "baseRefName": (pr.get("base") or {}).get("ref", ""),
             "mergedAt": pr.get("merged_at", ""),
+            # #2447: the merge commit sha feeds the stack-base ancestry guard's
+            # containment check (a frontier ancestor's squash must be reachable
+            # from the offered base head). REST's `merge_commit_sha` is only a
+            # real squash sha when `merged_at` is set — this list is already
+            # filtered to merged PRs above, so projecting it here costs zero
+            # extra API calls (the field rides the same /pulls payload).
+            "mergeCommitSha": pr.get("merge_commit_sha", "") or "",
         }
         for pr in merged
     ]
@@ -1391,6 +1411,15 @@ def resolve_blocked_by(state):
                     continue
                 unresolved.append(ref)
 
+            # #2447: preserve the pre-collapse blocker string. The mutation
+            # below drops merged/closed refs, which is exactly the "collapsed"
+            # data loss the stack-base ancestry guard needs to recover — a
+            # merged blocker that a stacked base forked before must still be
+            # checked for containment. `in_progress` tasks keep their raw
+            # blocked_by (resolve_blocked_by visits `open` only), so the walk
+            # reads blocked_by_raw here and blocked_by on those.
+            task["blocked_by_raw"] = raw
+
             if not unresolved:
                 task["blocked_by"] = "(none)"
             elif len(unresolved) == 1:
@@ -1564,6 +1593,128 @@ def resolve_epic_children(state):
                         repo_slug, child, per_tick_cache)
 
 
+# --- Stack-base ancestry guard (#2447) -------------------------------------
+#
+# `unsafe_base_reason` rejects a base by label/diff state; it never checks
+# whether the base branch actually CONTAINS the work of a blocker that merged
+# after the base forked. A four-task chain T1→T2→T3→T4 where T1 merged after T2
+# forked leaves T3's head (T4's offered base) missing every module T1 shipped —
+# a base T4 provably can't build on. T4's own `Blocked by:` names only T3, so a
+# check that looks at the candidate's own collapsed blockers finds nothing; the
+# hole lives in the BASE's ancestry and propagates transitively down the stack.
+# The pure walk lives in fleet_stack_base.missing_ancestor_reason; these helpers
+# wire it to the scout's in-memory projection + a compare-API containment check.
+
+
+def _fetch_contains(repo_slug, base_oid, sha):
+    """Compare-API containment verdict for the ancestry guard.
+
+    True when `base_oid`'s history contains `sha`, False when it provably does
+    not, None when the verdict is unavailable. `base_oid` is the compare base
+    and `sha` the head, so contained ⇔ `ahead_by == 0` (status `behind` or
+    `identical`: the merged ancestor adds no commits the base head lacks). Needs
+    no local git refs — the scout never fetches — and conditional_get ETag-caches
+    the immutable comparison, though the persistent memo normally answers first.
+    """
+    if not repo_slug or not base_oid or not sha:
+        return None
+    _changed, body = conditional_get(repo_slug, f"compare/{base_oid}...{sha}")
+    if body is None:
+        return None
+    try:
+        ahead = json.loads(body).get("ahead_by")
+    except json.JSONDecodeError:
+        return None
+    return None if ahead is None else ahead == 0
+
+
+def _load_ancestry_memo():
+    try:
+        data = json.loads(ANCESTRY_MEMO_FILE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_ancestry_memo(memo):
+    try:
+        ANCESTRY_MEMO_FILE.write_text(json.dumps(memo))
+    except OSError:
+        pass
+
+
+def _make_contains(memo, repo_slug, base_oid):
+    """One-arg containment predicate for missing_ancestor_reason, memoized on
+    the immutable `(base_oid, sha)` key so a warm memo costs zero network."""
+    def contains(sha):
+        key = f"{base_oid}:{sha}"
+        if key in memo:
+            return memo[key]
+        verdict = _fetch_contains(repo_slug, base_oid, sha)
+        if verdict is not None:
+            memo[key] = verdict
+        return verdict
+    return contains
+
+
+def _ancestry_ref_graph(repo_key, repo_state):
+    """Build the repo-scoped (get_blocker_refs, ref_merged, merged_sha)
+    callables the ancestry walk injects.
+
+    get_blocker_refs recovers each ancestor's *raw* (pre-collapse) same-repo
+    blocker refs: in_progress tasks keep their raw blocked_by (resolve_blocked_by
+    visits `open` only), open tasks carry blocked_by_raw (stashed before the
+    collapse). Cross-repo refs are dropped — same-repo git containment can't
+    evaluate them, and a cross-repo dependency is never in this repo's git head
+    (fleet-claim's routed blocker check owns that). An UNTRACKED base issue
+    (no queue record — e.g. a non-fleet Closes-#N base) returns [] rather than
+    suppressing: the scout has no in-memory ancestry for it, so it offers and
+    the claim-side LIVE gate (which reads the issue body directly) is the
+    authoritative re-verify. ref_merged classifies a ref as merged (in the
+    recent-merged or closed-queue window), open (a tracked open/in_progress
+    task), or unknown (None → fail closed). merged_sha resolves the squash sha
+    from the recent-merged window only (out-of-window → None → fail closed).
+    """
+    tasks = repo_state.get("tasks", {})
+    by_num = {}
+    for section in ("in_progress", "open"):
+        for t in tasks.get(section, []):
+            num = (t.get("issue") or "").lstrip("#")
+            if num:
+                by_num.setdefault(num, t)
+    closed_nums = _closed_issue_numbers(repo_state)
+    merged_shas = {}
+    for pr in repo_state.get("recent_merged_prs", []):
+        num = issue_from_branch(pr.get("headRefName", ""))
+        sha = pr.get("mergeCommitSha")
+        if num is not None and sha:
+            merged_shas[str(num)] = sha
+
+    def get_blocker_refs(issue):
+        rec = by_num.get(str(issue))
+        if rec is None:
+            return []  # untracked base → offer; claim-side live gate re-verifies
+        raw = rec.get("blocked_by_raw")
+        if raw is None:
+            raw = rec.get("blocked_by") or ""
+        if not raw or raw.strip().lower().startswith("(none"):
+            return []
+        return [ref for ref_key, ref in _parse_blocker_refs(raw, repo_key)
+                if ref_key == repo_key]  # same-repo git ancestry only
+
+    def ref_merged(ref):
+        if ref in merged_shas or ref in closed_nums:
+            return True
+        if ref in by_num:
+            return False
+        return None
+
+    def merged_sha(ref):
+        return merged_shas.get(ref)
+
+    return get_blocker_refs, ref_merged, merged_sha
+
+
 def enrich_stackable_blocker_prs(state):
     # Per T-110 PR 2: for each task whose blocked_by is exactly one issue
     # number (`#NNN`) with exactly one matching open PR in the same repo,
@@ -1597,8 +1748,18 @@ def enrich_stackable_blocker_prs(state):
     # Engine and game tasks are both enriched; worker pickup only honors
     # the field for engine in v1 (the merger's cascade-rebase doesn't
     # process game PRs yet) — that gating lives in the role doc.
+    #
+    # Filter (c) (#2447): the base's blocker ancestry must be contained in the
+    # base head — see _ancestry_ref_graph / missing_ancestor_reason. The memo is
+    # loaded once and threaded through so a warm containment verdict costs no
+    # network call.
+    memo = _load_ancestry_memo()
+    memo_size = len(memo)
     for repo_key, repo_state in state["repos"].items():
+        repo_slug = REPO_KEY_TO_SLUG.get(repo_key, "")
         prs = repo_state.get("prs", [])
+        get_blocker_refs, ref_merged, merged_sha = _ancestry_ref_graph(
+            repo_key, repo_state)
         for task in repo_state.get("tasks", {}).get("open", []):
             blocked_by = (task.get("blocked_by") or "").strip()
             issue_num = _single_blocker_issue(blocked_by)
@@ -1644,11 +1805,34 @@ def enrich_stackable_blocker_prs(state):
                 ):
                     continue
 
+            # Filter (c) (#2447): reject a base whose head is missing the squash
+            # of a merged blocker anywhere in its ancestry. issue_num IS the base
+            # issue (the task's sole blocker), so the walk starts from it; the
+            # base head oid keys the compare-API containment check. A
+            # suppression is LOGGED (never silent — the #2442 lesson) so an
+            # operator can see a churn base being correctly withheld.
+            base_head_oid = pr.get("headRefOid") or ""
+            ancestry_reason = missing_ancestor_reason(
+                issue_num, get_blocker_refs, ref_merged, merged_sha,
+                _make_contains(memo, repo_slug, base_head_oid),
+            )
+            if ancestry_reason:
+                log(f"stack-base ancestry guard: not offering PR "
+                    f"#{pr['number']} as base for {task.get('id', '?')} "
+                    f"— {ancestry_reason}")
+                continue
+
             task["stackable_blocker_pr"] = {
                 "number": pr["number"],
                 "headRefName": pr["headRefName"],
                 "author": pr.get("author", ""),
             }
+
+    # The memo only grows (immutable sha keys), so a length change means new
+    # verdicts were computed — persist only then, so quiescent ticks (the common
+    # no-candidate case) neither rewrite nor create the file.
+    if len(memo) != memo_size:
+        _save_ancestry_memo(memo)
 
 
 def enrich_inflight_pr_tasks(state):

--- a/scripts/fleet/fleet_stack_base.py
+++ b/scripts/fleet/fleet_stack_base.py
@@ -29,6 +29,12 @@ scout's existing reviewer-skip / design-block sets (a base in any of those
 states is mid-flux for the same reasons a reviewer would skip it) but is kept
 purpose-named here so the two concerns can evolve independently.
 
+`missing_ancestor_reason()` is the second shared predicate (#2447): the
+label/diff check above never verifies that the base branch actually contains
+the work of a blocker that merged after the base forked, so both surfaces also
+route the base's blocker ancestry through it (the scout with in-memory data +
+the compare API, `fleet-claim` with live gh + `git merge-base`).
+
 Stdlib only — imported by `fleet-state-scout` (pure Python) and by
 `fleet-claim` (bash, via an inline `python3` block through `FLEET_LIB_DIR`),
 exactly like `fleet_branch_match.py`.
@@ -92,3 +98,90 @@ def unsafe_base_reason(labels, changed_files=None):
         return "empty claim-commit"
 
     return None
+
+
+def missing_ancestor_reason(base_issue, get_blocker_refs, ref_merged,
+                            merged_sha, contains, max_depth=8):
+    """Return a short reason the stack base's head is missing a merged ancestor
+    (so it is NOT safe to stack on), or None when every merged ancestor in the
+    base's blocker chain is contained in the base head.
+
+    `unsafe_base_reason` above validates a base by label state and diff only.
+    It never checks ANCESTRY — whether the base branch actually contains work
+    that has already merged to master and that a task stacked on it depends on.
+    A base branch forks from some ancestor and can be missing a blocker that
+    merged to master *after* the fork: a "collapsed" merged ref that the
+    candidate task's own blocker list never names, because the hole lives one
+    or more levels up the stack (#2447). This walks the base issue's blocker
+    ancestry, treats every MERGED blocker as a frontier node, and asserts the
+    base head contains that blocker's squash commit.
+
+    Injected callables (the caller wires them to the scout's in-memory data or
+    to fleet-claim's live gh/git — the walk itself stays pure and hermetically
+    testable):
+
+      get_blocker_refs(issue) -> list[str] | None
+          Same-repo blocker issue numbers (strings, no '#') declared in
+          `issue`'s **Blocked by:** field, or None when undeterminable (issue
+          unresolvable, or a cross-repo ref is present that git containment
+          can't evaluate). None fails the walk CLOSED.
+      ref_merged(ref) -> bool | None
+          True when `ref` is a merged blocker (a frontier node), False when it
+          is still open (recurse through it), None when its state is unknown.
+      merged_sha(ref) -> str | None
+          The squash merge commit sha of a merged `ref`, or None when it can't
+          be resolved.
+      contains(sha) -> bool | None
+          True when the base head contains `sha`, False when it provably does
+          not, None when the verdict is unavailable. (The base head oid is
+          captured by the caller's closure — this predicate only varies in sha.)
+
+    Fail-closed rationale: any None (unknown blocker state, unresolvable sha,
+    unavailable containment verdict, unresolvable ancestor blockers), a
+    depth-cap hit, or a cycle returns an "ancestry undeterminable (...)" reason.
+    A suppressed offer degrades to the safe pre-stackable status quo (the task
+    waits for the blocker to merge), whereas failing OPEN reproduces the
+    guaranteed-no-op churn loop this guard exists to kill.
+
+    Merged nodes are checked, never recursed: master's squash history is
+    linear, so if a frontier ancestor's squash is contained in the base head,
+    everything merged before it is too — a deeper hole can't exist without a
+    frontier miss.
+    """
+    undet = "ancestry undeterminable"
+    visited = set()
+
+    def walk(issue, depth):
+        if depth > max_depth:
+            return f"{undet} (blocker chain deeper than {max_depth} from base)"
+        if issue in visited:
+            return f"{undet} (blocker cycle at #{issue})"
+        visited.add(issue)
+
+        refs = get_blocker_refs(issue)
+        if refs is None:
+            return f"{undet} (blockers of #{issue} unresolvable)"
+
+        for ref in refs:
+            merged = ref_merged(ref)
+            if merged is None:
+                return f"{undet} (state of blocker #{ref} unknown)"
+            if merged:
+                sha = merged_sha(ref)
+                if not sha:
+                    return f"{undet} (merge sha of #{ref} unresolvable)"
+                verdict = contains(sha)
+                if verdict is None:
+                    return f"{undet} (containment of #{ref} unverifiable)"
+                if not verdict:
+                    return f"missing merged ancestor #{ref}"
+                # Contained → this frontier is satisfied; linear history means
+                # everything merged before it is too, so don't recurse.
+            else:
+                # Open ancestor → its own merged blockers can be the hole.
+                reason = walk(ref, depth + 1)
+                if reason:
+                    return reason
+        return None
+
+    return walk(str(base_issue), 0)

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -455,5 +455,154 @@ class TestFetchPrs304Reuse(unittest.TestCase):
         self.assertIs(_mod.fetch_prs("repo", prev=prev), prev)
 
 
+class TestEnrichAncestryGuard(unittest.TestCase):
+    """Filter (c), the stack-base ancestry guard (#2447): a base whose head is
+    missing the squash of a MERGED blocker in its ancestry is not offered, even
+    when the candidate task's own blocker list never names that blocker.
+
+    Hermetic: the compare-API fetch seam (_fetch_contains) is stubbed so no
+    live GitHub call fires, and the persistent memo + PRS_DIR are redirected
+    into a TemporaryDirectory (scripts/fleet/CLAUDE.md)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_prs_dir = _mod.PRS_DIR
+        _mod.PRS_DIR = Path(self._tmp.name) / "prs"
+        self._orig_memo = _mod.ANCESTRY_MEMO_FILE
+        _mod.ANCESTRY_MEMO_FILE = Path(self._tmp.name) / "memo.json"
+        self._orig_fetch = _mod._fetch_contains
+        self._orig_log = _mod.log
+        self.fetch_calls = []
+        self.logs = []
+        _mod.log = lambda m: self.logs.append(m)
+
+    def tearDown(self):
+        _mod.PRS_DIR = self._orig_prs_dir
+        _mod.ANCESTRY_MEMO_FILE = self._orig_memo
+        _mod._fetch_contains = self._orig_fetch
+        _mod.log = self._orig_log
+        self._tmp.cleanup()
+
+    def _install_fetch(self, verdicts):
+        """verdicts: sha -> bool. An empty base_oid returns None, mirroring the
+        real _fetch_contains guard (undeterminable → fail closed)."""
+        def fake(repo_slug, base_oid, sha):
+            self.fetch_calls.append((base_oid, sha))
+            if not base_oid:
+                return None
+            return verdicts.get(sha)
+        _mod._fetch_contains = fake
+
+    def _state(self):
+        # Candidate #40 stacks on base #30's PR; #30 is blocked by #10 (merged)
+        # + #20 (open). #10's squash "sha10" is the frontier the base head
+        # (oid "oidbase") may or may not contain.
+        return {
+            "repos": {
+                "engine": {
+                    "tasks": {
+                        "open": [{"id": "#40", "issue": "#40",
+                                  "blocked_by": "#30", "area": None}],
+                        "in_progress": [
+                            {"id": "#30", "issue": "#30",
+                             "blocked_by": "#10, #20"},
+                            {"id": "#20", "issue": "#20",
+                             "blocked_by": "(none)"},
+                        ],
+                    },
+                    "prs": [{"number": 300, "headRefName": "claude/30-base",
+                             "headRefOid": "oidbase", "author": "bot",
+                             "labels": ["fleet:approved"]}],
+                    "recent_merged_prs": [
+                        {"number": 100, "headRefName": "claude/10-m",
+                         "mergeCommitSha": "sha10", "mergedAt": "t"}],
+                    "closed_fleet_queued": [],
+                },
+                "game": {"tasks": {"open": [], "in_progress": []}, "prs": [],
+                         "recent_merged_prs": [], "closed_fleet_queued": []},
+            }
+        }
+
+    def _candidate(self, state):
+        return state["repos"]["engine"]["tasks"]["open"][0]
+
+    def test_missing_ancestor_suppresses_and_logs(self):
+        """Base head lacks the merged frontier #10 → offer withheld, and the
+        suppression is LOGGED (never silent — the #2442 lesson)."""
+        self._install_fetch({"sha10": False})
+        state = self._state()
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr", self._candidate(state))
+        self.assertTrue(any("ancestry guard" in m for m in self.logs),
+                        f"no suppression logged: {self.logs}")
+        self.assertTrue(any("#10" in m for m in self.logs))
+
+    def test_contained_ancestor_offered(self):
+        """Base head contains the merged frontier → the base is offered."""
+        self._install_fetch({"sha10": True})
+        state = self._state()
+        enrich_stackable_blocker_prs(state)
+        task = self._candidate(state)
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 300)
+
+    def test_warm_memo_zero_fetch(self):
+        """A pre-populated memo answers the containment verdict with zero
+        network calls (pins the steady-state per-tick cost at 0)."""
+        self._install_fetch({"sha10": False})
+        _mod.ANCESTRY_MEMO_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _mod.ANCESTRY_MEMO_FILE.write_text(json.dumps({"oidbase:sha10": False}))
+        state = self._state()
+        enrich_stackable_blocker_prs(state)
+        self.assertEqual(self.fetch_calls, [], "warm memo must not fetch")
+        self.assertNotIn("stackable_blocker_pr", self._candidate(state))
+
+    def test_verdict_persisted_to_memo(self):
+        """A fresh verdict is written to the memo keyed on (base_oid, sha) so
+        the next tick is warm."""
+        self._install_fetch({"sha10": True})
+        state = self._state()
+        enrich_stackable_blocker_prs(state)
+        memo = json.loads(_mod.ANCESTRY_MEMO_FILE.read_text())
+        self.assertIs(memo.get("oidbase:sha10"), True)
+
+    def test_missing_head_oid_suppressed(self):
+        """A base PR with no headRefOid can't be containment-checked → the
+        frontier is undeterminable → fail closed (suppressed)."""
+        self._install_fetch({"sha10": False})
+        state = self._state()
+        del state["repos"]["engine"]["prs"][0]["headRefOid"]
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr", self._candidate(state))
+        self.assertTrue(any(oid == "" for oid, _ in self.fetch_calls))
+
+    def test_untracked_base_offered(self):
+        """A base whose issue has no queue record (e.g. a non-fleet Closes-#N
+        base) is offered — the scout has no in-memory ancestry, so the
+        claim-side live gate is the authoritative re-verify. No fetch fires."""
+        self._install_fetch({"sha10": False})
+        state = self._state()
+        state["repos"]["engine"]["tasks"]["in_progress"] = []
+        enrich_stackable_blocker_prs(state)
+        self.assertIn("stackable_blocker_pr", self._candidate(state))
+        self.assertEqual(self.fetch_calls, [])
+
+    def test_open_ancestor_recursed_transitive_hole(self):
+        """The hole two levels up: base #30's blocker #20 is OPEN and #20 is
+        itself blocked by merged #50, whose squash the base head lacks. #30's
+        collapsed list would never surface #50 — the walk recurses to find it."""
+        self._install_fetch({"sha10": True, "sha50": False})
+        state = self._state()
+        eng = state["repos"]["engine"]
+        # #20 now blocked by merged #50; add #50 to the merged window.
+        eng["tasks"]["in_progress"][1]["blocked_by"] = "#50"
+        eng["recent_merged_prs"].append(
+            {"number": 500, "headRefName": "claude/50-m",
+             "mergeCommitSha": "sha50", "mergedAt": "t"})
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr", self._candidate(state))
+        self.assertTrue(any("#50" in m for m in self.logs))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
@@ -85,6 +85,18 @@ if [[ "$*" == *"remote get-url"* ]]; then
     echo "git@github.com:jakildev/IrredenEngine.git"
     exit 0
 fi
+# #2447 ancestry gate: the base-branch fetch is a no-op here, and
+# merge-base --is-ancestor <sha> <base-oid> is answered from a fixture map
+# (exit 0 = contained, 1 = not contained) so the check stays hermetic.
+if [[ "$1" == "fetch" ]]; then
+    exit 0
+fi
+if [[ "$1" == "merge-base" && "$2" == "--is-ancestor" ]]; then
+    case "$3:$4" in
+        sha100:oid906) exit 0 ;;  # #100 contained in base #906's head
+        *)             exit 1 ;;  # e.g. sha100:oid905 → base #905 lacks it
+    esac
+fi
 exec /usr/bin/git "$@"
 GITSTUB
 chmod +x "$STUB_DIR/git"
@@ -117,6 +129,17 @@ done
 
 case "$1 $2" in
     "issue view")
+        if [[ "$has_jq" -eq 1 && "$*" == *"--json body"* ]]; then
+            # #2447 ancestry gate: the base issue's raw blocker body. #905/#906
+            # are both blocked by merged #100; the open ancestor #101 carries no
+            # further blocker so the recursion terminates.
+            case "$issue_num" in
+                905) echo "**Blocked by:** #100" ;;
+                906) echo "**Blocked by:** #100" ;;
+                *)   echo "" ;;
+            esac
+            exit 0
+        fi
         if [[ "$has_jq" -eq 1 ]]; then
             # check_blockers / find-stackable-blockers state-only lookup
             case "$issue_num" in
@@ -154,8 +177,14 @@ case "$1 $2" in
         ;;
     "pr list")
         if [[ "$pr_state" == "merged" ]]; then
-            # No merged PRs in these fixtures — resolution uses gh issue view only.
-            echo "[]"
+            if [[ "$*" == *mergeCommit* ]]; then
+                # #2447 ancestry gate frontier: #100 merged as claude/100-m with
+                # squash sha100. Only the ancestry call requests mergeCommit; the
+                # blocker/find-stackable calls (headRefName only) still get [].
+                printf '%s\n' '[{"number":100,"headRefName":"claude/100-m","mergeCommit":{"oid":"sha100"}}]'
+            else
+                echo "[]"
+            fi
             exit 0
         fi
         if [[ "$pr_state" == "open" ]]; then
@@ -167,6 +196,15 @@ case "$1 $2" in
         exit 0
         ;;
     "pr view")
+        if [[ "$*" == *headRefOid* ]]; then
+            # #2447 ancestry gate: base head oid for git merge-base --is-ancestor.
+            case "$3" in
+                905) echo "oid905" ;;
+                906) echo "oid906" ;;
+                *)   echo "oidx"   ;;
+            esac
+            exit 0
+        fi
         # claim --stackable-on base re-verify (#1751): state + head + labels.
         # $3 is the PR id passed to --stackable-on.
         case "$3" in
@@ -174,6 +212,8 @@ case "$1 $2" in
             902) printf '%s' '{"state":"OPEN","headRefName":"claude/902-empty","labels":[{"name":"fleet:queued"}]}' ;;
             903) printf '%s' '{"state":"OPEN","headRefName":"claude/903-clean","labels":[{"name":"fleet:queued"}]}' ;;
             904) printf '%s' '{"state":"OPEN","headRefName":"claude/904-difffail","labels":[{"name":"fleet:queued"}]}' ;;
+            905) printf '%s' '{"state":"OPEN","headRefName":"claude/905-anc","labels":[{"name":"fleet:queued"}]}' ;;
+            906) printf '%s' '{"state":"OPEN","headRefName":"claude/906-anc","labels":[{"name":"fleet:queued"}]}' ;;
             *)   printf '%s' '{"state":"OPEN","headRefName":"claude/x","labels":[]}' ;;
         esac
         exit 0
@@ -281,6 +321,25 @@ assert_refused 902 "not a stackable base (empty claim-commit)" "empty-claim base
 
 echo "T8: claim --stackable-on a base whose diff fetch fails (#904) → refused"
 assert_refused 904 "refusing to stack on an unverifiable base" "unverifiable base refused"
+
+# --- #2447: claim --stackable-on rejects a base missing a merged ancestor ----
+# The base passes labels + diff (unsafe_base_reason clean) but its head lacks
+# the squash of a merged blocker in its ancestry, so the ancestry gate refuses.
+echo "T9: claim --stackable-on a base missing a merged ancestor (#905) → refused"
+assert_refused 905 "missing merged ancestor #100" "ancestry-hole base refused"
+
+echo "T10: claim --stackable-on a base that contains its merged ancestor (#906) → ancestry passes"
+pass_err="$TMPROOT/anc_pass.err"
+"$FLEET_CLAIM" claim 3006 worker-test --stackable-on 906 >/dev/null 2>"$pass_err" \
+    && anc_rc=0 || anc_rc=$?
+if grep -qE "missing merged ancestor|base-ancestry check failed|not a stackable base" "$pass_err"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: contained base wrongly refused at the base/ancestry gate:"
+    sed 's/^/        /' "$pass_err"
+else
+    PASS=$((PASS + 1))
+    echo "  ok: contained base cleared the ancestry gate (claim rc=$anc_rc)"
+fi
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -42,6 +42,7 @@ import importlib.machinery
 import importlib.util
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -617,6 +618,86 @@ class SemanticConflictFeedbackExclusionIntegration(unittest.TestCase):
             plain = slice_worker(self._state(self._pr([label], "MERGEABLE")))
             self.assertEqual(resolve(combined, "sonnet", False),
                              resolve(plain, "sonnet", False), label)
+
+
+class StackAncestryDispatchAB(unittest.TestCase):
+    """#2447 integration: the scout's ancestry guard is what flips the whole
+    dispatcher from a guaranteed-no-op dispatch to `defer`. On a slice whose
+    ONLY non-terminal entry rides a base missing a transitively-merged ancestor,
+    the enrichment must withhold `stackable_blocker_pr` so the entry becomes
+    terminal and resolve() goes quiet (the #1726/#1998 go-quiet gate). Flip the
+    containment verdict and the same slice dispatches. The A/B's sole delta is
+    the compare-API verdict — pinning the observable behavior, not a reason
+    string. Hermetic: the fetch seam is stubbed and the memo/PRS dirs redirect
+    into a TemporaryDirectory (scripts/fleet/CLAUDE.md)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_prs_dir = _scout_mod.PRS_DIR
+        _scout_mod.PRS_DIR = Path(self._tmp.name) / "prs"
+        self._orig_memo = _scout_mod.ANCESTRY_MEMO_FILE
+        _scout_mod.ANCESTRY_MEMO_FILE = Path(self._tmp.name) / "memo.json"
+        self._orig_fetch = _scout_mod._fetch_contains
+        self._orig_log = _scout_mod.log
+        _scout_mod.log = lambda _m: None
+
+    def tearDown(self):
+        _scout_mod.PRS_DIR = self._orig_prs_dir
+        _scout_mod.ANCESTRY_MEMO_FILE = self._orig_memo
+        _scout_mod._fetch_contains = self._orig_fetch
+        _scout_mod.log = self._orig_log
+        self._tmp.cleanup()
+
+    def _enriched_slice(self, contained):
+        """Build the forensics-shaped state (candidate #40 → base #30's PR;
+        #30 blocked by merged #10 + open #20), enrich it with `contained` as
+        the containment verdict, and return the resolve() slice."""
+        _scout_mod._fetch_contains = lambda repo, oid, sha: contained
+        state = {
+            "repos": {
+                "engine": {
+                    "tasks": {
+                        "open": [{"id": "#40", "issue": "#40",
+                                  "blocked_by": "#30", "area": None,
+                                  "model": "opus", "owner": "free",
+                                  "blocked": True}],
+                        "in_progress": [
+                            {"id": "#30", "issue": "#30",
+                             "blocked_by": "#10, #20"},
+                            {"id": "#20", "issue": "#20",
+                             "blocked_by": "(none)"},
+                        ],
+                    },
+                    "prs": [{"number": 300, "headRefName": "claude/30-base",
+                             "headRefOid": "oidbase", "author": "bot",
+                             "labels": ["fleet:approved"]}],
+                    "recent_merged_prs": [
+                        {"number": 100, "headRefName": "claude/10-m",
+                         "mergeCommitSha": "sha10", "mergedAt": "t"}],
+                    "closed_fleet_queued": [],
+                },
+                "game": {"tasks": {"open": [], "in_progress": []}, "prs": [],
+                         "recent_merged_prs": [], "closed_fleet_queued": []},
+            }
+        }
+        _scout_mod.enrich_stackable_blocker_prs(state)
+        return {"tasks_open": state["repos"]["engine"]["tasks"]["open"]}
+
+    def test_invalid_base_defers(self):
+        """Base head missing the merged ancestor → offer withheld → the sole
+        blocked task is terminal → resolve defers (go quiet)."""
+        slice_data = self._enriched_slice(contained=False)
+        self.assertNotIn("stackable_blocker_pr", slice_data["tasks_open"][0])
+        self.assertEqual(resolve(slice_data, "opus", fable_blocked=False),
+                         "defer")
+
+    def test_valid_base_dispatches(self):
+        """Base head contains the merged ancestor → offer stands → the blocked
+        task is claimable as a stack → resolve dispatches opus."""
+        slice_data = self._enriched_slice(contained=True)
+        self.assertIn("stackable_blocker_pr", slice_data["tasks_open"][0])
+        out = resolve(slice_data, "opus", fable_blocked=False)
+        self.assertTrue(out.startswith("opus "), out)
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_stack_base_guard.py
+++ b/scripts/fleet/tests/test_stack_base_guard.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from fleet_stack_base import (  # noqa: E402
     NOT_STACKABLE_BASE_LABELS,
     NOT_STACKABLE_BASE_PREFIXES,
+    missing_ancestor_reason,
     unsafe_base_reason,
 )
 
@@ -96,6 +97,150 @@ class TestUnsafeBaseReason(unittest.TestCase):
         """labels may arrive as a list (scout) or a set (claim block)."""
         self.assertEqual(unsafe_base_reason({"fleet:wip"}), "fleet:wip")
         self.assertEqual(unsafe_base_reason(("fleet:wip",)), "fleet:wip")
+
+
+class TestMissingAncestorReason(unittest.TestCase):
+    """The transitive-ancestry containment walk (#2447). The base's head must
+    contain the squash of every MERGED blocker in its ancestry; a hole one or
+    more levels above the candidate task's own blocker list is the churn signature
+    this guard exists to catch. All inputs are injected callables so the walk is
+    pinned hermetically (no gh / no git)."""
+
+    def _graph(self, blockers, merged, shas, contained):
+        """Build (get_blocker_refs, ref_merged, merged_sha, contains) from plain
+        dicts. `blockers`: issue -> [refs]; `merged`: set of merged refs;
+        `shas`: ref -> squash sha; `contained`: set of shas in the base head."""
+        def gbr(issue):
+            return blockers.get(str(issue))
+
+        def rm(ref):
+            if ref in merged:
+                return True
+            if str(ref) in blockers:
+                return False
+            return None
+
+        def ms(ref):
+            return shas.get(ref)
+
+        def contains(sha):
+            return sha in contained
+
+        return gbr, rm, ms, contains
+
+    def test_direct_merged_hole_rejected(self):
+        """The #2447 signature: base #3's own blocker #1 merged after the fork
+        (its squash absent from the base head). Named in the reason."""
+        gbr, rm, ms, contains = self._graph(
+            blockers={"3": ["1", "2"], "2": []},
+            merged={"1"}, shas={"1": "sha1"}, contained=set())
+        self.assertEqual(
+            missing_ancestor_reason("3", gbr, rm, ms, contains),
+            "missing merged ancestor #1")
+
+    def test_direct_merged_contained_offered(self):
+        """Same base, but the merged blocker's squash IS in the base head → safe."""
+        gbr, rm, ms, contains = self._graph(
+            blockers={"3": ["1", "2"], "2": []},
+            merged={"1"}, shas={"1": "sha1"}, contained={"sha1"})
+        self.assertIsNone(missing_ancestor_reason("3", gbr, rm, ms, contains))
+
+    def test_transitive_hole_two_levels_up(self):
+        """The hole lives two levels above the base: base #4 → open #3 → merged
+        #1 (not contained). The candidate's own blocker list (#4→#3) never names
+        #1, yet the walk finds it."""
+        gbr, rm, ms, contains = self._graph(
+            blockers={"4": ["3"], "3": ["1"]},
+            merged={"1"}, shas={"1": "sha1"}, contained=set())
+        self.assertEqual(
+            missing_ancestor_reason("4", gbr, rm, ms, contains),
+            "missing merged ancestor #1")
+
+    def test_no_blockers_offered(self):
+        """A base with an empty blocker list has no ancestry to miss."""
+        gbr, rm, ms, contains = self._graph(
+            blockers={"5": []}, merged=set(), shas={}, contained=set())
+        self.assertIsNone(missing_ancestor_reason("5", gbr, rm, ms, contains))
+
+    def test_all_frontier_contained_offered(self):
+        """Every merged ancestor contained (including a transitive one) → safe."""
+        gbr, rm, ms, contains = self._graph(
+            blockers={"4": ["3", "1"], "3": ["2"]},
+            merged={"1", "2"}, shas={"1": "sha1", "2": "sha2"},
+            contained={"sha1", "sha2"})
+        self.assertIsNone(missing_ancestor_reason("4", gbr, rm, ms, contains))
+
+    def test_unresolvable_blockers_fail_closed(self):
+        """get_blocker_refs None (issue unfetchable / cross-repo ref) → undet."""
+        reason = missing_ancestor_reason(
+            "3", lambda i: None, lambda r: False, lambda r: None,
+            lambda s: True)
+        self.assertTrue(reason.startswith("ancestry undeterminable"))
+        self.assertIn("#3", reason)
+
+    def test_unknown_ref_state_fail_closed(self):
+        """ref_merged None (ref neither known-merged nor a tracked open task)."""
+        reason = missing_ancestor_reason(
+            "3", lambda i: ["99"], lambda r: None, lambda r: None,
+            lambda s: True)
+        self.assertTrue(reason.startswith("ancestry undeterminable"))
+        self.assertIn("#99", reason)
+
+    def test_unresolvable_sha_fail_closed(self):
+        """A merged frontier whose squash sha can't be resolved (out of the
+        recent-merged window) fails closed rather than assuming containment."""
+        gbr, rm, _ms, contains = self._graph(
+            blockers={"3": ["1"]}, merged={"1"}, shas={}, contained=set())
+        reason = missing_ancestor_reason("3", gbr, rm, lambda r: None, contains)
+        self.assertTrue(reason.startswith("ancestry undeterminable"))
+        self.assertIn("#1", reason)
+
+    def test_unavailable_containment_fail_closed(self):
+        """contains None (compare API / git verdict unavailable) → undet."""
+        gbr, rm, ms, _contains = self._graph(
+            blockers={"3": ["1"]}, merged={"1"}, shas={"1": "sha1"},
+            contained=set())
+        reason = missing_ancestor_reason("3", gbr, rm, ms, lambda s: None)
+        self.assertTrue(reason.startswith("ancestry undeterminable"))
+        self.assertIn("#1", reason)
+
+    def test_cycle_terminates_fail_closed(self):
+        """A blocker cycle terminates via the visited set instead of recursing
+        forever."""
+        cyc = {"1": ["2"], "2": ["1"]}
+        reason = missing_ancestor_reason(
+            "1", lambda i: cyc.get(str(i)), lambda r: False,
+            lambda r: None, lambda s: True)
+        self.assertTrue(reason.startswith("ancestry undeterminable"))
+        self.assertIn("cycle", reason)
+
+    def test_depth_cap_terminates_fail_closed(self):
+        """A blocker chain longer than max_depth fails closed at the cap."""
+        chain = {str(i): [str(i + 1)] for i in range(1, 20)}
+        reason = missing_ancestor_reason(
+            "1", lambda i: chain.get(str(i)), lambda r: False,
+            lambda r: None, lambda s: True, max_depth=3)
+        self.assertTrue(reason.startswith("ancestry undeterminable"))
+        self.assertIn("deeper than 3", reason)
+
+    def test_frontier_not_recursed(self):
+        """A merged, contained frontier is NOT recursed into — linear squash
+        history means everything before it is contained too. merged_sha/contains
+        are the only things consulted for it; get_blocker_refs is never called
+        on the merged ref."""
+        seen = []
+
+        def gbr(issue):
+            seen.append(str(issue))
+            return {"3": ["1"]}.get(str(issue), [])
+
+        def rm(ref):
+            return ref == "1"
+
+        self.assertIsNone(missing_ancestor_reason(
+            "3", gbr, rm, lambda r: "sha1", lambda s: True))
+        # #1 is merged+contained → walk consulted only #3's blockers, never #1's.
+        self.assertEqual(seen, ["3"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `fleet_stack_base.missing_ancestor_reason()` — a pure, hermetically-testable transitive-ancestry walk: recurse the base issue's blocker chain, treat every merged blocker as a frontier node, and assert the base head contains its squash. Fail-closed on any unresolvable input (undeterminable → suppress/refuse — the safe pre-stackable status quo, not the churn loop).
- Wire it into **both** stack-base surfaces so offer and accept can't disagree:
  - **Scout offer** (`enrich_stackable_blocker_prs`): in-memory blocker graph + compare-API containment (`ahead_by == 0`) with a persistent `(base_head_oid, sha)` memo → steady-state 0 network calls per tick. Suppressions are `log()`-ged (never silent). `resolve_blocked_by` now stashes `blocked_by_raw` before collapsing merged refs so the walk can recover the frontier; the scout projects `mergeCommitSha` (`recent_merged_prs`) and `headRefOid` (`prs[]`).
  - **`fleet-claim --stackable-on` accept**: same walk over live `gh` (issue blocker graph, merged-frontier shas) + `git merge-base --is-ancestor` containment, gated behind the existing label/diff check.
- Kills the #2447 churn loop where a provably-unbuildable base was offered, claimed, released, and re-offered every tick — a single false offer flips `resolve()` from `defer` to a full dispatch on a host where nothing else is claimable.

### Two refinements over the plan (both toward correctness)
- An **untracked** base issue (no queue record — e.g. a non-fleet `Closes #N` base) is **offered**, not suppressed: the scout has no in-memory ancestry for it, and the claim-side live gate re-verifies. This also avoids regressing existing offer behavior.
- **Cross-repo** blocker refs are **dropped**, not failed-closed: same-repo git containment can't evaluate them and they are never in this repo's git head (the routed blocker check owns cross-repo).

## Test plan
- [x] `test_stack_base_guard.py` — pure walk: direct/transitive hole, contained, no-blockers, all-frontier-contained, fail-closed (unresolvable refs / unknown state / unresolvable sha / unavailable containment), cycle, depth-cap, frontier-not-recursed.
- [x] `test_enrich_stackable_blocker_prs.py` — suppression + log, contained → offered, warm-memo zero-fetch, verdict persisted, missing-headRefOid → suppressed, untracked → offered, transitive open-ancestor recursion. Existing cases stay green.
- [x] `test_fleet_task_class.py` — the resolve() `defer` (invalid base) vs dispatch (contained) A/B.
- [x] `test_fleet_claim_stackable_live_resolve.sh` — accept-side: ancestry-hole base refused (names the ancestor), contained base clears the gate. Existing T1–T8 stay green.
- [x] Full `scripts/fleet` python suite (669) + claim bash suites green; `ruff check scripts/` clean.

Closes #2447

🤖 Generated with [Claude Code](https://claude.com/claude-code)