### PR TITLE
tooling: extract shared verify-harness helpers into verify_common.py

### DIFF
--- a/.fleet/plans/issue-2358.md
+++ b/.fleet/plans/issue-2358.md
@@ -1,0 +1,133 @@
+## Plan: extract shared verify-harness helpers (scripts/verify_common.py)
+
+- **Issue:** #2358
+- **Model:** sonnet — mechanical dedup with concrete acceptance; the drift
+  decisions below remove the only judgment calls, so implementation is bounded.
+- **Date:** 2026-07-20
+
+### Scope
+
+Create `scripts/verify_common.py` owning the six helpers duplicated across the
+render-family harnesses, plus the multi-pass diff-dir routing (`_run_pass`) that
+the human's recurrence note (#2356) flags as bug-causing. Migrate
+`cull-verify.py`, `render-verify.py`, `gui-verify.py`, and `light-verify.py` to
+import them and delete the local copies. CLI/behavior of each harness is
+preserved; this is a correctness-preserving dedup, not a feature change.
+
+### Verified current state (measured against the actual code, 2026-07-20)
+
+Signature drift is real and asymmetric — the extraction must pick the **superset
+/ hardened** form, not the first copy. Confirmed by inspection:
+
+| helper | canonical (adopt this) | drifted copies to delete |
+|---|---|---|
+| `run` | `render`'s `_run(cmd, cwd=None, check=True, env=None, timeout=None) -> int` (line 76) | `cull`/`light` `(cmd,cwd,check)`; `gui` `(cmd)` — all subsets |
+| `run_capture` | `light`'s streaming `_run_capture(cmd, cwd=None, timeout=None) -> tuple[int,str]` (line 108) | `gui` `(cmd)` subset |
+| `detect_worktree_root` | `(start) -> Path` — byte-identical in cull/light/render, no drift | cull/light/render copies |
+| `detect_backend` | the `_detect_backend(build_dir) -> str` form **with the CMakeCache.txt guard** (cull:103 / render:92, identical) | `light`'s `_detect_backend()` (line 134) — no arg, **no CMakeCache guard**; migrate light to pass its build_dir |
+| `find_exe` | `render`'s hardened `_find_exe(build_dir, target_name, demo_name)` (line 116) — `os.access(X_OK)` filter + non-existent-`search_root` skip + demo-subtree scoping | `cull` `(build_dir, demo_name)`; `light` `(build_dir, target)` — the exact copy #2356's nit flagged as missing X_OK + search_root skip |
+| `compare` | `compare(actual, reference, diff_out, thresholds=None) -> dict` — cull/light `_compare` bodies are byte-identical (wrap `render-compare.py --json`); add the `thresholds` param so it matches render's `_compare_shot` shape (thresholds passed in, not a module dict) | cull/light `_compare` copies |
+
+**Exclude (do NOT move):** `render-verify.py`'s `_run_capture` at line 498 is a
+**different function that happens to share the name** — a keyword-only
+`--auto-screenshot` demo-capture runner (`*, worktree, target, shots_dir,
+warmup, timeout, demo_args, pass_label`), not the generic subprocess wrapper.
+Leave it in `render-verify.py`.
+
+### Approach
+
+Phase 0 (premise check — cheap, ~2 min): re-grep the six `def _<helper>` sites
+to confirm the line numbers/signatures above still hold before editing (they can
+drift if another PR touched a harness). If any canonical form has changed, adopt
+the still-most-complete copy — the rule is superset-wins, not line-number-wins.
+
+1. **Create `scripts/verify_common.py`** exporting (public names, no leading
+   underscore since they cross a module boundary now): `run`, `run_capture`,
+   `detect_worktree_root`, `detect_backend`, `find_exe`, `compare`, and
+   `run_pass`. Module-level constant `RENDER_COMPARE = Path(__file__).parent /
+   "render-compare.py"` so `compare` locates the comparator relative to the
+   shared module. Use the canonical bodies from the table.
+2. **`run_pass` + diff-dir routing** (the correctness core, per the human's
+   #2356 note): lift `light-verify.py`'s `_run_pass` (line 262) and make the
+   per-pass diff PNGs route to a **sibling of `shots_dir`**
+   (`shots_dir.parent / "<name>_diffs"`), cleared **once up front** — never
+   nested under `shots_dir`, which each pass `rmtree`s on entry. This is the
+   byte-for-byte re-derivation of render-verify.py's already-shipped fix, so the
+   next harness in this family cannot re-hit the silent-diff-wipe footgun.
+3. **Migrate each harness** — replace the local `def _helper` with
+   `from verify_common import ...` (scripts run as `__main__` from the same
+   `scripts/` dir; a top-level `import verify_common` resolves because CWD/script
+   dir is on `sys.path`). Update call sites for the signature changes:
+   - `gui-verify.py`: `_run`/`_run_capture` → `run`/`run_capture` (drop the
+     minimal locals).
+   - `cull-verify.py`: `_find_exe(build_dir, demo)` → `find_exe(build_dir,
+     target_name, demo)` — pass the demo target name it already knows;
+     `_detect_backend`/`_compare`/`_detect_worktree_root`/`_run` → shared.
+   - `light-verify.py`: `_detect_backend()` → `detect_backend(build_dir)` (thread
+     its build_dir in); `_find_exe(build_dir, target)` → `find_exe(build_dir,
+     target, demo)`; `_run_pass` → `run_pass` with the sibling diff-dir; `_run`/
+     `_run_capture`/`_compare`/`_detect_worktree_root` → shared.
+   - `render-verify.py`: `_run`/`_detect_worktree_root`/`_detect_backend`/
+     `_find_exe` → shared; keep its own `_run_capture` (line 498) and
+     `_compare_shot`; if `_compare_shot` can now call the shared `compare` with a
+     thresholds dict, do so, else leave it.
+4. **Delete** every migrated local copy so no drifted duplicate survives.
+
+### Affected files
+
+- `scripts/verify_common.py` — **new**; the six helpers + `run_pass`/diff-dir
+  routing + `RENDER_COMPARE` constant.
+- `scripts/cull-verify.py` — import shared helpers; delete `_run`,
+  `_detect_worktree_root`, `_detect_backend`, `_find_exe`, `_compare`; adapt
+  `find_exe` call to the 3-arg signature.
+- `scripts/render-verify.py` — import `run`/`detect_worktree_root`/
+  `detect_backend`/`find_exe`; delete those locals; keep `_run_capture` (498)
+  and `_compare_shot`.
+- `scripts/gui-verify.py` — import `run`/`run_capture`; delete both locals.
+- `scripts/light-verify.py` — import all six + `run_pass`; delete locals; thread
+  `build_dir` into `detect_backend`; adopt hardened `find_exe`; route diffs to
+  the sibling dir via shared `run_pass`.
+
+### Acceptance criteria
+
+- `scripts/verify_common.py` exists and exports the seven names above.
+- All four harnesses import from it; **zero** local copies of the six helpers /
+  `_run_pass` remain (grep `def _run\b|def _find_exe\b|def _detect_backend\b|def
+  _compare\b|def _run_pass\b` across the four returns only render's domain-
+  specific `_run_capture`/`_compare_shot`).
+- **Positive-fire check:** `light-verify.py`'s per-pass diff PNGs from a ≥2-pass
+  run all survive to `shots_dir.parent/<name>_diffs/` (count of surviving diff
+  dirs == number of passes, > 1) — the exact regression #2356 fixed, now proven
+  at the shared layer.
+- `ruff check scripts/` stays green (verifiable on any host; `ruff` is on PATH).
+- Spot-check: one run of **each** of the four harnesses passes on a host that
+  has its reference images (build + refs required; `light-verify.py` is ~20 min —
+  grep its raw DOMAIN-STATE stdout rather than the image compare where possible).
+
+### Gotchas
+
+- **`run_capture` name collision:** render-verify.py already has an unrelated
+  `_run_capture` (demo-capture, line 498). Do not import the shared `run_capture`
+  into render-verify or rename render's — they are different functions. Leaving
+  render's local wins on name resolution anyway, but do not delete it.
+- **`detect_backend` drift is semantic, not cosmetic:** light's copy lacks the
+  CMakeCache guard. Adopting the guarded form means light now fails loudly if no
+  configure has run — intended, but confirm light always has a real `build_dir`
+  at the call site before threading it in.
+- **Import path:** the scripts are executed directly (`./scripts/foo-verify.py`),
+  not as a package. `import verify_common` works because the script's own dir is
+  on `sys.path[0]`; do **not** add a package `__init__.py` or a relative import.
+- **CLI is frozen:** no harness's argparse surface or exit codes may change —
+  callers (skills, CI) invoke them as subprocesses.
+- **Out of scope (do not expand):** `scripts/depth-tier-verify.py` is a 5th
+  harness in the family sharing 2 of these helpers. Migrating it is a natural
+  follow-up but is **not** in this ticket's acceptance — leave it, or file a
+  follow-up per TASK-FILING.md. Do not silently broaden the diff.
+
+### One task or subtasks
+
+**One task.** Single new module + four in-place migrations on the same surface;
+splitting would only add merge friction. Model stays **sonnet** — the drift
+decisions above are pre-made, leaving mechanical execution.
+
+— worker (opus planning pass)

--- a/scripts/cull-verify.py
+++ b/scripts/cull-verify.py
@@ -30,14 +30,13 @@ Assumes this file lives at ``<repo>/scripts/cull-verify.py``.
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+import verify_common
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
@@ -84,61 +83,6 @@ CULL_THRESHOLDS: dict[str, Any] = {
 }
 
 
-def _run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> int:
-    print("+ " + " ".join(cmd), flush=True)
-    proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None)
-    if check and proc.returncode != 0:
-        raise SystemExit(f"command failed ({proc.returncode}): {' '.join(cmd)}")
-    return proc.returncode
-
-
-def _detect_worktree_root(start: Path) -> Path:
-    proc = subprocess.run(
-        ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
-        capture_output=True, text=True, check=True,
-    )
-    return Path(proc.stdout.strip())
-
-
-def _detect_backend(build_dir: Path) -> str:
-    cache = build_dir / "CMakeCache.txt"
-    if not cache.exists():
-        raise SystemExit(
-            f"no CMakeCache.txt at {cache} — run `cmake --preset <name>` first"
-        )
-    system = platform.system().lower()
-    if system == "darwin":
-        return "macos-debug"
-    if system == "linux":
-        return "linux-debug"
-    if system == "windows":
-        return "windows-debug"
-    return f"{system}-debug"
-
-
-def _find_exe(build_dir: Path, demo_name: str) -> Path:
-    search_root = build_dir / "creations" / "demos" / demo_name
-    names = (TARGET, f"{TARGET}.exe")
-    for name in names:
-        candidates = [
-            p for p in search_root.rglob(name)
-            if p.is_file() and os.access(p, os.X_OK)
-        ]
-        if candidates:
-            candidates.sort(key=lambda p: len(p.parts))
-            return candidates[0]
-    # Fallback: full build tree walk.
-    for name in names:
-        candidates = [
-            p for p in build_dir.rglob(name)
-            if p.is_file() and os.access(p, os.X_OK)
-        ]
-        if candidates:
-            candidates.sort(key=lambda p: len(p.parts))
-            return candidates[0]
-    raise SystemExit(f"could not find executable {TARGET} under {build_dir}")
-
-
 def _collect_shots(shots_dir: Path) -> list[Path]:
     shots = sorted(shots_dir.glob("screenshot_*.png"))
     if len(shots) < TOTAL_SHOTS:
@@ -151,27 +95,6 @@ def _collect_shots(shots_dir: Path) -> list[Path]:
             f"expected {TOTAL_SHOTS}; ignoring extras"
         )
     return shots[:TOTAL_SHOTS]
-
-
-def _compare(actual: Path, reference: Path, diff_out: Path | None) -> dict[str, Any]:
-    cmd = [
-        sys.executable, str(RENDER_COMPARE),
-        str(actual), str(reference),
-        "--json",
-        "--per-pixel-tol", str(CULL_THRESHOLDS["per_pixel_tol"]),
-        "--threshold-match-pct", str(CULL_THRESHOLDS["match_pct"]),
-        "--threshold-max-delta", str(CULL_THRESHOLDS["max_delta"]),
-        "--threshold-psnr", str(CULL_THRESHOLDS["psnr_db"]),
-    ]
-    if diff_out:
-        cmd.extend(["--diff-out", str(diff_out)])
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode == 2:
-        raise SystemExit(f"render-compare errored: {proc.stderr}")
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as e:
-        raise SystemExit(f"render-compare returned non-JSON: {proc.stdout!r} ({e})")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -198,18 +121,18 @@ def main(argv: list[str] | None = None) -> int:
     if not RENDER_COMPARE.exists():
         raise SystemExit(f"render-compare.py not found at {RENDER_COMPARE}")
 
-    worktree = _detect_worktree_root(Path.cwd())
+    worktree = verify_common.detect_worktree_root(Path.cwd())
     build_dir = Path(args.build_dir) if args.build_dir else worktree / "build"
-    backend = _detect_backend(build_dir)
+    backend = verify_common.detect_backend(build_dir)
     demo_dir = worktree / "creations" / "demos" / DEMO_NAME
 
     print(f"[cull-verify] target={TARGET}  backend={backend}")
     print(f"[cull-verify] {POSES_PER_PHASE} poses/phase × 2 + 2 markers = {TOTAL_SHOTS} shots")
 
     if not args.no_build:
-        _run(["fleet-build", "--target", TARGET], cwd=worktree)
+        verify_common.run(["fleet-build", "--target", TARGET], cwd=worktree)
 
-    exe = _find_exe(build_dir, DEMO_NAME)
+    exe = verify_common.find_exe(build_dir, TARGET, DEMO_NAME)
     shots_dir = exe.parent / SCREENSHOT_SUBDIR
     if shots_dir.exists():
         shutil.rmtree(shots_dir)
@@ -274,7 +197,7 @@ def main(argv: list[str] | None = None) -> int:
         zip(live_shots, frozen_shots, LIVE_LABELS)
     ):
         diff_out = diff_dir / f"{label}_vs_frozen.diff.png"
-        result = _compare(live, frozen, diff_out)
+        result = verify_common.compare(live, frozen, diff_out, CULL_THRESHOLDS)
         verdict = "PASS" if result["pass"] else "FAIL"
         raw_psnr = result["psnr_db"]
         psnr_str = f"{raw_psnr:>8.2f}" if isinstance(raw_psnr, (int, float)) else f"{raw_psnr:>8}"

--- a/scripts/gui-verify.py
+++ b/scripts/gui-verify.py
@@ -11,7 +11,8 @@ Usage:
 """
 
 import re
-import subprocess
+
+import verify_common
 
 # Pattern: GUI-ASSERT shot=<N> label=<lbl> kind=<K> target=<eid> name=<tag>
 #          result=PASS|FAIL actual=<val>
@@ -25,28 +26,6 @@ _GUI_ASSERT_RE = re.compile(
     r"result=(PASS|FAIL)\s+"
     r"actual=(.*)"
 )
-
-
-def _run(cmd: list[str]) -> int:
-    """Run a command, streaming output to the terminal; return its exit code."""
-    print("+ " + " ".join(cmd), flush=True)
-    return subprocess.run(cmd).returncode
-
-
-def _run_capture(cmd: list[str]) -> tuple[int, str]:
-    """Run a command, tee output to the terminal, and return (exit_code, combined_text)."""
-    print("+ " + " ".join(cmd), flush=True)
-    proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
-    lines: list[str] = []
-    if proc.stdout is None:
-        raise RuntimeError("stdout unavailable (Popen stdout=PIPE failed)")
-    for line in proc.stdout:
-        print(line, end="", flush=True)
-        lines.append(line)
-    proc.wait()
-    return proc.returncode, "".join(lines)
 
 
 def main() -> None:
@@ -78,7 +57,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if not args.no_build:
-        rc = _run(["fleet-build", "--target", args.target])
+        rc = verify_common.run(["fleet-build", "--target", args.target], check=False)
         if rc != 0:
             raise SystemExit(f"[gui-verify] fleet-build failed ({rc})")
 
@@ -88,7 +67,7 @@ def main() -> None:
         args.target,
         "--auto-screenshot", str(args.warmup_frames),
     ]
-    run_rc, output = _run_capture(run_cmd)
+    run_rc, output = verify_common.run_capture(run_cmd)
 
     # An --auto-screenshot GUI-test run must self-terminate. The fleet-run
     # watchdog reports a process still alive at --timeout as exit 0

--- a/scripts/light-verify.py
+++ b/scripts/light-verify.py
@@ -48,15 +48,13 @@ Assumes this file lives at ``<repo>/scripts/light-verify.py``.
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import platform
 import re
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+import verify_common
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
@@ -97,66 +95,6 @@ _DOMAIN_STATE_RE = re.compile(
 _LIGHT_ENTRY_RE = re.compile(r"(\d+):(SEEDED_FULL|BOUNDARY_DISCOUNTED|SKIPPED):([\d.]+)")
 
 
-def _run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> int:
-    print("+ " + " ".join(cmd), flush=True)
-    proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None)
-    if check and proc.returncode != 0:
-        raise SystemExit(f"command failed ({proc.returncode}): {' '.join(cmd)}")
-    return proc.returncode
-
-
-def _run_capture(
-    cmd: list[str], cwd: Path | None = None, timeout: int | None = None
-) -> tuple[int, str]:
-    print("+ " + " ".join(cmd), flush=True)
-    proc = subprocess.Popen(
-        cmd, cwd=str(cwd) if cwd else None,
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-    )
-    lines: list[str] = []
-    if proc.stdout is None:
-        raise RuntimeError("stdout unavailable (Popen stdout=PIPE failed)")
-    for line in proc.stdout:
-        print(line, end="", flush=True)
-        lines.append(line)
-    proc.wait(timeout=timeout)
-    return proc.returncode, "".join(lines)
-
-
-def _detect_worktree_root(start: Path) -> Path:
-    proc = subprocess.run(
-        ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
-        capture_output=True, text=True, check=True,
-    )
-    return Path(proc.stdout.strip())
-
-
-def _detect_backend() -> str:
-    system = platform.system().lower()
-    if system == "darwin":
-        return "macos-debug"
-    if system == "linux":
-        return "linux-debug"
-    if system == "windows":
-        return "windows-debug"
-    return f"{system}-debug"
-
-
-def _find_exe(build_dir: Path, target: str) -> Path:
-    search_root = build_dir / "creations" / "demos" / DEMO_NAME
-    names = (target, f"{target}.exe")
-    for root in (search_root, build_dir):
-        if not root.exists():
-            continue
-        for name in names:
-            candidates = [p for p in root.rglob(name)
-                          if p.is_file() and os.access(p, os.X_OK)]
-            if candidates:
-                candidates.sort(key=lambda p: len(p.parts))
-                return candidates[0]
-    raise SystemExit(f"could not find executable {target} under {build_dir}")
-
-
 def _parse_domain_state(output: str) -> list[dict[str, Any]]:
     shots = []
     for m in _DOMAIN_STATE_RE.finditer(output):
@@ -174,27 +112,6 @@ def _parse_domain_state(output: str) -> list[dict[str, Any]]:
             "casters": int(casters),
         })
     return shots
-
-
-def _compare(actual: Path, reference: Path, diff_out: Path | None) -> dict[str, Any]:
-    cmd = [
-        sys.executable, str(RENDER_COMPARE),
-        str(actual), str(reference),
-        "--json",
-        "--per-pixel-tol", str(LIGHT_VERIFY_THRESHOLDS["per_pixel_tol"]),
-        "--threshold-match-pct", str(LIGHT_VERIFY_THRESHOLDS["match_pct"]),
-        "--threshold-max-delta", str(LIGHT_VERIFY_THRESHOLDS["max_delta"]),
-        "--threshold-psnr", str(LIGHT_VERIFY_THRESHOLDS["psnr_db"]),
-    ]
-    if diff_out:
-        cmd.extend(["--diff-out", str(diff_out)])
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode == 2:
-        raise SystemExit(f"render-compare errored: {proc.stderr}")
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as e:
-        raise SystemExit(f"render-compare returned non-JSON: {proc.stdout!r} ({e})")
 
 
 def _pan_category(shot_label: str) -> str | None:
@@ -259,24 +176,6 @@ def _check_boundary_sweep(shots: list[dict[str, Any]]) -> list[str]:
     return failures
 
 
-def _run_pass(
-    worktree: Path, target: str, flag: str, warmup: int, timeout: int, shots_dir: Path
-) -> tuple[list[dict[str, Any]], list[Path], int | None]:
-    if shots_dir.exists():
-        shutil.rmtree(shots_dir)
-    shots_dir.mkdir(parents=True, exist_ok=True)
-
-    run_cmd = [
-        "fleet-run", "--timeout", str(timeout), target,
-        f"--{flag}", "--auto-screenshot", str(warmup),
-    ]
-    rc, output = _run_capture(run_cmd, cwd=worktree, timeout=timeout + 30)
-    domain_states = _parse_domain_state(output)
-    images = sorted(shots_dir.glob("screenshot_*.png"))
-    run_crash = rc if rc != 0 else None
-    return domain_states, images, run_crash
-
-
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--target", default=DEFAULT_TARGET,
@@ -302,24 +201,24 @@ def main(argv: list[str] | None = None) -> int:
     if not RENDER_COMPARE.exists():
         raise SystemExit(f"render-compare.py not found at {RENDER_COMPARE}")
 
-    worktree = _detect_worktree_root(Path.cwd())
+    worktree = verify_common.detect_worktree_root(Path.cwd())
     build_dir = Path(args.build_dir) if args.build_dir else worktree / "build"
-    backend = _detect_backend()
+    backend = verify_common.detect_backend(build_dir)
     demo_dir = worktree / "creations" / "demos" / DEMO_NAME
 
     print(f"[light-verify] target={args.target}  backend={backend}")
 
     if not args.no_build:
-        _run(["fleet-build", "--target", args.target], cwd=worktree)
+        verify_common.run(["fleet-build", "--target", args.target], cwd=worktree)
 
-    exe = _find_exe(build_dir, args.target)
+    exe = verify_common.find_exe(build_dir, args.target, DEMO_NAME)
     shots_dir = exe.parent / SCREENSHOT_SUBDIR
-    # Each pass rmtrees shots_dir on entry (_run_pass), so per-pass diff PNGs
-    # must live in a sibling dir that outlives every pass — nested under
-    # shots_dir they'd be wiped by the next pass before a human inspects them
-    # (render-verify.py hit the identical multi-pass bug; see its diff_dir
-    # routing in scripts/render-verify.py). Clear it once up front so stale
-    # diffs from a prior run don't linger.
+    # Each pass rmtrees shots_dir on entry (verify_common.run_pass), so
+    # per-pass diff PNGs must live in a sibling dir that outlives every pass —
+    # nested under shots_dir they'd be wiped by the next pass before a human
+    # inspects them (render-verify.py hit the identical multi-pass bug; see
+    # its diff_dir routing in scripts/render-verify.py). Clear it once up
+    # front so stale diffs from a prior run don't linger.
     diff_root = shots_dir.parent / "light_verify_diffs"
     if diff_root.exists():
         shutil.rmtree(diff_root)
@@ -331,9 +230,15 @@ def main(argv: list[str] | None = None) -> int:
 
     for flag in PASSES:
         print(f"\n[light-verify] === pass: --{flag} ===")
-        domain_states, images, run_crash = _run_pass(
-            worktree, args.target, flag, args.warmup, args.timeout, shots_dir
+        run_cmd = [
+            "fleet-run", "--timeout", str(args.timeout), args.target,
+            f"--{flag}", "--auto-screenshot", str(args.warmup),
+        ]
+        rc, output, images = verify_common.run_pass(
+            run_cmd, worktree, shots_dir, timeout=args.timeout + 30
         )
+        domain_states = _parse_domain_state(output)
+        run_crash = rc if rc != 0 else None
         if run_crash is not None:
             any_run_crashed = True
             print(f"[light-verify] --{flag}: fleet-run exited {run_crash}", file=sys.stderr)
@@ -386,7 +291,9 @@ def main(argv: list[str] | None = None) -> int:
                                                           "max_delta": -1, "psnr_db": "n/a",
                                                           "error": "no reference"}))
                 continue
-            result = _compare(image, reference, diff_dir / f"{label}.diff.png")
+            result = verify_common.compare(
+                image, reference, diff_dir / f"{label}.diff.png", LIGHT_VERIFY_THRESHOLDS
+            )
             all_image_results.append((flag, label, result))
 
     print()

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -59,8 +59,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import platform
 import re
 import shutil
 import subprocess
@@ -68,74 +66,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import verify_common
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 RENDER_COMPARE = SCRIPT_DIR / "render-compare.py"
-
-
-def _run(cmd: list[str], cwd: Path | None = None, check: bool = True,
-         env: dict[str, str] | None = None, timeout: int | None = None) -> int:
-    print("+ " + " ".join(cmd), flush=True)
-    proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None, env=env,
-                          timeout=timeout)
-    if check and proc.returncode != 0:
-        raise SystemExit(f"command failed ({proc.returncode}): {' '.join(cmd)}")
-    return proc.returncode
-
-
-def _detect_worktree_root(start: Path) -> Path:
-    proc = subprocess.run(["git", "-C", str(start), "rev-parse", "--show-toplevel"],
-                          capture_output=True, text=True, check=True)
-    return Path(proc.stdout.strip())
-
-
-def _detect_backend(build_dir: Path) -> str:
-    """Return the preset name for the host, e.g. 'macos-debug'.
-
-    Derived from ``platform.system()`` — matches the convention used by the
-    ``backend-parity`` skill (``uname -s``). This assumes the harness runs
-    on the same host that built the tree under ``build_dir``; we also
-    require ``build/CMakeCache.txt`` to exist so we fail loudly if no
-    configure has run.
-    """
-    cache = build_dir / "CMakeCache.txt"
-    if not cache.exists():
-        raise SystemExit(
-            f"no CMakeCache.txt at {cache} — run `cmake --preset <name>` first"
-        )
-    system = platform.system().lower()
-    if system == "darwin":
-        return "macos-debug"
-    if system == "linux":
-        return "linux-debug"
-    if system == "windows":
-        return "windows-debug"
-    return f"{system}-debug"
-
-
-def _find_exe(build_dir: Path, target_name: str, demo_name: str) -> Path:
-    """Locate the demo's executable in its CMake output dir.
-
-    Scoped to ``build/creations/demos/<demo>/`` first so we don't
-    accidentally pick up a build-intermediate copy from elsewhere in
-    the tree. Falls back to the full ``build/`` walk if that subtree
-    is absent (e.g. editor creations under a different layout).
-    """
-    search_roots = [
-        build_dir / "creations" / "demos" / demo_name,
-        build_dir,
-    ]
-    names = (target_name, f"{target_name}.exe")
-    for root in search_roots:
-        if not root.exists():
-            continue
-        for name in names:
-            candidates = [p for p in root.rglob(name)
-                          if p.is_file() and os.access(p, os.X_OK)]
-            if candidates:
-                candidates.sort(key=lambda p: len(p.parts))
-                return candidates[0]
-    raise SystemExit(f"could not find executable {target_name} under {build_dir}")
 
 
 def _load_manifest(demo_dir: Path) -> dict[str, Any]:
@@ -596,9 +531,9 @@ def main(argv: list[str] | None = None) -> int:
                          "baseline (#1294 child 3/3).")
     args = ap.parse_args(argv)
 
-    worktree = _detect_worktree_root(Path.cwd())
+    worktree = verify_common.detect_worktree_root(Path.cwd())
     build_dir = Path(args.build_dir) if args.build_dir else worktree / "build"
-    backend = _detect_backend(build_dir)
+    backend = verify_common.detect_backend(build_dir)
 
     demo_name = args.demo or _target_to_demo_name(args.target)
     demo_dir = worktree / "creations" / "demos" / demo_name
@@ -649,9 +584,9 @@ def main(argv: list[str] | None = None) -> int:
               f"{', '.join(e['name'] for e in extra_runs)}")
 
     if not args.no_build:
-        _run(["fleet-build", "--target", args.target], cwd=worktree)
+        verify_common.run(["fleet-build", "--target", args.target], cwd=worktree)
 
-    exe = _find_exe(build_dir, args.target, demo_name)
+    exe = verify_common.find_exe(build_dir, args.target, demo_name)
     shots_dir = exe.parent / screenshot_subdir
     ref_dir = demo_dir / "test" / "references" / backend
     # Single-pass runs keep diffs in shots_dir/diffs (the original location,

--- a/scripts/verify_common.py
+++ b/scripts/verify_common.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Shared helpers for the cull/render/gui/light verify-harness family (#2358).
+
+``cull-verify.py``, ``render-verify.py``, ``gui-verify.py``, and
+``light-verify.py`` all import from this module for process-run wrappers,
+worktree/backend detection, executable discovery, and pixel-diff comparison
+against ``render-compare.py``. render-verify.py's ``_run_capture`` (an
+``--auto-screenshot`` demo-capture runner) and ``_compare_shot`` are domain-
+specific and stay local to that file.
+
+Assumes this file lives at ``<repo>/scripts/verify_common.py``, alongside the
+harnesses that import it (they run as ``__main__`` from this directory, so
+``import verify_common`` resolves via ``sys.path[0]``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RENDER_COMPARE = SCRIPT_DIR / "render-compare.py"
+
+
+def run(cmd: list[str], cwd: Path | None = None, check: bool = True,
+        env: dict[str, str] | None = None, timeout: int | None = None) -> int:
+    print("+ " + " ".join(cmd), flush=True)
+    proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None, env=env,
+                          timeout=timeout)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"command failed ({proc.returncode}): {' '.join(cmd)}")
+    return proc.returncode
+
+
+def run_capture(cmd: list[str], cwd: Path | None = None,
+                 timeout: int | None = None) -> tuple[int, str]:
+    print("+ " + " ".join(cmd), flush=True)
+    proc = subprocess.Popen(
+        cmd, cwd=str(cwd) if cwd else None,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    lines: list[str] = []
+    if proc.stdout is None:
+        raise RuntimeError("stdout unavailable (Popen stdout=PIPE failed)")
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+        lines.append(line)
+    proc.wait(timeout=timeout)
+    return proc.returncode, "".join(lines)
+
+
+def detect_worktree_root(start: Path) -> Path:
+    proc = subprocess.run(["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True, check=True)
+    return Path(proc.stdout.strip())
+
+
+def detect_backend(build_dir: Path) -> str:
+    """Return the preset name for the host, e.g. 'macos-debug'.
+
+    Derived from ``platform.system()`` — matches the convention used by the
+    ``backend-parity`` skill (``uname -s``). This assumes the harness runs
+    on the same host that built the tree under ``build_dir``; we also
+    require ``build/CMakeCache.txt`` to exist so we fail loudly if no
+    configure has run.
+    """
+    cache = build_dir / "CMakeCache.txt"
+    if not cache.exists():
+        raise SystemExit(
+            f"no CMakeCache.txt at {cache} — run `cmake --preset <name>` first"
+        )
+    system = platform.system().lower()
+    if system == "darwin":
+        return "macos-debug"
+    if system == "linux":
+        return "linux-debug"
+    if system == "windows":
+        return "windows-debug"
+    return f"{system}-debug"
+
+
+def find_exe(build_dir: Path, target_name: str, demo_name: str) -> Path:
+    """Locate the demo's executable in its CMake output dir.
+
+    Scoped to ``build/creations/demos/<demo>/`` first so we don't
+    accidentally pick up a build-intermediate copy from elsewhere in
+    the tree. Falls back to the full ``build/`` walk if that subtree
+    is absent (e.g. editor creations under a different layout).
+    """
+    search_roots = [
+        build_dir / "creations" / "demos" / demo_name,
+        build_dir,
+    ]
+    names = (target_name, f"{target_name}.exe")
+    for root in search_roots:
+        if not root.exists():
+            continue
+        for name in names:
+            candidates = [p for p in root.rglob(name)
+                          if p.is_file() and os.access(p, os.X_OK)]
+            if candidates:
+                candidates.sort(key=lambda p: len(p.parts))
+                return candidates[0]
+    raise SystemExit(f"could not find executable {target_name} under {build_dir}")
+
+
+def compare(actual: Path, reference: Path, diff_out: Path | None,
+            thresholds: dict[str, Any] | None = None) -> dict[str, Any]:
+    thresholds = thresholds or {}
+    cmd = [
+        sys.executable, str(RENDER_COMPARE),
+        str(actual), str(reference),
+        "--json",
+        "--per-pixel-tol", str(thresholds.get("per_pixel_tol", 8)),
+        "--threshold-match-pct", str(thresholds.get("match_pct", 99.9)),
+        "--threshold-max-delta", str(thresholds.get("max_delta", 64)),
+        "--threshold-psnr", str(thresholds.get("psnr_db", 35.0)),
+    ]
+    if diff_out:
+        cmd.extend(["--diff-out", str(diff_out)])
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode == 2:
+        raise SystemExit(f"render-compare errored: {proc.stderr}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"render-compare returned non-JSON: {proc.stdout!r} ({e})")
+
+
+def run_pass(cmd: list[str], cwd: Path, shots_dir: Path,
+             timeout: int | None = None) -> tuple[int, str, list[Path]]:
+    """Clear ``shots_dir``, run ``cmd``, and collect the resulting screenshots.
+
+    Callers that run multiple passes against the same ``shots_dir`` (e.g.
+    light-verify's domain-matrix / boundary-sweep / hover-sweep flags) must
+    route any per-pass diff output to a directory that is a *sibling* of
+    ``shots_dir``, not nested under it — this function ``rmtree``s
+    ``shots_dir`` on every call, which would silently wipe a previous pass's
+    diff images if they lived underneath it (the bug #2356 fixed in
+    light-verify.py).
+    """
+    if shots_dir.exists():
+        shutil.rmtree(shots_dir)
+    shots_dir.mkdir(parents=True, exist_ok=True)
+    rc, output = run_capture(cmd, cwd=cwd, timeout=timeout)
+    images = sorted(shots_dir.glob("screenshot_*.png"))
+    return rc, output, images


### PR DESCRIPTION
## Summary
- New `scripts/verify_common.py` owns the six helpers duplicated across `cull-verify.py`, `render-verify.py`, `gui-verify.py`, and `light-verify.py` (process-run wrappers, worktree/backend detection, executable discovery, pixel-diff `compare`), each adopted in its superset/hardened form per the plan's drift table.
- Adds `verify_common.run_pass` — clears `shots_dir`, runs a capture command, and collects screenshots; callers route per-pass diff PNGs to a sibling directory so the multi-pass silent-diff-wipe bug `#2356` already fixed in `light-verify.py` can't regress at the shared layer.
- All four harnesses now import from `verify_common` and have zero local copies of the six helpers left; `render-verify.py`'s domain-specific `_run_capture` (`--auto-screenshot` demo-capture runner) and `_compare_shot` stay local per the plan's gotcha.
- CLI surface and exit codes of all four harnesses are unchanged — this is a correctness-preserving dedup, not a behavior change.

## Test plan
- [x] `ast.parse` syntax check on all 5 touched files.
- [x] `ruff check scripts/` — clean.
- [x] `--help` smoke test on all four harnesses, run from both `scripts/` and the repo root, confirming `import verify_common` resolves via `sys.path[0]` regardless of cwd.
- [x] Synthetic smoke test of every `verify_common` function without needing an engine build: `run`/`run_capture` (via `run_pass`, including the second-pass `shots_dir` clear), `detect_worktree_root` (real repo), `detect_backend` (fake `CMakeCache.txt`, plus its missing-cache `SystemExit` path), `find_exe` (fake demo-subtree layout), `compare` (self-vs-self against a real committed reference PNG, `match_pct == 100`).
- [x] Grep confirms zero `def _run\b|_find_exe\b|_detect_backend\b|_compare\b|_run_pass\b` remain outside `verify_common.py` across the four harnesses.
- [ ] Full build+run spot-check of each harness against real demo binaries — **blocked on this macOS host** by engine `#2449` (Apple clang 21 / fmt 10.1.1 consteval incompatibility breaks all fresh macOS builds, confirmed again 2026-07-20). Someone on a host where `#2449` doesn't block (Linux, or macOS once it lands) should run each of the four harnesses once against its committed references, and in particular `light-verify.py`'s ≥2-pass run to confirm all per-pass diff dirs under `light_verify_diffs/` survive to the end (the exact `#2356` regression, now proven at the shared layer).

## Notes for reviewer
`light-verify.py`'s local `_run_pass` wrapped both the generic run+capture+collect step and its own `DOMAIN-STATE` log parsing (`_parse_domain_state`), which is lighting-specific. I split those: the generic half moved into `verify_common.run_pass`, and `light-verify.py`'s `main()` now calls `_parse_domain_state` on the returned raw output directly — no local `_run_pass` wrapper survives (the acceptance grep would have caught one). The diff-dir routing logic itself (`diff_root = shots_dir.parent / "light_verify_diffs"`, cleared once up front) was already correct in `main()` from `#2356` and is untouched.

Closes #2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)