### PR TITLE
fleet: scope-shipped skips all-.fleet/ steward bookkeeping PRs

### DIFF
--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -130,9 +130,12 @@ for issue in pending:
     # bodies, comments, line numbers, relevance) — so the search is a coarse
     # candidate set, not a reference match. select_shipped_pr() verifies a
     # genuine word-boundary #n cross-reference in title/body before trusting it.
+    # 'files' feeds the layer-8 bookkeeping-diff guard (a steward all-.fleet/ PR
+    # that names #n but ships no code scope); it rides the same query, no extra call.
     r = subprocess.run(
         ['gh', 'pr', 'list', '--repo', repo, '--state', 'merged',
-         '--search', f'#{n}', '--json', 'number,title,body,url,mergedAt', '--limit', '5'],
+         '--search', f'#{n}', '--json', 'number,title,body,url,mergedAt,files',
+         '--limit', '5'],
         capture_output=True, text=True, timeout=15,
     )
     try:

--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -77,14 +77,34 @@ incidental match have to be rejected:
    deferral marker (the prep word must sit directly on one side of the ref, so
    "ship #1234, prep #1235" still ships #1234).
 
+8. Bookkeeping diff — an all-``.fleet/`` PR (#2385 ← #2392). Layers 1-7 read the
+   PR's title/body text; this one reads its *diff*. An epic-steward bookkeeping
+   PR — a ledger rollup, a plan adoption, a projection edit — is titled *about*
+   the issues it accounts for ("docs/fleet: epic-steward — #2317 rollup + #2385
+   adoption (#2314)"), but its diff is entirely ``.fleet/`` files (here two
+   ``.fleet/plans/`` docs). Its subject is neither ``plan`` nor ``design``, so
+   the layer-4 guard does not fire, and the bare ``#2385`` in the title
+   satisfies title-trust — ingest false-stamped ``fleet:scope-shipped`` on #2385
+   (a render fix with no impl PR anywhere) one minute after the human cleared it
+   for the queue, and the reconcile loop then re-bounced it to
+   ``fleet:needs-plan``. A PR whose changed files are *all* under ``.fleet/``
+   maintains fleet state and never ships an issue's code scope, so its title ref
+   is NOT trusted: like layers 4/6/7 it falls through to the body closing-verb
+   check, where a ``.fleet/``-only PR whose deliverable genuinely IS the fleet
+   change still ships via a prose ``Closes #N``. Real impl PRs that commit a plan
+   file (``.fleet/plans/issue-N.md``, per #1932) also carry the code, so their
+   diff is never ``.fleet/``-only. The file list is optional — a caller that does
+   not supply it keeps the pre-layer-8 title-trust behavior.
+
 So a body ``#N`` counts only when a closing-action verb sits directly before it
 in prose (``Closes #N``, ``fixes (#N)``, ``supersedes #N``) — code spans are
 stripped first (layer 5), so a verb quoted in backticks does not count. A
 ``#N`` in the *title* is trusted as-is — PRs in this repo are named
 ``#N: <desc>`` after the issue they implement — EXCEPT (layer 3) when it is a
 range endpoint, (layer 4) when the title is a plan/design-doc title, (layer 6)
-when the ref is marked deferred, or (layer 7) when the ref is marked prep: all
-four shapes name issues they enumerate, plan, defer, or prepare without
+when the ref is marked deferred, (layer 7) when the ref is marked prep, or
+(layer 8) when the PR's diff is entirely ``.fleet/`` bookkeeping paths: all five
+shapes name issues they enumerate, plan, defer, prepare, or account for without
 implementing.
 """
 import re
@@ -198,7 +218,38 @@ def _ref_is_nonship_marked(text, n):
                 or re.search(leading, text, re.IGNORECASE))
 
 
-def pr_references_issue(title, body, n):
+# Fleet-internal bookkeeping prefix (layer 8). A merged PR whose changed files
+# are ALL under ``.fleet/`` — an epic-steward ledger rollup, a plan adoption, a
+# projection edit — maintains fleet state; it never ships an issue's code scope.
+# Real impl PRs that commit a plan file (``.fleet/plans/issue-N.md``, per #1932)
+# also carry the code, so their diff is never ``.fleet/``-only.
+_FLEET_BOOKKEEPING_PREFIX = '.fleet/'
+
+
+def _is_bookkeeping_diff(files):
+    """True iff every changed path in ``files`` is under ``.fleet/`` — a fleet
+    bookkeeping PR (steward ledger / plan adoption / projection edit) that does
+    not ship any issue's code scope (layer 8).
+
+    ``files`` is the ``gh pr list --json files`` shape (a list of
+    ``{'path': ...}`` dicts); a plain list of path strings is accepted too.
+    Returns False when ``files`` is falsy/empty (no diff info supplied) so a
+    caller that omits the file list keeps the pre-layer-8 title-trust behavior.
+    """
+    if not files:
+        return False
+    paths = []
+    for f in files:
+        p = (f.get('path') if isinstance(f, dict) else f) or ''
+        p = p.strip()
+        if p:
+            paths.append(p)
+    if not paths:
+        return False
+    return all(p.startswith(_FLEET_BOOKKEEPING_PREFIX) for p in paths)
+
+
+def pr_references_issue(title, body, n, files=None):
     """True iff the PR genuinely ships issue ``n`` (see module docstring).
 
     Title: any word-boundary ``#n`` counts (the ``#N: <desc>`` PR-naming
@@ -208,13 +259,19 @@ def pr_references_issue(title, body, n):
     never ships it), the ref is marked deferred ("(#n deferred)" / "defers #n"
     — layer 6, a doc-and-defer PR that escalates ``n`` rather than shipping it),
     OR the ref is marked prep ("(#n prep)" / "prep for #n" — layer 7, a narrowed
-    refactor that prepares ``n`` rather than shipping it).
+    refactor that prepares ``n`` rather than shipping it), OR (layer 8) the PR's
+    ``files`` diff is entirely ``.fleet/`` bookkeeping paths (a steward ledger /
+    plan-adoption PR that accounts for ``n`` rather than implementing it).
     Body: ``#n`` counts only when immediately preceded by a
     closing-action verb, and likewise never as a range endpoint. A bare body
     mention ("downstream #n", "pre-existing #n", "Refs #n") is rejected, as is
     a closing verb quoted inside a markdown code span (layer 5): code spans are
     stripped before the body scan so ``... + `Closes #n` `` in a plan PR's body
     does not read as a ship.
+
+    ``files`` is the optional ``gh pr list --json files`` list for this PR; when
+    omitted the layer-8 bookkeeping-diff guard is inert and title-trust is
+    unchanged.
     """
     if not n:
         return False
@@ -229,10 +286,13 @@ def pr_references_issue(title, body, n):
     # closing-verb check below (where a genuine doc-ship still says ``Closes #N``).
     # Layers 6-7: a title ref marked deferred ("(#N deferred)") or prep
     # ("(#N prep)") is an explicit non-ship, so it is likewise not trusted and
-    # falls through to the body.
+    # falls through to the body. Layer 8: a PR whose diff is entirely ``.fleet/``
+    # bookkeeping paths (steward ledger / plan adoption) accounts for the issue
+    # without implementing it, so its title ref falls through too.
     if (not _PLAN_DOC_TITLE.search(title)
             and re.search(ref, title)
-            and not _ref_is_nonship_marked(title, n)):
+            and not _ref_is_nonship_marked(title, n)
+            and not _is_bookkeeping_diff(files)):
         return True
     body_re = re.compile(
         r'\b(?:' + _CLOSING_VERB + r')\b' + _VERB_TO_REF_GAP + ref,
@@ -246,9 +306,12 @@ def select_shipped_pr(prs, n):
 
     Replaces the old ``prs[0]`` blind trust: a merged-PR search hit only counts
     as scope-shipped evidence when ``pr_references_issue`` confirms a genuine
-    ship (title ref or closing-verb body ref), not an incidental mention.
+    ship (title ref or closing-verb body ref), not an incidental mention. The
+    PR's ``files`` list (from ``gh pr list --json files``) feeds the layer-8
+    bookkeeping-diff guard; a candidate without it falls back to text-only.
     """
     for pr in prs:
-        if pr_references_issue(pr.get('title', ''), pr.get('body', ''), n):
+        if pr_references_issue(pr.get('title', ''), pr.get('body', ''), n,
+                               pr.get('files')):
             return pr
     return None

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -23,6 +23,11 @@ Covers the false-positive classes:
   trusted (non-plan) title ("render: extract … helper (#2258 prep)", linked
   `Part of` not `Closes`); a prep-marked ref prepares the issue rather than
   shipping it.
+* #2385 ← #2392 (layer 8) — an epic-steward bookkeeping PR ("docs/fleet:
+  epic-steward — #2317 rollup + #2385 adoption (#2314)") names #2385 in a
+  trusted (non-plan) title but its diff is entirely `.fleet/` files; an
+  all-`.fleet/` diff ships no code scope, so it falls through to the body
+  closing-verb check.
 
 The module is a real .py, but it is loaded via importlib (mirroring
 test_enrich_stackable_blocker_prs.py) so the test runs regardless of cwd.
@@ -42,8 +47,12 @@ pr_references_issue = _mod.pr_references_issue
 select_shipped_pr = _mod.select_shipped_pr
 
 
-def _pr(number, title="", body=""):
-    return {"number": number, "title": title, "body": body, "url": "", "mergedAt": ""}
+def _pr(number, title="", body="", files=None):
+    pr = {"number": number, "title": title, "body": body, "url": "", "mergedAt": ""}
+    if files is not None:
+        # Mirror the `gh pr list --json files` shape: a list of {'path': ...} dicts.
+        pr["files"] = [{"path": p} for p in files]
+    return pr
 
 
 class PrReferencesIssue(unittest.TestCase):
@@ -332,6 +341,53 @@ class PrReferencesIssue(unittest.TestCase):
         # "prep" inside "prepend").
         self.assertTrue(pr_references_issue("#2258 prepend the sun-bake header", "", 2258))
 
+    # --- bookkeeping diff — all-.fleet/ PRs (#2385 <- #2392 — layer 8) ---
+
+    _STEWARD_TITLE_2392 = (
+        "docs/fleet: epic-steward — #2317 rollup + #2385 adoption (#2314)")
+    _FLEET_FILES = [{"path": ".fleet/plans/issue-2314.md"},
+                    {"path": ".fleet/plans/issue-2385.md"}]
+
+    def test_bookkeeping_diff_title_ref_rejected(self):
+        # #2385 <- #2392: a steward rollup PR names #2385 in a trusted (non-plan)
+        # title, but its diff is two .fleet/plans/ docs — it adopts the plan, it
+        # does not ship #2385's render fix. Its subject is "epic-steward" (neither
+        # plan nor design), so layers 4/6/7 do not fire; the all-.fleet/ diff does.
+        self.assertFalse(pr_references_issue(
+            self._STEWARD_TITLE_2392, "", 2385, self._FLEET_FILES))
+        # The epic ref (#2314) it rolls up is likewise not shipped.
+        self.assertFalse(pr_references_issue(
+            self._STEWARD_TITLE_2392, "", 2314, self._FLEET_FILES))
+
+    def test_bookkeeping_diff_string_paths_accepted(self):
+        # Defensive: a plain list of path strings (not {'path': ...} dicts) works.
+        self.assertFalse(pr_references_issue(
+            self._STEWARD_TITLE_2392, "", 2385,
+            [".fleet/plans/issue-2314.md", ".fleet/plans/issue-2385.md"]))
+
+    def test_bookkeeping_diff_still_ships_via_body_closing_verb(self):
+        # A .fleet/-only PR whose deliverable genuinely IS the fleet change still
+        # ships via a prose body close (consistent with layers 4/6/7).
+        self.assertTrue(pr_references_issue(
+            self._STEWARD_TITLE_2392, "Closes #2385", 2385, self._FLEET_FILES))
+
+    def test_mixed_diff_keeps_title_trust(self):
+        # A real impl PR that commits its plan file (.fleet/plans/issue-N.md, per
+        # #1932) AND code is NOT all-.fleet/, so title-trust is retained.
+        files = [{"path": ".fleet/plans/issue-2385.md"},
+                 {"path": "engine/render/fog.cpp"}]
+        self.assertTrue(pr_references_issue("#2385: render: fog fix", "", 2385, files))
+
+    def test_no_files_keeps_pre_layer8_title_trust(self):
+        # files omitted (default None) — layer 8 inert, so the steward title's
+        # bare #2385 ref is still trusted (the pre-fix false positive; layer 8
+        # only fires once the caller supplies the diff).
+        self.assertTrue(pr_references_issue(self._STEWARD_TITLE_2392, "", 2385))
+
+    def test_empty_files_list_keeps_title_trust(self):
+        # An empty diff list carries no signal — treat as no-info, keep title-trust.
+        self.assertTrue(pr_references_issue(self._STEWARD_TITLE_2392, "", 2385, []))
+
 
 class SelectShippedPr(unittest.TestCase):
     def test_empty_candidates(self):
@@ -417,6 +473,21 @@ class SelectShippedPr(unittest.TestCase):
                  "drops the dead plumbing (the `feederSubCap` derivation, the "
                  "stage-1 feeder early-return).")
         self.assertIsNone(select_shipped_pr([pr], 2258))
+
+    def test_real_world_2385_bookkept_by_2392(self):
+        # #2385 <- #2392 (layer 8): the epic-steward rollup PR is a #2385 search
+        # hit whose diff is entirely .fleet/plans/ docs — it adopts the plan, it
+        # ships no render fix, so ingest must not stamp scope-shipped and bounce a
+        # queue-ready issue back to needs-plan.
+        pr = _pr(2392,
+                 "docs/fleet: epic-steward — #2317 rollup + #2385 adoption (#2314)",
+                 "Rolls up #2317; adopts the #2385 plan into the ledger.",
+                 files=[".fleet/plans/issue-2314.md", ".fleet/plans/issue-2385.md"])
+        self.assertIsNone(select_shipped_pr([pr], 2385))
+        # True-positive retained: a genuine impl PR delivering #2385 still stamps.
+        impl = _pr(2500, "#2385: render: fog vision fix", "Closes #2385",
+                   files=["engine/render/fog.cpp"])
+        self.assertEqual(select_shipped_pr([impl], 2385)["number"], 2500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `fleet-queue-ingest`'s scope-shipped pre-flight trusted any word-boundary `#N` in a merged PR's title, so a steward rollup/adoption PR whose diff is entirely `.fleet/` files false-stamped `fleet:scope-shipped` on issues it merely names — the `#2385` ← `#2392` bounce that filed this issue (a queue-ready, human-approved issue kicked back into planning one minute after it cleared review).
- Adds **layer 8** to `fleet_scope_shipped.py`: a PR whose changed files are all under `.fleet/` maintains fleet state and never ships an issue's code scope, so its title ref is not trusted — it falls through to the body closing-verb check, exactly like the plan-doc / deferral / prep layers.
- True-positive retained: a `.fleet/`-only PR that genuinely closes an issue via a prose `Closes #N` still ships, and a real impl PR carrying its plan file **plus** code is not `.fleet/`-only, so its title-trust is unaffected.
- Ingest now fetches the PR file list on the same `gh pr list` query (`--json …,files`) to feed the guard — no extra network call.

## Test plan
- [x] `python3 -m unittest tests.test_scope_shipped_reference` — 70 pass (6 new layer-8 unit tests + 1 real-world `select_shipped_pr` case).
- [x] End-to-end vs real #2392 data: `pr_references_issue(steward_title, body, 2385, .fleet/-only files)` → `False` (was `True`); a genuine impl PR still ships.
- [x] `ruff check scripts/` clean; existing `fleet-queue-ingest` bash tests all green.

Closes #2463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
