### PR TITLE
scripts/fleet: agent-positional flag-token guard on 8 more subcommands

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1757,7 +1757,7 @@ cmd_cleanup() {
 }
 
 # cmd_cleanup_gh <repo> [<repo> ...]
-#   Three-pass GitHub label sweep — see help text for the full contract.
+#   Five-pass GitHub label sweep — see help text for the full contract.
 cmd_cleanup_gh() {
     if ! command -v gh >/dev/null 2>&1; then
         echo "fleet-claim cleanup --gh: 'gh' not on PATH; skipping" >&2
@@ -4480,7 +4480,7 @@ commands:
                                 (default: 7200).
   cleanup [--repo o/r] [--gh] ...
                                 Remove claims whose linked issue is
-                                CLOSED. With --gh also runs four
+                                CLOSED. With --gh also runs five
                                 GitHub sweeps:
                                 (1) stale fleet:reviewing-*,
                                     fleet:resolving-*, and
@@ -4506,7 +4506,15 @@ commands:
                                 (4) stale fleet:planning-* labels off
                                     open fleet:needs-plan issues (age >
                                     FLEET_CLAIM_STALE_SECS_PLANNING,
-                                    default 3600s).
+                                    default 3600s),
+                                (5) orphan fleet:(reviewing|resolving|
+                                    amending|stewarding)-<host>---*
+                                    catalog labels off every issue/PR
+                                    (a flag was consumed as the <agent>
+                                    positional) — deleted outright via
+                                    `gh label delete`, no TTL/age check
+                                    since the `---` shape can never be a
+                                    real agent name (#2441).
                                 `fleet:claim-*` labels on CLOSED
                                 issues are preserved as a historical
                                 "who worked on this" record.

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -186,6 +186,25 @@ EOF
     return 0
 }
 
+# require_agent_token <cmd-name> <token>
+#   Exit 0 = valid; exit 2 = invalid (with stderr message). Refuses an empty
+#   token or one that looks like a flag (--*) — a caller mistake where a flag
+#   meant elsewhere (most commonly --repo placed after the subcommand instead
+#   of before it, or a stray --role/--agent) lands on the <agent> positional
+#   and gets silently stamped into a claim label, e.g.
+#   fleet:reviewing-mac---role (#2441). cmd_claim / cmd_planning_claim already
+#   guard this inline via their own optional-agent shift-parse and don't call
+#   this; every other fixed-arity agent-positional subcommand (review-/
+#   resolving-/amending-/steward- claim and release) does.
+require_agent_token() {
+    local cmd_name="$1" token="${2:-}"
+    if [[ -z "$token" || "$token" == --* ]]; then
+        echo "fleet-claim ${cmd_name}: <agent> is required and must not look like a flag, got '${token:-<empty>}'" >&2
+        return 2
+    fi
+    return 0
+}
+
 # --- slug canonicalization ------------------------------------------------
 
 slugify() {
@@ -2049,6 +2068,32 @@ for issue in issues:
                     "cleanup --gh: planning remove-label failed"
             fi
         done <<< "$planning_plan"
+    done
+
+    # Fifth pass: reap flag-token-consumed claim labels — a label whose
+    # <agent> segment starts with '--' can only exist because a flag was
+    # consumed as the <agent> positional, e.g. fleet:reviewing-mac---role
+    # from `review-claim <pr> --role <agent>`. No real agent name starts
+    # with '-', so this shape is unconditionally malformed — no TTL/age/
+    # heartbeat check needed, unlike the passes above. `gh label delete`
+    # removes the catalog entry AND strips it off every issue/PR carrying
+    # it in one call. See #2441.
+    for repo in "${repos[@]}"; do
+        local orphan_names
+        orphan_names=$(gh label list --repo "$repo" --limit 300 \
+            --json name --jq \
+            '.[] | select(.name | test("^fleet:(reviewing|resolving|amending|stewarding)-(mac|linux|windows)---")) | .name' \
+            2>/dev/null || echo "")
+        [[ -z "$orphan_names" ]] && continue
+        while IFS= read -r label_name; do
+            [[ -z "$label_name" ]] && continue
+            if gh label delete "$label_name" --repo "$repo" --yes >/dev/null 2>&1; then
+                echo "cleanup --gh: reaped orphan claim label '$label_name' on $repo (flag-token-consumed, #2441)"
+                total_removed=$((total_removed + 1))
+            else
+                echo "fleet-claim: WARN failed to delete orphan label '$label_name' on $repo" >&2
+            fi
+        done <<< "$orphan_names"
     done
 
     if [[ $total_removed -eq 0 ]]; then
@@ -4194,59 +4239,59 @@ case "${1:-}" in
         cmd_reconcile "$@"
         ;;
     review-claim)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "review-claim" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] review-claim <pr-number> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_review_claim "$2" "$3"
         ;;
     review-release)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "review-release" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] review-release <pr-number> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_review_release "$2" "$3"
         ;;
     resolving-claim)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "resolving-claim" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] resolving-claim <pr-number> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_resolving_claim "$2" "$3"
         ;;
     resolving-release)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "resolving-release" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] resolving-release <pr-number> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_resolving_release "$2" "$3"
         ;;
     amending-claim)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "amending-claim" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] amending-claim <pr-number> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_amending_claim "$2" "$3"
         ;;
     amending-release)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "amending-release" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] amending-release <pr-number> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_amending_release "$2" "$3"
         ;;
     steward-claim)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "steward-claim" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] steward-claim <umbrella-issue> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_steward_claim "$2" "$3"
         ;;
     steward-release)
-        if [[ -z "${3:-}" ]]; then
+        require_agent_token "steward-release" "${3:-}" || {
             echo "usage: fleet-claim [--repo <ns>] steward-release <umbrella-issue> <agent>" >&2
             exit 2
-        fi
+        }
         cmd_steward_release "$2" "$3"
         ;;
     planning-claim)

--- a/scripts/fleet/tests/test_fleet_claim_agent_flag_guard.sh
+++ b/scripts/fleet/tests/test_fleet_claim_agent_flag_guard.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Tests for require_agent_token (#2441): the #2201 flag-token guard
+# (`[[ "${1:-}" != --* ]]` in cmd_claim / cmd_planning_claim) only covered
+# those two subcommands. The other eight agent-positional subcommands
+# (review-/resolving-/amending-/steward- claim and release) took the dispatch
+# case block's raw "$3" verbatim as the agent, so a flag passed where <agent>
+# belongs (a caller mistake — most commonly a `--role`/`--agent`/`--repo`
+# meant elsewhere) got silently stamped into a claim label, e.g.
+# `fleet:reviewing-mac---role`. require_agent_token centralizes the guard and
+# is now called at all eight of those dispatch sites, before any `gh` call —
+# a rejected token acquires NO label.
+#
+# Hermetic per scripts/fleet/CLAUDE.md: no live GitHub. `gh` is stubbed to log
+# every invocation so a rejected call can be asserted to have made none.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+assert_exit() {
+    local actual_exit="$1" expected_exit="$2" msg="$3"
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        ok "$msg"
+    else
+        bad "$msg"
+        echo "        expected exit: $expected_exit"
+        echo "        actual exit:   $actual_exit"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_TEST_HOST="mac"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR"
+
+GH_LOG="$TMPROOT/gh.log"
+: > "$GH_LOG"
+
+# Stub `gh` — logs every call, then handles just enough to let a WELL-FORMED
+# claim/release round-trip succeed (positive control). `api ... labels`
+# echoes the posted label back so _acquire_label_on wins; `issue edit` is a
+# benign no-op (the release path).
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+cat >"$STUB_DIR/gh" <<GHSTUB
+#!/usr/bin/env bash
+echo "\$*" >> "$GH_LOG"
+case "\$1 \$2" in
+    "api "*)
+        label=""
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -f) shift
+                    case "\$1" in
+                        labels\\[\\]=*) label="\${1#labels[]=}" ;;
+                    esac
+                    ;;
+            esac
+            shift || true
+        done
+        if [[ -n "\$label" ]]; then
+            printf '[{"name":"%s"}]\n' "\$label"
+        else
+            echo '[]'
+        fi
+        exit 0
+        ;;
+    "issue edit"|"label "*|"repo view"|"pr list"|"issue list")
+        exit 0
+        ;;
+esac
+exit 0
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+gh_call_count() { wc -l < "$GH_LOG" | tr -d ' '; }
+
+# ============================================================================
+# A flag-shaped token in the <agent> position is refused, no label acquired
+# ============================================================================
+
+echo "== flag-shaped <agent> token: exit 2, zero gh calls =="
+
+declare -a CLAIM_CMDS=(review-claim resolving-claim amending-claim steward-claim)
+declare -a RELEASE_CMDS=(review-release resolving-release amending-release steward-release)
+
+for cmd in "${CLAIM_CMDS[@]}" "${RELEASE_CMDS[@]}"; do
+    # --role / --agent: the genuinely new coverage — require_agent_token is
+    # the only guard that catches these. --repo: already hard-errored by the
+    # pre-existing global Guard 2 (#2201) scan, which fires before dispatch
+    # even reaches require_agent_token — checked here as a no-regression
+    # pin, with its own (different) message.
+    for badtok in "--role" "--agent"; do
+        : > "$GH_LOG"
+        actual=0
+        err=$("$FLEET_CLAIM" "$cmd" 999 "$badtok" opus-reviewer 2>&1 1>/dev/null) || actual=$?
+        assert_exit "$actual" 2 "$cmd 999 $badtok → exit 2"
+        assert_eq "$(gh_call_count)" "0" "$cmd 999 $badtok → no gh calls (no label stamped)"
+        assert_contains "$err" "must not look like a flag" "$cmd 999 $badtok → guard message present"
+    done
+
+    : > "$GH_LOG"
+    actual=0
+    err=$("$FLEET_CLAIM" "$cmd" 999 --repo opus-reviewer 2>&1 1>/dev/null) || actual=$?
+    assert_exit "$actual" 2 "$cmd 999 --repo → exit 2 (pre-existing Guard 2)"
+    assert_eq "$(gh_call_count)" "0" "$cmd 999 --repo → no gh calls"
+    assert_contains "$err" "must precede the subcommand" "$cmd 999 --repo → Guard 2 message present"
+done
+
+echo "== empty <agent> token: exit 2, zero gh calls (no regression on the old -z check) =="
+
+for cmd in "${CLAIM_CMDS[@]}" "${RELEASE_CMDS[@]}"; do
+    : > "$GH_LOG"
+    actual=0
+    "$FLEET_CLAIM" "$cmd" 999 2>/dev/null || actual=$?
+    assert_exit "$actual" 2 "$cmd 999 (missing agent) → exit 2"
+    assert_eq "$(gh_call_count)" "0" "$cmd 999 (missing agent) → no gh calls"
+done
+
+# ============================================================================
+# Positive control — a well-formed agent name still claims/releases cleanly
+# ============================================================================
+
+echo "== well-formed <agent> token still round-trips (positive control) =="
+
+: > "$GH_LOG"
+actual=0
+out=$("$FLEET_CLAIM" review-claim 4242 opus-reviewer 2>&1) || actual=$?
+assert_exit "$actual" 0 "review-claim 4242 opus-reviewer → exit 0"
+assert_contains "$out" "acquired" "review-claim 4242 opus-reviewer → acquired"
+assert_contains "$(cat "$GH_LOG")" "labels[]=fleet:reviewing-mac-opus-reviewer" \
+    "review-claim 4242 opus-reviewer → posted the expected label, not a flag-mangled one"
+
+: > "$GH_LOG"
+actual=0
+"$FLEET_CLAIM" review-release 4242 opus-reviewer >/dev/null 2>&1 || actual=$?
+assert_exit "$actual" 0 "review-release 4242 opus-reviewer → exit 0"
+
+summarize

--- a/scripts/fleet/tests/test_fleet_claim_orphan_agent_label_reap.sh
+++ b/scripts/fleet/tests/test_fleet_claim_orphan_agent_label_reap.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for cmd_cleanup_gh's fifth pass (#2441): reaping flag-token-consumed
+# claim labels. Before require_agent_token existed, a flag passed where
+# <agent> belongs on review-/resolving-/amending-/steward- claim got stamped
+# verbatim into a label, e.g. `fleet:reviewing-mac---role` from
+# `review-claim <pr> --role <agent>`. Nothing swept these — the PR-label sweep
+# (first pass) only looks at labels attached to OPEN PRs, and #226's stray
+# `fleet:reviewing-mac---repo` sat on an ISSUE (steward-claim targets issues)
+# for 8+ days. The fifth pass instead scans the repo's whole label CATALOG for
+# the malformed <host>--- shape and `gh label delete`s it unconditionally —
+# no TTL, no per-issue lookup — which also strips it off wherever it's
+# attached (e.g. #226) in the same call.
+#
+# Hermetic per scripts/fleet/CLAUDE.md: no live GitHub. This test sources
+# fleet-claim as a library (FLEET_CLAIM_LIB=1) and shadows `gh` with an
+# in-process function so cmd_cleanup_gh's actual --jq filter expression runs
+# against a canned label catalog through the real `jq` binary — a regex bug
+# in the filter would be caught here, not just asserted away.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "test setup: jq not on PATH; skipping (this test exercises gh's real --jq filter)" >&2
+    exit 0
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_TEST_HOST="mac"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR"
+
+# Source fleet-claim as a library (defines cmd_cleanup_gh, skips dispatch).
+set --
+FLEET_CLAIM_LIB=1 source "$FLEET_CLAIM"
+
+DELETE_LOG="$TMPROOT/delete.log"; : > "$DELETE_LOG"
+
+# Canned catalog: three flag-token-consumed orphans (must be reaped) mixed
+# with legitimate labels that share prefixes/hosts and superficially similar
+# shapes (must survive) — including a real agent name that itself embeds the
+# host twice ("mac-mac"), to pin that the filter keys on the '---' shape and
+# not on any generic "looks weird" heuristic.
+LABELS_JSON='[
+  {"name":"fleet:reviewing-mac---role"},
+  {"name":"fleet:reviewing-mac---repo"},
+  {"name":"fleet:reviewing-mac---agent"},
+  {"name":"fleet:reviewing-mac-opus-reviewer"},
+  {"name":"fleet:reviewing-mac-mac-opus-reviewer"},
+  {"name":"fleet:stewarding-mac-epic-steward"},
+  {"name":"fleet:amending-linux-worker-1"},
+  {"name":"fleet:resolving-windows-opus-worker-1"},
+  {"name":"fleet:nit-of-pr"}
+]'
+
+gh() {
+    case "${1:-}" in
+        pr)
+            [[ "${2:-}" == "list" ]] && { echo "[]"; return 0; }
+            return 0
+            ;;
+        issue)
+            case "${2:-}" in
+                list) echo "[]"; return 0 ;;
+                edit) printf '%s\n' "$*" >> "$DELETE_LOG"; return 0 ;;
+                *) return 0 ;;
+            esac
+            ;;
+        label)
+            case "${2:-}" in
+                list)
+                    local jqexpr="" a prev=""
+                    for a in "$@"; do
+                        [[ "$prev" == "--jq" ]] && jqexpr="$a"
+                        prev="$a"
+                    done
+                    echo "$LABELS_JSON" | jq -r "$jqexpr"
+                    return 0
+                    ;;
+                delete)
+                    printf '%s\n' "$*" >> "$DELETE_LOG"
+                    return 0
+                    ;;
+                *) return 0 ;;
+            esac
+            ;;
+        api) echo "[]"; return 0 ;;
+        *) return 0 ;;
+    esac
+}
+
+echo "== cleanup --gh fifth pass: reap flag-token-consumed catalog labels =="
+
+out=$(cmd_cleanup_gh "jakildev/IrredenEngine" 2>&1)
+log=$(cat "$DELETE_LOG")
+
+for orphan in "fleet:reviewing-mac---role" "fleet:reviewing-mac---repo" "fleet:reviewing-mac---agent"; do
+    assert_contains "$log" "label delete $orphan --repo jakildev/IrredenEngine --yes" \
+        "$orphan reaped via gh label delete"
+    assert_contains "$out" "reaped orphan claim label '$orphan'" \
+        "$orphan reap reported in cleanup --gh output"
+done
+
+for legit in "fleet:reviewing-mac-opus-reviewer" "fleet:reviewing-mac-mac-opus-reviewer" \
+             "fleet:stewarding-mac-epic-steward" "fleet:amending-linux-worker-1" \
+             "fleet:resolving-windows-opus-worker-1" "fleet:nit-of-pr"; do
+    assert_absent "$log" "label delete $legit " "$legit NOT reaped (legitimate label)"
+done
+
+assert_eq "$(printf '%s\n' "$log" | grep -c '^label delete ' || true)" "3" \
+    "exactly three labels deleted (no over- or under-reap)"
+
+summarize


### PR DESCRIPTION
## Summary
- `require_agent_token` closes the flag-token-consumed-as-agent gap on the 8 dispatch subcommands `cmd_claim`/`cmd_planning_claim`'s own guard didn't cover (review-/resolving-/amending-/steward- claim and release) — a flag like `--role` in the `<agent>` slot now hard-errors before any `gh` call instead of getting stamped into a label.
- `cmd_cleanup_gh` grows a fifth pass that reaps any existing `fleet:<prefix>-<host>---*` catalog label unconditionally (no real agent name starts with `-`, so the shape is never legitimate) — this also fixes the umbrella #226 stranding cited in the issue evidence, once this PR's `cleanup --gh` next runs (live `gh label delete` was blocked by the sandbox's GitHub-mutation classifier from this session; a human or the next scheduled cleanup pass applies it).

## Test plan
- [x] `test_fleet_claim_agent_flag_guard.sh` (new, 92 assertions): all 8 subcommands reject `--role`/`--agent` with no `gh` call, existing `--repo` Guard 2 still fires unaffected, empty-agent still exit 2, well-formed agent still round-trips (positive control).
- [x] `test_fleet_claim_orphan_agent_label_reap.sh` (new, 13 assertions): the fifth pass's real `--jq` filter (run through actual `jq`) reaps exactly the 3 flag-shaped orphans from a mixed catalog and leaves every legitimate label — including a deliberately similar-looking real agent name — untouched.
- [x] Full `scripts/fleet/tests/test_fleet_claim_*.sh` suite: all pass (one pre-existing `test_fleet_claim_model_gate.sh` T7 failure traced to this session's ambient `FLEET_ROLE_MODEL=sonnet` leaking into the test's subprocess, confirmed present on unmodified master too — not a regression).
- [ ] Live `fleet-claim cleanup --gh` reap of #226 / the 3 catalog labels — blocked by the sandbox; needs a human or the next fleet maintenance cycle to run once this merges.

Closes #2441

🤖 Generated with [Claude Code](https://claude.com/claude-code)