### PR TITLE
fleet: fleet-plan-lint concept-based core-section matching (#2443)

### DIFF
--- a/.fleet/plans/issue-2443.md
+++ b/.fleet/plans/issue-2443.md
@@ -1,0 +1,114 @@
+## Plan: fleet-plan-lint concept-based core-section matching (kill the destructive leading-token false positive)
+
+- **Issue:** #2443
+- **Model:** sonnet — single-file regex change in `scripts/fleet/fleet-plan-lint` plus two test fixtures; the approach below is concrete enough that implementation is bounded.
+- **Date:** 2026-07-20
+
+### Scope
+
+Make `fleet-plan-lint`'s core-section check match the **concept** of each core heading
+(Scope / Approach / Acceptance) rather than requiring the heading text to *begin* with the
+literal token, so a sound plan that words its headings naturally no longer hard-fails. The
+`>= 2`-missing hard-fail and every other check are preserved.
+
+### Verified current state + confirmed repro
+
+Read `scripts/fleet/fleet-plan-lint:104-112` on `origin/master` (5c53d2e5). The core-section
+check anchors each token at the **start** of the heading:
+
+```python
+missing_core = [s for s in ("Scope", "Approach", "Acceptance")
+                if not re.search(r"(?im)^\s*#{1,4}\s+" + s + r"\b", plan)]
+...
+if len(missing_core) >= 2: hard.append("missing core sections: ...")   # exit 1
+elif missing_core:         warn.append(...)                            # exit 0
+```
+
+Confirmed the miss against the actual matcher (not the issue's guess) with the #2442-shaped
+headings `### Files / modules`, `### Committed approach — …`, `### Acceptance tests (positive-fire)`:
+
+- `Scope` → miss (heading leads with "Files"), `Approach` → miss (leads with "Committed"),
+  `Acceptance` → match (leads with "Acceptance" by luck) ⇒ `missing_core = [Scope, Approach]`,
+  len 2 ⇒ **hard fail (exit 1)** on a sound plan. Reproduced locally via the exact regex.
+
+A hard fail here is **destructive**: per `role-opus-reviewer`, exit 1 routes straight to the
+"Not sound" bounce, which **deletes the `## Plan` comment** before swapping back to
+`fleet:needs-plan` — a false positive forces a full re-plan, not a warning.
+
+The lint fetches via `gh issue view`, so its tests mock `gh` with a PATH-shim fake keyed by
+issue number (`scripts/fleet/tests/test_fleet_plan_lint.sh:47-83`). Existing fixtures #100
+(GOOD_PLAN) and #103 (skeletal, missing all core sections) already pin PASS / hard-fail.
+
+### Approach
+
+One approach, picked. Match the **concept**, not the leading token: per core section, accept
+a small synonym set and allow the word **anywhere** in the heading (`.*\b(?:…)\b`). Keep the
+`>= 2`-missing hard-fail and the `== 1` warn unchanged — only the per-section matcher changes.
+
+1. In `scripts/fleet/fleet-plan-lint`, replace the `missing_core` comprehension (lines
+   104-105) with a per-concept synonym-set search:
+
+   ```python
+   CORE = {
+       "Scope":      ("scope", "files", "modules", "affected"),
+       "Approach":   ("approach", "design", "implementation"),
+       "Acceptance": ("acceptance", "verification", "tests", "done"),
+   }
+   missing_core = [
+       name for name, syns in CORE.items()
+       if not re.search(r"(?im)^\s*#{1,4}\s+.*\b(?:" + "|".join(syns) + r")\b", plan)
+   ]
+   ```
+
+   Leave lines 106-112 (soft `Affected files`/`Gotchas` warns, the `>= 2` / `== 1`
+   branch) and every other check untouched. `missing_core` stays a list, so the existing
+   `>= 2` / `elif` logic and the `", ".join(missing_core)` message keep working.
+
+2. Add two fixtures + assertions to `scripts/fleet/tests/test_fleet_plan_lint.sh`:
+   - **#108 synonym-heading plan** (the false-positive regression): a plan whose headings are
+     `### Files / modules`, `### Committed approach — …`, `### Acceptance tests (positive-fire)`,
+     `### Gotchas` with a body. Assert **exit 0**. This is the red-against-master demonstration
+     (AC 3): it exits 1 on master and 0 after the fix.
+   - **#109 negative control**: a plan with a real `### Approach` section but **no** Scope-concept
+     and **no** Acceptance-concept heading (e.g. `### Approach` + `### Notes` only) ⇒
+     `missing_core = [Scope, Acceptance]`, len 2 ⇒ assert **exit 1**. This proves the broadened
+     matcher did not become so permissive it passes a genuinely-broken plan.
+
+### Affected files
+
+- `scripts/fleet/fleet-plan-lint` — lines 104-105: leading-token matcher → concept synonym-set matcher.
+- `scripts/fleet/tests/test_fleet_plan_lint.sh` — two new fixtures (#108, #109) + assertions.
+
+### Acceptance criteria
+
+1. The #2442-shaped synonym plan (`### Files / modules`, `### Committed approach — …`,
+   `### Acceptance tests (positive-fire)`) lints **exit 0** (AC 1).
+2. A plan missing ≥2 core concepts (no scope/files/modules/affected heading AND no
+   acceptance/verification/tests/done heading) still hard-fails **exit 1** — negative control (AC 2).
+3. `bash scripts/fleet/tests/test_fleet_plan_lint.sh` is green; existing fixtures #100 (pass) and
+   #103 (hard fail) keep their verdicts (no regression).
+4. **Demonstrate the red run**: run the new #108 assertion against `origin/master` (unfixed
+   matcher) and confirm it fails there — proving the test exercises the new matcher, not a
+   vacuous pass (AC 3).
+
+### Gotchas
+
+- **Exclude "plan" from the Approach synonym set.** Every plan comment's first heading is
+  `## Plan: <title>`; a synonym set containing `plan` matches that title via
+  `.*\bplan\b`, so **Approach would be satisfied for every comment** (vacuous — masks a plan
+  that genuinely lacks an approach section). The issue's own concrete regex example
+  (`\b(?:approach|design|implementation)\b`) already omits `plan` for this reason. Use only
+  `approach | design | implementation`.
+- **`### Affected files` will now also satisfy Scope** (via `files`/`affected`), because the
+  #2442 case requires `files`/`modules` to count as scope. This is an accepted trade-off: the
+  lint is conservative-by-design (it only hard-fails unambiguous structural gaps; the Opus
+  design-soundness pass is the real gate), and a plan carrying an affected-files list does convey
+  scope. Do **not** try to disambiguate Scope from Affected-files — it would re-introduce
+  brittleness.
+- **Keep `>= 2` hard-fail.** The threshold is retained per the issue's suggested shape; a plan
+  missing exactly one concept stays a warn (exit 0), so the negative control (#109) must miss
+  **two** concepts to hard-fail. Do not demote `missing core sections` to warn-only — AC 2
+  requires genuinely-broken plans to still hard-fail.
+- **Do not self-tag the issue `fleet:sonnet`.** The `**Model:** sonnet` here is the plan's
+  implementation-class recommendation; the implementing worker picks it up on the normal class
+  routing once queued.

--- a/scripts/fleet/fleet-plan-lint
+++ b/scripts/fleet/fleet-plan-lint
@@ -100,9 +100,22 @@ plan = plans[-1]
 low = plan.lower()
 is_spike = "investigation spike" in low or "investigation spike" in title.lower()
 
-# Core + soft sections (heading at any depth, case-insensitive).
-missing_core = [s for s in ("Scope", "Approach", "Acceptance")
-                if not re.search(r"(?im)^\s*#{1,4}\s+" + s + r"\b", plan)]
+# Core sections (heading at any depth, case-insensitive), matched by CONCEPT
+# rather than requiring the heading to *begin* with the literal token — a
+# sound plan that words its headings naturally (e.g. "Files / modules" for
+# Scope, "Committed approach" for Approach) must not hard-fail (#2443).
+# "plan" is deliberately excluded from the Approach synonym set: every plan
+# comment's first heading is "## Plan: <title>", which would otherwise
+# vacuously satisfy Approach for every comment.
+CORE = {
+    "Scope": ("scope", "files", "modules", "affected"),
+    "Approach": ("approach", "design", "implementation"),
+    "Acceptance": ("acceptance", "verification", "tests", "done"),
+}
+missing_core = [
+    name for name, syns in CORE.items()
+    if not re.search(r"(?im)^\s*#{1,4}\s+.*\b(?:" + "|".join(syns) + r")\b", plan)
+]
 for s in ("Affected files", "Gotchas"):
     if not re.search(r"(?im)^\s*#{1,4}\s+" + re.escape(s) + r"\b", plan):
         warn.append(f"no '### {s}' section")

--- a/scripts/fleet/tests/test_fleet_plan_lint.sh
+++ b/scripts/fleet/tests/test_fleet_plan_lint.sh
@@ -67,6 +67,34 @@ LEVER = GOOD.replace("one approach: edit foo.cpp then bar.cpp",
                      "the cost is dominated by the resolve loop; one approach: edit foo.cpp")
 LEVER_CITED = LEVER.replace("dominated by the resolve loop",
                             "dominated by the resolve loop, confirmed by a disarm probe")
+# #2443: synonym-headed plan (the #2442-shaped false-positive regression) — core
+# sections worded naturally instead of leading with the literal token. Must pass.
+SYNONYM = '''## Plan: synonym headings
+
+- **Model:** sonnet
+
+### Files / modules
+foo.cpp, bar.cpp
+
+### Committed approach - one approach, picked
+verified current state via grep; edit foo.cpp then bar.cpp
+
+### Acceptance tests (positive-fire)
+builds + tests
+
+### Gotchas
+none'''
+# #2443 negative control: a real Approach section but no Scope-concept and no
+# Acceptance-concept heading anywhere -- must still hard-fail (missing_core >= 2).
+NO_SCOPE_NO_ACCEPTANCE = '''## Plan: negative control
+
+- **Model:** sonnet
+
+### Approach
+verified current state via grep; one approach: edit foo.cpp
+
+### Notes
+none'''
 F = {
   "100": {"title": "sound task", "comments": [{"body": GOOD}]},
   "101": {"title": "defer task", "comments": [{"body": DEFER}]},
@@ -76,6 +104,8 @@ F = {
   "105": {"title": "tbd task", "comments": [{"body": GOOD + "\n\nopen question: TBD"}]},
   "106": {"title": "lever task", "comments": [{"body": LEVER}]},
   "107": {"title": "lever cited task", "comments": [{"body": LEVER_CITED}]},
+  "108": {"title": "synonym headings task", "comments": [{"body": SYNONYM}]},
+  "109": {"title": "negative control task", "comments": [{"body": NO_SCOPE_NO_ACCEPTANCE}]},
 }
 print(json.dumps(F.get(num, {"title": "missing", "comments": []})))
 PYEOF
@@ -104,6 +134,10 @@ case "$lever_out" in *"mechanism-lever language"*) ok "mechanism-lever warn fire
 cited_out=$("$LINT" 107 2>&1 || true)
 case "$cited_out" in *"mechanism-lever language"*) bad "mechanism-lever warn should be absent when premise cited: [$cited_out]";; *) ok "mechanism-lever warn absent when premise cited";; esac
 "$LINT" --repo bogus 100 >/dev/null 2>&1; assert_exit $? 2 "bad --repo -> usage exit 2"
+# #2443 — concept-based core-section matching: synonym-worded headings pass...
+"$LINT" 108 >/dev/null 2>&1; assert_exit $? 0 "synonym-headed plan (#2442-shaped) -> exit 0 (no longer a false positive)"
+# ...but a plan genuinely missing two core concepts still hard-fails.
+"$LINT" 109 >/dev/null 2>&1; assert_exit $? 1 "missing scope + acceptance concepts -> hard fail (negative control)"
 set -e
 
 echo "================================"

--- a/scripts/fleet/tests/test_fleet_plan_lint.sh
+++ b/scripts/fleet/tests/test_fleet_plan_lint.sh
@@ -95,6 +95,27 @@ verified current state via grep; one approach: edit foo.cpp
 
 ### Notes
 none'''
+# #2443 plan-exclusion guard: the mandatory "## Plan: <title>" heading is the
+# ONLY heading here that could match Approach -- Scope + Acceptance concepts are
+# present, no real Approach-shaped heading. "plan" is deliberately NOT an
+# Approach synonym, so Approach must report missing (single missing core -> warn,
+# exit 0), never vacuously match. Guards a future synonym-set edit that re-adds
+# "plan" to Approach (which would silently satisfy it for every plan comment).
+PLAN_ONLY_NO_APPROACH = '''## Plan: plan-heading only
+
+- **Model:** sonnet
+
+### Scope
+verified current state via grep; foo.cpp
+
+### Affected files
+foo.cpp
+
+### Acceptance criteria
+builds + tests
+
+### Gotchas
+none'''
 F = {
   "100": {"title": "sound task", "comments": [{"body": GOOD}]},
   "101": {"title": "defer task", "comments": [{"body": DEFER}]},
@@ -106,6 +127,7 @@ F = {
   "107": {"title": "lever cited task", "comments": [{"body": LEVER_CITED}]},
   "108": {"title": "synonym headings task", "comments": [{"body": SYNONYM}]},
   "109": {"title": "negative control task", "comments": [{"body": NO_SCOPE_NO_ACCEPTANCE}]},
+  "110": {"title": "plan-exclusion guard task", "comments": [{"body": PLAN_ONLY_NO_APPROACH}]},
 }
 print(json.dumps(F.get(num, {"title": "missing", "comments": []})))
 PYEOF
@@ -138,6 +160,15 @@ case "$cited_out" in *"mechanism-lever language"*) bad "mechanism-lever warn sho
 "$LINT" 108 >/dev/null 2>&1; assert_exit $? 0 "synonym-headed plan (#2442-shaped) -> exit 0 (no longer a false positive)"
 # ...but a plan genuinely missing two core concepts still hard-fails.
 "$LINT" 109 >/dev/null 2>&1; assert_exit $? 1 "missing scope + acceptance concepts -> hard fail (negative control)"
+# #2443 plan-exclusion guard — the mandatory "## Plan:" heading must NOT
+# vacuously satisfy Approach (that is why "plan" is excluded from its synonym
+# set). Scope + Acceptance present, no Approach-shaped heading -> single missing
+# core -> warn (exit 0) that names Approach. If a future edit re-adds "plan" to
+# the Approach synonyms, that heading would match, missing_core would go empty,
+# and the warn below would vanish -> this test fails.
+"$LINT" 110 >/dev/null 2>&1; assert_exit $? 0 "plan-only (no Approach heading) -> exit 0 (single missing core = warn)"
+plan_excl_out=$("$LINT" 110 2>&1 || true)
+case "$plan_excl_out" in *"core section absent"*"Approach"*) ok "Approach reported missing (## Plan: heading does not vacuously satisfy it)";; *) bad "Approach not reported missing — did 'plan' leak into the Approach synonym set? [$plan_excl_out]";; esac
 set -e
 
 echo "================================"


### PR DESCRIPTION
## Summary
- `fleet-plan-lint`'s core-section check anchored `Scope`/`Approach`/`Acceptance` at the *start* of the heading, so a sound plan worded naturally (`### Files / modules`, `### Committed approach — …`) hard-failed with `missing_core >= 2` — a destructive false positive, since the "Not sound" bounce deletes the `## Plan` comment.
- Replaced the leading-token matcher with a per-concept synonym-set search (word anywhere in the heading), excluding "plan" from the Approach synonyms so the `## Plan: <title>` heading itself can't vacuously satisfy it. The `>= 2` hard-fail threshold and every other check is unchanged.

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_plan_lint.sh` — 15/15 pass, including new fixtures #108 (synonym-headed plan, exit 0) and #109 (negative control missing 2 concepts, exit 1).
- [x] Confirmed #108 fails on the unfixed matcher (stashed the fix, re-ran, saw `expected 0, got 1`) before restoring — demonstrates the regression is real, not a vacuous pass.
- [x] `ruff check scripts/` — clean (no `.py` files touched; the bash-wrapped-python parse warning on `fleet-plan-lint` when force-targeted directly is pre-existing on master, confirmed via stash).
- Pure bash/Python fleet-tooling change — no C++ build required.

Closes #2443

🤖 Generated with [Claude Code](https://claude.com/claude-code)