### PR TITLE
render: widen per-voxel occlusion cull domain to shadow-feeder ring (#2298)

### DIFF
--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -47,6 +47,11 @@ struct GpuStageTiming {
     // VoxelCullAccumulator below.
     std::uint32_t visibleVoxelCount_ = 0;
     std::uint32_t totalVoxelCount_ = 0;
+    // Shadow-feeder (struct 1) survivors from the same prior-frame readback —
+    // the #2258 Step-B tail-append population the #2298 domain-widened cull
+    // targets. 0 whenever shadows are off / per-axis split active (feeders
+    // exist only on the single-canvas path).
+    std::uint32_t feederVoxelCount_ = 0;
     // Light-gather diagnostic. Populated by COMPUTE_LIGHT_VOLUME each
     // frame: `lightsSeeded_` = sources written to the seed SSBO (in-window
     // plus boundary-discounted), `lightsEligible_` = non-directional
@@ -138,23 +143,29 @@ inline ComputeLightVolumeTiming &computeLightVolumeTiming() {
 struct VoxelCullAccumulator {
     std::uint64_t visibleSum_ = 0;
     std::uint64_t totalSum_ = 0;
+    std::uint64_t feederSum_ = 0;
     std::uint32_t maxVisible_ = 0;
     std::uint32_t maxTotal_ = 0;
+    std::uint32_t maxFeeder_ = 0;
     std::uint32_t sampleCount_ = 0;
 
-    void record(std::uint32_t visible, std::uint32_t total) {
+    void record(std::uint32_t visible, std::uint32_t total, std::uint32_t feeder) {
         visibleSum_ += visible;
         totalSum_ += total;
+        feederSum_ += feeder;
         maxVisible_ = IRMath::max(maxVisible_, visible);
         maxTotal_ = IRMath::max(maxTotal_, total);
+        maxFeeder_ = IRMath::max(maxFeeder_, feeder);
         ++sampleCount_;
     }
 
     void reset() {
         visibleSum_ = 0;
         totalSum_ = 0;
+        feederSum_ = 0;
         maxVisible_ = 0;
         maxTotal_ = 0;
+        maxFeeder_ = 0;
         sampleCount_ = 0;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -1514,6 +1514,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // overlay wants, not a strict voxel count comparable 1:1 to cardinal.
         if (gpuStageTiming().enabled_) {
             std::uint32_t visible = 0;
+            std::uint32_t feeder = 0;
             if (skipSingleCanvasVoxels && perAxisIndirectBuf_ != nullptr) {
                 for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
                     VoxelIndirectDispatchParams region{};
@@ -1528,10 +1529,28 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                 VoxelIndirectDispatchParams previous{};
                 indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);
                 visible = previous.visibleCount;
+                // Struct 1 (the #2258 Step-B shadow-feeder tail list) shares
+                // indirectBuf_ at kPerAxisSsboAlignBytes and follows the same
+                // prior-frame-before-zeroing contract, so its count rides the
+                // same sync-free read. Single-canvas path only — the per-axis
+                // split never populates it. This is the #2298 target
+                // population; the acceptance gates diff it pv-on vs pv-off.
+                VoxelIndirectDispatchParams previousFeeder{};
+                indirectBuf_->getSubData(
+                    static_cast<std::ptrdiff_t>(kPerAxisSsboAlignBytes),
+                    sizeof(VoxelIndirectDispatchParams),
+                    &previousFeeder
+                );
+                feeder = previousFeeder.visibleCount;
             }
             gpuStageTiming().visibleVoxelCount_ = visible;
             gpuStageTiming().totalVoxelCount_ = static_cast<std::uint32_t>(effectiveVoxelCount);
-            voxelCullAccumulator().record(visible, static_cast<std::uint32_t>(effectiveVoxelCount));
+            gpuStageTiming().feederVoxelCount_ = feeder;
+            voxelCullAccumulator().record(
+                visible,
+                static_cast<std::uint32_t>(effectiveVoxelCount),
+                feeder
+            );
         }
 
         const VoxelIndirectDispatchParams zeroed{};

--- a/engine/profile/include/irreden/profile/profile_report.hpp
+++ b/engine/profile/include/irreden/profile/profile_report.hpp
@@ -42,8 +42,12 @@ struct CpuPhaseEntry {
 struct VoxelCullStatsSummary {
     uint64_t visibleSum_ = 0;
     uint64_t totalSum_ = 0;
+    // Shadow-feeder (struct 1) survivors — the off-screen caster list the
+    // #2298 domain-widened per-voxel cull targets. 0 with shadows off.
+    uint64_t feederSum_ = 0;
     uint32_t maxVisible_ = 0;
     uint32_t maxTotal_ = 0;
+    uint32_t maxFeeder_ = 0;
     uint32_t sampleCount_ = 0;
 };
 

--- a/engine/profile/src/profile_report.cpp
+++ b/engine/profile/src/profile_report.cpp
@@ -201,6 +201,8 @@ void writeProfileReport(const ProfileReport &report, const char *outputPath) {
             c.sampleCount_
         );
         std::fprintf(f, "%-12s %14.1f %14u %10u\n", "Total", avgTotal, c.maxTotal_, c.sampleCount_);
+        const double avgFeeder = static_cast<double>(c.feederSum_) / samples;
+        std::fprintf(f, "%-12s %14.1f %14u %10u\n", "Feeder", avgFeeder, c.maxFeeder_, c.sampleCount_);
         std::fprintf(
             f,
             "Ratio:       %14.4f (visible/total — 1.0 = no cull, 0.0 = all culled)\n",

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -35,14 +35,13 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     uniform ivec4 visibleFaceIds;       // offset 128
     uniform vec4 voxelDepthAxis;        // offset 144
     uniform vec4 detachedWorldReceive;  // offset 160
-    // Un-widened (no shadow-feeder sweep) visible iso viewport (#1740). Two
-    // consumers here: the per-voxel occlusion test only culls voxels fully
-    // inside this box — a caster in the shadow-feeder swept ring (inside
-    // cullIsoMin/Max but outside here) must keep its sun shadow (mirrors
-    // dispatchChunkOcclusion's fully-visible eligibility) — and the #2258
-    // Step-B classify routes a survivor OUTSIDE this box (an off-screen
-    // feeder, the exact stage-2 #1740 skip convention) to the feeder dispatch
-    // struct instead of the full-density visible list.
+    // Un-widened (no shadow-feeder sweep) visible iso viewport (#1740).
+    // Consumer here: the #2258 Step-B classify routes a survivor OUTSIDE this
+    // box (an off-screen feeder, the exact stage-2 #1740 skip convention) to
+    // the feeder dispatch struct instead of the full-density visible list. The
+    // per-voxel occlusion cull no longer gates on this box as of #2298 — it now
+    // tests the full shadow-feeder-widened canvas via a Hi-Z canvas-COVERAGE
+    // guard (see voxelOccludedByHiZ); visibleIsoBounds must stay for the classify.
     uniform ivec4 visibleIsoBounds;     // offset 176
     uniform int resolveMode;            // offset 192
     // Per-voxel Hi-Z occlusion-cull gate (#1812): 0 = off (byte-identical),
@@ -245,11 +244,19 @@ void writeDispatchDims(uint base, uint microSliceCount) {
 // chunk test leaves on the table. Conservative + off by default:
 //   * occlusionCullMipCount == 0 (the default; any non-cardinal / rotating /
 //     re-voxelize / no-Hi-Z frame) -> no test, byte-identical to master.
-//   * Only voxels inside the UN-WIDENED visible viewport are tested. A caster in
-//     the shadow-feeder swept ring (inside cullIsoMin/Max but outside
-//     visibleIsoBounds) is never culled — the Hi-Z covers only the visible
-//     viewport, so dropping it would lose its sun shadow. Mirrors
-//     dispatchChunkOcclusion's fully-inside-visible eligibility.
+//   * Domain = the full shadow-feeder-widened canvas (#2298). The Hi-Z
+//     downsample-maxes the WHOLE distance canvas — visible viewport plus the
+//     shadow-feeder ring the feeders raster into — so a ring caster's occluder
+//     data is real and testable. The gate is a canvas-COVERAGE guard, not a
+//     viewport box: a voxel is tested iff its expanded footprint lies fully
+//     inside the Hi-Z texel extent (a footprint spilling off-canvas would clamp
+//     onto the border texel and is kept — see the guard below). SOUNDNESS: a
+//     voxel conservatively occluded at every canvas texel it can raster to leaves
+//     no trace in trixelDistances, and BOTH the visible resolve and the
+//     sun-shadow bake consume trixelDistances (never voxels) — so dropping it is
+//     bit-identical for the shadow it would have cast too. This supersedes the
+//     #1812 "never cull a shadow-feeder" mitigation (correct only while the test
+//     domain was assumed visible-only).
 //   * A footprint that still sees background keeps the voxel (empty texels carry
 //     the 65535 sentinel -> hiZMax stays large -> never occlude). A false
 //     positive is a visible hole; a false negative is only lost savings.
@@ -264,10 +271,6 @@ void writeDispatchDims(uint base, uint microSliceCount) {
 // slot 0 / flip 0 is the correct encode; the margin absorbs the Hi-Z's low bits.
 bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
     if (occlusionCullMipCount <= 0) {
-        return false;
-    }
-    if (isoPos.x < visibleIsoBounds.x || isoPos.y < visibleIsoBounds.y ||
-        isoPos.x > visibleIsoBounds.z || isoPos.y > visibleIsoBounds.w) {
         return false;
     }
     // iso -> canvas pixel, exactly as dispatchChunkOcclusion / stage 1 at NONE
@@ -305,12 +308,26 @@ bool voxelOccludedByHiZ(ivec3 voxelPos, ivec2 isoPos) {
     ivec2 loTexel = (base + ivec2(floor(loF)) - ivec2(1)) >> 1;
     ivec2 hiTexel = (base + ivec2(ceil(hiF)) + ivec2(1)) >> 1;
     ivec2 sz = imageSize(hiZLevel0);
+    // Canvas-coverage guard (#2298): only cull a voxel whose full expanded
+    // footprint lies inside the Hi-Z texel extent [0, sz). c_build_distance_hiz
+    // ceil-sizes each level and writes every texel a real downsampled max
+    // (background sentinel 65535 where empty), so every read in [0, sz-1] is
+    // faithful. A footprint that spills PAST that extent has no data off-canvas;
+    // the former clamp folded such a tap onto the border texel — reading a near
+    // occluder in place of the empty-background sentinel, deflating hiZMax and
+    // risking a false cull of an edge voxel that actually sees background. Keep
+    // those voxels. Voxels fully inside the old visibleIsoBounds gate are a
+    // strict subset of this domain (the canvas >= the visible viewport), so their
+    // test — and the cull-off byte-identity — is unchanged; the widening only
+    // ADDS the shadow-feeder ring, this issue's target population. With the guard
+    // holding, the read is provably in-bounds, so the former per-tap clamp is dead.
+    if (loTexel.x < 0 || loTexel.y < 0 || hiTexel.x >= sz.x || hiTexel.y >= sz.y) {
+        return false;
+    }
     int hiZMax = -2147483648;
     for (int ty = loTexel.y; ty <= hiTexel.y; ++ty) {
         for (int tx = loTexel.x; tx <= hiTexel.x; ++tx) {
-            hiZMax = max(
-                hiZMax, imageLoad(hiZLevel0, clamp(ivec2(tx, ty), ivec2(0), sz - ivec2(1))).x
-            );
+            hiZMax = max(hiZMax, imageLoad(hiZLevel0, ivec2(tx, ty)).x);
         }
     }
     return encodeDepthWithFace(pos3DtoDistance(voxelPos), 0) > hiZMax + kOcclusionDepthMargin;

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -141,11 +141,14 @@ constant uint kFaceOccludedMaskBits = 0xFCu;
 // c_chunk_occlusion_cull.metal (both = the encode scale).
 constant int kOcclusionDepthMargin = kDepthEncodeShift;
 
-// Per-voxel Hi-Z occlusion refine (#1812) — see the GLSL twin
-// (c_voxel_visibility_compact.glsl) for the full rationale: conservative,
-// off by default (occlusionCullMipCount == 0 -> no-op), shadow-feeder-safe
-// (only voxels inside the un-widened visibleIsoBounds are tested), background
-// sentinel keeps a voxel that still sees background, and the encoding
+// Per-voxel Hi-Z occlusion refine (#1812, domain widened #2298) — see the GLSL
+// twin (c_voxel_visibility_compact.glsl) for the full rationale: conservative,
+// off by default (occlusionCullMipCount == 0 -> no-op), tests the full
+// shadow-feeder-widened canvas gated by a Hi-Z canvas-COVERAGE guard (a
+// footprint fully inside [0, sz) is testable; one spilling off-canvas is kept),
+// sound because a voxel occluded at every canvas texel leaves no trace in
+// trixelDistances that either the visible resolve or the sun bake consumes;
+// background sentinel keeps a voxel that still sees background, and the encoding
 // (encodeDepthWithFace(pos3DtoDistance(voxelPos), 0)) matches
 // dispatchChunkOcclusion's cb.minDepth_ * kDepthEncodeShift exactly — routed
 // through the shared encode helper because #2207 changed the cardinal layout
@@ -160,10 +163,6 @@ static bool voxelOccludedByHiZ(
     int2 isoPos
 ) {
     if (fd.occlusionCullMipCount <= 0) {
-        return false;
-    }
-    if (isoPos.x < fd.visibleIsoBounds.x || isoPos.y < fd.visibleIsoBounds.y ||
-        isoPos.x > fd.visibleIsoBounds.z || isoPos.y > fd.visibleIsoBounds.w) {
         return false;
     }
     // stage 1's emit `base` at NONE (effectiveTrixelSubdivisionScale == 1).
@@ -200,11 +199,24 @@ static bool voxelOccludedByHiZ(
     const int2 loTexel = (base + int2(floor(loF)) - int2(1)) >> 1;
     const int2 hiTexel = (base + int2(ceil(hiF)) + int2(1)) >> 1;
     const int2 sz = int2(int(hiZLevel0.get_width()), int(hiZLevel0.get_height()));
+    // Canvas-coverage guard (#2298) — mirror of the GLSL twin: only cull a voxel
+    // whose full expanded footprint lies inside the Hi-Z texel extent [0, sz).
+    // c_build_distance_hiz ceil-sizes each level and writes every texel a real
+    // downsampled max (background sentinel 65535 where empty), so every read in
+    // [0, sz-1] is faithful. A footprint spilling PAST that extent has no data
+    // off-canvas; the former clamp folded such a tap onto the border texel,
+    // deflating hiZMax and risking a false cull of an edge voxel that sees
+    // background — keep those. Voxels fully inside the old visibleIsoBounds gate
+    // are a strict subset of this domain, so cull-off byte-identity is unchanged;
+    // the widening only ADDS the shadow-feeder ring. Guard holding ⇒ the read is
+    // provably in-bounds, so the former per-tap clamp is dead.
+    if (loTexel.x < 0 || loTexel.y < 0 || hiTexel.x >= sz.x || hiTexel.y >= sz.y) {
+        return false;
+    }
     int hiZMax = -2147483648;
     for (int ty = loTexel.y; ty <= hiTexel.y; ++ty) {
         for (int tx = loTexel.x; tx <= hiTexel.x; ++tx) {
-            const int2 c = clamp(int2(tx, ty), int2(0), sz - int2(1));
-            hiZMax = max(hiZMax, hiZLevel0.read(uint2(c)).x);
+            hiZMax = max(hiZMax, hiZLevel0.read(uint2(int2(tx, ty))).x);
         }
     }
     return encodeDepthWithFace(pos3DtoDistance(voxelPos), 0) > hiZMax + kOcclusionDepthMargin;

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -178,13 +178,17 @@ void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings
         const auto &acc = IRRender::voxelCullAccumulator();
         out["visible"] = timing.visibleVoxelCount_;
         out["total"] = timing.totalVoxelCount_;
+        out["feeder"] = timing.feederVoxelCount_;
         out["samples"] = acc.sampleCount_;
         out["avgVisible"] =
             acc.sampleCount_ > 0 ? static_cast<double>(acc.visibleSum_) / acc.sampleCount_ : 0.0;
         out["avgTotal"] =
             acc.sampleCount_ > 0 ? static_cast<double>(acc.totalSum_) / acc.sampleCount_ : 0.0;
+        out["avgFeeder"] =
+            acc.sampleCount_ > 0 ? static_cast<double>(acc.feederSum_) / acc.sampleCount_ : 0.0;
         out["maxVisible"] = acc.maxVisible_;
         out["maxTotal"] = acc.maxTotal_;
+        out["maxFeeder"] = acc.maxFeeder_;
         return out;
     };
 
@@ -389,8 +393,10 @@ void World::buildAndWriteProfileReport() {
     const auto &cull = IRRender::voxelCullAccumulator();
     report.voxelCullStats_.visibleSum_ = cull.visibleSum_;
     report.voxelCullStats_.totalSum_ = cull.totalSum_;
+    report.voxelCullStats_.feederSum_ = cull.feederSum_;
     report.voxelCullStats_.maxVisible_ = cull.maxVisible_;
     report.voxelCullStats_.maxTotal_ = cull.maxTotal_;
+    report.voxelCullStats_.maxFeeder_ = cull.maxFeeder_;
     report.voxelCullStats_.sampleCount_ = cull.sampleCount_;
 
     // Collect per-system timing, grouped by pipeline


### PR DESCRIPTION
## Summary
- Replaces the #1812 `visibleIsoBounds` early-return in `voxelOccludedByHiZ` with a Hi-Z **canvas-coverage guard** (GLSL + Metal mirror), extending the per-voxel occlusion test from the visible viewport to the full shadow-feeder-widened canvas.
- Sound by the architect-endorsed trace invariant (#2278): a voxel occluded at every canvas texel it rasters to leaves no trace in `trixelDistances`, which both the visible resolve and the sun bake consume — so dropping it is bit-identical for its shadow too.
- Adds the **struct-1 feeder-count readback** the acceptance gates need (Feeder row in the profile report + `ir.render.getVoxelCullStats`): the #2258 Step-B feeder list — this PR's target population — previously had no CPU readback anywhere.

## Design-block resolution (was: captures zero)

The earlier zero-capture measurement is root-caused and does **not** falsify the mechanism. Two independent causes (full data in the `## DESIGN-UNBLOCKED` comment):

1. **Degenerate harness.** perf_grid's amp-0 face stamping (added Jul 15, after the plan's Jul 13 measurements) collapses the scene to a ~24K shell; the plan's dense regime is restored by `--wave-freeze --wave-amplitude 5` (visible chunk-only 166,868 ≈ the plan's 167,507).
2. **Metal-only data gap (#2488).** On Metal, feeder depth lives only in the #1640 image-atomic scratch; stage 2 (the sole texture writer) skips feeders per #1740, so the ring of the Hi-Z source texture is permanently sentinel — the widened test is a conservative no-op in the ring on Metal (98.4% of feeders sit on sentinel Hi-Z texels, probe-verified). On GL, stage 1 writes the texture directly and the ring data is real.

Net: this PR is byte-identical-safe on Metal (verified below) and its capture materializes on GL — where #2298 was already routed before a macOS pane picked it up. The ring positive-fire gate must run on a **Linux/GL host**.

## Test plan
- [x] Visible-domain marginal capture on the dense frozen harness (macOS/Metal): 234,589→28,818 (z4), 166,868→21,032 (z8), 67,342→14,615 (z16) — the relaxed gate doesn't regress the #1812 capture.
- [x] Marginal byte-identity, sun shadows ON (macOS/Metal): md5-identical pv-on vs pv-off on every cardinal `--auto-screenshot` shot (`fit_grid`, `zoom1_origin`, `profiler_overlay`, `zoom4_pan`) on `--wave-freeze --wave-amplitude 5`; yaw shots excluded (run-to-run drift with no change — #2479; cull disarmed at non-cardinal yaw).
- [x] Byte-identical where no feeder ring exists (shadows-off / no-ring pose: chunk+PV == chunk-only == 5013).
- [ ] **Ring positive-fire gate — Linux/GL host** (blocked on Metal by #2488): feeder count pv-on < pv-off with shadows ON on the dense harness, via the new Feeder profile row. One command per config, see the DESIGN-UNBLOCKED comment.
- [ ] GL parity smoke (Linux host).

Ref #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
