### PR TITLE
docs: acceptance-evidence exit gate closes the plan-to-PR loop

### DIFF
--- a/.claude/skills/commit-and-push/procedures/pr-body.md
+++ b/.claude/skills/commit-and-push/procedures/pr-body.md
@@ -12,6 +12,11 @@ stack modes apply a delta to the canonical template.
 ## Test plan
 - [ ] <verification steps>
 
+## Acceptance evidence
+| Criterion | Check run | Observed |
+|---|---|---|
+| <criterion from the plan> | `<command>` | <output line proving it fired> |
+
 ## Notes for reviewer
 <optional — include only when the reviewer needs specific guidance>
 
@@ -26,6 +31,16 @@ Omit the `Closes #<issue-N>` line when the task's `Issue:` field is `(none)`
 
 The `Closes #N` line is what makes GitHub auto-close the originating issue on
 merge. Always include it when an Issue number exists.
+
+`## Acceptance evidence` is required whenever the body carries a `Closes #N`
+line and issue N has a `## Plan` with `### Acceptance criteria`; omit it
+otherwise (`Issue: (none)`, plan-less issues). One row per criterion —
+authoring rules, the unverifiable-on-this-host convention, and the
+fails-means-not-done rule live in
+[`docs/agents/AUTHOR-PIPELINE.md`](../../../../docs/agents/AUTHOR-PIPELINE.md)
+§ "Acceptance evidence". The two sections answer different questions:
+`## Test plan` says how you verified the code doesn't break; `## Acceptance
+evidence` proves the ticket's named criteria actually fired.
 
 ## Fleet stack delta
 

--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -131,6 +131,54 @@ changed) before invoking `commit-and-push` to push the fix.
 
 ---
 
+## Acceptance evidence
+
+The ticket-derived exit gate. Every step above is keyed off *which
+files changed*. This step is keyed off the *ticket*: it closes the
+loop between the plan's `### Acceptance criteria` and the PR that
+claims to satisfy them. Criteria are authored at plan time under
+[`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md)'s positive-fire rule
+(step 2 of its flow); this is where they get re-checked against the
+finished tree instead of silently trusted.
+
+Skip only when the work has no originating issue (`Issue:` field
+`(none)`) or the issue has no `## Plan` comment / plan file — then
+there are no authored criteria to grade.
+
+1. **Re-read the plan's `### Acceptance criteria`** — from
+   `.fleet/plans/issue-<N>.md` if the branch carries it, else the
+   issue's `## Plan` comment (`gh issue view <N> --comments`).
+2. **Run each named check NOW, on the final tree.** Evidence from an
+   earlier iteration is stale if the tree changed since. Record the
+   exact command and the observed output line that proves the criterion
+   *fired* — a count > 0, an asserted probe reading, a visible delta.
+   "Nothing broke" is not evidence; that's what the build/run steps
+   already established.
+3. **Paste the results into the PR body** as an
+   `## Acceptance evidence` section (template:
+   `commit-and-push` `procedures/pr-body.md`) — one row per criterion:
+   criterion | check run | observed.
+4. **Grade honestly.** Three non-met shapes, each with its own move:
+   - *Unverifiable on this host* (needs the other backend, a GL host,
+     a game build): record `unverifiable on <host>: <reason>` in the
+     row — never silently drop it. The reviewer and the cross-host
+     smoke lane pick it up from there.
+   - *Fails*: the task is not done. Fix it — or, if the criterion
+     itself turned out to be wrong (plan premise falsified), escalate
+     per `role-worker.md` step 8 instead of shipping around it.
+   - *Satisfied by a different mechanism than planned*: record what
+     actually proves it and note the delta from the plan, so the
+     reviewer isn't grading against a stale approach.
+
+If the `commit-and-push` simplify pass later applies a
+behavior-affecting fix, re-run the affected checks before the PR
+opens — the table must describe the tree that ships.
+
+The reviewer side audits this table against the plan; a missing or
+hand-waved table costs a review round-trip.
+
+---
+
 ## Finalize the PR
 
 Use the `commit-and-push` skill to push your work commits to the


### PR DESCRIPTION
## Summary
- Adds an `## Acceptance evidence` exit gate to `docs/agents/AUTHOR-PIPELINE.md`: before finalizing a PR, the author re-runs each of the plan's `### Acceptance criteria` against the final tree and records criterion / check run / observed rows in the PR body.
- Adds the matching `## Acceptance evidence` section to the canonical PR-body template in `commit-and-push` `procedures/pr-body.md`, with the omit rule (`Issue: (none)` / plan-less issues) and the Test-plan-vs-evidence distinction.
- Grading rules: unverifiable-on-this-host rows are recorded (never dropped) for the reviewer + cross-host smoke lane; a failing criterion means the task is not done; mechanism-drift from the plan gets noted so the reviewer isn't grading a stale approach.

## Why
Acceptance criteria are required at plan time (PLANNING-PROTOCOL's positive-fire rule) but nothing downstream consumes them: AUTHOR-PIPELINE's verification is keyed off which files changed, and the review checklist grades code health, not objective satisfaction — "done" is currently just "the human merged it". This is the author-side half of closing that loop; the reviewer-side grader (a `review-acceptance` subagent for `review-pr`) lands as a separate PR.

## Test plan
- [x] All added cross-references resolve: `PLANNING-PROTOCOL.md` link, `role-worker.md` step 8, `procedures/pr-body.md`, and the pr-body → AUTHOR-PIPELINE relative link (four levels up from `procedures/`).
- [x] The § citation in pr-body.md exactly matches the new `## Acceptance evidence` heading.
- [x] Final newlines present on both changed `.md` files.
- [x] Doc-only diff — no build surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
