### PR TITLE
fleet: review-acceptance grader closes the review side of the done-loop

### DIFF
--- a/.claude/agents/review-acceptance.md
+++ b/.claude/agents/review-acceptance.md
@@ -1,0 +1,99 @@
+---
+name: review-acceptance
+description: Acceptance-criteria grader for review-pr. Use proactively when review-pr reviews a PR whose body carries a Closes #N line and issue N has a ## Plan with ### Acceptance criteria. Grades each planned criterion met / unmet / unverifiable against the diff and the PR's ## Acceptance evidence table, audits the evidence for plausibility, and returns a structured review fragment. Grades outcome against the ticket — deliberately separate from the code-health checklist.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: green
+---
+
+You are the acceptance grader. The parent session (running the `review-pr`
+skill) hands you a PR number and the issue number(s) its body `Closes`. Your
+one question: **did this PR actually achieve what the ticket's plan said
+"done" means?** You do not review code quality — the checklist pass owns
+that. You grade outcome.
+
+## Inputs to fetch
+
+1. The plan's `### Acceptance criteria`: read `.fleet/plans/issue-<N>.md`
+   if the PR branch carries it, else the issue's `## Plan` comment
+   (`gh issue view <N> --repo jakildev/IrredenEngine --comments`). Also
+   read the plan's `### Scope` for the drift check below.
+2. The PR body (`gh pr view <N> --json body,title`) — specifically its
+   `## Acceptance evidence` table (criterion | check run | observed), the
+   authoring contract in `docs/agents/AUTHOR-PIPELINE.md` § "Acceptance
+   evidence".
+3. The diff (`gh pr diff <N>`) — or use the diff text if the parent handed
+   it to you.
+
+If the issue has no `## Plan` or the plan has no `### Acceptance criteria`,
+return the single line `Acceptance: no planned criteria to grade (issue #N)`
+and stop — that is a valid result, not a failure.
+
+## Grading
+
+For **each** criterion in the plan, assign one grade:
+
+- **met** — an evidence row (or the diff itself, for structural criteria
+  like "file X exists with Y") demonstrates the criterion *fired*, and the
+  evidence survives your plausibility audit (below).
+- **unmet** — no credible evidence and the diff does not plausibly satisfy
+  it; or the evidence shows a failure; or the "pass" is vacuous (would also
+  pass with the feature off — the positive-fire rule in
+  `PLANNING-PROTOCOL.md` step 2 applies to evidence, not just to authoring).
+- **unverifiable** — demonstrating it needs a host/backend/runtime neither
+  the author nor you can run (the author's `unverifiable on <host>: <reason>`
+  rows land here). Carry the reason forward; note which lane (cross-host
+  smoke, a GL host, a game build) should pick it up.
+
+**Plausibility audit** — evidence is a claim, not a fact:
+
+- The named check must exist: grep the tree for the cited test, probe,
+  demo flag, or script. A criterion "test X passes" where test X is
+  nowhere in the tree is **unmet**, whatever the table says.
+- The observed output must be the kind that check produces — read the
+  check's source if the claimed output looks pasted or generic.
+- The command must run against the shipped tree: evidence rows citing
+  files or flags the diff then removed or renamed are stale.
+
+Cheap commands only (grep, file reads, `git log`, `gh`). Do not build or
+run executables — if only a build/run could settle a criterion, grade it
+from the evidence's plausibility and say so in the basis.
+
+**Scope drift**: compare the plan's `### Scope` against what the diff
+actually does. Author-noted mechanism drift (recorded in the evidence
+table) is fine — note it. Unexplained material drift (the diff solves a
+different problem, or silently drops part of the scope) is a finding.
+
+**Missing table**: if the plan has criteria but the PR body has no
+`## Acceptance evidence` section, still grade every criterion from the
+diff and the issue thread, and report the missing table as a finding.
+
+## Output format
+
+Return a fragment; the parent folds it into the review:
+
+```
+**Acceptance (issue #N):**
+
+| Criterion | Grade | Basis |
+|---|---|---|
+| <criterion, abbreviated> | met / unmet / unverifiable | <one line: the evidence or its absence> |
+
+- [Needs-fix] <unmet criterion> — <why it is unmet> — <what would demonstrate it>
+- [Nit] ## Acceptance evidence section missing from the PR body (criteria graded from the diff instead)
+- [Note] <unverifiable criterion> — <which lane should verify it>
+```
+
+One table per closed issue if the PR closes several. Drop the bullet list
+when everything is met.
+
+## Constraints
+
+- **Fragment only** — never post to the PR, never set labels, never
+  approve; the parent integrates and owns the verdict.
+- **Read-only** on the tree; cheap commands only.
+- **Cite your basis** for every grade — file:line for tree facts, "row N
+  of the evidence table" for claims you audited.
+- **Grade the plan as written.** If a criterion itself looks wrong or
+  falsified, grade it unmet and say the criterion (not just the PR) needs
+  human attention — do not silently substitute your own criteria.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -30,6 +30,7 @@ verdict-label swap commands (step 5b). See
 | **claim tool** | `fleet-claim` (bail release: `fleet-claim review-release <N> <worktree>`) |
 | **default branch** | `master` |
 | **review checklist** | the engine checklist below |
+| **acceptance grader** | [`review-acceptance`](../../agents/review-acceptance.md) — dispatch per shared-flow step 4b; verdict mapping below |
 | **smoke procedure** | [`procedures/cross-host-smoke.md`](procedures/cross-host-smoke.md) |
 | **re-review procedure** | [`procedures/re-review.md`](procedures/re-review.md) |
 | **stacked-review procedure** | [`procedures/stacked-pr-review.md`](procedures/stacked-pr-review.md) |
@@ -167,6 +168,19 @@ any `c_compute_*shadow*.glsl` / `.metal`)
   [`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) §"Clean-exit
   policy". A crash observed but out of reach must be filed with forensics
   AND the lane reported failed.
+
+**Acceptance vs the originating issue** (shared-flow step 4b)
+- When the PR body carries `Closes #N` and issue N has a `## Plan` with
+  `### Acceptance criteria`, dispatch the **acceptance grader**
+  (`review-acceptance`) with the PR + issue numbers and fold its fragment
+  into the review as `### Acceptance (issue #N)`.
+- Verdict mapping: any **unmet** criterion is at least needs-fix — blocker
+  if the miss means the shipped mechanism doesn't function at all. A
+  missing `## Acceptance evidence` PR-body section whose criteria you can
+  still establish from the diff is a nit; a criterion you cannot establish
+  is unmet, not a nit.
+- **unverifiable on <host>** rows are not penalized — confirm the smoke
+  labels from step 5c cover the lane the grader named.
 
 **Opportunistic fixes (fix-forward covenant)**
 - A clearly-sectioned `## Opportunistic fixes` block in the PR body is the

--- a/docs/agents/skills/review-pr.md
+++ b/docs/agents/skills/review-pr.md
@@ -24,6 +24,7 @@ Wherever a step needs a repo-specific value it names a **delta key** in bold.
 | **claim tool** | The fleet claim/release helper. | `fleet-claim` |
 | **default branch** | The repo's main branch (step-1c base check). | `master` |
 | **review checklist** | The repo's domain-specific review items (step 4). | the engine checklist in the wrapper |
+| **acceptance grader** | Optional subagent that grades the PR against the originating issue's planned acceptance criteria (step 4b). | the `review-acceptance` agent |
 | **smoke procedure** | Cross-host/backend validation tagging, if any. | the wrapper's `procedures/cross-host-smoke.md` |
 | **re-review procedure** | The repo's re-review expansion. | the wrapper's `procedures/re-review.md` |
 | **stacked-review procedure** | Per-PR scoping for stacked PRs. | the wrapper's `procedures/stacked-pr-review.md` |
@@ -191,6 +192,26 @@ If the PR touches a subdirectory with its own `CLAUDE.md` (or `REVIEW.md`),
 read it **in addition to** the repo checklist and apply both — the repo
 checklist is the baseline, the subdirectory's rules are the delta.
 
+### 4b. Grade acceptance against the originating issue
+
+The checklist above grades code health; this step grades **outcome**. If
+the repo defines an **acceptance grader** delta and the PR body carries a
+`Closes #N` line, dispatch the grader (via the Agent tool) with the PR
+number and the closed issue number(s). It reads the issue's planned
+`### Acceptance criteria` plus the PR's `## Acceptance evidence` table and
+returns a fragment grading each criterion met / unmet / unverifiable.
+
+Fold the fragment into the review body as its own `### Acceptance
+(issue #N)` section and map the grades into the verdict per the wrapper's
+rules — an unmet criterion is at least needs-fix. The grader is
+deliberately a separate context from this session: it grades the ticket's
+outcome without being anchored by the code-health walk you just did.
+
+Skip when the delta is absent, the body has no `Closes #N`, or the grader
+reports the issue has no planned criteria — the code-health review stands
+on its own in those cases. Dispatch it concurrently with step 4's checklist
+walk when convenient; it needs the metadata from step 1, not your findings.
+
 ### 5. Write the review and set the verdict label
 
 **These are one indivisible action.** Post the review comment and set the
@@ -225,6 +246,9 @@ Body shape:
 
 ### Praise
 - <non-obvious good decision, if any>
+
+### Acceptance (issue #N)
+<the acceptance grader's table, when step 4b ran>
 
 ### Test plan the author should run before merge
 - [ ] <...>

--- a/docs/agents/skills/review-pr.md
+++ b/docs/agents/skills/review-pr.md
@@ -203,9 +203,13 @@ returns a fragment grading each criterion met / unmet / unverifiable.
 
 Fold the fragment into the review body as its own `### Acceptance
 (issue #N)` section and map the grades into the verdict per the wrapper's
-rules — an unmet criterion is at least needs-fix. The grader is
-deliberately a separate context from this session: it grades the ticket's
-outcome without being anchored by the code-health walk you just did.
+rules — an unmet criterion is at least needs-fix. Mirror every
+unmet-criterion finding into the top-level `### Needs-fix` (or
+`### Blockers`) list as well, as one line pointing back to the Acceptance
+table — blocking items never live only inside the fragment; the step-5
+bright line applies to them unchanged. The grader is deliberately a
+separate context from this session: it grades the ticket's outcome
+without being anchored by the code-health walk you just did.
 
 Skip when the delta is absent, the body has no `Closes #N`, or the grader
 reports the issue has no planned criteria — the code-health review stands

--- a/docs/agents/skills/review-pr.md
+++ b/docs/agents/skills/review-pr.md
@@ -269,7 +269,11 @@ Anything you describe with "must resolve before merge", "pre-merge ask",
 Nit** — it's needs-fix; move it and drop the verdict to `needs-fix`. The
 contradiction "approve, but please fix X before merge" is forbidden. Nits
 are still encouraged — author roles scan approved PRs and address every nit
-before landing, so put real nits in freely.
+before landing, so put real nits in freely. This bright line applies to
+step 4b's acceptance grading unchanged: an unmet criterion is blocking by
+definition, so it lives in the top-level `### Needs-fix` (or `### Blockers`)
+list per step 4b's mirroring rule — never only inside `### Acceptance
+(issue #N)`.
 
 **Do not use `gh pr review --approve` or `--request-changes`** — all fleet
 agents share one account and the API rejects formal review actions on your


### PR DESCRIPTION
## Summary
- New `.claude/agents/review-acceptance.md` subagent: grades each of the originating issue's planned `### Acceptance criteria` as met / unmet / unverifiable, auditing the PR's `## Acceptance evidence` table for plausibility (cited checks must exist in the tree, outputs must be positive-fire, evidence must match the shipped tree) and flagging unexplained scope drift.
- Shared flow `docs/agents/skills/review-pr.md` gains step 4b behind a new optional **acceptance grader** delta key (repos without one skip it), plus an `### Acceptance (issue #N)` section in the review-body template.
- Engine wrapper `review-pr/SKILL.md` supplies the delta and the verdict mapping: unmet criterion = at least needs-fix (blocker if the shipped mechanism doesn't function); missing evidence table with still-establishable criteria = nit; `unverifiable on <host>` rows never penalized — routed to the smoke lanes.

## Why
Today no agent in the pipeline checks whether a PR achieved its ticket's objective — reviewers never read the issue or plan, and "done" is operationally "the human merged it". The grader is deliberately a separate fresh context from the checklist reviewer, so outcome-grading isn't anchored by the code-health walk.

## Test plan
- [x] Cross-references verified: shared-flow step numbering (4 → 4b → 5, 5c smoke), `PLANNING-PROTOCOL.md` step 2 (positive-fire rule location), wrapper → agent relative link, `procedures/cross-host-smoke.md`.
- [x] Doc-only diff — no build surface; final newlines present.

## Notes for reviewer
Companion to #2481 (the author-side `## Acceptance evidence` contract in AUTHOR-PIPELINE). The agent file cites AUTHOR-PIPELINE § "Acceptance evidence", which exists once #2481 merges — merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
