### PR TITLE
docs: objectives tier above epics + architect objectives-sweep duty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ working inside such a subdirectory, always read that subdirectory's own
 | Skills (named workflows like `simplify`, `commit-and-push`, `review-pr`) | [`.claude/skills/`](.claude/skills/) — each has its own `SKILL.md` |
 | Shared skill flows (fleet skills factored for cross-repo reuse) | [`docs/agents/skills/`](docs/agents/skills/) — canonical flows; each repo's `SKILL.md` is a thin wrapper (mechanism: [`docs/design/skill-sharing.md`](docs/design/skill-sharing.md)) |
 | Roles (autonomous personas — worker, reviewer, merger, architect) | [`.claude/commands/role-*.md`](.claude/commands/) |
+| Standing objectives (the human-owned "what" above epics) | [`docs/design/objectives/`](docs/design/objectives/README.md) |
 | Task queue (when running fleet roles) | `fleet-queue-list` or `gh issue list --label fleet:queued --repo jakildev/IrredenEngine` |
 | Cross-repo info isolation rule (engine repo public, game repo private) | [`docs/agents/CLAUDE-BASELINE.md`](docs/agents/CLAUDE-BASELINE.md) §"Cross-repo information isolation" |
 

--- a/docs/agents/TASK-FILING.md
+++ b/docs/agents/TASK-FILING.md
@@ -39,6 +39,13 @@ and `fleet-claim`'s blocker gate parse them):
 - **Acceptance criteria** — concrete check (build passes, test X works)
 - **Context** — why this matters, what you observed
 
+Optional, when the work serves a standing objective
+([`docs/design/objectives/`](../design/objectives/README.md)):
+
+- **Objective:** `<slug>` — the objective file's basename. No parser
+  reads it; the architect's objectives sweep and the human use it to
+  attribute shipped work to the objective's progress ledger.
+
 The issue sits in the backlog until the **human triages and adds
 `human:approved`**. Only then does the scout ingest it.
 

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -332,6 +332,46 @@ a no-op (see #1326). So for a self-config change, either apply it yourself in
 this interactive session (you have the human in the loop) or write it up for
 the human to apply directly — do NOT file it as a `human:approved` fleet task.
 
+## Objectives sweep
+
+The engine's standing direction lives in
+[`docs/design/objectives/`](../design/objectives/README.md) — human-owned
+outcome statements with measurable "Done means" rows, one tier above
+epics. The sweep is how that direction turns into filed work without the
+human inventing every task.
+
+**Cue-driven, never autonomous.** Run a sweep only when the human cues it
+("objectives sweep", "what should we work on next", "check the
+objectives") — it is a filing pass, and filing direction-shaped work
+without a cue violates the stand-by contract in § Loop behavior. A sweep
+is also a natural answer when the human asks for direction interactively.
+
+Per `active` objective:
+
+1. **Verify "Current state" against the tree, not memory.** Sync the
+   worktree first (startup step 1); every Done-means row gets re-checked
+   against actual code/demos/merged PRs. Update the objective file's
+   `## Current state` and `## Progress ledger` via PR when they drifted —
+   attribute shipped work using the issues' `**Objective:**` back-links.
+2. **File proposals for the gaps.** Each unmet Done-means row that has a
+   plannable next slice becomes a proposal issue per § Filing tasks:
+   unlabeled, structured body including the `**Objective:** <slug>`
+   back-link, acceptance criteria scoped to the slice (not the whole
+   row). Multi-issue decompositions go through `file-epic` as usual, with
+   the back-link on the umbrella.
+3. **Respect Non-goals.** A gap whose fix crosses the objective's
+   Non-goals is a proposal to *amend the objective* (a design-doc PR the
+   human merges), never a silently-widened task.
+4. **Report the sweep** to the human in one compact block: per objective,
+   rows verified / rows unmet / proposals filed (issue numbers) / ledger
+   deltas — so triage is one read.
+
+**Approval stays human.** Sweep proposals wait for `human:approved` like
+any filed task; they never take the agent-approved follow-up lane (that
+lane is for verified defect-shaped follow-ups, not direction). If every
+row of an objective verifies, propose the `Status: achieved` flip as a
+design-doc PR — the human merging it is the sign-off.
+
 ## Planning issues
 
 The **opus worker** autonomously handles `fleet:needs-plan` issues as a

--- a/docs/design/objectives/README.md
+++ b/docs/design/objectives/README.md
@@ -1,0 +1,102 @@
+# Objectives — the standing "what" above epics
+
+An **objective** is a human-owned statement of direction with a measurable
+definition of done, sitting one level above epics in the work hierarchy:
+
+```
+objective  →  epics / standalone issues  →  PRs
+(the what)    (the decomposition)           (the how, shipped)
+```
+
+Epics already prove the pattern this tier generalizes: the human signs off
+on an umbrella plan once and its children flow through filing → planning →
+workers without per-child judgment. Objectives aim that same trust one
+level up — the human states *where the engine is going* once, and the
+architect proposes the decomposition against it instead of waiting to be
+handed work. Approval authority does not move: every proposal still waits
+for `human:approved` (see "What this tier changes" below).
+
+## File format
+
+One objective per file, `docs/design/objectives/<slug>.md`:
+
+```markdown
+# Objective: <outcome phrase>
+
+**Status:** active | paused | achieved
+
+## Outcome
+One paragraph describing the end state in engine/user terms — what is
+true when this objective is achieved, not the work to get there.
+
+## Done means
+Measurable, tree-checkable statements. Same positive-fire bar as
+PLANNING-PROTOCOL acceptance criteria, at direction scale: each row
+names something observable (a demo that runs, a harness that passes, a
+capability a creation can call), never "progress on X".
+- [ ] <observable statement>
+
+## Non-goals
+What this objective deliberately excludes — the boundary that keeps
+sweep proposals from scope-creeping.
+
+## Current state
+Where the tree stands against "Done means", with citations (files,
+demos, merged PRs). Updated by objectives sweeps; every claim verified
+against the tree at update time, never carried forward from memory.
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+```
+
+## Lifecycle
+
+- **Human-owned.** Objectives are the human's direction. They are created
+  and amended via PR like any design doc — the human merging the PR *is*
+  the sign-off. The architect may draft or propose amendments; it never
+  merges them.
+- **Status transitions are the human's call.** A sweep may report "every
+  Done-means row now verifies" and propose the `achieved` flip; the flip
+  itself ships in a human-merged PR.
+- **Scope: engine only.** This repo is public. Game-side objectives live
+  in the game repo's own docs — never referenced here, per
+  [`CLAUDE-BASELINE.md`](../../agents/CLAUDE-BASELINE.md)
+  §"Cross-repo information isolation".
+
+## Linkage from issues
+
+Issues and epic umbrellas that serve an objective carry an optional
+standalone line in the structured body (parsers ignore it; humans and
+sweeps read it):
+
+```
+**Objective:** <slug>
+```
+
+See [`TASK-FILING.md`](../../agents/TASK-FILING.md) § Single issue. The
+sweep uses these back-links plus the progress ledger to attribute shipped
+work to the objective without re-deriving it each pass.
+
+## The objectives sweep
+
+The consumption side. On the human's cue, the architect diffs each
+`active` objective's "Done means" against the actual tree and files
+proposal issues for the gaps — mechanics and rules in
+[`architect-protocol.md`](../../agents/architect-protocol.md)
+§"Objectives sweep".
+
+## What this tier changes — and what it doesn't
+
+It changes where work *originates*: from "the human invents every task"
+to "the architect proposes tasks against a signed direction, and the
+human approves". It does **not** change who approves — sweep proposals
+are filed unlabeled and wait for `human:approved` like any other filed
+task, and they are explicitly outside the agent-approved follow-up lane
+(that lane is for verified defect-shaped follow-ups, not direction).
+
+A per-objective pre-approved lane — where children filed under a
+signed-off objective queue without per-ticket approval, the way epic
+children already do under a signed umbrella — is the natural next step
+once sweep proposals have earned trust. It is deliberately **not** part
+of this mechanism yet; nothing in the queue gates reads objective files.


### PR DESCRIPTION
## Summary
- New `docs/design/objectives/README.md`: the format and lifecycle for a human-owned direction tier above epics — one file per objective with `Outcome`, measurable `Done means` rows (positive-fire bar at direction scale), `Non-goals`, sweep-maintained `Current state`, and a progress ledger. Human-owned end to end: authored/amended/achieved via human-merged PRs; engine-scope only (game objectives stay in the game repo per the isolation rule).
- `architect-protocol.md` gains an "Objectives sweep" section: cue-driven only (stand-by contract preserved), verify Done-means rows against the tree (never memory), file proposal issues for gaps per TASK-FILING with an `**Objective:** <slug>` back-link, route Non-goal-crossing gaps as objective-amendment PRs, report one compact triage block.
- `TASK-FILING.md`: optional `**Objective:**` standalone body line (no parser reads it; sweeps and humans use it for progress attribution). Root `CLAUDE.md` gets a Where-to-find-things row.

## Why
There is currently no work tier above the epic and no standing direction artifact — every task originates from the human, which is also why fleet information flows human-pull. The epic mechanism already proves the pattern (sign the umbrella once, children flow); this generalizes it one level up while moving zero approval authority: sweep proposals wait for `human:approved` like any filed task and are explicitly outside the agent-approved follow-up lane. A per-objective pre-approved lane is named as an explicit non-goal until sweeps earn trust — no queue-gate script reads objective files today.

## Test plan
- [x] All relative links resolve from their locations (`../../agents/*` from `docs/design/objectives/`, `../design/objectives/README.md` from `docs/agents/`, root-relative from `CLAUDE.md`).
- [x] Cited headings exist: architect-protocol § Loop behavior / § Filing tasks / startup step 1, `CLAUDE-BASELINE.md` § "Cross-repo information isolation".
- [x] Doc-only diff — no build surface; no state labels created or claimed by any new text.

## Notes for reviewer
No mechanism changes ship here — no script reads objective files or the `**Objective:**` line yet. This PR establishes the artifact + duty; the human authors the first actual objective files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
