### PR TITLE
render: standardize shader rounding on roundHalfUp + hoist shared world-lighting include

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -115,7 +115,9 @@ Location: `engine/render/src/shaders/` (GLSL) and
 
 Naming prefixes follow the convention in
 [`CLAUDE-BASELINE.md §Naming`](../../docs/agents/CLAUDE-BASELINE.md#naming).
-Shared includes: `ir_iso_common.glsl`, `ir_constants.glsl`.
+Shared includes: `ir_iso_common.glsl`, `ir_constants.glsl`,
+`ir_world_lighting.glsl` (light-source list layout + SPOT cone +
+ACES tonemap, shared by the world-lighting passes).
 Shader file paths are stored in `render/shader_names.hpp`. Update that
 header when you add or rename a shader.
 

--- a/engine/render/src/shaders/c_light_overflow_faces.glsl
+++ b/engine/render/src/shaders/c_light_overflow_faces.glsl
@@ -29,6 +29,7 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 // resolver is non-recursive) — same order as c_lighting_to_trixel.glsl.
 #include "ir_sun_projection.glsl"
 #include "ir_sun_shadow_sample.glsl" // FrameDataSun(29), sun-depth SSBO(28), worldSunShadowFactor()
+#include "ir_world_lighting.glsl"    // GPULightSource list (slot 4), spotConeFactor, ACESFilm
 
 layout(std140, binding = 27) uniform FrameDataLightingToTrixel {
     int   lightingEnabled;
@@ -96,51 +97,6 @@ layout(rgba8, binding = 7) readonly uniform image3D lightVolumeId;
 layout(std430, binding = 8) buffer OverflowLightingScratch {
     uint overflowScratch[];
 };
-
-// --- shared world-lighting primitives -----------------------------------------
-// These MIRROR c_lighting_to_trixel.glsl (kept in lockstep). Duplicated rather
-// than extracted so the shipped lighting kernel stays byte-identical — a future
-// simplify pass can hoist both into a shared ir_world_lighting.glsl include.
-struct GPULightSource {
-    vec4 originAndType;
-    vec4 colorAndIntensity;
-    vec4 directionAndRadius;
-    vec4 coneAndSeedAlpha;
-    vec4 trueOriginVoxel;
-};
-layout(std430, binding = 4) readonly buffer LightSourceBuffer {
-    GPULightSource lights[];
-};
-
-const float kLightVolumeSize = 128.0;
-const float kLightVolumeHalfExtent = 64.0;
-const int   kLightTypeSpot = 3;
-const float kConeEdgeSoftness = 1.15;
-
-float spotConeFactor(int lightIdx, vec3 pos3D) {
-    const GPULightSource L = lights[lightIdx];
-    const vec3 axis = normalize(L.directionAndRadius.xyz);
-    const vec3 toCell = pos3D - L.trueOriginVoxel.xyz;
-    const float toCellLen = length(toCell);
-    if (toCellLen < 1e-4) {
-        return 1.0;
-    }
-    const float cosToCell = dot(toCell / toCellLen, axis);
-    const float halfAngle = radians(L.coneAndSeedAlpha.x * 0.5);
-    const float cosInner = cos(halfAngle);
-    const float cosOuter = cos(min(halfAngle * kConeEdgeSoftness, radians(90.0)));
-    return smoothstep(cosOuter, cosInner, cosToCell);
-}
-
-vec3 ACESFilm(vec3 x) {
-    const float a = 2.51;
-    const float b = 0.03;
-    const float c = 2.43;
-    const float d = 0.59;
-    const float e = 0.14;
-    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
-}
-// -----------------------------------------------------------------------------
 
 void main() {
     // The dispatch is a 2-D group grid (voxelDispatchGridForCount wraps past
@@ -224,7 +180,7 @@ void main() {
                 ivec3(floor(localPos + vec3(kLightVolumeHalfExtent) + vec3(0.5)));
             if (all(greaterThanEqual(idCell, ivec3(0))) &&
                 all(lessThan(idCell, ivec3(int(kLightVolumeSize))))) {
-                const int winId = int(round(imageLoad(lightVolumeId, idCell).r * 255.0));
+                const int winId = roundHalfUp(imageLoad(lightVolumeId, idCell).r * 255.0);
                 if (winId > 0 && int(lights[winId - 1].originAndType.w) == kLightTypeSpot) {
                     light *= spotConeFactor(winId - 1, pos3D);
                 }

--- a/engine/render/src/shaders/c_lighting_to_trixel.glsl
+++ b/engine/render/src/shaders/c_lighting_to_trixel.glsl
@@ -23,6 +23,8 @@ layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 // the opt-in detached re-voxelize world-receive path (#1576 P4b-2). Shared with
 // c_compute_sun_shadow; replaces this pass's former local FrameDataSun block.
 #include "ir_sun_shadow_sample.glsl"
+// GPULightSource list (slot 4), light-volume extents, spotConeFactor, ACESFilm.
+#include "ir_world_lighting.glsl"
 
 layout(std140, binding = 27) uniform FrameDataLightingToTrixel {
     uniform int   lightingEnabled;
@@ -93,21 +95,6 @@ layout(rg32ui, binding = 6) readonly uniform uimage2D trixelEntityIds;
 // byte-identical. Bound every tick so Metal's slot table is populated.
 layout(rgba8, binding = 7) readonly uniform image3D lightVolumeId;
 
-// SPOT cone shaping (#2318). The winning-light ID indexes this list to recover
-// the light's cone axis (`directionAndRadius.xyz`), aperture
-// (`coneAndSeedAlpha.x`, full degrees), and TRUE apex (`trueOriginVoxel.xyz`).
-// Bound transiently at slot 4 by LIGHTING_TO_TRIXEL; only read on the spot path.
-struct GPULightSource {
-    vec4 originAndType;
-    vec4 colorAndIntensity;
-    vec4 directionAndRadius;
-    vec4 coneAndSeedAlpha;
-    vec4 trueOriginVoxel;
-};
-layout(std430, binding = 4) readonly buffer LightSourceBuffer {
-    GPULightSource lights[];
-};
-
 // Per-axis empty-cell compaction (#2256): on the per-axis route (perAxisRoute !=
 // 0) this kernel is dispatched indirectly over only each axis's OCCUPIED cells
 // (compacted by the STAGE_1 per-axis pre-pass) instead of sweeping the full
@@ -140,51 +127,6 @@ layout(std140, binding = 23) uniform LightVolumeParams {
     float _stepFalloff;
     ivec4 lightVolumeWorldOrigin;
 };
-
-// Mirror of `kLightVolumeSize` in component_canvas_light_volume.hpp.
-// The volume covers world voxels in [-half, half) with one texel per
-// voxel; sample coords are `(worldVoxel + half + 0.5) / size` to land
-// at texel centers.
-const float kLightVolumeSize = 128.0;
-const float kLightVolumeHalfExtent = 64.0;
-
-// SPOT cone shaping (#2318). Mirrors `LightType::SPOT` in
-// component_light_source.hpp. The cone factor smoothly falls off across a
-// band from the nominal half-aperture to `kConeEdgeSoftness ×` that angle so
-// the cone edge is anti-aliased rather than a hard step.
-const int kLightTypeSpot = 3;
-const float kConeEdgeSoftness = 1.15;
-
-// Analytic SPOT falloff at world position `pos3D` for the light whose 0-based
-// index is `lightIdx`. 1.0 inside the cone, smoothstep to 0.0 across the soft
-// edge band, 0.0 outside. The apex is the light's TRUE (unclamped) origin so
-// an out-of-window spot's cone stays oriented from its real position.
-float spotConeFactor(int lightIdx, vec3 pos3D) {
-    const GPULightSource L = lights[lightIdx];
-    const vec3 axis = normalize(L.directionAndRadius.xyz);
-    const vec3 toCell = pos3D - L.trueOriginVoxel.xyz;
-    const float toCellLen = length(toCell);
-    if (toCellLen < 1e-4) {
-        return 1.0;   // at the apex — fully lit, avoid a 0/0 direction.
-    }
-    const float cosToCell = dot(toCell / toCellLen, axis);
-    const float halfAngle = radians(L.coneAndSeedAlpha.x * 0.5);
-    const float cosInner = cos(halfAngle);
-    const float cosOuter = cos(min(halfAngle * kConeEdgeSoftness, radians(90.0)));
-    return smoothstep(cosOuter, cosInner, cosToCell);
-}
-
-// ACES Filmic tone mapping (Stephen Hill's fitted curve).
-// Maps [0, ∞) → [0, 1) with a gentle shoulder that preserves color
-// saturation in bright highlights better than Reinhard.
-vec3 ACESFilm(vec3 x) {
-    const float a = 2.51;
-    const float b = 0.03;
-    const float c = 2.43;
-    const float d = 0.59;
-    const float e = 0.14;
-    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
-}
 
 void main() {
     if (lightingEnabled == 0) {
@@ -394,7 +336,7 @@ void main() {
             const ivec3 idCell = ivec3(floor(localPos + vec3(kLightVolumeHalfExtent) + vec3(0.5)));
             if (all(greaterThanEqual(idCell, ivec3(0))) &&
                 all(lessThan(idCell, ivec3(int(kLightVolumeSize))))) {
-                const int winId = int(round(imageLoad(lightVolumeId, idCell).r * 255.0));
+                const int winId = roundHalfUp(imageLoad(lightVolumeId, idCell).r * 255.0);
                 if (winId > 0 && int(lights[winId - 1].originAndType.w) == kLightTypeSpot) {
                     light *= spotConeFactor(winId - 1, pos3D);
                 }

--- a/engine/render/src/shaders/c_render_gpu_particles_to_trixel.glsl
+++ b/engine/render/src/shaders/c_render_gpu_particles_to_trixel.glsl
@@ -54,7 +54,7 @@ void main() {
     Particle p = particles[idx];
     if (p.lifetime <= 0.0) return;
 
-    const ivec3 posI = ivec3(round(p.position));
+    const ivec3 posI = roundHalfUp(p.position);
     const ivec2 frameOffset = trixelCanvasOffsetZ1 + ivec2(floor(cameraTrixelOffset));
     const vec4 baseColor = unpackColor(p.color);
     const ivec2 canvasSize = imageSize(triangleCanvasDistances);

--- a/engine/render/src/shaders/c_render_stateless_particles_to_trixel.glsl
+++ b/engine/render/src/shaders/c_render_stateless_particles_to_trixel.glsl
@@ -121,7 +121,7 @@ void main() {
     // positional precision matching the voxel-pool `position * sub` cast
     // in c_voxel_to_trixel_stage_1.glsl.
     const int subdivisions = effectiveTrixelSubdivisionScale(voxelRenderOptions);
-    const ivec3 posScaled = ivec3(round(position * float(subdivisions)));
+    const ivec3 posScaled = roundHalfUp(position * float(subdivisions));
 
     const ivec2 frameOffset =
         trixelFrameOffset(trixelCanvasOffsetZ1, cameraTrixelOffset, voxelRenderOptions);

--- a/engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl
+++ b/engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl
@@ -103,7 +103,7 @@ void main() {
     // base-resolution origin into the SUBDIVIDED main-canvas cardinal layout.)
     const ivec2 perAxisBase = trixelOriginOffsetZ1(perAxisSize) + ivec2(floor(frameCanvasOffset));
     const ivec2 isoPix = cell - perAxisBase;
-    const ivec3 origin = ivec3(round(isoPixelToPos3D(isoPix.x, isoPix.y, float(rawDepth))));
+    const ivec3 origin = roundHalfUp(isoPixelToPos3D(isoPix.x, isoPix.y, float(rawDepth)));
 
     // Re-project into the MAIN-canvas cardinal distance layout, mirroring
     // c_voxel_to_trixel_stage_1's cardinal (perAxisRoute==0) store exactly:

--- a/engine/render/src/shaders/c_seed_light_volume.glsl
+++ b/engine/render/src/shaders/c_seed_light_volume.glsl
@@ -25,19 +25,8 @@
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
-struct GPULightSource {
-    vec4 originAndType;
-    vec4 colorAndIntensity;
-    vec4 directionAndRadius;
-    vec4 coneAndSeedAlpha;
-    // #2318: true (unclamped) world voxel apex — read by the spot-cone
-    // consumer, not here; declared for std430 stride parity (80 bytes).
-    vec4 trueOriginVoxel;
-};
-
-layout(std430, binding = 4) readonly buffer LightSourceBuffer {
-    GPULightSource lights[];
-};
+// GPULightSource + the LightSourceBuffer (slot 4) SSBO declaration.
+#include "ir_world_lighting.glsl"
 
 layout(std140, binding = 23) uniform LightVolumeParams {
     int gridSize;

--- a/engine/render/src/shaders/f_trixel_to_framebuffer.glsl
+++ b/engine/render/src/shaders/f_trixel_to_framebuffer.glsl
@@ -89,7 +89,10 @@ void main() {
     // i.e. the byte-identical fast path.
     float depthScale = effectiveSubdivisionsForHover.y;
     if (depthScale <= 0.0) depthScale = 1.0;
-    int base = int(round(float(rawDist) * depthScale));
+    // roundHalfUp, not hardware round(): a fractional depthScale (effSub /
+    // cubeSub) lands odd rawDist values on exact .5 ties, where GLSL round()
+    // is implementation-defined and diverges from the Metal twin.
+    int base = roundHalfUp(float(rawDist) * depthScale);
     // Hover state, computed BEFORE the (now-conditional) entity-id read (#2155).
     // It needs only `origin` + the hover uniforms — no texture fetch — so hoisting
     // it above the read is inert, and it lets the read be gated on hover too.

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -447,6 +447,9 @@ bool isInsideCanvas(ivec2 pixel, ivec2 canvasSize) {
            pixel.y >= 0 && pixel.y < canvasSize.y;
 }
 
+// Hardware round() is safe here: the 1e-4 near-grid gate excludes
+// half-integer inputs, so the tie direction — the only point where
+// round() is implementation-defined — is unobservable.
 vec3 snapNearIntegerVoxelPosition(vec3 voxelPosition) {
     vec3 voxelRounded = round(voxelPosition);
     bvec3 nearGrid = lessThanEqual(abs(voxelPosition - voxelRounded), vec3(0.0001));

--- a/engine/render/src/shaders/ir_world_lighting.glsl
+++ b/engine/render/src/shaders/ir_world_lighting.glsl
@@ -1,0 +1,65 @@
+// Shared world-space lighting primitives — the light-source list layout, the
+// light-volume extent constants, analytic SPOT cone shaping, and the ACES
+// tonemap. Consumed by every pass that lights recovered WORLD positions
+// (c_lighting_to_trixel, c_light_overflow_faces). Metal twin:
+// metal/ir_world_lighting.metal — keep byte-identical math.
+
+// The winning-light ID indexes this list to recover the light's cone axis
+// (`directionAndRadius.xyz`), aperture (`coneAndSeedAlpha.x`, full degrees),
+// and TRUE apex (`trueOriginVoxel.xyz`). Bound transiently at slot 4 by the
+// consuming system; only read on the spot path.
+struct GPULightSource {
+    vec4 originAndType;
+    vec4 colorAndIntensity;
+    vec4 directionAndRadius;
+    vec4 coneAndSeedAlpha;
+    vec4 trueOriginVoxel;
+};
+layout(std430, binding = 4) readonly buffer LightSourceBuffer {
+    GPULightSource lights[];
+};
+
+// Mirror of `kLightVolumeSize` in component_canvas_light_volume.hpp.
+// The volume covers world voxels in [-half, half) with one texel per
+// voxel; sample coords are `(worldVoxel + half + 0.5) / size` to land
+// at texel centers.
+const float kLightVolumeSize = 128.0;
+const float kLightVolumeHalfExtent = 64.0;
+
+// SPOT cone shaping (#2318). Mirrors `LightType::SPOT` in
+// component_light_source.hpp. The cone factor smoothly falls off across a
+// band from the nominal half-aperture to `kConeEdgeSoftness ×` that angle so
+// the cone edge is anti-aliased rather than a hard step.
+const int kLightTypeSpot = 3;
+const float kConeEdgeSoftness = 1.15;
+
+// Analytic SPOT falloff at world position `pos3D` for the light whose 0-based
+// index is `lightIdx`. 1.0 inside the cone, smoothstep to 0.0 across the soft
+// edge band, 0.0 outside. The apex is the light's TRUE (unclamped) origin so
+// an out-of-window spot's cone stays oriented from its real position.
+float spotConeFactor(int lightIdx, vec3 pos3D) {
+    const GPULightSource L = lights[lightIdx];
+    const vec3 axis = normalize(L.directionAndRadius.xyz);
+    const vec3 toCell = pos3D - L.trueOriginVoxel.xyz;
+    const float toCellLen = length(toCell);
+    if (toCellLen < 1e-4) {
+        return 1.0;   // at the apex — fully lit, avoid a 0/0 direction.
+    }
+    const float cosToCell = dot(toCell / toCellLen, axis);
+    const float halfAngle = radians(L.coneAndSeedAlpha.x * 0.5);
+    const float cosInner = cos(halfAngle);
+    const float cosOuter = cos(min(halfAngle * kConeEdgeSoftness, radians(90.0)));
+    return smoothstep(cosOuter, cosInner, cosToCell);
+}
+
+// ACES Filmic tone mapping (Stephen Hill's fitted curve).
+// Maps [0, ∞) → [0, 1) with a gentle shoulder that preserves color
+// saturation in bright highlights better than Reinhard.
+vec3 ACESFilm(vec3 x) {
+    const float a = 2.51;
+    const float b = 0.03;
+    const float c = 2.43;
+    const float d = 0.59;
+    const float e = 0.14;
+    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+}

--- a/engine/render/src/shaders/metal/c_light_overflow_faces.metal
+++ b/engine/render/src/shaders/metal/c_light_overflow_faces.metal
@@ -2,6 +2,7 @@
                                      // FrameDataVoxelToTrixel (with overflowScratchLayout)
 #include "ir_per_axis_lighting.metal" // perAxisCellToWorld3D
 #include "ir_sun_shadow_sample.metal" // FrameDataSun + worldSunShadowFactor()
+#include "ir_world_lighting.metal"    // GPULightSource layout, spotConeFactor, ACESFilm
 
 // Mirrors shaders/c_light_overflow_faces.glsl — view-visibility overflow-face
 // lighting (#2334, epic #2331 phase C2). Dispatched inside LIGHTING_TO_TRIXEL
@@ -30,49 +31,6 @@ struct LightVolumeParams {
     float _stepFalloff;
     int4  worldOriginVoxel;
 };
-
-// --- shared world-lighting primitives -----------------------------------------
-// These MIRROR c_lighting_to_trixel.metal (kept in lockstep). Duplicated rather
-// than extracted so the shipped lighting kernel stays byte-identical — a future
-// simplify pass can hoist both into a shared ir_world_lighting.metal include.
-constant float kLightVolumeSize = 128.0;
-constant float kLightVolumeHalfExtent = 64.0;
-constant int   kLightTypeSpot = 3;
-constant float kConeEdgeSoftness = 1.15f;
-constant float kDegToRad = 3.14159265358979323846f / 180.0f;
-
-struct GPULightSource {
-    float4 originAndType;
-    float4 colorAndIntensity;
-    float4 directionAndRadius;
-    float4 coneAndSeedAlpha;
-    float4 trueOriginVoxel;
-};
-
-float spotConeFactor(device const GPULightSource* lights, int lightIdx, float3 pos3D) {
-    const GPULightSource L = lights[lightIdx];
-    const float3 axis = normalize(L.directionAndRadius.xyz);
-    const float3 toCell = pos3D - L.trueOriginVoxel.xyz;
-    const float toCellLen = length(toCell);
-    if (toCellLen < 1e-4f) {
-        return 1.0f;
-    }
-    const float cosToCell = dot(toCell / toCellLen, axis);
-    const float halfAngle = L.coneAndSeedAlpha.x * 0.5f * kDegToRad;
-    const float cosInner = cos(halfAngle);
-    const float cosOuter = cos(min(halfAngle * kConeEdgeSoftness, 90.0f * kDegToRad));
-    return smoothstep(cosOuter, cosInner, cosToCell);
-}
-
-float3 ACESFilm(float3 x) {
-    const float a = 2.51f;
-    const float b = 0.03f;
-    const float c = 2.43f;
-    const float d = 0.59f;
-    const float e = 0.14f;
-    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0f, 1.0f);
-}
-// -----------------------------------------------------------------------------
 
 kernel void c_light_overflow_faces(
     constant FrameDataLightingToTrixel& frameData [[buffer(27)]],
@@ -162,7 +120,7 @@ kernel void c_light_overflow_faces(
         if (lightVolumeParams.worldOriginVoxel.w != 0) {
             const int3 idCell = int3(floor(localPos + float3(kLightVolumeHalfExtent) + float3(0.5)));
             if (all(idCell >= int3(0)) && all(idCell < int3(int(kLightVolumeSize)))) {
-                const int winId = int(round(lightVolumeId.read(uint3(idCell)).r * 255.0f));
+                const int winId = roundHalfUp(lightVolumeId.read(uint3(idCell)).r * 255.0f);
                 if (winId > 0 && int(lights[winId - 1].originAndType.w) == kLightTypeSpot) {
                     light *= spotConeFactor(lights, winId - 1, pos3D);
                 }

--- a/engine/render/src/shaders/metal/c_lighting_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_lighting_to_trixel.metal
@@ -4,6 +4,8 @@
 // for the opt-in detached re-voxelize world-receive path (#1576 P4b-2). Shared
 // with c_compute_sun_shadow; replaces this kernel's former local FrameDataSun.
 #include "ir_sun_shadow_sample.metal"
+// GPULightSource layout, light-volume extents, spotConeFactor, ACESFilm.
+#include "ir_world_lighting.metal"
 
 // Mirrors shaders/c_lighting_to_trixel.glsl. Screen-space lighting
 // application pass — modulates trixelColors.rgb by (AO × sun-shadow),
@@ -26,10 +28,6 @@ struct FrameDataLightingToTrixel {
     float4 skyColor;
 };
 
-// Mirror of `kLightVolumeSize` in component_canvas_light_volume.hpp.
-constant float kLightVolumeSize = 128.0;
-constant float kLightVolumeHalfExtent = 64.0;
-
 // Layout must match the propagate/seed UBO layout so the shared buffer
 // binding works. Lighting reads `worldOriginVoxel.xyz` (volume origin) and
 // `.w` (has-SPOT flag, #2318).
@@ -40,48 +38,6 @@ struct LightVolumeParams {
     float _stepFalloff;
     int4  worldOriginVoxel;
 };
-
-// SPOT cone shaping (#2318). Mirrors GPULightSource / LightType::SPOT.
-struct GPULightSource {
-    float4 originAndType;
-    float4 colorAndIntensity;
-    float4 directionAndRadius;
-    float4 coneAndSeedAlpha;
-    float4 trueOriginVoxel;
-};
-constant int kLightTypeSpot = 3;
-constant float kConeEdgeSoftness = 1.15f;
-// Metal has no radians() builtin (GLSL does); convert degrees inline.
-constant float kDegToRad = 3.14159265358979323846f / 180.0f;
-
-// Analytic SPOT falloff at world position `pos3D` for the 0-based light
-// `lightIdx`. 1.0 inside the cone, smoothstep to 0.0 across the soft edge
-// band, 0.0 outside. Apex is the light's TRUE (unclamped) origin. Mirrors
-// the GLSL twin.
-float spotConeFactor(device const GPULightSource* lights, int lightIdx, float3 pos3D) {
-    const GPULightSource L = lights[lightIdx];
-    const float3 axis = normalize(L.directionAndRadius.xyz);
-    const float3 toCell = pos3D - L.trueOriginVoxel.xyz;
-    const float toCellLen = length(toCell);
-    if (toCellLen < 1e-4f) {
-        return 1.0f;   // at the apex — fully lit, avoid a 0/0 direction.
-    }
-    const float cosToCell = dot(toCell / toCellLen, axis);
-    const float halfAngle = L.coneAndSeedAlpha.x * 0.5f * kDegToRad;
-    const float cosInner = cos(halfAngle);
-    const float cosOuter = cos(min(halfAngle * kConeEdgeSoftness, 90.0f * kDegToRad));
-    return smoothstep(cosOuter, cosInner, cosToCell);
-}
-
-// ACES Filmic tone mapping (Stephen Hill's fitted curve).
-float3 ACESFilm(float3 x) {
-    const float a = 2.51f;
-    const float b = 0.03f;
-    const float c = 2.43f;
-    const float d = 0.59f;
-    const float e = 0.14f;
-    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0f, 1.0f);
-}
 
 // Per-axis empty-cell compaction (#2256): on the per-axis route
 // (perAxisRoute != 0) this kernel is dispatched indirectly over only each axis's
@@ -324,7 +280,7 @@ kernel void c_lighting_to_trixel(
         if (lightVolumeParams.worldOriginVoxel.w != 0) {
             const int3 idCell = int3(floor(localPos + float3(kLightVolumeHalfExtent) + float3(0.5)));
             if (all(idCell >= int3(0)) && all(idCell < int3(int(kLightVolumeSize)))) {
-                const int winId = int(round(lightVolumeId.read(uint3(idCell)).r * 255.0f));
+                const int winId = roundHalfUp(lightVolumeId.read(uint3(idCell)).r * 255.0f);
                 if (winId > 0 && int(lights[winId - 1].originAndType.w) == kLightTypeSpot) {
                     light *= spotConeFactor(lights, winId - 1, pos3D);
                 }

--- a/engine/render/src/shaders/metal/c_render_gpu_particles_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_render_gpu_particles_to_trixel.metal
@@ -46,7 +46,7 @@ kernel void c_render_gpu_particles_to_trixel(
     Particle p = particles[gid];
     if (p.lifetime <= 0.0) return;
 
-    const int3 posI = int3(round(float3(p.position)));
+    const int3 posI = roundHalfUp(float3(p.position));
     const int2 frameOffset = frameData.trixelCanvasOffsetZ1 + int2(floor(frameData.cameraTrixelOffset));
     const float4 baseColor = unpackColor(p.color);
 

--- a/engine/render/src/shaders/metal/c_render_stateless_particles_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_render_stateless_particles_to_trixel.metal
@@ -84,7 +84,7 @@ kernel void c_render_stateless_particles_to_trixel(
     // pool uses under FULL subdivision mode (sub > 1 → sub-voxel precision;
     // sub == 1 collapses to plain integer rounding).
     const int subdivisions = effectiveTrixelSubdivisionScale(frameData.voxelRenderOptions);
-    const int3 posScaled = int3(round(position * float(subdivisions)));
+    const int3 posScaled = roundHalfUp(position * float(subdivisions));
 
     const int2 frameOffset = trixelFrameOffset(
         frameData.trixelCanvasOffsetZ1,

--- a/engine/render/src/shaders/metal/c_resolve_per_axis_screen_depth.metal
+++ b/engine/render/src/shaders/metal/c_resolve_per_axis_screen_depth.metal
@@ -65,7 +65,7 @@ kernel void c_resolve_per_axis_screen_depth(
     // `perAxisBase + pos3DtoPos2DIso(facePos)`; invert via isoPixelToPos3D
     // (exact integer facePos for integer cell + rawDepth).
     const int2 isoPix = cell - perAxisBase;
-    const int3 origin = int3(round(isoPixelToPos3D(isoPix.x, isoPix.y, float(rawDepth))));
+    const int3 origin = roundHalfUp(isoPixelToPos3D(isoPix.x, isoPix.y, float(rawDepth)));
 
     // Re-project into the MAIN-canvas cardinal distance layout, mirroring
     // c_voxel_to_trixel_stage_1.metal's cardinal store, so the BAKE cardinal

--- a/engine/render/src/shaders/metal/c_seed_light_volume.metal
+++ b/engine/render/src/shaders/metal/c_seed_light_volume.metal
@@ -9,15 +9,8 @@ using namespace metal;
 // window edge (see `gatherLightSources`). The propagate pass decrements
 // alpha by `stepFalloff` per step.
 
-struct GPULightSource {
-    float4 originAndType;
-    float4 colorAndIntensity;
-    float4 directionAndRadius;
-    float4 coneAndSeedAlpha;
-    // #2318: true (unclamped) apex — read by the spot-cone consumer, not
-    // here; declared for std430 stride parity (80 bytes).
-    float4 trueOriginVoxel;
-};
+// GPULightSource layout (the light-list entry this kernel seeds from).
+#include "ir_world_lighting.metal"
 
 struct LightVolumeParams {
     int gridSize;

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -415,6 +415,9 @@ inline bool isInsideCanvas(int2 pixel, int2 canvasSize) {
            pixel.y >= 0 && pixel.y < canvasSize.y;
 }
 
+// Hardware round() is safe here: the 1e-4 near-grid gate excludes
+// half-integer inputs, so the tie direction — the only point where
+// round() can differ from the GLSL twin — is unobservable.
 inline float3 snapNearIntegerVoxelPosition(float3 voxelPosition) {
     float3 voxelRounded = round(voxelPosition);
     bool3 nearGrid = abs(voxelPosition - voxelRounded) <= float3(0.0001);

--- a/engine/render/src/shaders/metal/ir_world_lighting.metal
+++ b/engine/render/src/shaders/metal/ir_world_lighting.metal
@@ -1,0 +1,62 @@
+// Shared world-space lighting primitives — the light-source list layout, the
+// light-volume extent constants, analytic SPOT cone shaping, and the ACES
+// tonemap. Consumed by every pass that lights recovered WORLD positions
+// (c_lighting_to_trixel, c_light_overflow_faces). GLSL twin:
+// ../ir_world_lighting.glsl — keep byte-identical math. Metal has no global
+// buffer bindings, so consumers pass the light list (`[[buffer(4)]]`) into
+// spotConeFactor explicitly.
+
+// Mirror of `kLightVolumeSize` in component_canvas_light_volume.hpp.
+// The volume covers world voxels in [-half, half) with one texel per
+// voxel; sample coords are `(worldVoxel + half + 0.5) / size` to land
+// at texel centers.
+constant float kLightVolumeSize = 128.0;
+constant float kLightVolumeHalfExtent = 64.0;
+
+// SPOT cone shaping (#2318). Mirrors `LightType::SPOT` in
+// component_light_source.hpp. The cone factor smoothly falls off across a
+// band from the nominal half-aperture to `kConeEdgeSoftness ×` that angle so
+// the cone edge is anti-aliased rather than a hard step.
+constant int kLightTypeSpot = 3;
+constant float kConeEdgeSoftness = 1.15f;
+// Metal has no radians() builtin (GLSL does); convert degrees inline.
+constant float kDegToRad = 3.14159265358979323846f / 180.0f;
+
+struct GPULightSource {
+    float4 originAndType;
+    float4 colorAndIntensity;
+    float4 directionAndRadius;
+    float4 coneAndSeedAlpha;
+    float4 trueOriginVoxel;
+};
+
+// Analytic SPOT falloff at world position `pos3D` for the 0-based light
+// `lightIdx`. 1.0 inside the cone, smoothstep to 0.0 across the soft edge
+// band, 0.0 outside. Apex is the light's TRUE (unclamped) origin. Mirrors
+// the GLSL twin.
+float spotConeFactor(device const GPULightSource* lights, int lightIdx, float3 pos3D) {
+    const GPULightSource L = lights[lightIdx];
+    const float3 axis = normalize(L.directionAndRadius.xyz);
+    const float3 toCell = pos3D - L.trueOriginVoxel.xyz;
+    const float toCellLen = length(toCell);
+    if (toCellLen < 1e-4f) {
+        return 1.0f;   // at the apex — fully lit, avoid a 0/0 direction.
+    }
+    const float cosToCell = dot(toCell / toCellLen, axis);
+    const float halfAngle = L.coneAndSeedAlpha.x * 0.5f * kDegToRad;
+    const float cosInner = cos(halfAngle);
+    const float cosOuter = cos(min(halfAngle * kConeEdgeSoftness, 90.0f * kDegToRad));
+    return smoothstep(cosOuter, cosInner, cosToCell);
+}
+
+// ACES Filmic tone mapping (Stephen Hill's fitted curve).
+// Maps [0, ∞) → [0, 1) with a gentle shoulder that preserves color
+// saturation in bright highlights better than Reinhard.
+float3 ACESFilm(float3 x) {
+    const float a = 2.51f;
+    const float b = 0.03f;
+    const float c = 2.43f;
+    const float d = 0.59f;
+    const float e = 0.14f;
+    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0f, 1.0f);
+}

--- a/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
+++ b/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
@@ -121,7 +121,10 @@ fragment FragmentOut f_trixel_to_framebuffer(
     // (the byte-identical world/overlay fast path).
     float depthScale = frameData.effectiveSubdivisionsForHover.y;
     if (depthScale <= 0.0f) depthScale = 1.0f;
-    int base = int(round(float(rawDist) * depthScale));
+    // roundHalfUp, not hardware round(): a fractional depthScale (effSub /
+    // cubeSub) lands odd rawDist values on exact .5 ties, where the GLSL
+    // twin's round() is implementation-defined; both twins share roundHalfUp.
+    int base = roundHalfUp(float(rawDist) * depthScale);
     // Per-trixel priority tiers (#1960) — twin of f_trixel_to_framebuffer.glsl.
     // No-priority perf fast-path (#2155): read this fragment's entity id (at the
     // SAME texel its color/depth came from — sampleCoord, the raw position) only


### PR DESCRIPTION
## Summary
- **Rounding standardization**: every world-position → integer-cell quantization in the shader tree now routes through `roundHalfUp` (the documented IRMath CPU↔GPU handshake convention) instead of hardware `round()`, whose half-integer tie direction is implementation-defined in GLSL and differs from Metal's half-away-from-zero. Converted sites, GLSL + Metal twins: the per-axis screen-depth resolve's voxel-origin recovery (`c_resolve_per_axis_screen_depth`), GPU + stateless particle cell quantization, the trixel→framebuffer depth lift (a fractional `effSub/cubeSub` depthScale lands odd `rawDist` on exact `.5` ties — a real GL↔Metal divergence), and the light-volume winner-id decode.
- The two remaining hardware `round()` sites (`snapNearIntegerVoxelPosition`, `rasterYawCardinalIndex`) are tie-unreachable by construction; each now carries the one-line invariant saying why. End state: every rounding site in `engine/render/src/shaders/` is either `roundHalfUp` or documented-why-not.
- **Shared world-lighting include**: `GPULightSource` + the `LightSourceBuffer` (slot 4) declaration, the light-volume extent constants, `spotConeFactor`, and `ACESFilm` move from per-kernel copies (`c_lighting_to_trixel`, `c_light_overflow_faces`, `c_seed_light_volume`) into new `ir_world_lighting.{glsl,metal}` — the hoist `c_light_overflow_faces`'s own comment sanctioned. Kills the three-way struct-layout drift risk. Net **−200 lines**.
- `engine/render/CLAUDE.md` shared-includes list updated.

## Verification (macOS/Metal, M4 Max — A/B against the base commit, per-side rebuilds)
| surface | result |
|---|---|
| shape_debug full shot table (28 shots incl. yaw-45 rotating poses) | **byte-identical** (max_delta 0) |
| render-verify vs committed refs | 22/24 PASS; the 2 yaw-45 FAILs are **stale refs** — master fails them identically (refs predate #2471's intentional yaw-45 drift; see note below) |
| canvas_stress cardinal shots (lit scenes, LUT/HDR/ACES/light-volume/seed) | 11/12 byte-identical; `so3_offsnap_disc` (yaw=π/4): 8 px @ max_delta 9 — **attributed** (below) |
| canvas_stress `--sweep-yaw` (overflow relight + per-axis lighting active) | 3/3 **byte-identical** |
| seed-kernel include swap | 12/12 byte-identical vs pre-swap capture |
| particle demos | inherently run-to-run nondeterministic (wall-clock `currentTime`; identical-code noise max_delta 171–255), so screenshot A/B carries no signal; 3/3 `RESULT=CLEAN`; edits are analytically no-op off exact ties |
| jitter floor (#2469): `--yaw-sweep` zoom 4 voxel cylinder | x rev=2, max_residual=1.01px — **exactly the documented accepted floor** |
| cardinal byte-identity | holds on every cardinal pose of every demo tested |

**The one intentional drift** (stepwise copy-patch bisect): the resolve's `round()`→`roundHalfUp` alone reproduces the 8-pixel yaw-pose delta — the old hardware `round()` picked a *different caster cell* than the store/receive `roundHalfUp` convention at half-integer FP boundaries, violating the file's own "cast and receive agree by construction" contract at those pixels. The remaining ≤9/255 scheduling-level drift on the same rotating pose comes from the function hoist (Metal compiler re-scheduling; the winId decode is provably inert on unorm inputs). Both are confined to the rotating path; well inside render-verify thresholds (64/99.9%).

## Test plan
- [x] macOS/Metal: full A/B suite above; all runs `ir-run: RESULT=CLEAN`
- [ ] Linux/GL smoke: `fleet-build --target IRShapeDebug` + `fleet-run IRShapeDebug --auto-screenshot 10` (validates the GLSL twins compile — no GLSL validator on the authoring host)

## Notes for reviewer
- No screenshots attached: before/after pairs are byte-identical at every cardinal pose and the yaw-pose delta is 8 pixels at ≤9/255 — the A/B tables above are the visual evidence (`render-debug-loop`'s "provably no runtime effect" carve-out, with the effect quantified instead of assumed).
- shape_debug's committed macos render-verify refs are stale on **master** for the two yaw-45 shots (#2466 refresh predates #2471's intentional drift) — same class as #2473/#2426; refresh should ride its own mechanical ticket, not this PR.
- Known residual duplicate deliberately left: `c_clear_light_volume.{glsl,metal}` declares `const int kLightVolumeSize = 128` (int, bounds-check-only) — different type/purpose than the shared float constant; folding it in is a separate judgment call.
- One SIGABRT observed once on `IRStatelessParticles` during A/B — not reproducible (3/3 CLEAN after rebuild), matches the documented intermittent macOS CoreMIDI startup abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6v8rYcLosaHJghwGqBCRp
