### PR TITLE
render: per-axis GPU burst sub-stage attribution (#2281 Phase 2)

### DIFF
--- a/docs/design/per-axis-yaw-gpu-attribution.md
+++ b/docs/design/per-axis-yaw-gpu-attribution.md
@@ -182,3 +182,90 @@ now possible.
 **Not deferring on the merits:** the delta is user-visible (~3.5× frame time at
 zoom 3 during any rotation transient = dropped frames on every rotation), and
 the measurement step Phase 2 needs is cheap now that the #2288 tooling merged.
+
+## Phase 2 — separated per-axis burst attribution (#2281, 2026-07-20)
+
+Instrumentation: `GpuSubStageScope` brackets on every rotating-only dispatch
+group (the #2280 mechanism, extended). New registry rows: `voxelPerAxisStore`
+(phase A: clears + cardinal stores ×3), `voxelPerAxisOverflow` (phases B+C:
+view mask ×3 + overflow append ×3), `voxelPerAxisFinalize` (phase D: winner
+election + stage-2 ×3), `perAxisCellCompact`, `computeVoxelAoPerAxis`,
+`lightingPerAxis`, `lightingOverflow`, `perAxisScatter` — and
+`COMPUTE_VOXEL_AO` / `LIGHTING_TO_TRIXEL` / `TRIXEL_TO_FRAMEBUFFER` are
+untagged from the per-system observer with their rows narrowed to the
+main-canvas dispatch only (the #2280 `voxelStage1` precedent). Cardinal
+`IRShapeDebug` full shot table byte-identical pre/post (28/28, max_delta 0);
+every per-axis row reads 0.0 at cardinal, so row deltas ARE the burst.
+
+Matrix (macOS/Metal, M4 Max; `IRPerfGrid --auto-profile 300 --no-overlay`;
+avg over 3 repeats; spread = max−min of per-run avgs, well under every quoted
+delta):
+
+### voxel_set `--zoom 3` — frame 14.92 → 28.16 ms (+13.24)
+
+| stage | cardinal | yaw 0.35 | Δ |
+|---|---|---|---|
+| voxelStage1 + voxelStage2 (single-canvas raster) | 3.61 | 0.00 | −3.61 |
+| voxelPerAxisStore | 0.00 | 6.91 | +6.91 |
+| voxelPerAxisOverflow | 0.00 | 6.37 | +6.37 |
+| voxelPerAxisFinalize | 0.00 | 5.60 | +5.60 |
+| perAxisScatter | 0.00 | 2.19 | +2.19 |
+| trixelToFb (gather, SDF/text fall-through) | 0.04 | 1.53 | +1.50 |
+| perAxisCellCompact + AO + lighting + overflow relight | 0.00 | 0.20 | +0.20 |
+| computeLightVolume | 7.56 | 4.83 | −2.73 |
+| bakeSunShadowMap | 4.82 | 18.59 | +13.78 * |
+
+### wave (default) — frame 8.60 → 20.36 ms (+11.77)
+
+| stage | cardinal | yaw 0.35 | Δ |
+|---|---|---|---|
+| voxelStage1 + voxelStage2 | 1.32 | 0.00 | −1.32 |
+| voxelPerAxisStore | 0.00 | 5.27 | +5.27 |
+| voxelPerAxisOverflow | 0.00 | 3.27 | +3.27 |
+| voxelPerAxisFinalize | 0.00 | 2.93 | +2.93 |
+| perAxisScatter | 0.00 | 2.59 | +2.59 |
+| trixelToFb (gather) | 0.04 | 1.93 | +1.88 |
+| perAxisCellCompact + AO + lighting + overflow relight | 0.00 | 0.21 | +0.21 |
+| bakeSunShadowMap | 1.50 | 11.22 | +9.72 * |
+
+\* **The bake row's yaw swing is an overlap artifact, not real cost.** The
+stage rows are genuine GPU-timeline windows and still overlap across systems
+(voxel_set yaw rows sum ≈ 46 ms against a 28 ms frame). The decisive
+counter-probe: `--no-sun-shadows` moves the yaw frame only 20.2 → 18.9 ms
+(−1.3 ms) while moving cardinal 8.6 → 5.9 ms — the sun path's real marginal
+cost at yaw is ~1.3 ms; the bake's whole-tick bracket absorbs concurrent
+per-axis work. (perf_grid also registers no
+`RESOLVE_PER_AXIS_SCREEN_DEPTH`, so per-axis voxels do not cast shadows
+there at all — a demo-pipeline drift vs the five demos that do register it;
+adding it would raise the yaw baseline and should ride its own change.)
+
+### Findings
+
+1. **The burst is the stage-1 rotating kernel family, full stop.** Store +
+   overflow + finalize ≈ 18.9 ms (voxel_set) / 11.5 ms (wave) — ~85 % of the
+   attributable delta. Per-axis AO and lighting are ~0.05 ms combined
+   (occupied-cell-bound, exactly as the #2273 result predicted); the scatter
+   draw is a bounded 2.2–2.6 ms.
+2. **The same per-axis face geometry is dispatched five times per axis** —
+   store (mode 0), view mask (mode 2), overflow append (mode 3), winner
+   election (mode 1), stage-2 — 15 sweeps of the compacted face list per
+   rotating frame, all through one runtime-`resolveMode`-branched kernel.
+   The overflow lane's two extra phases (B+C) alone cost 6.4 / 3.3 ms — a
+   third of the burst — matching the frame-level
+   `IR_PERAXIS_OVERFLOW_DISABLE` kill-switch probe (~2.9 ms on wave).
+3. **Candidate lever** (plan option (a), now with row-level evidence): reduce
+   the pass count over the face list — fold the view-mask tap into the store
+   pass (both write disjoint scratch; the mask needs only the yawed
+   projection the store already computes), and/or compile-time-specialize
+   `resolveMode` into per-pass kernel variants to remove the 4-way
+   predication tax from the hottest kernel (the #2325 `IR_FEEDER_PASS` a′
+   precedent measured a 16 % tax for ONE such uniform branch). Election +
+   stage-2 fusion is constrained by the winner-scratch serial reuse across
+   axes (#2255) — evaluate last.
+4. **Pursue-at-all:** the delta exists only while the camera is actively
+   rotating (canvases release at every cardinal), but it is user-visible on
+   every rotation: voxel_set 69 → 37 FPS, wave 120 → 50 FPS. Given the
+   standing yaw-parity goal, the lever is worth a design-gated follow-up.
+
+Lever implementation is a **separate task** behind the design gate, per the
+Phase-2 plan.

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -14,13 +14,24 @@ inline constexpr float kFrameTimeBudgetMs = 1000.0f / 60.0f;
 
 // Number of named GPU stages in `gpuStageRegistry()`. Single source of truth
 // for both the registry array and the parallel per-stage accumulator array.
-inline constexpr std::size_t kGpuStageCount = 20;
+inline constexpr std::size_t kGpuStageCount = 28;
 
 struct GpuStageTiming {
     float canvasClearMs_ = 0.0f;
     float voxelCompactMs_ = 0.0f;
     float voxelStage1Ms_ = 0.0f;
     float voxelStage2Ms_ = 0.0f;
+    // Rotating-only per-axis burst sub-rows (#2281 Phase 2). Attributed by
+    // GpuSubStageScope brackets inside the owning ticks; 0.0 at cardinal
+    // (the per-axis canvases are released, none of the dispatches run).
+    float voxelPerAxisStoreMs_ = 0.0f;
+    float voxelPerAxisOverflowMs_ = 0.0f;
+    float voxelPerAxisFinalizeMs_ = 0.0f;
+    float perAxisCellCompactMs_ = 0.0f;
+    float computeVoxelAoPerAxisMs_ = 0.0f;
+    float lightingPerAxisMs_ = 0.0f;
+    float lightingOverflowMs_ = 0.0f;
+    float perAxisScatterMs_ = 0.0f;
     float shapeCompactMs_ = 0.0f;
     float shapePass0Ms_ = 0.0f;
     float shapePass1Ms_ = 0.0f;
@@ -240,7 +251,31 @@ inline void commitGpuStageSample(const GpuStageInfo &info, int registryIndex, fl
 // The old bundled `voxelStage1` value is reconstructed as the sum of these
 // four rows. Sub-scopes are single-canvas-exact and record the last canvas's
 // sample on multi-canvas scenes (like every `*Ms_` field's last-sample
-// semantics); the rotating-only per-axis voxel dispatch is not sub-scoped.
+// semantics).
+//
+// Per-axis burst sub-rows (#2281 Phase 2): COMPUTE_VOXEL_AO,
+// LIGHTING_TO_TRIXEL, and TRIXEL_TO_FRAMEBUFFER are likewise NOT tagged for
+// the per-system observer; each brackets its dispatch groups with
+// GpuSubStageScopes so the rotating-only per-axis work is attributed
+// separately from the always-on main-canvas work:
+//   `computeVoxelAO`        ← the main-canvas AO dispatch ONLY
+//   `computeVoxelAoPerAxis` ← the 3 per-axis AO dispatches
+//   `lightingToTrixel`      ← the main-canvas lighting dispatch ONLY
+//   `lightingPerAxis`       ← the 3 per-axis relight dispatches
+//   `lightingOverflow`      ← the overflow-face relight dispatch (#2334)
+//   `trixelToFb`            ← the single-canvas gather draw ONLY
+//   `perAxisScatter`        ← the 3 per-axis scatter draws + overflow draw
+// and VOXEL_TO_TRIXEL_STAGE_1's rotating-only per-axis dispatch groups get
+// their own rows (phases per docs/design/per-axis-trixel-canvas-rotation.md
+// §"The overflow lane"):
+//   `voxelPerAxisStore`     ← phase A: per-axis clears + cardinal stores ×3
+//   `voxelPerAxisOverflow`  ← phases B+C: view mask ×3 + overflow append ×3
+//   `voxelPerAxisFinalize`  ← phase D: winner election + stage-2 ×3
+//   `perAxisCellCompact`    ← the occupied-cell compaction + finalize
+//                             dispatches feeding every per-axis consumer
+// Every per-axis row reads 0.0 at cardinal (the canvases are released and
+// none of those dispatches run), so cardinal-vs-yaw row deltas ARE the
+// per-axis burst attribution.
 //
 // Two rows still have no current writer: `shapePass0` (folded into the
 // SHAPES_TO_TRIXEL per-system measurement) and `shapeCompact` (no system has
@@ -253,6 +288,14 @@ inline const std::array<GpuStageInfo, kGpuStageCount> &gpuStageRegistry() {
         {"voxelCompact", &GpuStageTiming::voxelCompactMs_, 0.10f},
         {"voxelStage1", &GpuStageTiming::voxelStage1Ms_, 0.20f},
         {"voxelStage2", &GpuStageTiming::voxelStage2Ms_, 0.15f},
+        {"voxelPerAxisStore", &GpuStageTiming::voxelPerAxisStoreMs_, 0.10f},
+        {"voxelPerAxisOverflow", &GpuStageTiming::voxelPerAxisOverflowMs_, 0.05f},
+        {"voxelPerAxisFinalize", &GpuStageTiming::voxelPerAxisFinalizeMs_, 0.10f},
+        {"perAxisCellCompact", &GpuStageTiming::perAxisCellCompactMs_, 0.05f},
+        {"computeVoxelAoPerAxis", &GpuStageTiming::computeVoxelAoPerAxisMs_, 0.05f},
+        {"lightingPerAxis", &GpuStageTiming::lightingPerAxisMs_, 0.05f},
+        {"lightingOverflow", &GpuStageTiming::lightingOverflowMs_, 0.05f},
+        {"perAxisScatter", &GpuStageTiming::perAxisScatterMs_, 0.10f},
         {"shapeCompact", &GpuStageTiming::shapeCompactMs_, 0.05f},
         {"shapePass0", &GpuStageTiming::shapePass0Ms_, 0.10f},
         {"shapePass1", &GpuStageTiming::shapePass1Ms_, 0.10f},

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -24,7 +24,7 @@
 #include <irreden/render/per_axis_canvas.hpp>
 #include <irreden/render/voxel_frame_data.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
-#include <irreden/render/gpu_stage_timing_observer.hpp>
+#include <irreden/render/gpu_substage_timing.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -99,22 +99,32 @@ template <> struct System<COMPUTE_VOXEL_AO> {
             canvasTextures
         );
 
-        canvasTextures.getTextureDistances()
-            ->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
-        ao.getTexture()->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-        voxelFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataVoxelToCanvas);
-        sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
+        {
+            // Sub-scope (#2281): the main-canvas AO dispatch only — the system
+            // is untagged from the per-system observer so the per-axis rows
+            // below stay separable (a sub-scope reuses the observer's slot).
+            GpuSubStageScope aoScope("computeVoxelAO");
+            canvasTextures.getTextureDistances()
+                ->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+            ao.getTexture()->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+            voxelFrameDataBuf_->bindBase(
+                BufferTarget::UNIFORM,
+                kBufferIndex_FrameDataVoxelToCanvas
+            );
+            sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
 
-        const int groupsX = IRMath::divCeil(canvasTextures.size_.x, kComputeVoxelAOGroupSize);
-        const int groupsY = IRMath::divCeil(canvasTextures.size_.y, kComputeVoxelAOGroupSize);
-        IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            const int groupsX = IRMath::divCeil(canvasTextures.size_.x, kComputeVoxelAOGroupSize);
+            const int groupsY = IRMath::divCeil(canvasTextures.size_.y, kComputeVoxelAOGroupSize);
+            IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+        }
 
         // Smooth camera Z-yaw (#1311): compute AO for each per-axis voxel
         // canvas so the framebuffer scatter composites LIT voxels while rotating.
         // Only the main canvas owns them, and only while at a non-cardinal yaw.
         if (entity == perAxisCanvasEntity_ && perAxisCanvases_ != nullptr &&
             perAxisCanvases_->isAllocated()) {
+            GpuSubStageScope perAxisScope("computeVoxelAoPerAxis");
             dispatchPerAxisAO(*perAxisCanvases_, canvasTextures, ao);
         }
     }
@@ -269,7 +279,8 @@ template <> struct System<COMPUTE_VOXEL_AO> {
         auto *p = getSystemParams<System<COMPUTE_VOXEL_AO>>(systemId);
         p->program_ = IRRender::getNamedResource<ShaderProgram>("ComputeVoxelAOProgram");
         p->voxelFrameDataBuf_ = IRRender::getNamedResource<Buffer>("SingleVoxelFrameData");
-        IRRender::tagGpuStage(systemId, "computeVoxelAO");
+        // NOT observer-tagged: the tick owns GpuSubStageScopes (#2281), which
+        // reuse the observer's timestamp attachment slot.
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -85,6 +85,10 @@ template <> struct System<COMPUTE_VOXEL_AO> {
         if (!behavior.useCameraPositionIso_)
             return;
         IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
+        // CPU histogram bracket — this system is not observer-tagged (#2281),
+        // so without it the perf overlay's VOXEL-AO CPU row reads 0.0. The
+        // IR_PROFILE_FUNCTION above feeds easy_profiler, not cpuFrameHistogram.
+        IR_PROFILE_SCOPE("computeVoxelAO");
 
         // Author THIS canvas's voxel frame data so AO shades it with its own
         // visible-triplet / detached state (#1558). No-op for a canvas with no

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -22,7 +22,8 @@
 #include <irreden/render/voxel_dispatch_grid.hpp>
 #include <irreden/render/voxel_frame_data.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
-#include <irreden/render/gpu_stage_timing_observer.hpp>
+#include <irreden/render/gpu_substage_timing.hpp>
+#include <irreden/ir_profile.hpp>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -151,6 +152,8 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
         if (!behavior.useCameraPositionIso_) {
             return;
         }
+        // CPU histogram bracket — this system is not observer-tagged (#2281).
+        IR_PROFILE_SCOPE("lightingToTrixel");
 
         // Author THIS canvas's voxel frame data so the Lambert + sky terms read
         // its own visible-triplet world normals and isDetachedCanvas flag, not
@@ -176,75 +179,85 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
         const C_CanvasLightVolume *lightVolume =
             lightVolumeOpt.has_value() ? lightVolumeOpt.value() : mainCanvasLightVolume_;
 
-        canvasTextures.getTextureColors()
-            ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
-        canvasTextures.getTextureDistances()
-            ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-        ao.getTexture()->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-        // Texture/image unit layout (must match GLSL + MSL):
-        //   3: paletteLUT (sampler2D)
-        //   4: canvasSunShadow (image2D, R/O)
-        //   5: lightVolume (sampler3D)
-        // Metal flattens the sampler and image namespaces into a
-        // shared setTexture slot space, so all three slots must be
-        // unique across both kinds.
-        paletteLUT_->bind(3);
-        // Metal requires every setTexture slot to be populated (it does not
-        // default-bind a null slot). `shadow` is the per-canvas component when
-        // present, else the main canvas's as an inert placeholder — the main canvas
-        // always carries C_CanvasSunShadow when LIGHTING_TO_TRIXEL is registered.
-        IR_ASSERT(
-            shadow != nullptr,
-            "Metal requires slot 4 bound — main canvas must carry C_CanvasSunShadow "
-            "when LIGHTING_TO_TRIXEL iterates"
-        );
-        if (shadow != nullptr) {
-            shadow->getTexture()->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-        }
-        // `getReadTexture()` returns whichever ping-pong texture
-        // the GPU light-volume producer last wrote to, so this
-        // sampler always sees the latest dilation result.
-        if (lightVolume != nullptr) {
-            lightVolume->getReadTexture()->bind(5);
-            // Winning-light ID volume (image unit 7, #2318). Bound every tick so
-            // Metal's slot table is populated; only fetched on the has-SPOT
-            // path. Stays resident across the per-axis dispatches below (they
-            // never rebind unit 7), so per-axis canvases get spot cones too.
-            lightVolume->getIdReadTexture()
-                ->bindAsImage(7, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-        }
-        // Entity-id image (unit 6, R/O): the lighting shader reads it ONLY to
-        // recover the fog cut-face flag (bit 29) and force those faces fully lit
-        // (#2124 lit-cross-section follow-up). Bound every tick so Metal's slot
-        // table is populated; the per-axis dispatch below leaves it resident and
-        // its perAxisRoute != 0 skips the read.
-        canvasTextures.getTextureEntityIds()
-            ->bindAsImage(6, TextureAccess::READ_ONLY, TextureFormat::RG32UI);
-        frameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataLightingToTrixel);
-        voxelFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataVoxelToCanvas);
-        sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
-        lightVolumeParamsBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_LightVolumeParams);
-        // Light list (SSBO slot 4) for the spot-cone factor (#2318). SSBO and
-        // image bindings are independent namespaces on both backends, so slot 4
-        // here does not collide with the image-unit-4 sun-shadow texture. Stays
-        // resident across the per-axis dispatches (they never rebind slot 4).
-        lightSourceBuf_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_LightSourceBuffer);
-        // Sun-depth map (slot 28) for the opt-in detached world-receive path
-        // (#1576 P4b-2). Bound every tick — the shader declares the SSBO
-        // unconditionally (Metal kernel arg); only a world-placed detached solid
-        // reads it. Persists across the per-axis lighting dispatches below (they
-        // only rebind the colour/dist/AO/sun-shadow images).
-        if (sunShadowDepthMap_ != nullptr) {
-            sunShadowDepthMap_->bindBase(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_SunShadowDepthMap
+        // Sub-scope (#2281): the main-canvas lighting dispatch only. The braces
+        // bound the TIMER, not the GPU bindings — image/buffer binds are global
+        // state and stay resident for the per-axis dispatches below.
+        {
+            GpuSubStageScope lightingScope("lightingToTrixel");
+            canvasTextures.getTextureColors()
+                ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
+            canvasTextures.getTextureDistances()
+                ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+            ao.getTexture()->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+            // Texture/image unit layout (must match GLSL + MSL):
+            //   3: paletteLUT (sampler2D)
+            //   4: canvasSunShadow (image2D, R/O)
+            //   5: lightVolume (sampler3D)
+            // Metal flattens the sampler and image namespaces into a
+            // shared setTexture slot space, so all three slots must be
+            // unique across both kinds.
+            paletteLUT_->bind(3);
+            // Metal requires every setTexture slot to be populated (it does not
+            // default-bind a null slot). `shadow` is the per-canvas component when
+            // present, else the main canvas's as an inert placeholder — the main canvas
+            // always carries C_CanvasSunShadow when LIGHTING_TO_TRIXEL is registered.
+            IR_ASSERT(
+                shadow != nullptr,
+                "Metal requires slot 4 bound — main canvas must carry C_CanvasSunShadow "
+                "when LIGHTING_TO_TRIXEL iterates"
             );
-        }
+            if (shadow != nullptr) {
+                shadow->getTexture()
+                    ->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+            }
+            // `getReadTexture()` returns whichever ping-pong texture
+            // the GPU light-volume producer last wrote to, so this
+            // sampler always sees the latest dilation result.
+            if (lightVolume != nullptr) {
+                lightVolume->getReadTexture()->bind(5);
+                // Winning-light ID volume (image unit 7, #2318). Bound every tick so
+                // Metal's slot table is populated; only fetched on the has-SPOT
+                // path. Stays resident across the per-axis dispatches below (they
+                // never rebind unit 7), so per-axis canvases get spot cones too.
+                lightVolume->getIdReadTexture()
+                    ->bindAsImage(7, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+            }
+            // Entity-id image (unit 6, R/O): the lighting shader reads it ONLY to
+            // recover the fog cut-face flag (bit 29) and force those faces fully lit
+            // (#2124 lit-cross-section follow-up). Bound every tick so Metal's slot
+            // table is populated; the per-axis dispatch below leaves it resident and
+            // its perAxisRoute != 0 skips the read.
+            canvasTextures.getTextureEntityIds()
+                ->bindAsImage(6, TextureAccess::READ_ONLY, TextureFormat::RG32UI);
+            frameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataLightingToTrixel);
+            voxelFrameDataBuf_->bindBase(
+                BufferTarget::UNIFORM,
+                kBufferIndex_FrameDataVoxelToCanvas
+            );
+            sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
+            lightVolumeParamsBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_LightVolumeParams);
+            // Light list (SSBO slot 4) for the spot-cone factor (#2318). SSBO and
+            // image bindings are independent namespaces on both backends, so slot 4
+            // here does not collide with the image-unit-4 sun-shadow texture. Stays
+            // resident across the per-axis dispatches (they never rebind slot 4).
+            lightSourceBuf_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_LightSourceBuffer);
+            // Sun-depth map (slot 28) for the opt-in detached world-receive path
+            // (#1576 P4b-2). Bound every tick — the shader declares the SSBO
+            // unconditionally (Metal kernel arg); only a world-placed detached solid
+            // reads it. Persists across the per-axis lighting dispatches below (they
+            // only rebind the colour/dist/AO/sun-shadow images).
+            if (sunShadowDepthMap_ != nullptr) {
+                sunShadowDepthMap_->bindBase(
+                    BufferTarget::SHADER_STORAGE,
+                    kBufferIndex_SunShadowDepthMap
+                );
+            }
 
-        const int groupsX = IRMath::divCeil(canvasTextures.size_.x, kLightingToTrixelGroupSize);
-        const int groupsY = IRMath::divCeil(canvasTextures.size_.y, kLightingToTrixelGroupSize);
-        IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            const int groupsX = IRMath::divCeil(canvasTextures.size_.x, kLightingToTrixelGroupSize);
+            const int groupsY = IRMath::divCeil(canvasTextures.size_.y, kLightingToTrixelGroupSize);
+            IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+        }
 
         // Smooth camera Z-yaw (#1311): apply lighting to each per-axis voxel
         // canvas (AO x sun-shadow x face Lambert + shared world light volume) so
@@ -267,56 +280,66 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
         const C_CanvasAOTexture &mainAO,
         const C_CanvasSunShadow &mainShadow
     ) {
-        // perAxisRoute is a boolean route flag on the lighting path (any nonzero
-        // = per-axis canvas); the shader recovers the axis per-pixel from faceId,
-        // NOT from this field — distinct from stage-1's 1/2/3 = X/Y/Z axis selector.
-        const int kPerAxisRoute = 1;
-        voxelFrameDataBuf_
-            ->subData(offsetof(FrameDataVoxelToCanvas, perAxisRoute_), sizeof(int), &kPerAxisRoute);
-        // Recover world-pos with the SAME #1431-capped lattice density the store
-        // wrote (perAxisCellToWorld3D reads voxelRenderOptions.y); restored below.
-        IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
-            voxelFrameDataBuf_,
-            IRPrefab::PerAxisCanvas::subdivisionDensity()
-        );
-        // #2256: dispatch indirectly over only each axis's OCCUPIED cells
-        // (compacted by the STAGE_1 per-axis pre-pass) instead of sweeping the
-        // full worst-case per-axis grid. Each kernel recovers its cell from the
-        // compacted list (slot 25) and reads visibleCount for its 1-D bound guard
-        // from the indirect-args region (slot 26).
-        Buffer *cellCompacted = axes.cellCompacted_.second;
-        Buffer *cellIndirect = axes.cellIndirect_.second;
-        const int regionStride = axes.cellRegionStride_;
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            auto &tex = axes.axes_[axis];
-            tex.colors_.second->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
-            tex.distances_.second->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            tex.ao_.second->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            tex.sunShadow_.second->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            cellCompacted->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellCompacted,
-                static_cast<std::ptrdiff_t>(axis) * regionStride *
-                    static_cast<int>(sizeof(std::uint32_t)),
-                static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
+        // Sub-scope (#2281): the 3 per-axis relight dispatches; the overflow
+        // relight below gets its own row.
+        {
+            GpuSubStageScope perAxisScope("lightingPerAxis");
+            // perAxisRoute is a boolean route flag on the lighting path (any nonzero
+            // = per-axis canvas); the shader recovers the axis per-pixel from faceId,
+            // NOT from this field — distinct from stage-1's 1/2/3 = X/Y/Z axis selector.
+            const int kPerAxisRoute = 1;
+            voxelFrameDataBuf_->subData(
+                offsetof(FrameDataVoxelToCanvas, perAxisRoute_),
+                sizeof(int),
+                &kPerAxisRoute
             );
-            cellIndirect->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                kPerAxisCellIndirectStrideBytes
+            // Recover world-pos with the SAME #1431-capped lattice density the store
+            // wrote (perAxisCellToWorld3D reads voxelRenderOptions.y); restored below.
+            IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
+                voxelFrameDataBuf_,
+                IRPrefab::PerAxisCanvas::subdivisionDensity()
             );
-            IRRender::device()->dispatchComputeIndirect(
-                cellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
-                    kPerAxisCellDispatchArgsOffsetBytes
-            );
+            // #2256: dispatch indirectly over only each axis's OCCUPIED cells
+            // (compacted by the STAGE_1 per-axis pre-pass) instead of sweeping the
+            // full worst-case per-axis grid. Each kernel recovers its cell from the
+            // compacted list (slot 25) and reads visibleCount for its 1-D bound guard
+            // from the indirect-args region (slot 26).
+            Buffer *cellCompacted = axes.cellCompacted_.second;
+            Buffer *cellIndirect = axes.cellIndirect_.second;
+            const int regionStride = axes.cellRegionStride_;
+            for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                auto &tex = axes.axes_[axis];
+                tex.colors_.second->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
+                tex.distances_.second
+                    ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                tex.ao_.second->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                tex.sunShadow_.second
+                    ->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                cellCompacted->bindRange(
+                    BufferTarget::SHADER_STORAGE,
+                    kBufferIndex_PerAxisCellCompacted,
+                    static_cast<std::ptrdiff_t>(axis) * regionStride *
+                        static_cast<int>(sizeof(std::uint32_t)),
+                    static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
+                );
+                cellIndirect->bindRange(
+                    BufferTarget::SHADER_STORAGE,
+                    kBufferIndex_PerAxisCellIndirect,
+                    static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
+                    kPerAxisCellIndirectStrideBytes
+                );
+                IRRender::device()->dispatchComputeIndirect(
+                    cellIndirect,
+                    static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
+                        kPerAxisCellDispatchArgsOffsetBytes
+                );
+            }
+            // One barrier after the 3 independent per-axis dispatches (each axis
+            // writes its own colour image texture in place — disjoint outputs, so
+            // dispatch order doesn't matter) so they overlap on the GPU instead of
+            // serializing per axis (#1311).
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
         }
-        // One barrier after the 3 independent per-axis dispatches (each axis
-        // writes its own colour image texture in place — disjoint outputs, so
-        // dispatch order doesn't matter) so they overlap on the GPU instead of
-        // serializing per axis (#1311).
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
         // #2334: relight the overflow entries the C1 lane appended albedo-only,
         // at their recovered world pos, while the sun-depth map (slot 28) + light
         // volume are still bound from the cell pass above. Switches the compute
@@ -381,6 +404,10 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
             axes.winnerIds_.second == nullptr) {
             return;
         }
+        // Sub-scope (#2281) — opened after the early-return so the row only
+        // samples when the dispatch actually runs (a scope with no enclosed
+        // encoder never resolves its pair).
+        GpuSubStageScope overflowScope("lightingOverflow");
         overflowLightingProgram_->use();
         // The kernel indexes entries + the ctrl-block count via overflowScratchLayout
         // read from the voxel-frame UBO (slot 7). Only VOXEL_TO_TRIXEL_STAGE_1 sets
@@ -590,7 +617,8 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
         // ahead of LIGHTING_TO_TRIXEL); safe to resolve here (#2318).
         p->lightSourceBuf_ = IRRender::getNamedResource<Buffer>("LightSourceBuffer");
         p->paletteLUT_ = IRRender::getNamedResource<Texture2D>("PaletteLUT_Nearest");
-        IRRender::tagGpuStage(systemId, "lightingToTrixel");
+        // NOT observer-tagged: the tick owns GpuSubStageScopes (#2281), which
+        // reuse the observer's timestamp attachment slot.
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -79,11 +79,12 @@ template <> struct System<PERF_STATS_OVERLAY> {
     // slot per registry entry — adding a stage to the registry surfaces here
     // automatically with no edit to this system.
     static_assert(
-        std::tuple_size_v<std::remove_reference_t<decltype(IRRender::gpuStageRegistry())>> == 20,
+        std::tuple_size_v<std::remove_reference_t<decltype(IRRender::gpuStageRegistry())>> ==
+            IRRender::kGpuStageCount,
         "EMA arrays must be resized to match gpuStageRegistry size"
     );
-    std::array<double, 20> gpuStageMsEma_{};
-    std::array<double, 20> cpuStageMsEma_{};
+    std::array<double, IRRender::kGpuStageCount> gpuStageMsEma_{};
+    std::array<double, IRRender::kGpuStageCount> cpuStageMsEma_{};
 
     // Refresh throttle counter and the last-built text. Reused on
     // non-refresh frames to keep the displayed digits stable.
@@ -188,6 +189,22 @@ template <> struct System<PERF_STATS_OVERLAY> {
             return "VOX-STAGE1";
         if (name == "voxelStage2")
             return "VOX-STAGE2";
+        if (name == "voxelPerAxisStore")
+            return "PA-STORE";
+        if (name == "voxelPerAxisOverflow")
+            return "PA-OVERFLOW";
+        if (name == "voxelPerAxisFinalize")
+            return "PA-FINALIZE";
+        if (name == "perAxisCellCompact")
+            return "PA-COMPACT";
+        if (name == "computeVoxelAoPerAxis")
+            return "PA-AO";
+        if (name == "lightingPerAxis")
+            return "PA-LIGHTING";
+        if (name == "lightingOverflow")
+            return "PA-OVF-LIGHT";
+        if (name == "perAxisScatter")
+            return "PA-SCATTER";
         if (name == "shapeCompact")
             return "SHP-COMPACT";
         if (name == "shapePass0")

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -20,6 +20,8 @@
 #include <irreden/common/components/component_name.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
+#include <irreden/render/gpu_substage_timing.hpp>
+#include <irreden/ir_profile.hpp>
 
 #include <cstdlib>
 
@@ -79,6 +81,8 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         const C_TriangleCanvasTextures &triangleCanvasTextures,
         const C_Name &
     ) {
+        // CPU histogram bracket — this system is not observer-tagged (#2281).
+        IR_PROFILE_SCOPE("trixelToFb");
         auto &framebuffer = IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
         auto &frameData = IREntity::getComponent<C_FrameDataTrixelToFramebuffer>("mainFramebuffer");
         vec2 framebufferResolution = vec2(framebuffer.getResolutionPlusBuffer());
@@ -176,14 +180,19 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
 
         frameData.updateFrameData(frameDataBuf_);
 
-        triangleCanvasTextures.bind(0, 1, 2);
-        IRRender::device()->setPolygonMode(PolygonMode::FILL);
-        IRRender::device()->drawElements(
-            DrawMode::TRIANGLES,
-            IRShapes2D::kQuadIndicesLength,
-            IndexType::UNSIGNED_SHORT
-        );
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+        {
+            // Sub-scope (#2281): the single-canvas gather draw only — the
+            // per-axis scatter above owns its own row (perAxisScatter).
+            GpuSubStageScope gatherScope("trixelToFb");
+            triangleCanvasTextures.bind(0, 1, 2);
+            IRRender::device()->setPolygonMode(PolygonMode::FILL);
+            IRRender::device()->drawElements(
+                DrawMode::TRIANGLES,
+                IRShapes2D::kQuadIndicesLength,
+                IndexType::UNSIGNED_SHORT
+            );
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+        }
     }
 
     // Smooth camera Z-yaw forward-scatter composite (Option 4, T3 / #1310;
@@ -324,6 +333,10 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         frameData.frameData_.scatterDebugMode_ = static_cast<int>(IRRender::getDebugOverlay());
         frameData.updateFrameData(frameDataBuf_);
 
+        // Sub-scope (#2281): the 3 per-axis instanced scatter draws + the
+        // overflow-entry draw — the rotating-only composite work, separated
+        // from the fall-through gather's trixelToFb row.
+        GpuSubStageScope scatterScope("perAxisScatter");
         scatterProgram_->use();
         IRRender::device()->setPolygonMode(PolygonMode::FILL);
         // #1961: instance over only the compacted occupied cells (filled by the
@@ -489,7 +502,8 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         sys->scatterProgram_ = IRRender::getNamedResource<ShaderProgram>("PerAxisScatterProgram");
         sys->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAO");
         sys->overflowDrawDisabled_ = std::getenv("IR_PERAXIS_OVERFLOW_DISABLE") != nullptr;
-        IRRender::tagGpuStage(id, "trixelToFb");
+        // NOT observer-tagged: the tick owns GpuSubStageScopes (#2281), which
+        // reuse the observer's timestamp attachment slot.
         return id;
     }
 

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -2,6 +2,7 @@
 #define SYSTEM_TRIXEL_TO_FRAMEBUFFER_H
 
 #include <irreden/ir_render.hpp>
+#include <irreden/ir_system.hpp>
 #include <irreden/ir_constants.hpp>
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_entity.hpp>
@@ -19,7 +20,6 @@
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/common/components/component_name.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
-#include <irreden/render/gpu_stage_timing_observer.hpp>
 #include <irreden/render/gpu_substage_timing.hpp>
 #include <irreden/ir_profile.hpp>
 

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -766,120 +766,154 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // never overlaps the mask/append reads.
         //
         // Phase A — clears + cardinal stores (mode 0).
-        stage1Program_->use();
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            auto &tex = axes.axes_[axis];
-            Texture2D *colors = tex.colors_.second;
-            Texture2D *distances = tex.distances_.second;
-            Texture2D *entityIds = tex.entityIds_.second;
-
-            // Bind the distance image first so its Metal atomic-scratch buffer
-            // exists before clearTexImage mirrors the clear value into it (a
-            // freshly allocated scratch is zero-initialised, which would
-            // otherwise reject every depth-matched color write on the first
-            // rotating frame).
-            distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->clearTexImage(distances, 0, &kDistanceClear);
-            colors->clear(PixelDataFormat::RGBA, PixelDataType::UNSIGNED_BYTE, &kColorClear[0]);
-            entityIds->clear(PixelDataFormat::RG_INTEGER, PixelDataType::UINT32, &kEntityIdClear);
-
-            uploadAxisFrameData(axis, 0);
-            const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
-
-            // STAGE_1 reads the fog grid (slot 0) + observers (binding 27) for its
-            // per-voxel fog clip (#2102) + cut-face test (#2125). The per-axis
-            // rotation route now runs that clip/cut too (#2128), so bind the REAL
-            // fog grid (or the placeholder on a non-fog canvas — short-circuits,
-            // byte-identical) + the live observer buffer here, not a no-op
-            // placeholder. Without the live grid a rotating boundary object would
-            // render its hidden half as black hard-fog instead of clipping + cut.
-            fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
-            distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->dispatchComputeIndirect(perAxisIndirectBuf_, indirectOffsetBytes);
-        }
-        // All three distance stores settled — read below by the mode-3
-        // cardinal-winner test, the elections, and stage 2's depth re-test.
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-        // Phase B — view mask (mode 2), all three axis routes into the SHARED
-        // mask region (view visibility competes across axes). Same geometry,
-        // fog early-outs, and binds as the store dispatch.
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            uploadAxisFrameData(axis, 2);
-            const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
-            fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
-            axes.axes_[axis]
-                .distances_.second->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->dispatchComputeIndirect(perAxisIndirectBuf_, indirectOffsetBytes);
-        }
-        // Mask writes must settle before any mode-3 compare.
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-
-        // Phase C — overflow append (mode 3): faces that win (tie) their view
-        // cell but lost their cardinal store cell append scatter entries.
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            uploadAxisFrameData(axis, 3);
-            const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
-            fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
-            axes.axes_[axis]
-                .distances_.second->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->dispatchComputeIndirect(perAxisIndirectBuf_, indirectOffsetBytes);
-        }
-        // Entry + instanceCount writes feed the overflow indirect draw in
-        // TRIXEL_TO_FRAMEBUFFER — barrier both the storage reads and the
-        // indirect-command source (same pairing as compactPerAxisCells).
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-        IRRender::device()->memoryBarrier(BarrierType::COMMAND);
-
-        // Phase D — #2255 winner election (mode 1) + stage 2, per axis. The
-        // winner scratch (region 0) is serially reused across axes: refill to
-        // the no-winner sentinel, elect this axis's winners, then let stage 2's
-        // guard admit exactly one tied face per cell — byte-identical semantics
-        // to the pre-#2333 interleaved loop (the election ran after this axis's
-        // store then too; the mask/append phases in between touch only the
-        // other scratch regions).
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            auto &tex = axes.axes_[axis];
-            Texture2D *colors = tex.colors_.second;
-            Texture2D *distances = tex.distances_.second;
-            Texture2D *entityIds = tex.entityIds_.second;
-
-            // #2255: reset the winner scratch to the no-winner sentinel
-            // (0xFFFFFFFF — a repeating byte, so both backends fill GPU-side)
-            // before this axis's winner-resolve dispatch below.
-            IRRender::device()->fillBuffer(axes.winnerIds_.second, winnerScratchBytes, 0xFFu);
-
+        // Sub-scope (#2281): each phase group below owns its GPU row so the
+        // rotating burst is attributable per phase (the braces bound the
+        // timers, not the GPU bindings).
+        {
+            GpuSubStageScope storeScope("voxelPerAxisStore");
             stage1Program_->use();
-            uploadAxisFrameData(axis, 1);
-            const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
-            fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
-            distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            IRRender::device()->dispatchComputeIndirect(perAxisIndirectBuf_, indirectOffsetBytes);
-            // The winner SSBO writes must land before stage 2's guard reads.
-            IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-            frameData_.resolveMode_ = 0;
-            frameDataBuf_->subData(
-                offsetof(FrameDataVoxelToCanvas, resolveMode_),
-                sizeof(int),
-                &frameData_.resolveMode_
-            );
+            for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                auto &tex = axes.axes_[axis];
+                Texture2D *colors = tex.colors_.second;
+                Texture2D *distances = tex.distances_.second;
+                Texture2D *entityIds = tex.entityIds_.second;
 
-            stage2Program_->use();
-            colors->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-            distances->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
-            entityIds->bindAsImage(2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI);
-            // STAGE_2 re-evaluates STAGE_1's cut-face predicate (#2125/#2128) so its
-            // colour tap lands on the same faces. Slot 0 is the colour output here,
-            // so the fog grid binds on slot 3 (slots 1/2 = distance + entity-id).
-            // Same real-grid-or-placeholder choice as STAGE_1 above.
-            fogTex->bindAsImage(3, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-            fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
-            IRRender::device()->dispatchComputeIndirect(perAxisIndirectBuf_, indirectOffsetBytes);
+                // Bind the distance image first so its Metal atomic-scratch buffer
+                // exists before clearTexImage mirrors the clear value into it (a
+                // freshly allocated scratch is zero-initialised, which would
+                // otherwise reject every depth-matched color write on the first
+                // rotating frame).
+                distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                IRRender::device()->clearTexImage(distances, 0, &kDistanceClear);
+                colors->clear(PixelDataFormat::RGBA, PixelDataType::UNSIGNED_BYTE, &kColorClear[0]);
+                entityIds
+                    ->clear(PixelDataFormat::RG_INTEGER, PixelDataType::UINT32, &kEntityIdClear);
+
+                uploadAxisFrameData(axis, 0);
+                const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
+
+                // STAGE_1 reads the fog grid (slot 0) + observers (binding 27) for its
+                // per-voxel fog clip (#2102) + cut-face test (#2125). The per-axis
+                // rotation route now runs that clip/cut too (#2128), so bind the REAL
+                // fog grid (or the placeholder on a non-fog canvas — short-circuits,
+                // byte-identical) + the live observer buffer here, not a no-op
+                // placeholder. Without the live grid a rotating boundary object would
+                // render its hidden half as black hard-fog instead of clipping + cut.
+                fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
+                distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                IRRender::device()->dispatchComputeIndirect(
+                    perAxisIndirectBuf_,
+                    indirectOffsetBytes
+                );
+            }
+            // All three distance stores settled — read below by the mode-3
+            // cardinal-winner test, the elections, and stage 2's depth re-test.
             IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+        }
+
+        {
+            GpuSubStageScope overflowScope("voxelPerAxisOverflow");
+            // Phase B — view mask (mode 2), all three axis routes into the SHARED
+            // mask region (view visibility competes across axes). Same geometry,
+            // fog early-outs, and binds as the store dispatch.
+            for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                uploadAxisFrameData(axis, 2);
+                const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
+                fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
+                axes.axes_[axis].distances_.second->bindAsImage(
+                    1,
+                    TextureAccess::READ_ONLY,
+                    TextureFormat::R32I
+                );
+                IRRender::device()->dispatchComputeIndirect(
+                    perAxisIndirectBuf_,
+                    indirectOffsetBytes
+                );
+            }
+            // Mask writes must settle before any mode-3 compare.
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+
+            // Phase C — overflow append (mode 3): faces that win (tie) their view
+            // cell but lost their cardinal store cell append scatter entries.
+            for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                uploadAxisFrameData(axis, 3);
+                const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
+                fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
+                axes.axes_[axis].distances_.second->bindAsImage(
+                    1,
+                    TextureAccess::READ_ONLY,
+                    TextureFormat::R32I
+                );
+                IRRender::device()->dispatchComputeIndirect(
+                    perAxisIndirectBuf_,
+                    indirectOffsetBytes
+                );
+            }
+            // Entry + instanceCount writes feed the overflow indirect draw in
+            // TRIXEL_TO_FRAMEBUFFER — barrier both the storage reads and the
+            // indirect-command source (same pairing as compactPerAxisCells).
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+            IRRender::device()->memoryBarrier(BarrierType::COMMAND);
+        }
+
+        {
+            GpuSubStageScope finalizeScope("voxelPerAxisFinalize");
+            // Phase D — #2255 winner election (mode 1) + stage 2, per axis. The
+            // winner scratch (region 0) is serially reused across axes: refill to
+            // the no-winner sentinel, elect this axis's winners, then let stage 2's
+            // guard admit exactly one tied face per cell — byte-identical semantics
+            // to the pre-#2333 interleaved loop (the election ran after this axis's
+            // store then too; the mask/append phases in between touch only the
+            // other scratch regions).
+            for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                auto &tex = axes.axes_[axis];
+                Texture2D *colors = tex.colors_.second;
+                Texture2D *distances = tex.distances_.second;
+                Texture2D *entityIds = tex.entityIds_.second;
+
+                // #2255: reset the winner scratch to the no-winner sentinel
+                // (0xFFFFFFFF — a repeating byte, so both backends fill GPU-side)
+                // before this axis's winner-resolve dispatch below.
+                IRRender::device()->fillBuffer(axes.winnerIds_.second, winnerScratchBytes, 0xFFu);
+
+                stage1Program_->use();
+                uploadAxisFrameData(axis, 1);
+                const std::ptrdiff_t indirectOffsetBytes = bindAxisListRegions(axis);
+                fogTex->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
+                distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                IRRender::device()->dispatchComputeIndirect(
+                    perAxisIndirectBuf_,
+                    indirectOffsetBytes
+                );
+                // The winner SSBO writes must land before stage 2's guard reads.
+                IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+                frameData_.resolveMode_ = 0;
+                frameDataBuf_->subData(
+                    offsetof(FrameDataVoxelToCanvas, resolveMode_),
+                    sizeof(int),
+                    &frameData_.resolveMode_
+                );
+
+                stage2Program_->use();
+                colors->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+                distances->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
+                entityIds->bindAsImage(2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI);
+                // STAGE_2 re-evaluates STAGE_1's cut-face predicate (#2125/#2128) so its
+                // colour tap lands on the same faces. Slot 0 is the colour output here,
+                // so the fog grid binds on slot 3 (slots 1/2 = distance + entity-id).
+                // Same real-grid-or-placeholder choice as STAGE_1 above.
+                fogTex->bindAsImage(3, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                fogObserverBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FogObservers);
+                IRRender::device()->dispatchComputeIndirect(
+                    perAxisIndirectBuf_,
+                    indirectOffsetBytes
+                );
+                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            }
         }
 
         // Restore the full compact buffers to 25/26 so the next canvas's compact +
@@ -911,6 +945,9 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         if (cellCompacted == nullptr || cellIndirect == nullptr) {
             return;
         }
+        // Sub-scope (#2281) — after the early-return so the row only samples
+        // when the dispatches actually run.
+        GpuSubStageScope compactScope("perAxisCellCompact");
         const ivec2 axisSize = axes.size_;
         const int regionStride = axes.cellRegionStride_;
 


### PR DESCRIPTION
## Summary
- **#2281 Phase 2 — the rotating per-axis GPU burst is now attributable per dispatch group.** Eight new `GpuSubStageScope` registry rows (`voxelPerAxisStore`, `voxelPerAxisOverflow`, `voxelPerAxisFinalize`, `perAxisCellCompact`, `computeVoxelAoPerAxis`, `lightingPerAxis`, `lightingOverflow`, `perAxisScatter`) bracket every rotating-only dispatch group, following #2280's encoder-boundary mechanism exactly.
- `COMPUTE_VOXEL_AO`, `LIGHTING_TO_TRIXEL`, and `TRIXEL_TO_FRAMEBUFFER` are untagged from the per-system observer (sub-scopes reuse its attachment slot) and their rows narrowed to the main-canvas dispatch only — the same precedent #2280 set when it narrowed `voxelStage1`. CPU histogram continuity via `IR_PROFILE_SCOPE` brackets.
- Every per-axis row reads 0.0 at cardinal (the canvases are released), so cardinal-vs-yaw row deltas ARE the burst attribution. Overlay gets ≤13-char labels for the new rows; Lua `getPassTimings` and the shutdown report pick them up generically.
- **Phase-2 table + findings appended to `docs/design/per-axis-yaw-gpu-attribution.md`** and posted on #2281: the burst is the stage-1 rotating kernel family (store 6.9/5.3 ms + overflow mask/append 6.4/3.3 ms + finalize 5.6/2.9 ms ≈ 85% of the attributable delta on voxel_set/wave); per-axis AO+lighting are ~0.05 ms; the scatter is a bounded ~2.4 ms. The same face list is swept **five times per axis** through one runtime-`resolveMode`-branched kernel — that is the lever surface, and it re-enters the design gate per the plan (no lever in this PR).

## Verification
- [x] Cardinal `IRShapeDebug` full shot table **byte-identical** pre/post instrumentation (28/28, max_delta 0; timers are pure readback) — the plan's acceptance criterion.
- [x] Measurement matrix: 2 scenes × {cardinal, yaw 0.35} × 3 repeats, `--auto-profile 300`; spreads ≪ deltas (tables in the design doc).
- [x] `fleet-build` clean; `format-changed` applied; all runs `ir-run: RESULT=CLEAN`.
- [ ] Linux/GL smoke (timers use the shared device timestamp machinery; GL path untested on this host).

## Notes for reviewer
- The `bakeSunShadowMap` +13.8 ms yaw reading in the table is an overlap artifact, refuted by the `--no-sun-shadows` probe (yaw frame moves only −1.3 ms) — documented in the doc's footnote, not a regression.
- Side finding (documented, not changed here): perf_grid registers no `RESOLVE_PER_AXIS_SCREEN_DEPTH` while five other demos do, so the perf demo underpays the yaw path vs real creations.

Closes #2281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6v8rYcLosaHJghwGqBCRp
