### PR TITLE
editor: F-1.6 Phase 0 probe — world→screen click mapping (#766)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -322,6 +322,87 @@ constexpr IRVideo::GuiInputEvent kPickVoxelEvents[] = {
     {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(800, 450)},
 };
 
+// --- Phase 0 mechanism probes (#766) --------------------------------------
+// De-risk the auto-authoring premise before building session infrastructure:
+// prove keyboard→command dispatch, world→screen click mapping, and measure the
+// A/D binding overload — all through the live GUI harness on the seed scene.
+// These shots append after the stable framings so existing labels and the
+// screen→world regression baseline (kPickVoxelShotIndex) stay untouched.
+
+// Probe 1 — keyboard→command dispatch: hold Ctrl, tap S, release. The editor's
+// Ctrl+S handler writes data/editor_scene/scene_frame_0.vxs; the runner checks
+// the file exists post-run (no screen mapping needed — the lowest-risk probe).
+// Ctrl leads S by two frames so the modifier is held when the S press drains.
+constexpr IRVideo::GuiInputEvent kProbeSaveEvents[] = {
+    {0,
+     IRVideo::GuiInputEvent::Type::PRESS,
+     IRMath::ivec2(0),
+     IRMath::vec2(0.0f),
+     IRInput::kKeyButtonLeftControl},
+    {2,
+     IRVideo::GuiInputEvent::Type::PRESS,
+     IRMath::ivec2(0),
+     IRMath::vec2(0.0f),
+     IRInput::kKeyButtonS},
+    {3,
+     IRVideo::GuiInputEvent::Type::RELEASE,
+     IRMath::ivec2(0),
+     IRMath::vec2(0.0f),
+     IRInput::kKeyButtonS},
+    {4,
+     IRVideo::GuiInputEvent::Type::RELEASE,
+     IRMath::ivec2(0),
+     IRMath::vec2(0.0f),
+     IRInput::kKeyButtonLeftControl},
+};
+
+// Probe 4 — A/D binding overload: tap A. The plain-PRESSED A binding both starts
+// a camera-left move AND adds an animation frame (no modifier guard, main.cpp
+// ~2130 vs ~2290) — one press fires both. The runner greps the "Added blank
+// frame" log to confirm the overload so later sessions re-establish the camera
+// after any frame op.
+constexpr IRVideo::GuiInputEvent kProbeADEvents[] = {
+    {0,
+     IRVideo::GuiInputEvent::Type::PRESS,
+     IRMath::ivec2(0),
+     IRMath::vec2(0.0f),
+     IRInput::kKeyButtonA},
+    {1,
+     IRVideo::GuiInputEvent::Type::RELEASE,
+     IRMath::ivec2(0),
+     IRMath::vec2(0.0f),
+     IRInput::kKeyButtonA},
+};
+
+// Probe 2 (the gate) — world→screen mapping accuracy. Eight central seed
+// ground-plane cells (local z == size-1); each probe shot moves the cursor to
+// the pixel IRRender::worldPos3DToMouseScreenPx computes for the cell centre,
+// then a PICKS_VOXEL assertion checks the ray hit that world voxel. Cells stay
+// near the plane centre so all project on-screen at zoom 1.0. The move pixel is
+// filled at shot-run time in onGuiAssertFrame (needs the shot's live camera
+// state), so g_probeMapMoves is mutable, not constexpr.
+constexpr int kProbeMapCount = 8;
+constexpr IRMath::ivec3 kProbeMapLocalCells[kProbeMapCount] = {
+    {4, 4, 15},
+    {11, 11, 15},
+    {4, 11, 15},
+    {11, 4, 15},
+    {7, 7, 15},
+    {8, 8, 15},
+    {5, 9, 15},
+    {9, 5, 15},
+};
+IRVideo::GuiInputEvent g_probeMapMoves[kProbeMapCount] = {
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
+};
+
 // GUI-test shot table covering stable render framings plus the scripted-click
 // shots. Superset of the previous kShots[] — render-verify labels still match.
 // kGuiAssertShotIndex / kPickVoxelShotIndex select the assertion-bearing shots.
@@ -332,10 +413,33 @@ constexpr IRVideo::GuiTestShot kGuiTestShots[] = {
     {{1.5f, IRMath::vec2(0.0f), 0.0f, "editor_zoom_in"}, nullptr, 0},
     {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_gui_assert"}, kGuiAssertEvents, 3},
     {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_pick_voxel"}, kPickVoxelEvents, 1},
+    // Phase 0 probes (#766), appended after the stable shots so their indices
+    // stay fixed. The eight mapping-accuracy shots come first (clean read-only
+    // picks), then the Ctrl+S dispatch and A/D-overload shots (both mutate state).
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_0"}, &g_probeMapMoves[0], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_1"}, &g_probeMapMoves[1], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_2"}, &g_probeMapMoves[2], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_3"}, &g_probeMapMoves[3], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_4"}, &g_probeMapMoves[4], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_5"}, &g_probeMapMoves[5], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_6"}, &g_probeMapMoves[6], 1},
+    {{2.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_map_7"}, &g_probeMapMoves[7], 1},
+    {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_save"}, kProbeSaveEvents, 4},
+    {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_probe_ad"}, kProbeADEvents, 2},
 };
 constexpr int kNumGuiTestShots = static_cast<int>(sizeof(kGuiTestShots) / sizeof(kGuiTestShots[0]));
 constexpr int kGuiAssertShotIndex = 4;
 constexpr int kPickVoxelShotIndex = 5;
+// Phase 0 probe shot indices (#766). Map shots occupy [start, start+count);
+// the dispatch and overload shots follow. Derived from kPickVoxelShotIndex so
+// they track any reordering of the stable shots.
+constexpr int kProbeMapShotStart = kPickVoxelShotIndex + 1;
+constexpr int kProbeSaveShotIndex = kProbeMapShotStart + kProbeMapCount;
+constexpr int kProbeADShotIndex = kProbeSaveShotIndex + 1;
+static_assert(
+    kProbeADShotIndex + 1 == kNumGuiTestShots,
+    "Phase 0 probe shots (#766) must be the final kGuiTestShots entries"
+);
 
 // GUI-test assertion tables (P3, #1796). Filled in initEntities once the widget
 // entities exist — assertions reference runtime EntityIds, so unlike the shot
@@ -351,6 +455,17 @@ std::vector<IRPrefab::GuiTest::Assertion> g_shotAssertions[kNumGuiTestShots];
 void onGuiAssertFrame(int shotIndex, bool isCaptureFrame) {
     if (shotIndex < 0 || shotIndex >= kNumGuiTestShots)
         return;
+    // Phase 0 probe 2 (#766): fill this probe-map shot's cursor move with the
+    // pixel worldPos3DToMouseScreenPx computes for the target cell at the shot's
+    // live camera state. This runs before the harness's event phase on the same
+    // tick, so the frame-0 MOVE injects the freshly-computed pixel; the write is
+    // idempotent across the shot's frames.
+    if (shotIndex >= kProbeMapShotStart && shotIndex < kProbeMapShotStart + kProbeMapCount) {
+        const int cellIndex = shotIndex - kProbeMapShotStart;
+        const IRMath::vec3 worldCenter =
+            kEditableSceneOrigin + IRMath::vec3(kProbeMapLocalCells[cellIndex]);
+        g_probeMapMoves[cellIndex].screenPx_ = IRRender::worldPos3DToMouseScreenPx(worldCenter);
+    }
     const auto &assertions = g_shotAssertions[shotIndex];
     if (assertions.empty())
         return; // shots without assertions (idle / zoom framings) skip latch+eval
@@ -3275,4 +3390,16 @@ void initEntities() {
     IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kPickVoxelShotIndex] = {
         IRPrefab::GuiTest::picksVoxel(kScenePickExpected, "scene_pick"),
     };
+    // Phase 0 probe 2 (#766): each probe-map shot asserts the ray landed on the
+    // target cell's iso COLUMN (not the exact voxel) — mapping accuracy is a 2D
+    // screen-projection property, and the seed scene's rig geometry can occlude
+    // the ground cell along the aimed column. Target = scene origin + local cell
+    // (integers, so exact). onGuiAssertFrame supplies the matching cursor pixel.
+    for (int i = 0; i < IRVoxelEditor::kProbeMapCount; ++i) {
+        const ivec3 target =
+            ivec3(IRVoxelEditor::kEditableSceneOrigin) + IRVoxelEditor::kProbeMapLocalCells[i];
+        IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kProbeMapShotStart + i] = {
+            IRPrefab::GuiTest::picksIsoColumn(target, "probe_map"),
+        };
+    }
 }

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -69,34 +69,81 @@ was confirmed empirically against current `origin/master`:
 
 ---
 
-## Phase 0 mechanism probe — status: NOT YET RUN (next slice)
+## Phase 0 mechanism probe — status: RUN, GATE PASSED (macOS/Metal)
 
-Phase 0 (per the plan) extends the editor shot table with four probes that gate
-the rest of the task. Groundwork located this slice, to be implemented next:
+Phase 0 added probe shots to the editor GUI-test shot table (`editor_probe_*`,
+appended after the stable framings so existing labels + the `editor_pick_voxel`
+regression baseline are untouched). **Result: the auto-authoring premise holds.**
+`gui-verify.py IRVoxelEditor` → `13/13 assertions passed`, exit 0, on
+macOS/Metal. Findings per probe:
 
-1. **Keyboard→command dispatch** — inject Ctrl+S; assert
-   `data/editor_scene/scene_frame_0.vxs` exists post-run (runner-side file check).
-   *Lowest risk; no coordinate mapping needed.*
-2. **World→screen mapping accuracy** — the crux. Compute screen px for ~8
-   ground-plane cells' top faces at one fixed zoom/yaw → `MOVE` + `PICKS_VOXEL`
-   each; expect 8/8 PASS. Reference forward-projection:
-   `worldToScreen(vec3)` at
-   `engine/prefabs/irreden/render/systems/system_debug_overlay.hpp:181`
-   (uses `pos3DtoPos2DIso` + `IRRender::getCameraPosition2DIso()` +
-   `getTriangleStepSizeScreen()` + viewport). **Gotcha:** GUI panels render on
-   the full-resolution GUI canvas (`setGuiCanvasFullResolution`, gui_scale=2)
-   while the scene lives in game-canvas space — the `GuiInputEvent.screenPx_`
-   window coordinate and the `worldToScreen` game-canvas output are *not* the
-   same space; the mapping must reconcile them. The seed ground plane is at
-   `z == size_.z - 1` (`main.cpp` `fillPlane(2, set.size_.z-1, …)`), the
-   editable set is 16³ by default at `kEditableSceneOrigin`.
-3. **Drag stroke** — `PRESS` + per-frame `MOVE`s + `RELEASE` → box-fill fires;
-   verify by hovering a newly placed voxel (`PICKS_VOXEL` occupancy proxy).
-4. **A/D overload measurement** — inject `A`; expect frame count 2 and record the
-   camera delta (A/D frame-add/duplicate share the WASD camera bindings, no
-   modifier guard — `main.cpp:2130-2155` vs `2290,2326`).
+### P0-1 — keyboard→command dispatch (PASS)
+Injected Ctrl+S (`PRESS LeftControl`, `PRESS S`, releases; Ctrl leads S by two
+frames so the modifier is held when the S press drains). The editor logged
+`Scene saved to data/editor_scene/scene` and wrote `scene_frame_0.vxs` (~52 KB).
+Scripted keyboard **and modifier chords** drive the real command dispatch — the
+runner clears stale `.vxs` pre-run and file-checks post-run.
 
-**Bail path (opus judgment).** If probe (2) cannot hit target cells reliably at
-*any* zoom (GUI-canvas scaling / rounding), STOP — post the measurements on #766
-and design-block. Do **not** fall back to hand-tuned pixel constants for five
-entities; that defeats the "author by really using the editor" premise.
+### P0-2 — world→screen mapping accuracy (PASS — the gate)
+This is the crux, and it passed 8/8. Key results:
+
+- **The mapping is `IRRender::worldPos3DToMouseScreenPx(vec3)` (new, this PR),
+  the exact inverse of the picking chain `mouseWorldPos3DAtIsoDepth`** — NOT the
+  debug-overlay `worldToScreen` the groundwork cited. `worldToScreen` omits the
+  letterbox offset, the framebuffer buffer-correction (`kSizeExtraPixelBuffer`),
+  and the canvas-centre reference term that the *picking* read-chain applies, so
+  it is off by a constant. The inverse reuses the picking chain's own live
+  getters (zoom, iso offset, main-canvas size, step size, letterbox, buffer),
+  so screen↔world stays consistent across backends and camera state with **zero
+  hand-tuned constants** (the bail-path anti-pattern is avoided).
+- **`GuiInputEvent.screenPx_` is window pixels, top-left origin, and reads back
+  byte-identically** (`injPx == cursor`) — no retina/DPI scaling confound on
+  the injected cursor. The GUI-canvas full-resolution setting only affects
+  widget hitboxes; scene picking goes through the output-view/game-canvas chain,
+  which `worldPos3DToMouseScreenPx` mirrors.
+- **Vertical picking needs zoom ≥ 2.** At zoom 1.0 the iso step is `(2,1)` px
+  per iso unit — only **1 px per iso-Y unit**, so the cell-centre half-offset
+  is below integer-pixel resolution and `floor()` tips to the neighbouring iso
+  column (a 1-cell miss). At zoom 2.0 the step doubles to `(4,2)` and all 8
+  cells land on the exact target column. The probe shots therefore run at zoom
+  2.0. **Authoring implication:** the SessionBuilder must author at zoom ≥ 2 for
+  reliable per-cell vertical aim (or accept ±1-cell tolerance and aim at exposed
+  faces, where placement-adjacent absorbs it).
+- **Mapping accuracy is an iso-*column* property, asserted with a new
+  `PICKS_ISO_COLUMN` GuiTest kind (this PR).** The seed scene is NOT just the
+  ground plane: it also carries the skeleton rig voxel set (`31×3×3`) + joints,
+  which `VOXEL_PICKING` walks as active geometry and which occlude the ground
+  plane along many columns. So a click aimed at a ground cell correctly hits its
+  iso column but returns whatever voxel is front-most on it — not necessarily
+  the ground cell. Depth/occlusion is scene state, not a mapping fact, so the
+  honest test compares iso projections (`pos3DtoPos2DIso(hit) ==
+  pos3DtoPos2DIso(target)`). Every probe pick differed from its target by an
+  exact multiple of the `(1,1,1)` view-ray direction (iso-invariant) —
+  conclusive proof the mapping hits the intended column. In real authoring the
+  builder aims at *exposed* faces (front-most by construction), where the
+  stricter `PICKS_VOXEL` will be exact.
+
+### P0-3 — drag stroke — DEFERRED to the session-infrastructure slice
+The press→per-frame-MOVE→release → box-fill path is verifiable with the same
+harness, but a placement-verify depends on box-fill's placement geometry (where
+voxels land relative to the ray-hit face), which is cleaner to pin down once the
+`worldPos3DToMouseScreenPx` primitive (validated here) drives real placement.
+Sequenced as the first task of the session-infrastructure slice, not a gate.
+
+### P0-4 — A/D binding overload (PASS, + bug found)
+One injected `A` press logged `Added blank frame` — confirming the plain-PRESSED
+`A` binding both adds an animation frame **and** starts a camera-left move (no
+modifier guard). Sessions must re-establish the camera after any A/D frame op;
+the per-shot camera re-apply already handles this. **Bug surfaced:** the add-frame
+log line (`main.cpp` ~2314) uses printf `%d` inside the fmt-style `IR_LOG_INFO`,
+so it prints the literal `Added blank frame %d / %d`. Pre-existing, cosmetic
+(log-only); filed as a follow-up, not fixed in this de-risk PR.
+
+### Reusable primitives this slice lands for the session infrastructure
+- `IRRender::worldPos3DToMouseScreenPx(vec3)` — world voxel → click pixel; the
+  aiming primitive the `SessionBuilder` needs.
+- `IRPrefab::GuiTest::picksIsoColumn(...)` / `AssertKind::PICKS_ISO_COLUMN` —
+  occlusion-robust mapping assertion for the harness.
+- The `editor_probe_*` shot pattern (runtime-computed `MOVE` pixels filled in
+  `onGuiAssertFrame` before the same-tick event injection, so the aim uses the
+  shot's live camera state — no init-time viewport-timing fragility).

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -412,9 +412,13 @@ wiring contract in `engine/script/CLAUDE.md` §"Widget framework bindings".
 
 **Headless GUI assertions (P3, #1796).** `gui_test_assertions.hpp`
 exposes `IRPrefab::GuiTest::` — capture-frame assertions
-(`hovers` / `clickFires` / `sliderValue` / `checkbox` / `picksVoxel`)
-over the introspectable widget + picking state, each emitting one
-machine-readable `GUI-ASSERT …` log line. Evaluation lives in the prefab
+(`hovers` / `clickFires` / `sliderValue` / `checkbox` / `picksVoxel` /
+`picksIsoColumn`) over the introspectable widget + picking state, each
+emitting one machine-readable `GUI-ASSERT …` log line. `picksIsoColumn`
+(#766) asserts the click's ray hit a voxel on the target's iso column —
+the occlusion-independent test of screen→world mapping accuracy, since
+which voxel along the column is front-most is scene state, not a mapping
+fact. Evaluation lives in the prefab
 layer (it needs widget / picking access engine/video lacks); the
 `engine/video` scripted-shot harness drives it through the type-erased
 `IRVideo::GuiTestConfig::onAssertFrame_` callback, threading a

--- a/engine/prefabs/irreden/render/gui_test_assertions.hpp
+++ b/engine/prefabs/irreden/render/gui_test_assertions.hpp
@@ -28,11 +28,12 @@
 namespace IRPrefab::GuiTest {
 
 enum class AssertKind {
-    HOVERS,       // IRPrefab::Widget::hoveredWidget() == widget_
-    CLICK_FIRES,  // widget_ pulsed C_WidgetState::fireAction_ during the shot
-    SLIDER_VALUE, // |sliderValue(widget_) - expectedFloat_| <= tolerance_
-    CHECKBOX,     // checkboxState(widget_) == expectedBool_
-    PICKS_VOXEL,  // castVoxelRay() hits with voxelPos_ == expectedVoxel_
+    HOVERS,           // IRPrefab::Widget::hoveredWidget() == widget_
+    CLICK_FIRES,      // widget_ pulsed C_WidgetState::fireAction_ during the shot
+    SLIDER_VALUE,     // |sliderValue(widget_) - expectedFloat_| <= tolerance_
+    CHECKBOX,         // checkboxState(widget_) == expectedBool_
+    PICKS_VOXEL,      // castVoxelRay() hits with voxelPos_ == expectedVoxel_
+    PICKS_ISO_COLUMN, // castVoxelRay() hits a voxel on expectedVoxel_'s iso column
 };
 
 // One assertion evaluated at a shot's capture frame. Only the fields a given
@@ -98,6 +99,19 @@ inline Assertion picksVoxel(IRMath::ivec3 expected, const char *label = "picks_v
     return assertion;
 }
 
+// Assert the click's ray hit a voxel on @p targetVoxel's iso column (same
+// screen projection) — the occlusion-independent test of screen→world mapping
+// accuracy. Unlike picksVoxel it does not require the target to be the
+// front-most voxel, so it validates the mapping even when scene geometry sits
+// in front of the aimed cell.
+inline Assertion picksIsoColumn(IRMath::ivec3 targetVoxel, const char *label = "picks_iso_column") {
+    Assertion assertion;
+    assertion.kind_ = AssertKind::PICKS_ISO_COLUMN;
+    assertion.expectedVoxel_ = targetVoxel;
+    assertion.label_ = label;
+    return assertion;
+}
+
 // Caller-owned latch. CLICK_FIRES needs it: C_WidgetState::fireAction_ is a
 // single-frame pulse on click-release, gone by the post-settle capture frame,
 // so we accumulate which widgets fired across the shot window. The creation
@@ -121,6 +135,8 @@ inline const char *kindName(AssertKind kind) {
         return "CHECKBOX";
     case AssertKind::PICKS_VOXEL:
         return "PICKS_VOXEL";
+    case AssertKind::PICKS_ISO_COLUMN:
+        return "PICKS_ISO_COLUMN";
     }
     return "UNKNOWN";
 }
@@ -176,6 +192,22 @@ inline bool evaluateOne(const Assertion &assertion, const LatchState &latch, std
         actual = "voxel=(" + std::to_string(v.x) + "," + std::to_string(v.y) + "," +
                  std::to_string(v.z) + ")";
         return v == assertion.expectedVoxel_;
+    }
+    case AssertKind::PICKS_ISO_COLUMN: {
+        const std::optional<IRPrefab::Picking::RayHit> hit = IRPrefab::Picking::castVoxelRay();
+        if (!hit) {
+            actual = "miss";
+            return false;
+        }
+        // Screen→world mapping accuracy is a 2D iso-column property: the click
+        // must land the ray on the target voxel's iso column. Which voxel along
+        // that column is front-most is scene/occlusion-dependent, not a mapping
+        // fact, so compare iso projections rather than exact world voxels.
+        const IRMath::ivec2 hitIso = IRMath::pos3DtoPos2DIso(hit->voxelPos_);
+        const IRMath::ivec2 wantIso = IRMath::pos3DtoPos2DIso(assertion.expectedVoxel_);
+        actual = "iso=(" + std::to_string(hitIso.x) + "," + std::to_string(hitIso.y) + ") want=(" +
+                 std::to_string(wantIso.x) + "," + std::to_string(wantIso.y) + ")";
+        return hitIso == wantIso;
     }
     }
     actual = "unknown-kind";

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -261,6 +261,20 @@ ivec2 mouseTrixelPositionWorld();
 /// Use this when world-frame coordinates are needed (e.g. spawning an
 /// entity at the click location).
 vec3 mouseWorldPos3DAtIsoDepth(float canvasIsoDepth);
+/// Inverse of @ref mouseWorldPos3DAtIsoDepth: the window pixel (top-left
+/// origin, GLFW cursor convention) that — injected as the mouse position —
+/// makes the picking chain read @p worldPos's iso column. Reuses the exact
+/// same live camera / canvas / viewport terms as the forward chain (camera
+/// zoom, iso offset, main-canvas size, step size, letterbox offset,
+/// framebuffer buffer correction), so screen↔world stays consistent across
+/// backends and camera state with no hand-tuned constants. The +0.5 iso
+/// offset aims at the iso cell centre so the forward chain's `floor()` lands
+/// on @p worldPos's integer iso pixel. Because the iso projection is
+/// many-to-one along the view ray, @ref IRPrefab::Picking::castVoxelRay
+/// returns the front-most active voxel in that column — for the aimed voxel
+/// this is exact when nothing occludes it. Scripted GUI-harness input
+/// (auto-authoring sessions, alignment probes) is the primary caller.
+ivec2 worldPos3DToMouseScreenPx(vec3 worldPos);
 /// Entity id of the voxel under the mouse cursor, read from the entity-id GPU texture.
 /// @note This reads a persistent-mapped GPU buffer — values become valid only after the
 ///       GPU pipeline has completed the previous frame's @c FRAMEBUFFER_TO_SCREEN pass.

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -154,6 +154,26 @@ vec3 mouseWorldPos3DAtIsoDepth(float canvasIsoDepth) {
     return IRMath::rotateCardinalZInv(rotatedWorld, IRMath::rasterYawCardinalIndex(rasterYaw));
 }
 
+ivec2 worldPos3DToMouseScreenPx(vec3 worldPos) {
+    // Exact inverse of mouseWorldPos3DAtIsoDepth's screen→world chain, run in
+    // reverse and reusing the identical live terms so the two never drift:
+    //   world → rotateCardinalZ → pos3DtoPos2DIso (iso pixel of worldPos)
+    //         → +0.5 (aim iso cell centre) → +effectiveCameraIso
+    //         → +mainCanvasSizeTrixels/zoom/2 → *stepSize (undo /stepSize)
+    //         → +letterboxOffset − bufferCorrection (undo getMousePositionOutputView)
+    const float rasterYaw = IRPrefab::Camera::getRasterYaw();
+    const vec3 rotated =
+        IRMath::rotateCardinalZ(worldPos, IRMath::rasterYawCardinalIndex(rasterYaw));
+    const vec2 canvasIso = IRMath::pos3DtoPos2DIso(rotated) + vec2(0.5f);
+    const vec2 isoScreen = canvasIso + IRRender::getEffectiveCameraIso() +
+                           getMainCanvasSizeTrixels() / getCameraZoom() / vec2(2.0f);
+    const vec2 outputView = isoScreen * IRRender::getTriangleStepSizeScreen();
+    const vec2 offset = getRenderManager().screenToOutputWindowOffset();
+    const vec2 bufferCorrection = vec2(IRConstants::kSizeExtraPixelBuffer) / vec2(2.0f) *
+                                  vec2(getRenderManager().getOutputScaleFactor());
+    return IRMath::roundVec(outputView + offset - bufferCorrection);
+}
+
 ivec2 mouseTrixelPositionWorld() {
     const ivec2 canvasSize = getRenderManager().getMainCanvasSizeTriangles();
     const ivec2 z1 = IRMath::trixelOriginOffsetZ1(canvasSize);


### PR DESCRIPTION
## Summary
Part 1 of **#766** (F-1.6 — first authored entities via the GUI interaction
harness); **does not close the issue**. Phase 0 de-risk gate for the
auto-authoring premise, run end-to-end through the live `IRVoxelEditor`
GUI-test harness on macOS/Metal (`gui-verify` → **13/13, exit 0**).

- **`IRRender::worldPos3DToMouseScreenPx(vec3)`** (new) — the exact inverse of
  the picking chain `mouseWorldPos3DAtIsoDepth`, reusing its live camera /
  canvas / viewport terms so screen↔world stays consistent across backends and
  camera state with **no hand-tuned constants** (the bail-path anti-pattern is
  avoided). The aiming primitive the SessionBuilder needs.
- **`IRPrefab::GuiTest::PICKS_ISO_COLUMN`** (new assertion kind) — an
  occlusion-independent test of mapping accuracy: compares iso projections,
  since which voxel is front-most on a column is scene state (the seed scene's
  rig geometry occludes the ground plane), not a mapping fact.
- **Editor probe shots** (`editor_probe_*`, appended so existing shot indices +
  the `editor_pick_voxel` regression baseline are untouched):
  - P0-1 — Ctrl+S keyboard/modifier dispatch → writes `scene_frame_0.vxs`.
  - P0-2 — world→screen mapping: 8/8 cells hit their target iso column.
  - P0-4 — A/D binding-overload measurement (one `A` adds a frame + moves camera).
- **Finding — vertical picking needs zoom ≥ 2** (in `editor-authoring-friction.md`):
  at zoom 1 the iso step is 1 px per iso-Y unit (below integer-pixel resolution),
  so `floor()` tips to the neighbouring iso column. The doc also records the
  rig-occlusion diagnosis and an A/D printf-`%d`-in-fmt-logger bug (follow-up,
  not fixed here).

## Test plan
- [x] `gui-verify.py IRVoxelEditor` → 13/13 assertions passed, exit 0 (macOS/Metal)
- [x] P0-1: `scene_frame_0.vxs` written + "Scene saved to" logged
- [x] P0-2: 8/8 `PICKS_ISO_COLUMN` PASS at zoom 2.0
- [x] `fleet-build --target IRVoxelEditor` clean, no warnings
- [ ] Linux/GL parity of the gui-verify run — nice-to-have; the assertion path
      is CPU-state / backend-agnostic, so not a gate

## Notes for reviewer
No visual/render-path change: `worldPos3DToMouseScreenPx` is a pure computation
not called in the normal render loop, and the probe shots run only under
`--auto-screenshot`. Before/after screenshots would be byte-identical, so none
are attached. P0-3 (drag-stroke → box-fill placement) is deferred to the
session-infrastructure slice, where it builds on the validated mapping
primitive. #766 stays open through Parts 2–4.

Part 1 of #766 — stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
