### PR TITLE
docs: seed six engine objectives — the standing direction above epics

### DIFF
--- a/docs/design/objectives/backend-parity.md
+++ b/docs/design/objectives/backend-parity.md
@@ -1,0 +1,44 @@
+# Objective: OpenGL and Metal are functionally interchangeable
+
+**Status:** active
+
+## Outcome
+A feature landing on one render backend is expected — and verified — on
+both. Choosing a host never changes what the engine can render, only how
+fast the developer's inner loop runs.
+
+## Done means
+- [ ] Shader counterpart coverage stays complete: every `c_*` compute and
+  `ir_*` include has an exact 1:1 counterpart; raster `v_`/`f_` pairs map
+  to their bundled `.metal` equivalents; the `backend-parity` audit
+  reports zero unexplained gaps.
+- [ ] Detached (world-placed) rotating entities receive and cast per-axis
+  lighting on both backends (#1375 receive, #1376 cast) — today they
+  composite raw unlit voxel color on both.
+- [ ] A CI parity guard exists: a PR adding a `.glsl` without a matching
+  `.metal` (or an acknowledged deferral + follow-up reference) fails a
+  workflow check instead of relying on reviewer memory.
+- [ ] Cross-backend perf comparison captured: `perf_grid` numbers from an
+  OpenGL host beside the committed Metal baseline
+  (`docs/perf/metal_perf_grid_baseline.md` admits the GL side is
+  uncaptured).
+
+## Non-goals
+Identical performance across backends (parity is functional, not
+frame-time); additional backends (Vulkan / WebGPU); porting the
+macOS-only bridge files (`metal_cocoa_bridge.mm` et al.) — those are
+by-design asymmetric.
+
+## Current state
+Coverage is effectively complete today: 33/33 compute shaders and 6/6
+shared includes are 1:1 (`engine/render/src/shaders/` vs `shaders/metal/`);
+the apparent 49-vs-44 file delta is the raster pair-vs-bundled convention,
+not missing ports. The `backend-parity` skill carries the audit loop and
+the no-port-without-target-backend-smoke rule. What's missing is wired
+per-axis lighting for detached rotation (both backends), any CI-side
+guard, and the GL half of the perf story.
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+| 2026-07-20 | — | objective seeded |

--- a/docs/design/objectives/cross-host-shippability.md
+++ b/docs/design/objectives/cross-host-shippability.md
@@ -1,0 +1,42 @@
+# Objective: any fleet host can produce a clean-box-runnable package
+
+**Status:** active
+
+## Outcome
+From any of the three supported hosts (Linux/WSL2, native Windows,
+macOS), a creation packages into a double-clickable artifact that runs
+on a machine with none of the dev toolchain installed.
+
+## Done means
+- [ ] The macOS bundle walks transitive dependencies — today
+  `cmake/macos_bundle_dylibs.cmake` copies direct non-system dylibs but
+  not their Homebrew transitive deps (ffmpeg codec libs), so a truly
+  clean-box macOS bundle is admitted follow-up work (`BUILD.md`
+  § packaging).
+- [ ] A per-host package smoke exists: build + clean-box-run of a
+  packaged reference demo (`IRShapeDebug` is the wired
+  `irreden_package_target` reference) on each of the three hosts.
+- [ ] The `BUILD.md` "maturing the Linux build is first-class ongoing
+  work / expect Linux-only breaks" caveat is retired — Linux build
+  breakage is no longer an expected class.
+- [ ] `fleet:needs-<host>-smoke` backlogs stay drained as a matter of
+  course (platform-catchup is routine, not archaeology).
+
+## Non-goals
+Mobile or console targets; installer tooling, notarization, or signing
+beyond the existing ad-hoc re-sign; WSL MIDI forwarding (MIDI demos run
+from the Windows-native clone by design).
+
+## Current state
+Three presets (`linux-debug` / `windows-debug` / `macos-debug`) with
+per-host build docs and bootstrap scripts; `irreden_package_target`
+produces per-platform zips; the native-Windows clone is the
+authoritative does-this-actually-ship host; platform-catchup processes
+cross-host smoke labels on all three hosts. The gaps are bundle depth
+(macOS transitive dylibs), the absence of an automated clean-box smoke,
+and Linux build maturity.
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+| 2026-07-20 | — | objective seeded |

--- a/docs/design/objectives/editor-authoring.md
+++ b/docs/design/objectives/editor-authoring.md
@@ -1,0 +1,45 @@
+# Objective: the voxel editor is how the engine's assets actually get made
+
+**Status:** active
+
+## Outcome
+`IRVoxelEditor` is the tool real assets are authored with — creating,
+editing, saving, and loading voxel entities end-to-end through the UI is
+routine, proven by scripted interaction rather than claimed.
+
+## Done means
+- [ ] The #766 proof-of-usability lands: five test entities (ant, bird,
+  rock, mushroom, tree) authored end-to-end through the editor via
+  scripted GUI interaction and saved as `.vxs`.
+- [ ] The Phase-0 mechanism probes pass: keyboard→command dispatch,
+  world→screen mapping accuracy, drag stroke, A/D binding overload
+  (`docs/design/editor-authoring-friction.md` — probes defined, not yet
+  run).
+- [ ] The gui_scale space mismatch is reconciled —
+  `GuiInputEvent.screenPx_` and `worldToScreen` agree on one space
+  (the known ergonomic gap in `editor-authoring-friction.md`).
+- [ ] The editor participates in the verify culture beyond its current
+  5 GUI assertions: assertion coverage grows with each authoring
+  feature, and editor scenes get reference images or a structural
+  oracle.
+
+## Non-goals
+Entity-editor epic phases 3–8 (animation timeline, IK/chain solvers,
+bind-points, procedural authoring, particles/lights/audio, multi-window
+polish — `docs/design/entity-editor-epic.md`) until static authoring
+proves out through #766. Adopting dear-imgui — the trixel-rendered UI is
+the standing bet.
+
+## Current state
+The editor builds clean on macOS/Metal and runs green headless through
+the GUI-test harness (5/5 assertions including the load-bearing
+`PICKS_VOXEL` over the real picking/ray path). Phase 1 static authoring
+(#604) shipped; the `.vxs` v1 save format with JSON sidecar has asset
+tests. The honest gap the friction log records: nobody has yet authored
+a real asset all the way through, and the #766 probes that de-risk that
+are groundwork-only.
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+| 2026-07-20 | — | objective seeded |

--- a/docs/design/objectives/lua-creation-authoring.md
+++ b/docs/design/objectives/lua-creation-authoring.md
@@ -1,0 +1,46 @@
+# Objective: a complete creation is authorable in Lua without touching C++
+
+**Status:** active
+
+## Outcome
+A creation author builds a game-like creation — components, systems,
+pipelines, input, behavior — entirely in Lua, at CODEGEN-native speed,
+with the C++ engine consumed as primitives rather than edited.
+
+## Done means
+- [ ] EVAL-mode canonical-grid (16³/64³) perf numbers captured on the
+  Linux fleet host (the repeatedly-flagged mechanical follow-up in
+  `docs/design/lua-driven-ecs.md`).
+- [ ] The G1–G4 authoring gaps close far enough that a many-agent
+  navigation/steering demo is authorable in Lua: structured/container
+  field types, shared-index capability, control flow for iterative
+  kernels, structural change in a tick (`lua-driven-ecs.md` follow-ups).
+- [ ] The binding-automation follow-ups land: shared
+  `registerStandardBindings()` header and the `IR_BIND_LUA_COMPONENT`
+  macro (`docs/design/lua-binding-automation.md` — plan exists, tasks
+  unstarted).
+- [ ] A demo authored 100% via Lua schema ships and participates in the
+  verify culture (render-verify or gui-verify, not just "it runs").
+
+## Non-goals
+Replacing C++ for cross-entity stateful solvers — the authoring boundary
+ruled in #1400 stands (per-entity data-parallel arithmetic → Lua/CODEGEN;
+solvers → C++ primitives consumed by batched query). Component-schema
+hot-reload (explicitly deferred). Codegen'ing the binding files
+themselves (rejected in `lua-binding-automation.md`).
+
+## Current state
+The two-path architecture shipped and met its gate: CODEGEN (default,
+build-time typed C++ from `.lua` schemas) runs the 64³ wave tick at
+~0.46× of the C++ baseline (`creations/demos/lua_perf_grid/`), and EVAL
+(LuaJIT + sol2) keeps hot-reload alive via
+`IRSystem.replaceSystemBody`. Components, batched systems, pipeline
+composition, enums, and modifier bindings are authorable today; 39
+hand-written `*_lua.hpp` binding files (~1.6k lines) carry the surface.
+The gaps are EVAL perf validation, the nav/steering feature classes
+(G1–G4), and the binding-boilerplate reduction.
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+| 2026-07-20 | — | objective seeded |

--- a/docs/design/objectives/machine-verified-behavior.md
+++ b/docs/design/objectives/machine-verified-behavior.md
@@ -1,0 +1,42 @@
+# Objective: behavior changes are provable by harness on every supported host
+
+**Status:** active
+
+## Outcome
+No reviewer — human or agent — ever takes "it looks right" on faith. Every
+behavior-bearing change is demonstrable by a committed harness (render
+refs, GUI assertions, perf gate, acceptance evidence), on the hosts the
+engine actually ships from.
+
+## Done means
+- [ ] render-verify reference sets exist for `linux-debug` and
+  `windows-debug` on the covered demos — today refs are essentially
+  macOS-only (shape_debug 33 / lighting 51 / fog_demo 13 / canvas_stress
+  14 PNGs, vs a single 6-PNG linux set for canvas_stress and zero
+  windows refs).
+- [ ] gui-verify coverage grows beyond its two participants
+  (`voxel_editor`, `lua_widgets`): every interactive creation that ships
+  hover/click/pick behavior carries assertions.
+- [ ] The CI perf gate covers a second surface beyond `IRPerfGrid`, and
+  an OpenGL-host baseline exists beside the committed Metal one.
+- [ ] The acceptance-evidence loop (author table + `review-acceptance`
+  grading, shipped 2026-07-20) is observably in force: recently merged
+  planned PRs carry graded `## Acceptance evidence` tables.
+
+## Non-goals
+Pixel-reference coverage for every demo (structural/analytic oracles like
+`analytic_oracle`'s manifest are the preferred form where pixel refs would
+be brittle); gating on hosts the fleet doesn't run.
+
+## Current state
+The culture is established and multi-modal: 4 demos with committed
+render-verify refs + manifests, a structural-oracle demo with deliberately
+zero PNGs, a real CI perf gate (`perf-gate.yml`, >10% mean-frame fails the
+PR), 103 test files across 13 domains, and stdlib-only comparators with
+their own unit tests. The gaps are host breadth (refs), interaction
+breadth (gui-verify), and perf breadth (one demo, one backend).
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+| 2026-07-20 | — | objective seeded |

--- a/docs/design/objectives/render-correctness-under-motion.md
+++ b/docs/design/objectives/render-correctness-under-motion.md
@@ -1,0 +1,45 @@
+# Objective: rendering stays correct and temporally stable under motion
+
+**Status:** active
+
+## Outcome
+Camera motion (yaw / zoom / pan) and entity rotation produce artifact-free,
+temporally stable output, and every stability claim is machine-gated — a
+regression in crawl, cull, or rotation correctness fails a harness, not an
+eyeball.
+
+## Done means
+- [ ] All 8 SDF shapes pass the jitter gate (`MAX_JITTER=4.0`) in
+  `shape-rotate-jitter-sweep` on `origin/master` — today 4/8 fail: the
+  hard-edge seam-crawl family (box, wedge — #1883) and the curved-SDF
+  depth-band family (curved_panel, ellipsoid — #1920).
+- [ ] The voxel-path per-shape jitter table is captured and gated (the
+  follow-up `docs/design/jitter-validation-harness.md` names).
+- [ ] An OpenGL/Linux jitter baseline exists and the gate runs on both
+  backends, not only Metal/macOS.
+- [ ] Picking works during rotation — the per-axis scatter path writes the
+  hovered-id SSBO (`docs/design/per-axis-trixel-canvas-rotation.md`).
+- [ ] Per-axis rotating voxels cast into the shared sun map again without
+  the self-occlusion artifact (#1435); scatter-quad conservative-coverage
+  waffle resolved (#1494).
+- [ ] Cull-freeze validation stays green: yaw-time culling never drops
+  on-screen content (`IRShapeDebug --cull-validate`).
+
+## Non-goals
+Frame-rate / perf targets (tracked by the perf gate, not this objective);
+LOD strategy; new projection modes.
+
+## Current state
+The measurement culture exists and is the strength: the jitter harness
+(`docs/design/jitter-validation-harness.md`, `scripts/render-jitter-metric.py`)
+pins temporal second-difference under a 1°/step 360° sweep; the cull harness
+(`docs/design/cull-validation-harness.md`) proves yaw culling against a
+frozen wide viewport; `render-verify` / `light-verify` gate stills. Committed
+baselines: sphere/cylinder/cone/torus pass ~1.1, canvas_stress passes 1.19.
+The open work is the two crawl families, the voxel-path table, the GL
+baseline, and the rotation residuals (picking, cast shadows, waffle).
+
+## Progress ledger
+| Date | Epic / issue | Delta |
+|---|---|---|
+| 2026-07-20 | — | objective seeded |


### PR DESCRIPTION
## Summary
Seeds `docs/design/objectives/` with six draft objectives, each following the tier's README format (Outcome / measurable Done-means / Non-goals / cited Current-state / Progress ledger):

- **render-correctness-under-motion** — all 8 shapes through the jitter gate (4/8 fail today: #1883, #1920), voxel-path table, GL baseline, rotation residuals (picking, cast shadows #1435, waffle #1494).
- **backend-parity** — coverage stays 1:1 (it is today), per-axis lighting for detached rotation on both backends (#1375/#1376), a CI parity guard, the uncaptured GL perf half.
- **machine-verified-behavior** — render refs beyond macOS, gui-verify beyond its two participants, perf gate beyond one demo/backend, acceptance-evidence adoption observable.
- **lua-creation-authoring** — EVAL perf validation, the G1–G4 nav/steering gaps, binding-automation follow-ups, a 100%-Lua demo in the verify culture.
- **editor-authoring** — the #766 five-entities proof, Phase-0 probes, the gui_scale space mismatch, editor in the verify culture.
- **cross-host-shippability** — macOS bundle transitive deps, per-host clean-box package smoke, retiring the Linux-maturity caveat.

## Why
The objectives tier landed with only its README — the sweep has had nothing to sweep, and the upcoming triage role needs a written direction to judge issues against. Every Done-means row here is grounded in what the design docs and harnesses already admit is open (citations in each file's Current state), not invented direction.

## Notes for reviewer / human
**These are drafts for you to edit — merging is the sign-off** that makes them the standing direction, per the README's human-owned lifecycle. Rewrite, cut, or split freely; the one property worth preserving is that every Done-means row stays tree-checkable (the positive-fire bar at direction scale).

## Test plan
- [x] Every cited design doc / harness / cmake artifact exists in the tree.
- [x] No game-repo references (cross-repo isolation check clean).
- [x] Format matches `docs/design/objectives/README.md`; doc-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
