### PR TITLE
fleet: dry-run triage role — untriaged issues judged against the objectives

### DIFF
--- a/.claude/commands/role-triage.md
+++ b/.claude/commands/role-triage.md
@@ -1,0 +1,31 @@
+---
+name: role-triage
+description: Dry-run issue triage — classifies untriaged issues against the standing objectives; posts verdicts, never approves
+---
+
+You are the **triage** agent for the Irreden Engine fleet.
+
+**The shared triage protocol lives in
+[`docs/agents/triage-protocol.md`](../../docs/agents/triage-protocol.md).**
+Read it first — it owns the hard rules (dry-run: verdict comment +
+`fleet:triage-recommend` label only, never approval labels, never closes),
+the singleton designation (`FLEET_TRIAGE=1`), the idempotency guard, the
+verdict classes, the comment format, the per-run cap, and the graduation
+bar. This wrapper carries only the engine's deltas. See
+[`docs/design/role-sharing.md`](../../docs/design/role-sharing.md) for the
+delta-key mechanism.
+
+Mode (optional argument): $ARGUMENTS
+
+## Deltas (Irreden Engine)
+
+| Delta key | Engine value |
+|---|---|
+| **repo-slug** | `jakildev/IrredenEngine` |
+| **repo-root** | `~/src/IrredenEngine` |
+| **worktree-path** | the pool worktree you were dispatched into: `~/src/IrredenEngine/.claude/worktrees/pool-<N>` (basename from `basename $PWD`, never from the role name) |
+| **role-name** | `triage` |
+| **role-banner** | `[triage] Dry-run issue triage — untriaged issues vs docs/design/objectives/; verdicts only, never approvals. Transient.` |
+| **objectives-path** | `docs/design/objectives/` |
+| **singleton-env** | `FLEET_TRIAGE=1` (exactly one host) |
+| **feedback-file** | `~/.fleet/feedback/triage.md` |

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -96,6 +96,17 @@ Specifically, **never pass these via `--label` when filing**:
   drained in batches by the human-cued `triage-coding-improvements` skill,
   which triages each ticket with the human and bundles the accepted
   convention changes into one PR per run.
+- `fleet:triage-recommend` — owned by the **triage role**
+  (`docs/agents/triage-protocol.md`), dry-run only. Applied together with a
+  `## Triage` comment when the role classifies an untriaged issue against
+  the standing objectives (`docs/design/objectives/`). Deliberately
+  **inert**: no queue machinery reads it — it routes the issue into
+  `fleet-decisions`' decision list so the verdict reaches the human via the
+  digest. The human acts (approve / close / park / reply) and removes the
+  label; removal re-arms the role's idempotency guard for a re-triage
+  after edits. The role never adds `human:approved`, `fleet:agent-approved`,
+  or `fleet:queued` — graduation to live approval is a human-authorized
+  protocol change (triage-protocol.md § Graduation).
 - `fleet:queued` / `fleet:task` — owned by **`fleet-queue-ingest`**,
   set after `human:approved` (or `fleet:agent-approved`) has been
   observed. Adding it at filing time excludes the issue from the ingest

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -27,6 +27,12 @@
       "description": "Worker-filed: a fix revealed a generalizable rule for the fleet's dev procedures; human triages"
     },
     {
+      "name": "fleet:triage-recommend",
+      "scope": "issue",
+      "color": "d4c5f9",
+      "description": "Dry-run triage verdict posted as a ## Triage comment; inert - human reads, decides, removes"
+    },
+    {
       "name": "fleet:task",
       "scope": "issue",
       "color": "0366d6",

--- a/docs/agents/triage-protocol.md
+++ b/docs/agents/triage-protocol.md
@@ -1,0 +1,110 @@
+# Triage protocol — dry-run issue triage against the standing objectives
+
+The judgment layer between "an issue exists" and "the human approves it".
+The triage role reads every **untriaged** open issue (no `fleet:` / `human:`
+labels), judges it against the standing direction in
+[`docs/design/objectives/`](../design/objectives/README.md) and the fleet's
+scoping rules, and posts a verdict the human can act on in one read.
+
+**This protocol defines DRY-RUN only.** The role recommends; it never
+approves. Graduating any verdict class to live approval
+(`fleet:agent-approved` stamping) is a separate, human-authorized protocol
+change — see § Graduation.
+
+## Hard rules
+
+- **Outputs are exactly two things**: a `## Triage` comment on the issue and
+  the inert `fleet:triage-recommend` label. Never add `human:approved`,
+  `fleet:agent-approved`, `fleet:queued`, or any model-affinity label; never
+  close an issue; never edit an issue body or title.
+- **Singleton by designation.** Run only on the host opted in with
+  `FLEET_TRIAGE=1` (the `FLEET_EPIC_STEWARD` pattern). Exactly one host in
+  the fleet carries the flag — triage spends LLM judgment and posts
+  comments, which are not idempotent across hosts.
+- **Idempotent by guard, regardless of designation.** Skip any issue that
+  already carries `fleet:triage-recommend` OR already has a `## Triage`
+  comment. A misconfigured second host must converge, not double-post.
+- **Read-only on the tree.** Cheap verification only (grep, file reads,
+  `gh` queries) — no builds, no runs.
+- **Engine repo only** until the human extends scope. Never read or cite
+  the private game repo
+  ([`CLAUDE-BASELINE.md`](CLAUDE-BASELINE.md) § Cross-repo information
+  isolation).
+
+## Inputs
+
+1. Every `Status: active` objective in `docs/design/objectives/*.md` —
+   the direction issues are judged against.
+2. The untriaged set: open issues with no `fleet:` / `human:` label (the
+   same predicate `fleet-decisions` surfaces as the untriaged cue), minus
+   the idempotency-guard skips.
+3. The issue thread in full — body AND comments.
+4. [`TASK-FILING.md`](TASK-FILING.md) (the structured-body bar) and
+   [`fleet-labels-reference.md`](fleet-labels-reference.md).
+
+Process oldest-first, capped at **10 issues per run** — bounded token
+spend; the backlog drains across runs.
+
+## Per-issue judgment
+
+Verify before classifying: an issue's premise is a claim. Grep the cited
+files/symbols; check whether a named defect is already fixed on `master`;
+search for an open duplicate. Then classify into exactly one verdict:
+
+- **recommend-approve** — serves an active objective (name the objective
+  and the specific Done-means row) or is defect-shaped with credible,
+  verifiable forensics; scoped to a plannable surface. Include a suggested
+  `**Model:**` class and, if the body lacks it, the `**Objective:** <slug>`
+  line the filer should add.
+- **park (needs-human)** — direction-shaped (new capability, public-API
+  surface, design choice), crosses an objective's Non-goals, targets gated
+  self-config, or has a premise you could not verify either way.
+- **recommend-close** — duplicate (cite the open issue) or already
+  shipped (cite the merged PR / the master evidence you checked).
+- **insufficient-info** — name exactly what is missing (repro command,
+  observed output, the file the report is about). Vague "needs more
+  detail" verdicts are banned; the comment must let the filer fix the gap
+  in one edit.
+
+## The `## Triage` comment
+
+```markdown
+## Triage
+
+**Verdict:** recommend-approve | park | recommend-close | insufficient-info
+**Objective:** <slug + Done-means row, or "(none — defect-shaped)" or "(none — see verdict)">
+**Suggested model:** opus | sonnet | (n/a)
+**Basis:** <2-5 lines: what you verified in the tree, what you searched,
+what the issue serves or duplicates — citations, not vibes>
+```
+
+Post the comment and add `fleet:triage-recommend` in immediate succession.
+The label routes the issue into `fleet-decisions`' decision list, so the
+verdict reaches the human through the digest push — the human then acts
+with ordinary mechanics (`human:approved`, close, `human:owned`, or a
+reply asking for changes) and removes the label, which also re-arms the
+idempotency guard if they want a re-triage after edits.
+
+## Invocation
+
+Cue-driven today: the human says "triage sweep", or a cron one-shot runs
+on the designated host:
+
+```
+cd ~/src/IrredenEngine/.claude/worktrees/pool-0 && \
+  FLEET_TRIAGE=1 fleet-dispatch-wrap pane-0 "$FLEET_MODEL_OPUS" high triage "" live
+```
+
+Fleet-native scout → dispatcher wiring (untriaged fetch, projection,
+trigger, `FLEET_TRIAGE` dispatch gate) is tracked in #2494.
+
+## Graduation (not in effect)
+
+Live approval is earned, not assumed. The human audits verdict quality
+over a sustained window (the digest surfaces every verdict; spot-check
+`Basis` claims), then explicitly authorizes flipping **bounded classes**
+— e.g. sonnet-scale, single-module, defect/parity/test-debt — to stamp
+`fleet:agent-approved` directly, while direction-shaped work stays
+recommend-only forever. That flip is a change to this protocol plus the
+role doc (gated self-config, human-applied by definition). Until it
+lands, every verdict is advisory.

--- a/scripts/fleet/fleet-decisions
+++ b/scripts/fleet/fleet-decisions
@@ -106,6 +106,7 @@ DECISION_TAGS = {
     "fleet:steward-proposal": "steward proposal to answer",
     "fleet:state-drift": "state drift to reconcile",
     "human:review-plan": "plan approach sign-off",
+    "fleet:triage-recommend": "triage verdict to review",
 }
 
 repos = []

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -101,6 +101,7 @@ LABELS=(
     "fleet:needs-human|fbca04|Fleet can't finish autonomously (e.g. gated self-config); human acts. Held, keeps human:approved"
     "fleet:state-drift|fbca04|reconcile found claim-surface drift persisting N ticks; one deduped tracking issue for a human"
     "fleet:coding-improvement|c2e0c6|Worker-filed: a fix revealed a generalizable rule for the fleet's dev procedures; human triages"
+    "fleet:triage-recommend|d4c5f9|Dry-run triage verdict posted as a ## Triage comment; inert - human reads, decides, removes"
     "fleet:task|0366d6|Task from the fleet issue queue"
     "fleet:epic|cc317c|Parent issue tracking child issues; epic-steward maintains the Children checklist, closes it out"
     "fleet:queued|c5def5|Queued for fleet pickup (requires human:approved or fleet:agent-approved)"

--- a/scripts/fleet/tests/test_decisions.sh
+++ b/scripts/fleet/tests/test_decisions.sh
@@ -58,7 +58,9 @@ cat > "$TMP/engine-issues.json" << 'EOF'
   {"number": 204, "title": "task: queued", "url": "u",
    "labels": [{"name": "fleet:queued"}, {"name": "human:approved"}]},
   {"number": 205, "title": "task: needs plan", "url": "u",
-   "labels": [{"name": "fleet:needs-plan"}, {"name": "human:approved"}]}
+   "labels": [{"name": "fleet:needs-plan"}, {"name": "human:approved"}]},
+  {"number": 206, "title": "idea: triaged, verdict pending", "url": "u",
+   "labels": [{"name": "fleet:triage-recommend"}]}
 ]
 EOF
 
@@ -108,17 +110,19 @@ err=$(cat "$TMP/err.txt")
 assert_eq "$status" "0" "default run exits 0 despite unreachable game repo"
 assert_contains "$err" "skipping jakildev/irreden" "unreachable repo warned on stderr"
 
-assert_contains "$out" "5 decision(s) waiting" "headline counts merge queue + decisions"
+assert_contains "$out" "6 decision(s) waiting" "headline counts merge queue + decisions"
 assert_contains "$out" "Merge queue (2)" "merge queue counts both approved PRs"
 assert_contains "$out" "engine PR #101" "clean approved PR listed"
 assert_contains "$out" "#102" "approved-with-nits PR listed"
 assert_contains "$out" "[approved+nits]" "has-nits annotated"
 assert_contains "$out" "hold: fleet:needs-linux-smoke outstanding" "smoke hold sub-line"
-assert_contains "$out" "Decisions (3)" "decision bucket counts gated + design-blocked + plan hold"
+assert_contains "$out" "Decisions (4)" "decision bucket counts gated + design-blocked + plan hold + triage verdict"
 assert_contains "$out" "engine PR #103" "gated PR in decisions"
 assert_contains "$out" "gated self-config edit" "gated tag rendered"
 assert_contains "$out" "engine PR #104" "design-blocked PR in decisions"
 assert_contains "$out" "engine issue #201" "plan sign-off issue in decisions"
+assert_contains "$out" "engine issue #206" "triage-recommend issue in decisions"
+assert_contains "$out" "triage verdict to review" "triage tag rendered"
 assert_absent  "$out" "#105" "wip-only PR appears in no bucket"
 assert_contains "$out" "fleet:coding-improvement: 1 open" "coding-improvement cue with count"
 assert_contains "$out" "untriaged (no state labels): 1" "untriaged cue counts label-less issue"


### PR DESCRIPTION
## Summary
- New `docs/agents/triage-protocol.md` + `.claude/commands/role-triage.md`: a transient role that classifies every untriaged open issue (no `fleet:`/`human:` labels) against the standing objectives — verdicts are recommend-approve (objective + Done-means attribution, suggested model class), park, recommend-close (with citations), or insufficient-info. **Dry-run by hard rule**: outputs are exactly a `## Triage` comment + the inert `fleet:triage-recommend` label; never approval labels, never closes, never edits bodies.
- Concurrency: singleton via `FLEET_TRIAGE=1` host opt-in (mirrors `FLEET_EPIC_STEWARD`), plus a per-issue idempotency guard (skip on existing label or `## Triage` comment) so even a misconfigured second host converges instead of double-posting.
- `fleet:triage-recommend` registered via the three-file sync (`fleet-labels` catalog / `fleet-state-machine.json` / `fleet-labels-reference.md`); `fleet-labels --check` green at 60 labels.
- `fleet-decisions` gains the tag in `DECISION_TAGS` (+2 test assertions, suite now 28/28): verdicts flow into the decision digest and reach the human through the push tick — the human approves/closes/parks and removes the label, which re-arms the guard for re-triage after edits.
- Graduation to live `fleet:agent-approved` stamping is documented as a future human-authorized protocol change for bounded classes only — explicitly not in effect.

## Why
Closes the origination gap in the autonomy loop: objectives (#2492) say where the engine is going; this role turns "issues exist" into "here are the judged, attributed candidates" without moving any approval authority. The human's decision arrives pre-verified through the digest instead of being a backlog to excavate.

## Test plan
- [x] `bash scripts/fleet/tests/test_decisions.sh` — 28 passed, 0 failed (triage-recommend fixture issue lands in the Decisions bucket with its tag).
- [x] `fleet-labels --check` — catalog and state-machine agree, 60 labels, descriptions ≤100 chars.
- [x] Cross-refs verified: objectives README, TASK-FILING, CLAUDE-BASELINE § isolation, role-sharing.md, #2494.
- [ ] Post-merge: run `fleet-labels` once so `fleet:triage-recommend` is created on GitHub.

## Notes for reviewer
Scout → dispatcher trigger wiring is deliberately NOT in this PR — it's filed with a full plan as #2494 (opus-class scripts/fleet work) so the fleet can build its own trigger through the normal queue. Until then the role is cue/cron-invocable on the designated host (invocation snippet in the protocol). Sibling context: #2492 seeds the objectives this role judges against; merge order between the two doesn't matter mechanically, but verdicts are only as good as the signed objectives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
