### PR TITLE
editor: runtime --scene-size for IRVoxelEditor (#766 Part 2)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -120,8 +120,27 @@ namespace IRVoxelEditor {
 // Scene + palette config (kept as named constants so the editor never
 // inlines a hardcoded dimension — D1 in the T-211 architect direction
 // calls out that the size be configurable per scene).
-constexpr ivec3 kEditableSceneSize{16, 16, 16};
-constexpr vec3 kEditableSceneOrigin{-8.0f, -8.0f, -12.0f};
+//
+// The editable grid dimensions are runtime-configurable via --scene-size W H D
+// (#766 Part 2 — the ant needs 20³, the tree ~26 tall). g_editableSceneSize /
+// g_editableSceneOrigin default to the historical 16³ scene and are overwritten
+// in main() after arg parse. deriveSceneOrigin keeps the scene centred in X/Y
+// and pins the seed ground plane (local z == size.z-1) at world z == 3 for any
+// height, so authoring recipes and probe cells stay height-agnostic.
+constexpr ivec3 kDefaultEditableSceneSize{16, 16, 16};
+// The seed ground plane lives at local z == size.z-1; anchoring it to a fixed
+// world z keeps the camera framing and authoring recipes stable as the scene
+// grows taller (origin.z shifts down by exactly the height increase).
+constexpr int kSeedGroundPlaneWorldZ = 3;
+inline vec3 deriveSceneOrigin(ivec3 size) {
+    return vec3(
+        -static_cast<float>(size.x) / 2.0f,
+        -static_cast<float>(size.y) / 2.0f,
+        static_cast<float>(kSeedGroundPlaneWorldZ - (size.z - 1))
+    );
+}
+ivec3 g_editableSceneSize = kDefaultEditableSceneSize;
+vec3 g_editableSceneOrigin = deriveSceneOrigin(kDefaultEditableSceneSize);
 constexpr int kPaletteCount = 16;
 
 // 16 distinct palette colors. Indexed in row-major order across the
@@ -403,6 +422,17 @@ IRVideo::GuiInputEvent g_probeMapMoves[kProbeMapCount] = {
     {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
 };
 
+// The i-th probe-map cell with its z snapped to the live ground plane
+// (local z == size.z-1). Keeps the probe valid under --scene-size — the stored
+// z is the 16³ default; the actual seed plane moves with the scene height.
+inline IRMath::ivec3 probeGroundCell(int i) {
+    return IRMath::ivec3(
+        kProbeMapLocalCells[i].x,
+        kProbeMapLocalCells[i].y,
+        g_editableSceneSize.z - 1
+    );
+}
+
 // GUI-test shot table covering stable render framings plus the scripted-click
 // shots. Superset of the previous kShots[] — render-verify labels still match.
 // kGuiAssertShotIndex / kPickVoxelShotIndex select the assertion-bearing shots.
@@ -462,8 +492,11 @@ void onGuiAssertFrame(int shotIndex, bool isCaptureFrame) {
     // idempotent across the shot's frames.
     if (shotIndex >= kProbeMapShotStart && shotIndex < kProbeMapShotStart + kProbeMapCount) {
         const int cellIndex = shotIndex - kProbeMapShotStart;
-        const IRMath::vec3 worldCenter =
-            kEditableSceneOrigin + IRMath::vec3(kProbeMapLocalCells[cellIndex]);
+        // Derive the ground-plane z from the live scene size so the probe stays
+        // valid under --scene-size (the seed plane is always local z==size.z-1);
+        // at the default 16³ this is the cell's stored z==15.
+        const IRMath::ivec3 cell = probeGroundCell(cellIndex);
+        const IRMath::vec3 worldCenter = g_editableSceneOrigin + IRMath::vec3(cell);
         g_probeMapMoves[cellIndex].screenPx_ = IRRender::worldPos3DToMouseScreenPx(worldCenter);
     }
     const auto &assertions = g_shotAssertions[shotIndex];
@@ -1232,7 +1265,33 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("  N: toggle bone-paint mode (click swatch in BONE panel to pick bone)");
     IR_LOG_INFO("  Joint arrows place (re-binds at release); rings FK-pose (live deform)");
     IR_LOG_INFO("  T: set current pose as bind (joint mode)");
+    // Editable grid dims (#766 Part 2): the ant needs 20³, the tree ~26 tall.
+    // Register before init (which owns the parse); read back + derive the origin
+    // after. Omitted / non-positive dims keep the historical 16³ scene.
+    IREngine::args()
+        .numbers("--scene-size", "editable voxel grid dims: W H D (default 16 16 16)", 3);
     IREngine::init(argc, argv);
+    {
+        const std::vector<float> &dims = IREngine::args().getFloats("--scene-size");
+        if (dims.size() == 3 && dims[0] >= 1.0f && dims[1] >= 1.0f && dims[2] >= 1.0f) {
+            IRVoxelEditor::g_editableSceneSize = ivec3(
+                static_cast<int>(dims[0]),
+                static_cast<int>(dims[1]),
+                static_cast<int>(dims[2])
+            );
+            IRVoxelEditor::g_editableSceneOrigin =
+                IRVoxelEditor::deriveSceneOrigin(IRVoxelEditor::g_editableSceneSize);
+        }
+        IR_LOG_INFO(
+            "Editor scene size: {}x{}x{} (origin {},{},{})",
+            IRVoxelEditor::g_editableSceneSize.x,
+            IRVoxelEditor::g_editableSceneSize.y,
+            IRVoxelEditor::g_editableSceneSize.z,
+            IRVoxelEditor::g_editableSceneOrigin.x,
+            IRVoxelEditor::g_editableSceneOrigin.y,
+            IRVoxelEditor::g_editableSceneOrigin.z
+        );
+    }
     initSystems();
     initCommands();
     initEntities();
@@ -1279,9 +1338,9 @@ void initSystems() {
             if (!IRVoxelEditor::g_loftTool.active_ || !lrp->canvas_)
                 return;
             auto &loft = IRVoxelEditor::g_loftTool;
-            const int sx = IRVoxelEditor::kEditableSceneSize.x;
-            const int sy = IRVoxelEditor::kEditableSceneSize.y;
-            const int sz = IRVoxelEditor::kEditableSceneSize.z;
+            const int sx = IRVoxelEditor::g_editableSceneSize.x;
+            const int sy = IRVoxelEditor::g_editableSceneSize.y;
+            const int sz = IRVoxelEditor::g_editableSceneSize.z;
             IRRender::drawMaskGridOntoCanvas(
                 *lrp->canvas_,
                 loft.maskXZ_,
@@ -1431,9 +1490,9 @@ void initSystems() {
                 static_cast<int>(lip->mouseGuiTrixel_.y)
             );
             const bool shiftHeld = IRInput::checkKeyMouseModifiers(IRInput::kModifierShift, 0u);
-            const int sx = IRVoxelEditor::kEditableSceneSize.x;
-            const int sy = IRVoxelEditor::kEditableSceneSize.y;
-            const int sz = IRVoxelEditor::kEditableSceneSize.z;
+            const int sx = IRVoxelEditor::g_editableSceneSize.x;
+            const int sy = IRVoxelEditor::g_editableSceneSize.y;
+            const int sz = IRVoxelEditor::g_editableSceneSize.z;
             const int cell = IRVoxelEditor::kLoftCellPx;
 
             auto paintCell = [&](std::vector<bool> &mask, ivec2 cellHV, int sH) {
@@ -2734,7 +2793,7 @@ void initCommands() {
                 std::string(IRVoxelEditor::kSceneSaveDir),
                 std::string(IRVoxelEditor::kSceneBaseName),
                 snapshots,
-                IRVoxelEditor::kEditableSceneSize,
+                IRVoxelEditor::g_editableSceneSize,
                 IRVoxelEditor::g_layerManager,
                 anim,
                 IRVoxelEditor::g_symmetry
@@ -3044,8 +3103,8 @@ void initEntities() {
     // first click to land on. Architect D1: the size is a named
     // constant on the editor side, not hardcoded inline.
     g_editor.editableVoxelSet_ = IREntity::createEntity(
-        C_LocalTransform{IRVoxelEditor::kEditableSceneOrigin},
-        C_VoxelSetNew{IRVoxelEditor::kEditableSceneSize, Color{200, 200, 210, 255}}
+        C_LocalTransform{IRVoxelEditor::g_editableSceneOrigin},
+        C_VoxelSetNew{IRVoxelEditor::g_editableSceneSize, Color{200, 200, 210, 255}}
     );
     IRVoxelEditor::g_sceneVoxelSetEntity = g_editor.editableVoxelSet_;
     {
@@ -3386,10 +3445,16 @@ void initEntities() {
             "fps_value"
         ),
     };
-    constexpr ivec3 kScenePickExpected{-1, -1, -1};
-    IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kPickVoxelShotIndex] = {
-        IRPrefab::GuiTest::picksVoxel(kScenePickExpected, "scene_pick"),
-    };
+    // The pick_voxel baseline is a specific 16³-scene voxel; it only holds at the
+    // default size, so skip it under --scene-size (the probe_map assertions below
+    // cover mapping accuracy at any size). Leaving the table empty makes
+    // onGuiAssertFrame skip the shot cleanly.
+    if (IRVoxelEditor::g_editableSceneSize == IRVoxelEditor::kDefaultEditableSceneSize) {
+        constexpr ivec3 kScenePickExpected{-1, -1, -1};
+        IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kPickVoxelShotIndex] = {
+            IRPrefab::GuiTest::picksVoxel(kScenePickExpected, "scene_pick"),
+        };
+    }
     // Phase 0 probe 2 (#766): each probe-map shot asserts the ray landed on the
     // target cell's iso COLUMN (not the exact voxel) — mapping accuracy is a 2D
     // screen-projection property, and the seed scene's rig geometry can occlude
@@ -3397,7 +3462,7 @@ void initEntities() {
     // (integers, so exact). onGuiAssertFrame supplies the matching cursor pixel.
     for (int i = 0; i < IRVoxelEditor::kProbeMapCount; ++i) {
         const ivec3 target =
-            ivec3(IRVoxelEditor::kEditableSceneOrigin) + IRVoxelEditor::kProbeMapLocalCells[i];
+            ivec3(IRVoxelEditor::g_editableSceneOrigin) + IRVoxelEditor::probeGroundCell(i);
         IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kProbeMapShotStart + i] = {
             IRPrefab::GuiTest::picksIsoColumn(target, "probe_map"),
         };

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -422,13 +422,20 @@ IRVideo::GuiInputEvent g_probeMapMoves[kProbeMapCount] = {
     {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(0)},
 };
 
-// The i-th probe-map cell with its z snapped to the live ground plane
-// (local z == size.z-1). Keeps the probe valid under --scene-size — the stored
-// z is the 16³ default; the actual seed plane moves with the scene height.
+// The i-th probe-map cell snapped into the live scene bounds so the probe
+// stays valid under --scene-size: z rides the ground plane (local z ==
+// size.z-1), and x/y clamp into the live footprint. The stored cells target a
+// 16³ grid (x/y up to 11), so a --scene-size narrower than 12 in x or y would
+// otherwise push them off-grid; clamping collapses those onto the nearest edge
+// cell (a valid ground cell that still projects on-screen), trading probe
+// coverage for a probe that asserts at any footprint. At the default 16³ every
+// stored x/y is < 16 and passes through unchanged. Both the assertion target
+// (initEntities) and the cursor-move pixel (onGuiAssertFrame) go through this
+// helper, so they stay consistent for whatever cell it returns.
 inline IRMath::ivec3 probeGroundCell(int i) {
     return IRMath::ivec3(
-        kProbeMapLocalCells[i].x,
-        kProbeMapLocalCells[i].y,
+        IRMath::min(kProbeMapLocalCells[i].x, g_editableSceneSize.x - 1),
+        IRMath::min(kProbeMapLocalCells[i].y, g_editableSceneSize.y - 1),
         g_editableSceneSize.z - 1
     );
 }

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -147,3 +147,43 @@ so it prints the literal `Added blank frame %d / %d`. Pre-existing, cosmetic
 - The `editor_probe_*` shot pattern (runtime-computed `MOVE` pixels filled in
   `onGuiAssertFrame` before the same-tick event injection, so the aim uses the
   shot's live camera state — no init-time viewport-timing fragility).
+
+---
+
+## Part 2 — session infrastructure + first entities
+
+Builds on the Phase 0 primitives above. Sequence: (a) editor-authoring
+prerequisites → (b) `SessionBuilder` + `--gui-session` + `scripts/author-entity.py`
+runner → (c) the five entities (rock first). This slice appends as it lands.
+
+### 2a — `--scene-size W H D` (LANDED)
+
+The ant needs a 20³ grid and the tree ~26 tall, so the editable scene size is
+now a runtime arg instead of the constexpr 16³. `kEditableSceneSize` /
+`kEditableSceneOrigin` became `g_editableSceneSize` / `g_editableSceneOrigin`,
+set in `main()` after the engine arg parse. `deriveSceneOrigin(size)` keeps the
+scene centred in X/Y (`origin.{x,y} = -size.{x,y}/2`) and pins the seed ground
+plane (local `z == size.z-1`) at **world z == 3 for any height**
+(`origin.z = -(size.z-4)`), so authoring recipes and probe cells stay
+height-agnostic — the ground never moves under the camera as the scene grows.
+
+Friction notes for the session slice:
+- **The seed ground plane is a saved slab.** `fillPlane(2, size.z-1, …)` puts a
+  full gray layer in the scene; a clean entity save wants it erased first. Confirms
+  the plan's call for an **erase-fill mode** (2b) to clear the slab and carve —
+  single-voxel right-click is the only erase today, so clearing a 20×20 slab by
+  hand is ~400 clicks.
+- **The `editor_pick_voxel` baseline is 16³-specific** (a hardcoded expected
+  voxel at a hardcoded pixel), so it is skipped under `--scene-size`. The
+  `editor_probe_*` mapping shots are size-robust — their target z derives from
+  `g_editableSceneSize.z-1` — and pass at 20³ (`gui-verify` default 13/13; a
+  direct `--scene-size 20 20 20` run is CLEAN with all 8 mapping probes PASS).
+
+### 2b — erase-fill mode, SessionBuilder, runner, ROCK — NEXT
+Remaining Part 2 work, in order: erase-fill mode toggle (flips place↔erase for
+the click/box/line/face paths); `SessionBuilder` compiling authoring recipes to
+`GuiInputEvent` streams via `worldPos3DToMouseScreenPx`; `--gui-session <name>`
+selection; `scripts/author-entity.py` (run → parse `GUI-ASSERT` → verify saves →
+copy to `assets/voxel/entities/` → re-run byte-compare); then the ROCK session
+(sequence the P0-3 drag-stroke probe here). Note: vertical picking needs
+**zoom ≥ 2** (see P0-2) — session shots that pick by column must honour it.


### PR DESCRIPTION
## Summary
- Adds `--scene-size W H D` to `IRVoxelEditor`; the editable grid + origin are now runtime state (`g_editableSceneSize` / `g_editableSceneOrigin`) resolved after the engine arg parse. **Part 2 of #766 (does not close it)** — F-1.6's entities need more than the hardcoded 16³ (the ant is 20³, the tree ~26 tall).
- `deriveSceneOrigin` centres the scene in X/Y and pins the seed ground plane at a fixed world z (`kSeedGroundPlaneWorldZ`), so the ground stays put under the camera as the scene grows taller.
- The Phase 0 (#2489) mapping probes are made size-robust (`probeGroundCell` snaps each cell's z to the live plane) so they assert at any size; the `editor_pick_voxel` baseline is a specific 16³ voxel and is skipped under `--scene-size`. The default 16³ path is behaviourally identical to before.

## Test plan
- [x] `gui-verify IRVoxelEditor` → **13/13** at the default size — no regression to #2489's freshly-merged probe suite.
- [x] `IRVoxelEditor --auto-screenshot 10 --scene-size 20 20 20` → **CLEAN (exit 0)**; logs `Editor scene size: 20x20x20 (origin -10,-10,-16)`; all **8 mapping probes PASS at 20³**; the 16³ pick baseline correctly skipped.

## Notes
- Next in Part 2: erase-fill mode, `SessionBuilder` + `--gui-session`, `scripts/author-entity.py`, then the first entities (rock first). Tracked in `docs/design/editor-authoring-friction.md` §"Part 2".

🤖 Generated with [Claude Code](https://claude.com/claude-code)