### PR TITLE
build: link Scripting -> World to break the static-lib cycle (#2499)

### DIFF
--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -1055,11 +1055,16 @@ IRSave.has("highscores", "top1"); IRSave.remove("highscores", "top1"); IRSave.cl
 
 `bindLuaDrivenEcs()` also exposes the ECS **world snapshot** (persist P7, #2218,
 epic #667) as the `IRPersist` table — whole-world binary save/load, distinct
-from `IRSave` (the flat KV store above). `lua_world_snapshot_bindings.hpp` is
-**include-only glue** (`bindWorldSnapshotApi`): a thin forward to
-`IRWorld::saveWorld/loadWorld(path)` over `makeDefaultSaveRegistry()`, wired via
-the same generator-expression include of `IrredenEngineWorld` as the render/
-audio glue — no link edge (World links Scripting; a link back would cycle).
+from `IRSave` (the flat KV store above). `lua_world_snapshot_bindings.hpp`'s
+`bindWorldSnapshotApi` is a thin forward to
+`IRWorld::saveWorld/loadWorld(path)` over `makeDefaultSaveRegistry()`. Because
+that inline glue *calls* those symbols — not just includes the header, as the
+render/audio glue does — Scripting **links** `IrredenEngineWorld`. World links
+Scripting back, so the edge closes a static-library cycle; CMake resolves it by
+repeating both archives on the final link line, which is what lets single-pass
+linkers (mingw / GNU ld) rescan World after Scripting's back-reference. Without
+the link those symbols went undefined on native-Windows demo links; Apple
+ld64's multi-pass resolver had masked the gap (#2499).
 
 ```lua
 IRPersist.saveWorld("scene.irws")   -- serialize the live world (+ .json sidecar).

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -53,14 +53,23 @@ target_include_directories(
     IrredenEngineScripting PRIVATE
     $<TARGET_PROPERTY:IrredenEngineAudio,INTERFACE_INCLUDE_DIRECTORIES>
 )
-# lua_world_snapshot_bindings.hpp includes <irreden/world/world_snapshot.hpp>
-# (IRPersist world save/load, persist P7 #2218). Same include-only generator-
-# expression pattern — IRWorld:: symbols resolve at final exe link through
-# IrredenEngineWorld. NO library link: World links Scripting, so a link back
-# would form a cycle.
-target_include_directories(
-    IrredenEngineScripting PRIVATE
-    $<TARGET_PROPERTY:IrredenEngineWorld,INTERFACE_INCLUDE_DIRECTORIES>
+# lua_world_snapshot_bindings.hpp's inline bindWorldSnapshotApi references
+# IRWorld::saveWorld / IRWorld::loadWorld (IRPersist world save/load, persist
+# P7 #2218 / #2244), which are DEFINED in IrredenEngineWorld
+# (world_default_registry.cpp) — a genuine link-time dependency Scripting ->
+# World. World already links Scripting back, so declaring this edge closes a
+# static-library cycle; CMake resolves such cycles by REPEATING the archives on
+# the final link line, which lets single-pass linkers (mingw / GNU ld) rescan
+# World after Scripting's back-reference and pull world_default_registry.obj.
+# The prior include-only workaround (bare INTERFACE_INCLUDE_DIRECTORIES, no
+# link) left those symbols undefined on single-pass ld — every native-Windows
+# demo link failed (#2499); Apple ld64's multi-pass resolver masked the gap.
+# PUBLIC so consumers that include this header and instantiate the bindings
+# resolve the World symbols too. World's include dirs propagate via the link, so
+# no separate target_include_directories is needed.
+target_link_libraries(
+    IrredenEngineScripting PUBLIC
+    IrredenEngineWorld
 )
 # Force sol2 to use its try/catch trampoline rather than letting C++
 # exceptions propagate through the LuaJIT VM. With LuaJIT 2.1 sol2's

--- a/engine/script/include/irreden/script/lua_world_snapshot_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_world_snapshot_bindings.hpp
@@ -14,12 +14,13 @@ namespace IRScript::detail {
 
 // Exposes the ECS world snapshot (persist P7, #2218, epic #667) as the
 // `IRPersist` Lua table: whole-world binary save/load over the process-default
-// SaveRegistry (IRWorld::makeDefaultSaveRegistry). Include-only glue mirroring
-// bindRenderGlue / bindAudioApi — every binding is a thin forward to an
-// IRWorld:: entry point; no persistence logic lives here, and there is no link
-// edge to IrredenEngineWorld (World links Scripting; a link back would cycle —
-// IRWorld:: symbols resolve at final-executable link, the same generator-
-// expression include-only pattern the render/audio glue uses).
+// SaveRegistry (IRWorld::makeDefaultSaveRegistry). Every binding is a thin
+// forward to an IRWorld:: entry point; no persistence logic lives here. Unlike
+// bindRenderGlue / bindAudioApi (include-only glue with no link edge), this
+// binding genuinely calls IRWorld::saveWorld/loadWorld, so IrredenEngineScripting
+// links IrredenEngineWorld (engine/script/CMakeLists.txt). World links
+// Scripting back, closing a static-lib cycle that CMake resolves by repeating
+// both archives on the final link line (#2499).
 //
 // Surface:
 //   IRPersist.saveWorld(path) -> bool   serialize the live world to `path`


### PR DESCRIPTION
## Summary

Fixes the native-Windows (MSYS2 mingw64) demo link failure where every demo
build died at the final exe link with `undefined reference to
IRWorld::saveWorld(std::string const&)` / `IRWorld::loadWorld(...)` (#2499).

**Root cause — undeclared static-library cycle.** `IrredenEngineScripting`'s
inline `bindWorldSnapshotApi` (`lua_world_snapshot_bindings.hpp`) calls
`IRWorld::saveWorld/loadWorld`, which are *defined* in `IrredenEngineWorld`
(`world_default_registry.cpp`). But `engine/script/CMakeLists.txt` only pulled
World's `INTERFACE_INCLUDE_DIRECTORIES` — **no link edge** — deliberately, to
avoid a cycle (World already links Scripting back). With no declared
Scripting→World dependency, CMake emitted each archive once on the demo link
line, World **before** Scripting. On single-pass linkers (mingw / GNU ld) World
is scanned first while nothing yet references the persist symbols, so
`world_default_registry.obj` is never pulled; Scripting is scanned next,
references `saveWorld`/`loadWorld`, and they resolve to nothing → undefined.
Latent since the persist bindings landed (2026-07-05, #2218 / #2244); surfaced
once native-Windows started running full demo builds. Apple ld64's multi-pass
resolver masked the gap on macOS.

**Fix — CMake-only, no source or behavior change.** Declare the real
`target_link_libraries(IrredenEngineScripting PUBLIC IrredenEngineWorld)`,
replacing the include-only workaround (a PUBLIC link supersedes it — it
propagates World's include dirs too). World↔Scripting is now a declared static
cycle, which CMake resolves by **repeating both archives** on the link line so
single-pass ld rescans World after Scripting's back-reference. PUBLIC because
the reference lives in a public inline header, so external consumers that
instantiate the bindings resolve the World symbols too.

## macOS verification (this host)

macOS ld64 already linked before this change (multi-pass), so it cannot
exercise the acceptance directly — but it does confirm no regression and, via
the generated link line, the fix *mechanism* (CMake's archive repetition is
computed generator-independently, so the Windows/Linux Unix-/MinGW-Makefiles
link lines get the same repetition):

- **Link line, before → after** (`IRShapeDebug.dir/link.txt`):
  - before: `libIrredenEngineWorld.a libIrredenEngineScripting.a` — each once, World first (the bug)
  - after:  `…Scripting World Scripting World…` — both archives repeated (the cycle fix)
- `cmake --preset macos-debug` configures with no cycle error.
- `fleet-build --target IRShapeDebug` links clean; `fleet-run` runs 5s without crashing.
- One benign macOS-only note: `ld: warning: ignoring duplicate libraries` —
  ld64 doesn't *need* the repeated archives (multi-pass) so it dedupes them
  with a warning. That repetition is exactly what single-pass GNU/mingw ld
  *requires*; no warning there.

## Cross-host validation needed (acceptance)

The issue's acceptance is a clean link on **windows-debug** AND **linux-debug** —
neither buildable on this macOS host. This PR carries `fleet:needs-windows-smoke`
+ `fleet:needs-linux-smoke` so a Windows/Linux host confirms the actual link
(the reviewer's smoke tagging is path-based and won't fire on a CMakeLists-only
diff, so I've added them proactively — the whole point of the fix is those two
linkers).

## Test plan

- [ ] `fleet-build --target IRShapeDebug` (and `IRPerfGrid`) links clean on **windows-debug** (native mingw64)
- [ ] `fleet-build --target IRShapeDebug` still links on **linux-debug** (no regression)
- [x] macOS: configures, links, runs; link line shows the archive repetition

Closes #2499
