### PR TITLE
render+build: unbreak native-Windows master — GNU-ld link cycle + two NVIDIA GLSL rejections

### DIFF
--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -464,9 +464,14 @@ void main() {
                 uint feederSlices = (voxelRenderOptions.x != 0) ? uint(cap * cap) : 1u;
                 writeDispatchDims(kPerAxisIndirectStrideUints, feederSlices);
             } else {
-                for (int axis = 0; axis < 3; ++axis) {
-                    writeDispatchDims(uint(axis) * kPerAxisIndirectStrideUints, visibleSlices);
-                }
+                // Unrolled (was a for over axis 0..2): NVIDIA's link-time
+                // optimizer dies with "C5025 lvalue in array access too
+                // complex" + a C9999 ICE when the loop-variant base mixes
+                // with the constant-base call sites above; constant bases
+                // at every call site keep the inlined stores foldable.
+                writeDispatchDims(0u, visibleSlices);
+                writeDispatchDims(kPerAxisIndirectStrideUints, visibleSlices);
+                writeDispatchDims(2u * kPerAxisIndirectStrideUints, visibleSlices);
             }
         }
     }

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -248,9 +248,12 @@ uvec2 encodeEntityIdWithPriority(uvec2 id, uint priority) {
 }
 // Set the fog cut-face flag on an ALREADY priority-encoded id. Call after
 // encodeEntityIdWithPriority (which strips this bit via kEntityIdHighWordMask).
-uvec2 encodeEntityIdCutFace(uvec2 packed, bool isCutFace) {
-    return isCutFace ? uvec2(packed.x, packed.y | kEntityIdCutFaceMaskInHighWord)
-                     : packed;
+// `packedId`, not `packed` — `packed` is a reserved GLSL keyword (the
+// layout qualifier); NVIDIA's compiler rejects it as an identifier while
+// the GLSL->Metal path accepts it, so the slip only surfaces on GL hosts.
+uvec2 encodeEntityIdCutFace(uvec2 packedId, bool isCutFace) {
+    return isCutFace ? uvec2(packedId.x, packedId.y | kEntityIdCutFaceMaskInHighWord)
+                     : packedId;
 }
 
 // Per-axis fractional encoding (#1458, flip carrier #2207, wFrac carrier):

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -221,9 +221,11 @@ inline uint2 encodeEntityIdWithPriority(uint2 id, uint priority) {
                            ((priority & 0x3u) << kEntityIdPriorityShiftInHighWord));
 }
 // Set the fog cut-face flag on an ALREADY priority-encoded id — GLSL twin.
-inline uint2 encodeEntityIdCutFace(uint2 packed, bool isCutFace) {
-    return isCutFace ? uint2(packed.x, packed.y | kEntityIdCutFaceMaskInHighWord)
-                     : packed;
+// `packedId` mirrors the GLSL side, where `packed` is a reserved keyword
+// (NVIDIA rejects it as an identifier); keep the twins in lockstep.
+inline uint2 encodeEntityIdCutFace(uint2 packedId, bool isCutFace) {
+    return isCutFace ? uint2(packedId.x, packedId.y | kEntityIdCutFaceMaskInHighWord)
+                     : packedId;
 }
 
 // Per-axis fractional encoding (#1458, flip carrier #2207, wFrac carrier):


### PR DESCRIPTION
## Summary
Two functionality-preserving shader fixes that unbreak master's first
voxel-pipeline shader compile on NVIDIA hosts (native Windows, Linux). These
regressions merged mac-validated, where Apple's permissive shader frontend
accepts them. Found by the first Windows platform-catchup since June 27.

Closes #2504 — the `packed` GLSL reserved-keyword crash in `encodeEntityIdCutFace`; this PR's `ir_iso_common.glsl` rename (+ Metal twin) is that exact fix. A comment-stripped reserved-word sweep of all 50 GLSL files finds no *other* reserved-word identifier, so #2504's "no further latent error hiding behind this one" bullet holds (final empirical confirmation via the post-#2501 Windows-smoke run).

> **Scope reduced (amend 2026-07-21):** the GNU-ld `Scripting`→`World`
> link-cycle fix originally bundled here has been **dropped** — it duplicated
> the already-`fleet:approved` PR **#2501** (`build: link Scripting -> World to
> break the static-lib cycle (#2499)`), which is the *complete* fix (it also
> updates the stale `lua_world_snapshot_bindings.hpp` header comment this PR
> left untouched). This PR is now **shader-only**. Sequencing: land **#2501
> first**, then rebase this onto it so it links on GNU-ld hosts.

- **`packed` reserved keyword (from #2175 / fog cut-face).**
  `encodeEntityIdCutFace(uvec2 packed, …)` — `packed` is a reserved GLSL
  keyword (the layout qualifier); NVIDIA rejects it as an identifier
  (`error C0000 … at token "isCutFace"`), killing the first voxel-pipeline
  shader compile in every demo. Renamed `packedId` in both backend twins
  (`ir_iso_common.glsl` + `metal/ir_iso_common.metal`), kept in lockstep.
- **NVIDIA link-time ICE in the compact kernel (trigger from #2325 / #2258
  Step B).** Once the constant-base feeder
  `writeDispatchDims(kPerAxisIndirectStrideUints, …)` call coexists with the
  loop-variant per-axis call, NVIDIA's link-time optimizer fails with
  `C5025: lvalue in array access too complex` + `C9999 *** exception during
  compilation ***`. Fix: unroll the 3-iteration axis loop so every call site
  passes a constant base — semantically identical. Metal keeps its loop (its
  compiler is unaffected); the divergence is documented at the unroll site.

## Test plan
- [x] **macOS / Metal (this amend):** `IRShapeDebug` builds clean and runs
  `RESULT=CLEAN exit=0` across all 21 auto-screenshot shots — verifies the
  Metal `packedId` twin loads & renders, and that master's include-only
  `Scripting` CMake (restored here by dropping the #2501 duplicate) still
  links on ld64.
- [x] Full 41-target windows-debug cohort built clean & ran (author's original
  run) **with #2501's link fix present**. Both shader fixes here are
  independent of that link fix and are individually correct (reviewer-confirmed
  in the first review).
- [ ] **Deferred to post-#2501:** this shader-only branch is based on
  pre-#2501 master, so it will NOT *link* on GNU-ld hosts (the
  `IRWorld::saveWorld` undefined-reference cycle returns) until #2501 lands and
  this rebases onto it. Re-run the windows/linux cohort at that point.
- [x] Sole red at author time: `IRLuaPerfGrid` hangs under `--auto-screenshot`
  — bisect-window regression independent of these fixes; filed as #2502.

## Notes for reviewer
- Both shader changes are functionality-preserving by construction (identifier
  rename; 3-iteration loop unroll with identical bodies). No named-argument
  call sites exist in GLSL or MSL, so the rename is safe across twins.
- The Metal side is now macOS-verified (above) — `fleet:needs-macos-smoke` is
  not needed for the `.metal` edit.
- The #2501 duplication flagged in the first review is resolved here by
  dropping the `engine/script/CMakeLists.txt` + `engine/script/CLAUDE.md`
  hunks; #2501 remains the sole owner of the link-cycle fix.

🤖 Amended by Claude Opus (worker feedback pass)

