### PR TITLE
render(shader): rename GLSL-reserved 'packed' param in encodeEntityIdCutFace (#2504)

### DIFF
--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -248,9 +248,9 @@ uvec2 encodeEntityIdWithPriority(uvec2 id, uint priority) {
 }
 // Set the fog cut-face flag on an ALREADY priority-encoded id. Call after
 // encodeEntityIdWithPriority (which strips this bit via kEntityIdHighWordMask).
-uvec2 encodeEntityIdCutFace(uvec2 packed, bool isCutFace) {
-    return isCutFace ? uvec2(packed.x, packed.y | kEntityIdCutFaceMaskInHighWord)
-                     : packed;
+uvec2 encodeEntityIdCutFace(uvec2 packedId, bool isCutFace) {
+    return isCutFace ? uvec2(packedId.x, packedId.y | kEntityIdCutFaceMaskInHighWord)
+                     : packedId;
 }
 
 // Per-axis fractional encoding (#1458, flip carrier #2207, wFrac carrier):

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -221,9 +221,9 @@ inline uint2 encodeEntityIdWithPriority(uint2 id, uint priority) {
                            ((priority & 0x3u) << kEntityIdPriorityShiftInHighWord));
 }
 // Set the fog cut-face flag on an ALREADY priority-encoded id — GLSL twin.
-inline uint2 encodeEntityIdCutFace(uint2 packed, bool isCutFace) {
-    return isCutFace ? uint2(packed.x, packed.y | kEntityIdCutFaceMaskInHighWord)
-                     : packed;
+inline uint2 encodeEntityIdCutFace(uint2 packedId, bool isCutFace) {
+    return isCutFace ? uint2(packedId.x, packedId.y | kEntityIdCutFaceMaskInHighWord)
+                     : packedId;
 }
 
 // Per-axis fractional encoding (#1458, flip carrier #2207, wFrac carrier):


### PR DESCRIPTION
## Summary
- Rename the GLSL-reserved keyword `packed` → `packedId` in
  `encodeEntityIdCutFace` (`ir_iso_common.glsl` + its Metal twin).
- NVIDIA's GLSL front-end rejects `packed` as an identifier (reserved
  layout qualifier), cascading into a shader-compile failure that crashed
  `IRShapeDebug` at world-init on native-Windows/NVIDIA. Latent ~3 weeks
  (since #2175): MSL and Linux/Mesa both tolerate the name, and the
  native-Windows OpenGL smoke lane was itself blocked by the #2499 link
  cycle so no strict-GLSL front end ever compiled this shader.
- Swept the whole GLSL shader tree for other reserved-word identifiers —
  `packed` was the only one (the `restrict` hits are the legitimate
  memory qualifier, not identifier misuse), so no second latent
  shader-compile error is hiding behind this one.

## Notes
- **Pure parameter rename, no semantic change** — the compiled shader is
  byte-identical by construction, so this qualifies for the render
  CLAUDE.md "internal refactor with provably no runtime effect" exception
  to the render-debug-loop / screenshot requirement.
- Stacked on #2501 per the issue's acceptance criteria: the Windows crash
  is only reachable once #2501's link fix lets `IRShapeDebug` link. The
  shader fix itself is orthogonal to #2501 (touches only shaders).

## Test plan
- [x] macOS/Metal: `fleet-build --target IRShapeDebug` builds clean (only
  the benign #2501 ld64 dup-library warning).
- [x] macOS/Metal: `fleet-run IRShapeDebug --auto-screenshot 10` →
  `RESULT=CLEAN` (21 shots, no shader-compile assertion).
- [ ] native-Windows/NVIDIA (Windows-smoke lane, post-merge): `IRShapeDebug`
  reaches `RESULT=CLEAN` with no `encodeEntityIdCutFace` shader-compile error.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2501

Closes #2504
