### PR TITLE
render: one definition for the stage-1/stage-2 mirrored face-select + fog + per-axis store key

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -117,7 +117,10 @@ Naming prefixes follow the convention in
 [`CLAUDE-BASELINE.md §Naming`](../../docs/agents/CLAUDE-BASELINE.md#naming).
 Shared includes: `ir_iso_common.glsl`, `ir_constants.glsl`,
 `ir_world_lighting.glsl` (light-source list layout + SPOT cone +
-ACES tonemap, shared by the world-lighting passes).
+ACES tonemap, shared by the world-lighting passes),
+`ir_voxel_face_select.glsl` (fog reveal + face selection + per-axis
+store key, shared by the stage-1/stage-2 kernel family — the fog grid
+image slot is wrapper-supplied via `IR_VOXEL_FOG_GRID_BINDING`).
 Shader file paths are stored in `render/shader_names.hpp`. Update that
 header when you add or rename a shader.
 

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
@@ -19,5 +19,7 @@
 #define IR_FEEDER_PASS 0
 #define IR_STORE_WINNER_ELECTION 0
 #include "ir_iso_common.glsl"
+#define IR_VOXEL_FOG_GRID_BINDING 0
 #include "ir_constants.glsl"
+#include "ir_voxel_face_select.glsl"
 #include "c_voxel_to_trixel_stage_1_body.glsl"

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1_body.glsl
@@ -18,8 +18,10 @@
 // ir_sun_shadow_sample.glsl idiom):
 //   #define IR_FEEDER_PASS {0|1}
 //   #define IR_STORE_WINNER_ELECTION {0|1}
+//   #define IR_VOXEL_FOG_GRID_BINDING 0
 //   #include "ir_iso_common.glsl"
 //   #include "ir_constants.glsl"
+//   #include "ir_voxel_face_select.glsl"
 //   #include "c_voxel_to_trixel_stage_1_body.glsl"
 // The three wrappers:
 //   c_voxel_to_trixel_stage_1.glsl        → FEEDER 0, ELECTION 0 = visible dispatch
@@ -202,22 +204,10 @@ layout(std430, binding = 28) buffer PerAxisWinnerScratch {
     uint perAxisWinnerIds[];
 };
 
-// Per-voxel analytic fog clip inputs (#2102), mirroring c_voxel_visibility_compact
-// + c_fog_to_trixel. The world fog canvas binds its 256² grid texture on image
-// slot 0 and uploads the live vision circles at binding 27; every non-fog /
-// detached canvas binds the shared 1×1 all-visible placeholder + a count-0
-// observer buffer, so `fogColumnReveal` short-circuits to "fully visible"
-// and those scenes stay byte-identical. Slot 0 is free in STAGE_1 (it writes
-// only the distance image on slot 1); STAGE_2 rebinds slot 0 to the colour
-// image and reads the fog grid on slot 3 instead.
-const int kFogOfWarHalfExtent = 128;
-const float kFogExploredThreshold = 0.25;
-const int kMaxFogVisionCircles = 8; // mirror of component_canvas_fog_of_war.hpp kMaxFogVisionCircles
-layout(rgba8, binding = 0) readonly uniform image2D canvasFogOfWar;
-layout(std140, binding = 27) uniform FogObserverData {
-    vec4 visionCircles[kMaxFogVisionCircles]; // (centerX, centerY, radius, edgeSoftness)
-    int visionCircleCount;
-};
+// Fog grid + observers + fogColumnReveal/Nearest and the shared face-selection
+// / per-axis store-key math live in ir_voxel_face_select.glsl (the wrapper
+// includes it before this body; STAGE_1's fog grid rides image slot 0 via
+// IR_VOXEL_FOG_GRID_BINDING — free here, the distance image is slot 1).
 
 void writeDistanceTap(const ivec2 canvasPixel, const int voxelDistance) {
     if (!isInsideCanvas(canvasPixel, imageSize(triangleCanvasDistances))) return;
@@ -426,106 +416,6 @@ void emitDeformedFace(
     }
 }
 
-// Fog reveal of world grid COLUMN `col` (xy world units) in [0,1]: the strongest
-// live vision-circle reveal at the column center (aa = 0), or 1.0 ("fully visible")
-// for explored grid memory, OOB columns, and the 1×1 placeholder. Two callers
-// threshold this on the SAME analytic curve, each with the comparison its job
-// needs:
-//   - #2102 own-column drop: drop iff `reveal <= 0.0` (FULLY hidden — past the
-//     disc's outer soft edge). Such a column's voxel would only let FOG_TO_TRIXEL
-//     hard-black its faces; dropping it (STAGE_2 inherits the drop via its depth
-//     re-test) shows the revealed floor / background behind instead. A PARTIALLY
-//     revealed boundary column (0 < reveal < 1) is KEPT and rasterizes, so the
-//     per-pixel FOG_TO_TRIXEL mask fades the object's silhouette on the SAME
-//     smooth curve it fades the floor (#2126 Mode B — "reveal whole voxels then
-//     smooth like the floor").
-//   - #2125/#2126 neighbor cut-face test: emit a cut face iff `reveal < 1.0`
-//     ("neighbor not fully revealed") so a cut face exists across the whole soft
-//     boundary band for the per-pixel mask to trim.
-// With a hard disc (edgeSoftness == 0, Mode A / the default) reveal is binary
-// {0,1}, so `reveal <= 0.0`, `reveal < 0.5`, and `reveal < 1.0` all coincide at
-// "center outside radius" — Mode A and non-fog scenes stay byte-identical.
-//
-// This is c_voxel_visibility_compact's drop test taken to the PRECISE radius:
-// the compact keeps a permissive +edgeSoftness+1-cell margin so the per-pixel
-// floor reveal stays smooth (no grid-aligned notches, #2068); STAGE_1 tightens
-// that margin away for the voxel object so its fully-hidden faces no longer
-// rasterize. Explored grid memory and in/at-disc columns are kept; the 1×1
-// placeholder + OOB columns read as fully visible, matching the OOB-as-visible
-// invariant — so non-fog / detached canvases are byte-identical.
-// Duplicated byte-identically in c_voxel_to_trixel_stage_2.{glsl,metal} (fog
-// grid binds on slot 3 there instead of slot 0 — slot-parameterized images are
-// not possible in GLSL/MSL, hence the duplication). Keep them in sync.
-float fogColumnReveal(ivec2 col) {
-    const ivec2 fogSize = imageSize(canvasFogOfWar);
-    if (fogSize.x <= 1) {
-        return 1.0; // 1×1 all-visible placeholder (non-fog / detached canvas)
-    }
-    const ivec2 cell = col + ivec2(kFogOfWarHalfExtent);
-    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
-        return 1.0; // out-of-range column reads as visible
-    }
-    if (imageLoad(canvasFogOfWar, cell).r >= kFogExploredThreshold) {
-        return 1.0; // explored / visible grid memory — keep (FOG_TO_TRIXEL fades it)
-    }
-    float reveal = 0.0;
-    for (int i = 0; i < visionCircleCount; ++i) {
-        reveal = max(reveal, fogVisionCircleReveal(vec2(col), visionCircles[i], 0.0));
-    }
-    return reveal;
-}
-
-// Own-column DROP reveal, evaluated at the cell point NEAREST each vision-circle
-// center rather than the cell center (#2124 screen-space cross-section) — see the
-// Metal twin. The drop keeps a column iff this is > 0, so a column the disc merely
-// CLIPS (center outside R, unit cell still overlaps the reveal region) is KEPT and
-// rasters its full footprint; FOG_TO_TRIXEL then trims it per pixel at the exact
-// analytic edge (a game-resolution silhouette) instead of the geometry ending on
-// the voxel lattice (the #2102 voxel-jagged edge). Evaluating at the nearest cell
-// point keeps ONLY the one-cell ring the disc crosses (tight, not a blanket
-// margin); kFogColumnKeepAa is a small rim so the hard-disc smoothstep is
-// non-degenerate and the AA rim / reconstruction skew never notches the edge.
-//
-// kFogHiddenKeepCells widens that keep into a RING of fog-hidden columns
-// around the disc (#2124 analytic cross-section): FOG_TO_TRIXEL's image-space
-// cut repaints a hidden pixel as the cylinder's cut surface, so hidden matter
-// near the rim must still RENDER (lit, normally shaded) for the cut to have
-// colour to work from — the scene renders as if unfogged in the ring and the
-// fog pass owns the reveal per pixel. The ring bounds how deep a cut face can
-// be recovered (≈ keep/√2 cells of height); columns past it drop as before
-// (their pixels could only ever read black). Ring voxels also resume casting
-// sun shadows / AO near the rim — the pre-cull (#2040) behaviour. Mirrored in
-// c_voxel_visibility_compact.{glsl,metal}'s kCullSafetyCells (keep superset).
-const float kFogColumnCellHalf = 0.5;
-const float kFogColumnKeepAa = 0.5;
-const float kFogHiddenKeepCells = 8.0;
-float fogColumnRevealNearest(ivec2 col) {
-    const ivec2 fogSize = imageSize(canvasFogOfWar);
-    if (fogSize.x <= 1) {
-        return 1.0;
-    }
-    const ivec2 cell = col + ivec2(kFogOfWarHalfExtent);
-    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
-        return 1.0;
-    }
-    if (imageLoad(canvasFogOfWar, cell).r >= kFogExploredThreshold) {
-        return 1.0;
-    }
-    float reveal = 0.0;
-    for (int i = 0; i < visionCircleCount; ++i) {
-        const vec2 nearest = clamp(
-            visionCircles[i].xy, vec2(col) - kFogColumnCellHalf, vec2(col) + kFogColumnCellHalf
-        );
-        reveal = max(
-            reveal,
-            fogVisionCircleReveal(
-                nearest, visionCircles[i], kFogColumnKeepAa + kFogHiddenKeepCells
-            )
-        );
-    }
-    return reveal;
-}
-
 void main() {
     uint compactedIdx = gl_WorkGroupID.x + gl_WorkGroupID.y * numGroupsX;
     if (compactedIdx >= visibleCount) return;
@@ -597,147 +487,41 @@ void main() {
     // the emit dilation below.
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
 
-    // Silhouette-riser face selection (rotated-footprint gap fix). The visible
-    // triplet (#1278) picks ONE polarity per axis — the camera-facing one for a
-    // convex, axis-aligned solid. A ROTATED voxel footprint (GRID re-voxelize cells
-    // / detached re-voxelize) round-to-cells into a STAIRCASE whose camera-side
-    // grazing edge presents the OPPOSITE polarity of an axis (e.g. +X where the
-    // cardinal triplet carries X_NEG): that face is exposed and on the silhouette
-    // yet absent from the triplet, so it was never emitted — the see-through
-    // "venetian-blind" gaps that appear only at the camera directions where the
-    // yaw chirality turns that edge toward the camera (worst at 90/270 here).
-    // Fix: if this slot's triplet face is occluded but the opposite same-axis face
-    // is exposed, emit that opposite face — it is the missing silhouette riser.
-    // GATED to ROTATED content only — the detached re-voxelize uniform
-    // (visibleFaceIds.w) OR the per-voxel kRotatedEmit marker (reserved bit 2, set
-    // by REBUILD_GRID_VOXELS on rotated GRID cells; see component_voxel.hpp). Static
-    // / axis-aligned content never flips, so BOTH the single-canvas and the
-    // per-axis camera-yaw fast paths stay byte-identical (the convex back face the
-    // flip would emit loses the depth atomicMin everywhere it is occluded, but
-    // gating avoids even that wasted emit + the per-axis store's sub-pixel drift).
-    // On a concave/rotated staircase the riser's pixel has NO nearer front face, so
-    // the flip correctly fills the gap. Stage 2 MUST apply the identical flip or the
-    // colour tap desyncs from the distance.
-    const bool rotatedEmit = reVoxelize || (voxels[voxelIndex].reserved & 4u) != 0u;
-    // Polarity carrier (#2207): riserFlip = 1 marks every emit below as the
-    // OPPOSITE polarity of this slot's triplet face, so the distance encoding
-    // carries the true outward normal to lighting/AO/shadow and the per-axis
-    // store/scatter can represent the flipped plane. Non-rotated content never
-    // flips, so the fast paths encode flip = 0 (byte-identical).
-    int riserFlip = 0;
-    if (rotatedEmit && !faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1)) {
-        faceId = faceId ^ 1;
-        riserFlip = 1;
-    }
+    // Face selection — the visible-triplet × exposed-mask gate (#1278), the
+    // silhouette-riser flip (#2207) + dual-emit predicate (#2157) for rotated
+    // content, and the fog cut-face widening (#2125/#2126/#2127; per-axis
+    // #2128) — is shared with stage 2 via ir_voxel_face_select.glsl: both
+    // stages key their taps off ONE definition, so the colour tap cannot
+    // desync from the distance tap.
+    const VoxelFaceSelect sel = selectVoxelFace(
+        faceId, reVoxelize, voxels[voxelIndex].reserved, flagsByte,
+        voxelPosition, perAxisRoute, isDetachedCanvas, detachedWorldReceive
+    );
+    if (!sel.keepFace) return;
+    faceId = sel.faceId;
+    const int riserFlip = sel.riserFlip;
+    const bool bothPolaritiesExposed = sel.bothPolaritiesExposed;
 
-    // Both-exposed silhouette-riser dual emit (#2157). The flip above covers a
-    // riser cell whose triplet face is OCCLUDED — but a rotated staircase EDGE
-    // cell can have BOTH polarities of a slot's axis exposed (no solid neighbour
-    // on either side). The flip never fires there, and the face-plane position
-    // (`faceMicroPositionFixed6`) is polarity-dependent on the subdivided
-    // cardinal path, so the opposite plane — the silhouette riser — rasters
-    // different pixels than the triplet face and stayed background. Emit BOTH
-    // planes for such cells on the CARDINAL subdivided path (the tail below).
-    // The base (`voxelRenderOptions.x == 0`) cardinal path is polarity-agnostic
-    // (whole-voxel footprint emit), so it needs no second emit. The PER-AXIS
-    // store shares the dropout but takes NO second tap — measured net-worse
-    // at non-cardinal yaw even with the #2207 polarity carrier (which fixes
-    // the flipped tap's lighting decode): the opposite plane's cell key
-    // collides with neighbour cells and the atomicMin winner swap uncovers
-    // more pixels than the riser fills. See #2207. Gated to rotated content via
-    // `rotatedEmit`, so axis-aligned fast paths remain byte-identical; the
-    // extra emit costs only rotated staircase edge cells. Stage 2 mirrors the
-    // predicate + the emit site.
-    const bool bothPolaritiesExposed = rotatedEmit && faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1);
-
-    // World fog route + world-column recovery (#2125 GRID, #2127 detached;
-    // per-axis #2128). The fog grid is world-space, so the cut-face + own-column
-    // tests below decide "hidden" on this voxel's WORLD column. `fogActive` is the
-    // single cheap (uniform-only) gate that keeps every non-fog / plain-DETACHED /
-    // Z-route voxel byte-identical to master AND free of the world-column rounding
-    // below. It fires on the world fog route (perAxisRoute==0: the GRID world canvas
-    // or a world-placed re-voxelize detached canvas, #2127) AND the X/Y per-axis
-    // rotation routes (1/2, #2128 — a cut face is a vertical X/Y face that rides the
-    // matching axis canvas under continuous yaw). Plain octahedral DETACHED and the
-    // Z route (3, which carries no cut faces) stay on the no-fog placeholder.
-    const bool fogActive = visionCircleCount > 0 && perAxisRoute <= 2 &&
-        (isDetachedCanvas < 0.5 ||
-         (perAxisRoute == 0 && detachedWorldReceive.w != 0.0));
-    // The GRID world canvas already rasters in world space (offset 0) and the X/Y
-    // per-axis canvases are non-detached (offset 0); a world-placed detached
-    // re-voxelize canvas rasters its pool in the pool-centered MODEL frame, so
-    // recover its world column as model + the published cell origin — the SAME
-    // (model + offset) recovery c_lighting_to_trixel uses to world-sample shadow +
-    // light. The re-voxelize bake is a pure translation off world (the rotation is
-    // baked into the integer cells), so the model-frame face normal equals the
-    // world-frame one and the neighbor column below is correct.
-    ivec2 worldColumn = ivec2(0);
-    if (fogActive) {
-        worldColumn = roundHalfUp(voxelPosition.xyz).xy +
-            (isDetachedCanvas > 0.5 ? roundHalfUp(detachedWorldReceive.xy) : ivec2(0));
-    }
-
-    // Exposed-face gate (#1278) widened with the fog CUT-FACE rule (#2125/#2127;
-    // per-axis #2128). A camera-visible face normally emits only when exposed
-    // (neighbor cell empty). At the fog boundary a non-exposed VERTICAL face
-    // (faceId 0..3 = ±X/±Y; ±Z never cut — the vision region is a vertical cylinder)
-    // becomes the object's interior cross-section wall when the solid neighbor
-    // COLUMN it faces is NOT fully revealed — so a boundary-cut object caps with a
-    // real interior face instead of a see-through hole. faceOutwardNormal6I(faceId).xy
-    // is the neighbor column offset (±1 along X/Y; 0 for ±Z, never reached here). The
-    // `fogActive` gate (#2127) extends the cut to a world-placed re-voxelize DETACHED
-    // canvas via the `worldColumn` recovery above; it also carries the per-axis route
-    // selection (routes 0/1/2, #2128 — under continuous yaw the cut face rides the
-    // matching X (route 1) or Y (route 2) axis canvas via the `(faceId>>1)!=axis`
-    // store filter below; the Z route (3) is excluded). Keeping a `perAxisRoute`
-    // comparison term in `fogActive` (rather than dropping it) makes the GLSL/MSL
-    // compiler schedule the non-fog per-axis store identically to the pre-#2128
-    // `== 0` gate, so non-fog rotating scenes stay byte-identical (a bare-removed
-    // term reshuffled the Metal per-axis tie-winner resolution). Non-fog /
-    // plain-DETACHED scenes short-circuit on `fogActive` and stay byte-identical.
-    // Distance (here) and colour (stage 2) MUST apply the identical predicate or the
-    // cut wall's depth and colour desync — keep this block byte-identical to stage 2's.
-    //
-    // P2 (#2126): the cut fires when the neighbor is "not fully revealed"
-    // (reveal < 1.0), so a cut face is emitted across the WHOLE soft boundary band
-    // and the per-pixel FOG_TO_TRIXEL mask owns the smooth silhouette (Mode B).
-    // With a hard disc (edgeSoftness == 0, Mode A / the default) reveal is binary
-    // so < 1.0 collapses to the binary boundary — Mode A is byte-identical, so the
-    // re-voxelize detached fog cut (#2127) keeps its merged behaviour at the default.
-    bool keepFace = faceIsExposed(flagsByte, faceId);
-    if (!keepFace && faceId < kFaceZNeg && fogActive) {
-        keepFace = fogColumnReveal(worldColumn + faceOutwardNormal6I(faceId).xy) < 1.0;
-    }
-    if (!keepFace) return;
-
-    // Per-voxel analytic fog clip (#2102 + #2126 P2 + #2127; per-axis split #2128).
-    // On the single-canvas world fog route (perAxisRoute==0), drop a voxel whose OWN
-    // world column is FULLY hidden (reveal <= 0, past the disc's outer soft edge) so
-    // FOG_TO_TRIXEL can't hard-black its faces (the revealed floor / background behind
-    // shows through instead); the cut faces above cap the revealed half. A PARTIALLY
-    // revealed boundary column (0 < reveal < 1) is KEPT so it rasterizes and
-    // FOG_TO_TRIXEL fades the object's silhouette on the same smooth curve as the
-    // floor (Mode B). At edgeSoftness 0 (Mode A / default) reveal is binary, so this
-    // is exactly the #2125 "drop outside radius". The per-axis rotation routes run the
-    // SAME reveal<=0 clip inside the per-axis branch below (#2128) rather than here,
-    // so the shared pre-split code stays byte-identical to the pre-#2128 per-axis
-    // store (a perAxisRoute!=0 early-return here reshuffles the compiler's per-axis
-    // tie-winner resolution); the explicit perAxisRoute==0 term keeps this an
-    // unconditional no-op on routes 1/2/3. `fogActive` gates the world GRID canvas +
-    // world-placed re-voxelize detached canvas (#2127) and short-circuits every other
-    // route, keeping non-fog scenes byte-identical.
-    // The GRID canvas keeps a disc-adjacent RING of hidden columns
-    // (fogColumnRevealNearest's kFogHiddenKeepCells) so FOG_TO_TRIXEL's image-space
-    // cut (#2124) has hidden matter to repaint per pixel. A world-placed DETACHED
-    // canvas carries no fog pass, so nothing reclaims those kept columns — it clips
-    // tight at the voxel lattice (fogColumnReveal <= 0), the #2137-era behaviour the
-    // per-axis routes also apply. See #2248.
+    // Per-voxel analytic fog clip (#2102 + #2126 P2 + #2127; per-axis split
+    // #2128) — STAGE-1-ONLY (stage 2 never repeats it: with the distances
+    // dropped, its colour taps are rejected by the depth re-test). On the
+    // single-canvas world fog route, drop a voxel whose OWN world column is
+    // FULLY hidden (reveal <= 0) so FOG_TO_TRIXEL can't hard-black its faces;
+    // a PARTIALLY revealed boundary column is KEPT so FOG_TO_TRIXEL fades the
+    // object's silhouette on the same smooth curve as the floor (Mode B). The
+    // GRID canvas keeps a disc-adjacent RING of hidden columns
+    // (fogColumnRevealNearest's kFogHiddenKeepCells) so the #2124 image-space
+    // cut has hidden matter to repaint; a world-placed DETACHED canvas carries
+    // no fog pass, so it clips tight at the voxel lattice (fogColumnReveal <=
+    // 0) — see #2248. The per-axis rotation routes run the SAME reveal<=0 clip
+    // inside the per-axis branch below (#2128), so the shared pre-split code
+    // stays byte-identical; the explicit perAxisRoute==0 term keeps this an
+    // unconditional no-op on routes 1/2/3, and non-fog scenes short-circuit on
+    // fogActive.
     bool ownColumnHidden = isDetachedCanvas > 0.5
-        ? fogColumnReveal(worldColumn) <= 0.0
-        : fogColumnRevealNearest(worldColumn) <= 0.0;
-    if (fogActive && perAxisRoute == 0 && ownColumnHidden) {
+        ? fogColumnReveal(sel.worldColumn) <= 0.0
+        : fogColumnRevealNearest(sel.worldColumn) <= 0.0;
+    if (sel.fogActive && perAxisRoute == 0 && ownColumnHidden) {
         return;
     }
 
@@ -809,65 +593,30 @@ void main() {
         // ir_iso_common). The cardinal single-canvas paths below keep
         // trixelFrameOffset (their content IS subdivided).
         const ivec2 perAxisBase = trixelOriginOffsetZ1(canvasSizePixels) + ivec2(floor(frameCanvasOffset));
-        if (voxelRenderOptions.x == 0) {
-            const vec3 worldAlignedBase = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-            const ivec3 worldPos = roundHalfUp(worldAlignedBase);
-            const ivec3 facePos = faceMicroPositionFixed6(faceId, worldPos, 0, 0, 1);
-            // Full sub-cell fracs (u/v in-plane + w out-of-plane) so a
-            // fractionally-positioned face reconstructs on its TRUE plane,
-            // not the integer lattice plane. Integer content encodes 8/8/8
-            // (zero offsets) — byte-identical to the old centre-frac store.
-            const vec3 fracInCellBase = worldAlignedBase - vec3(worldPos);
-            const int voxelDistance = encodeDepthWithFaceFrac(
-                pos3DtoDistance(facePos), slot, axis, fracInCellBase, riserFlip
-            );
-            if (resolveMode == 2) {
-                viewMaskTap(perAxisBase, facePos);
-                return;
-            }
-            if (resolveMode == 3) {
-                overflowAppendTap(
-                    perAxisBase, facePos, voxelDistance, voxels[voxelIndex].colorPacked
-                );
-                return;
-            }
-            if (resolveMode != 0) {
-                resolveWinnerTap(perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance, voxelIndex);
-                return;
-            }
-            writeDistanceTap(perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance);
-            return;
-        }
-        // #1458: store at BASE (world-unit) resolution regardless of effSub.
-        // Only the z=0 invocation writes; higher z-slices return early.
-        // The voxel's continuous sub-cell offset is packed into the lower bits
-        // of the encoding so scatter can sub-pixel-shift the face quad.
-        if (zIdx != 0) return;
-        const vec3 worldAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-        const ivec3 worldPos_sub = roundHalfUp(worldAligned);
-        const ivec3 facePos_sub = faceMicroPositionFixed6(faceId, worldPos_sub, 0, 0, 1);
-        const vec3 fracInCell = worldAligned - vec3(worldPos_sub);
-        const int voxelDistance =
-            encodeDepthWithFaceFrac(pos3DtoDistance(facePos_sub), slot, axis, fracInCell, riserFlip);
+        // #1458: store at BASE (world-unit) resolution regardless of effSub —
+        // on the subdivided path only the z=0 invocation writes (the voxel's
+        // continuous sub-cell offset rides the encoding so the scatter can
+        // sub-pixel-shift the face quad).
+        if (voxelRenderOptions.x != 0 && zIdx != 0) return;
+        int voxelDistance;
+        const ivec3 facePos =
+            perAxisStoreFacePos(voxelPosition, faceId, slot, axis, riserFlip, voxelDistance);
         if (resolveMode == 2) {
-            viewMaskTap(perAxisBase, facePos_sub);
+            viewMaskTap(perAxisBase, facePos);
             return;
         }
         if (resolveMode == 3) {
-            overflowAppendTap(
-                perAxisBase, facePos_sub, voxelDistance, voxels[voxelIndex].colorPacked
-            );
+            overflowAppendTap(perAxisBase, facePos, voxelDistance, voxels[voxelIndex].colorPacked);
             return;
         }
-        // #2255: the 4-bit frac quantization above is where equal keys arise —
-        // two sub-cell offsets in one 1/16 bucket (or both clamp-saturated)
-        // encode byte-identically, so the winner election below is what keeps
-        // the stage-2 color tap deterministic among them.
+        // #2255: equal keys arise from the 4-bit frac quantization (see
+        // perAxisStoreFacePos) — the winner election here is what keeps the
+        // stage-2 color tap deterministic among them.
         if (resolveMode != 0) {
-            resolveWinnerTap(perAxisBase + pos3DtoPos2DIso(facePos_sub), voxelDistance, voxelIndex);
+            resolveWinnerTap(perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance, voxelIndex);
             return;
         }
-        writeDistanceTap(perAxisBase + pos3DtoPos2DIso(facePos_sub), voxelDistance);
+        writeDistanceTap(perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance);
         return;
     }
 

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1_feeder.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1_feeder.glsl
@@ -22,5 +22,7 @@
 #define IR_FEEDER_PASS 1
 #define IR_STORE_WINNER_ELECTION 0
 #include "ir_iso_common.glsl"
+#define IR_VOXEL_FOG_GRID_BINDING 0
 #include "ir_constants.glsl"
+#include "ir_voxel_face_select.glsl"
 #include "c_voxel_to_trixel_stage_1_body.glsl"

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1_winner_resolve.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1_winner_resolve.glsl
@@ -27,5 +27,7 @@
 #define IR_FEEDER_PASS 0
 #define IR_STORE_WINNER_ELECTION 1
 #include "ir_iso_common.glsl"
+#define IR_VOXEL_FOG_GRID_BINDING 0
 #include "ir_constants.glsl"
+#include "ir_voxel_face_select.glsl"
 #include "c_voxel_to_trixel_stage_1_body.glsl"

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -18,5 +18,7 @@
 #version 450 core
 #define IR_STORE_WINNER_ELECTION 0
 #include "ir_iso_common.glsl"
+#define IR_VOXEL_FOG_GRID_BINDING 3
 #include "ir_constants.glsl"
+#include "ir_voxel_face_select.glsl"
 #include "c_voxel_to_trixel_stage_2_body.glsl"

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
@@ -14,8 +14,10 @@
 // non-recursive, so this file lists NO `#include`s of its own — each wrapper
 // MUST include, IN THIS ORDER and with the macro defined FIRST, before it:
 //   #define IR_STORE_WINNER_ELECTION {0|1}
+//   #define IR_VOXEL_FOG_GRID_BINDING 3
 //   #include "ir_iso_common.glsl"
 //   #include "ir_constants.glsl"
+//   #include "ir_voxel_face_select.glsl"
 //   #include "c_voxel_to_trixel_stage_2_body.glsl"
 // The two wrappers:
 //   c_voxel_to_trixel_stage_2.glsl        → ELECTION 0 = the default dispatch
@@ -130,46 +132,11 @@ layout(std430, binding = 28) readonly buffer PerAxisWinnerScratch {
     uint perAxisWinnerIds[];
 };
 
-// Fog cut-face inputs (#2125). STAGE_1 binds the fog grid on image slot 0 (free
-// there), but slot 0 is the colour output here, so the fog grid binds on slot 3
-// instead (slots 1/2 are the distance + entity-id outputs). The world fog canvas
-// binds its 256² grid; every non-fog / detached canvas binds the shared 1×1
-// all-visible placeholder + a count-0 observer buffer, so fogColumnReveal
-// short-circuits to "fully visible" and those scenes stay byte-identical.
-const int kFogOfWarHalfExtent = 128;
-const float kFogExploredThreshold = 0.25;
-const int kMaxFogVisionCircles = 8; // mirror of component_canvas_fog_of_war.hpp kMaxFogVisionCircles
-layout(rgba8, binding = 3) readonly uniform image2D canvasFogOfWar;
-layout(std140, binding = 27) uniform FogObserverData {
-    vec4 visionCircles[kMaxFogVisionCircles]; // (centerX, centerY, radius, edgeSoftness)
-    int visionCircleCount;
-};
-
-// Fog reveal of world grid COLUMN `col` in [0,1]. MUST stay byte-identical to
-// c_voxel_to_trixel_stage_1.glsl::fogColumnReveal — stage 1 emits the cut face's
-// DISTANCE for `reveal < 1.0` (#2126 P2), and stage 2 must paint colour on the same
-// set of faces or the cut wall reads as cleared background. Kept inline (not in
-// ir_iso_common) because the fog grid binds on a DIFFERENT slot in each stage
-// (0 vs 3), and adding a symbol to ir_iso_common risks the cardinal fast path's
-// byte-identity (see the #1944 NOTE there).
-float fogColumnReveal(ivec2 col) {
-    const ivec2 fogSize = imageSize(canvasFogOfWar);
-    if (fogSize.x <= 1) {
-        return 1.0; // 1×1 all-visible placeholder (non-fog / detached canvas)
-    }
-    const ivec2 cell = col + ivec2(kFogOfWarHalfExtent);
-    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
-        return 1.0; // out-of-range column reads as visible
-    }
-    if (imageLoad(canvasFogOfWar, cell).r >= kFogExploredThreshold) {
-        return 1.0; // explored / visible grid memory — keep (FOG_TO_TRIXEL fades it)
-    }
-    float reveal = 0.0;
-    for (int i = 0; i < visionCircleCount; ++i) {
-        reveal = max(reveal, fogVisionCircleReveal(vec2(col), visionCircles[i], 0.0));
-    }
-    return reveal;
-}
+// Fog grid + observers + fogColumnReveal and the shared face-selection /
+// per-axis store-key math live in ir_voxel_face_select.glsl (the wrapper
+// includes it before this body). STAGE_2's slot 0 is the colour output, so its
+// wrapper routes the fog grid to image slot 3 via IR_VOXEL_FOG_GRID_BINDING
+// (slots 1/2 are the distance + entity-id outputs).
 
 void writeColorTap(
     const ivec2 canvasPixel,
@@ -344,67 +311,27 @@ void main() {
     // the colour tap matches the distance tap.
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
 
-    // Silhouette-riser face selection — MUST mirror stage 1's flip (and its
-    // rotated-content gate) EXACTLY so the colour tap lands on the same (possibly
-    // opposite-polarity) face stage 1 wrote the distance for. See
-    // c_voxel_to_trixel_stage_1.glsl for the full rationale.
-    const bool rotatedEmit = reVoxelize || (voxels[voxelIndex].reserved & 4u) != 0u;
-    // Polarity carrier (#2207) — mirror of stage 1's riserFlip: the colour tap
-    // must re-derive the identical encoding (flip bit included) or the depth
-    // re-test in writeColorTap rejects every flipped-face tap.
-    int riserFlip = 0;
-    if (rotatedEmit && !faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1)) {
-        faceId = faceId ^ 1;
-        riserFlip = 1;
-    }
-
-    // Both-exposed silhouette-riser dual emit (#2157) — MUST mirror stage 1's
-    // predicate + emit site so the colour taps land on the dual-emitted
-    // distance taps. See c_voxel_to_trixel_stage_1.glsl for the full rationale.
-    const bool bothPolaritiesExposed = rotatedEmit && faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1);
-
-    // Exposed-face gate + fog CUT-FACE widening (#2125/#2127; per-axis #2128) —
-    // MUST mirror stage 1's predicate EXACTLY so the colour tap lands on the same
-    // face set stage 1 wrote distances for, on the single-canvas (0) and X/Y
-    // per-axis routes (1/2) alike. A cut face is non-exposed, so without this
-    // widening stage 2 would skip it and the cut wall would read as the cleared
-    // background colour (distance set by stage 1, colour unset). See
-    // c_voxel_to_trixel_stage_1.glsl for the rationale + the world-column recovery
-    // (a world-placed detached re-voxelize canvas rasters in the MODEL frame, so its
-    // world column is model + detachedWorldReceive.xy) and why a `perAxisRoute`
-    // comparison term is kept in `fogActive` for non-fog byte-identity. The
-    // own-column drop (#2102/#2127) is NOT repeated here — stage 1 already dropped
-    // those voxels' distances on every route, so the depth re-test in writeColorTap
-    // rejects their colour taps.
-    const bool fogActive = visionCircleCount > 0 && perAxisRoute <= 2 &&
-        (isDetachedCanvas < 0.5 ||
-         (perAxisRoute == 0 && detachedWorldReceive.w != 0.0));
-    ivec2 worldColumn = ivec2(0);
-    if (fogActive) {
-        worldColumn = roundHalfUp(voxelPosition.xyz).xy +
-            (isDetachedCanvas > 0.5 ? roundHalfUp(detachedWorldReceive.xy) : ivec2(0));
-    }
-    bool keepFace = faceIsExposed(flagsByte, faceId);
-    bool isCutFace = false;
-    if (!keepFace && faceId < kFaceZNeg && fogActive) {
-        // P2 (#2126): cut iff the neighbor column is not fully revealed (reveal <
-        // 1.0) — mirrors stage 1 exactly. Mode A (edgeSoftness 0) reveal is binary
-        // so this collapses to the #2125/#2127 boolean boundary (byte-identical).
-        keepFace = fogColumnReveal(worldColumn + faceOutwardNormal6I(faceId).xy) < 1.0;
-        // A non-exposed VERTICAL face kept ONLY by the fog cut rule is the object's
-        // interior cross-section wall — flag it (bit 29 of the stored id) so
-        // LIGHTING_TO_TRIXEL force-lights it as a clean exposed face rather than
-        // self-shadowing it with the fog-hidden neighbors (#2124 lit-cross-section
-        // follow-up). Exposed faces (keepFace true above) are NOT flagged.
-        isCutFace = keepFace;
-    }
-    if (!keepFace) return;
-    // Fold the cut-face flag into the id AFTER the priority encode (which strips
-    // this bit via kEntityIdHighWordMask). Non-cut ⇒ id unchanged, so non-fog
-    // scenes stay byte-identical.
-    packedEntityId = encodeEntityIdCutFace(packedEntityId, isCutFace);
+    // Face selection — the visible-triplet × exposed-mask gate (#1278), the
+    // silhouette-riser flip (#2207) + dual-emit predicate (#2157), and the fog
+    // cut-face widening (#2125/#2126/#2127; per-axis #2128) — is shared with
+    // stage 1 via ir_voxel_face_select.glsl: both stages key their taps off
+    // ONE definition, so the colour tap cannot desync from the distance tap.
+    // The own-column drop (#2102/#2127) is NOT repeated here — stage 1 already
+    // dropped those voxels' distances on every route, so the depth re-test in
+    // writeColorTap rejects their colour taps.
+    const VoxelFaceSelect sel = selectVoxelFace(
+        faceId, reVoxelize, voxels[voxelIndex].reserved, flagsByte,
+        voxelPosition, perAxisRoute, isDetachedCanvas, detachedWorldReceive
+    );
+    if (!sel.keepFace) return;
+    faceId = sel.faceId;
+    const int riserFlip = sel.riserFlip;
+    const bool bothPolaritiesExposed = sel.bothPolaritiesExposed;
+    // A face kept ONLY by the fog cut rule is the interior cross-section wall —
+    // fold the flag into the id (bit 29) AFTER the priority encode (which strips
+    // it via kEntityIdHighWordMask) so LIGHTING_TO_TRIXEL force-lights it
+    // (#2124). Non-cut ⇒ id unchanged, so non-fog scenes stay byte-identical.
+    packedEntityId = encodeEntityIdCutFace(packedEntityId, sel.isCutFace);
 
     // Per-slot deformation matrix — see stage 1 for the contract.
     const mat2 D = mat2(faceDeform[slot].xy, faceDeform[slot].zw);
@@ -423,32 +350,15 @@ void main() {
         // Whole-iso base anchor (#1944) — MUST match stage 1's per-axis anchor
         // exactly, or color/id taps land on a different cell than the distance.
         const ivec2 perAxisBase = trixelOriginOffsetZ1(canvasSizePixels) + ivec2(floor(frameCanvasOffset));
-        if (voxelRenderOptions.x == 0) {
-            const vec3 worldAlignedBase = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-            const ivec3 worldPos = roundHalfUp(worldAlignedBase);
-            const ivec3 facePos = faceMicroPositionFixed6(faceId, worldPos, 0, 0, 1);
-            // Full sub-cell fracs — MUST mirror stage 1's base-resolution
-            // store exactly or the colour tap desyncs from the distance.
-            const vec3 fracInCellBase = worldAlignedBase - vec3(worldPos);
-            const int voxelDistance = encodeDepthWithFaceFrac(
-                pos3DtoDistance(facePos), slot, axis, fracInCellBase, riserFlip
-            );
-            writeColorTapPerAxis(
-                perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance,
-                voxelColor, packedEntityId, voxelIndex
-            );
-            return;
-        }
-        // #1458: mirror stage 1's base-resolution store (z=0 only).
-        if (zIdx != 0) return;
-        const vec3 worldAligned_s2 = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-        const ivec3 worldPos_s2 = roundHalfUp(worldAligned_s2);
-        const ivec3 facePos_s2 = faceMicroPositionFixed6(faceId, worldPos_s2, 0, 0, 1);
-        const vec3 fracInCell_s2 = worldAligned_s2 - vec3(worldPos_s2);
-        const int voxelDistance_s2 =
-            encodeDepthWithFaceFrac(pos3DtoDistance(facePos_s2), slot, axis, fracInCell_s2, riserFlip);
+        // #1458: store at BASE (world-unit) resolution regardless of effSub —
+        // on the subdivided path only the z=0 invocation writes. The cell + key
+        // derive through the SAME shared helper stage 1's taps used.
+        if (voxelRenderOptions.x != 0 && zIdx != 0) return;
+        int voxelDistance;
+        const ivec3 facePos =
+            perAxisStoreFacePos(voxelPosition, faceId, slot, axis, riserFlip, voxelDistance);
         writeColorTapPerAxis(
-            perAxisBase + pos3DtoPos2DIso(facePos_s2), voxelDistance_s2,
+            perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance,
             voxelColor, packedEntityId, voxelIndex
         );
         return;

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2_winner.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2_winner.glsl
@@ -21,5 +21,7 @@
 #version 450 core
 #define IR_STORE_WINNER_ELECTION 1
 #include "ir_iso_common.glsl"
+#define IR_VOXEL_FOG_GRID_BINDING 3
 #include "ir_constants.glsl"
+#include "ir_voxel_face_select.glsl"
 #include "c_voxel_to_trixel_stage_2_body.glsl"

--- a/engine/render/src/shaders/ir_voxel_face_select.glsl
+++ b/engine/render/src/shaders/ir_voxel_face_select.glsl
@@ -1,0 +1,226 @@
+// Shared voxel face-selection + per-axis store-key math for the
+// c_voxel_to_trixel stage-1 / stage-2 kernel family. Both stage BODIES used to
+// carry byte-identical copies of everything here under "MUST mirror stage 1
+// EXACTLY" comments — a one-sided edit silently desynced the colour tap from
+// the distance tap. One definition makes that class of bug unrepresentable.
+//
+// This is an include-FRAGMENT (like the stage bodies): the kernel wrappers
+// include it AFTER ir_iso_common.glsl / ir_constants.glsl and BEFORE the stage
+// body, with the fog-grid image slot supplied as a compile-time macro:
+//   #define IR_VOXEL_FOG_GRID_BINDING {0|3}
+// STAGE_1 binds the fog grid on image slot 0 (free there — it writes only the
+// distance image on slot 1); STAGE_2's slot 0 is the colour output, so it
+// binds the grid on slot 3. A wrapper-#define'd binding is what makes the
+// single definition possible — image slots cannot be runtime-parameterized in
+// GLSL/MSL, which is why the functions were historically duplicated per stage.
+// Metal twin: metal/ir_voxel_face_select.metal — keep byte-identical math.
+
+// Per-voxel analytic fog clip inputs (#2102), mirroring
+// c_voxel_visibility_compact + c_fog_to_trixel. The world fog canvas binds its
+// 256² grid texture and uploads the live vision circles at binding 27; every
+// non-fog / detached canvas binds the shared 1×1 all-visible placeholder + a
+// count-0 observer buffer, so `fogColumnReveal` short-circuits to "fully
+// visible" and those scenes stay byte-identical.
+const int kFogOfWarHalfExtent = 128;
+const float kFogExploredThreshold = 0.25;
+const int kMaxFogVisionCircles = 8; // mirror of component_canvas_fog_of_war.hpp kMaxFogVisionCircles
+layout(rgba8, binding = IR_VOXEL_FOG_GRID_BINDING) readonly uniform image2D canvasFogOfWar;
+layout(std140, binding = 27) uniform FogObserverData {
+    vec4 visionCircles[kMaxFogVisionCircles]; // (centerX, centerY, radius, edgeSoftness)
+    int visionCircleCount;
+};
+
+// Fog reveal of world grid COLUMN `col` in [0,1]. Stage 1 emits the cut face's
+// DISTANCE for `reveal < 1.0` (#2126 P2) and stage 2 paints colour on the same
+// set of faces — both through this one definition, so the cut wall's depth and
+// colour cannot desync. Explored grid memory and in/at-disc columns are kept;
+// the 1×1 placeholder + OOB columns read as fully visible, matching the
+// OOB-as-visible invariant — so non-fog / detached canvases are byte-identical.
+float fogColumnReveal(ivec2 col) {
+    const ivec2 fogSize = imageSize(canvasFogOfWar);
+    if (fogSize.x <= 1) {
+        return 1.0; // 1×1 all-visible placeholder (non-fog / detached canvas)
+    }
+    const ivec2 cell = col + ivec2(kFogOfWarHalfExtent);
+    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
+        return 1.0; // out-of-range column reads as visible
+    }
+    if (imageLoad(canvasFogOfWar, cell).r >= kFogExploredThreshold) {
+        return 1.0; // explored / visible grid memory — keep (FOG_TO_TRIXEL fades it)
+    }
+    float reveal = 0.0;
+    for (int i = 0; i < visionCircleCount; ++i) {
+        reveal = max(reveal, fogVisionCircleReveal(vec2(col), visionCircles[i], 0.0));
+    }
+    return reveal;
+}
+
+// Own-column DROP reveal, evaluated at the cell point NEAREST each vision-circle
+// center rather than the cell center (#2124 screen-space cross-section). The
+// drop keeps a column iff this is > 0, so a column the disc merely CLIPS
+// (center outside R, unit cell still overlaps the reveal region) is KEPT and
+// rasters its full footprint; FOG_TO_TRIXEL then trims it per pixel at the
+// exact analytic edge instead of the geometry ending on the voxel lattice (the
+// #2102 voxel-jagged edge). Evaluating at the nearest cell point keeps ONLY the
+// one-cell ring the disc crosses; kFogColumnKeepAa is a small rim so the
+// hard-disc smoothstep is non-degenerate.
+//
+// kFogHiddenKeepCells widens that keep into a RING of fog-hidden columns
+// around the disc (#2124 analytic cross-section): FOG_TO_TRIXEL's image-space
+// cut repaints a hidden pixel as the cylinder's cut surface, so hidden matter
+// near the rim must still RENDER (lit, normally shaded) for the cut to have
+// colour to work from. The ring bounds how deep a cut face can be recovered
+// (≈ keep/√2 cells of height); columns past it drop as before. Ring voxels
+// also resume casting sun shadows / AO near the rim. Mirrored in
+// c_voxel_visibility_compact.{glsl,metal}'s kCullSafetyCells (keep superset).
+const float kFogColumnCellHalf = 0.5;
+const float kFogColumnKeepAa = 0.5;
+const float kFogHiddenKeepCells = 8.0;
+float fogColumnRevealNearest(ivec2 col) {
+    const ivec2 fogSize = imageSize(canvasFogOfWar);
+    if (fogSize.x <= 1) {
+        return 1.0;
+    }
+    const ivec2 cell = col + ivec2(kFogOfWarHalfExtent);
+    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
+        return 1.0;
+    }
+    if (imageLoad(canvasFogOfWar, cell).r >= kFogExploredThreshold) {
+        return 1.0;
+    }
+    float reveal = 0.0;
+    for (int i = 0; i < visionCircleCount; ++i) {
+        const vec2 nearest = clamp(
+            visionCircles[i].xy, vec2(col) - kFogColumnCellHalf, vec2(col) + kFogColumnCellHalf
+        );
+        reveal = max(
+            reveal,
+            fogVisionCircleReveal(
+                nearest, visionCircles[i], kFogColumnKeepAa + kFogHiddenKeepCells
+            )
+        );
+    }
+    return reveal;
+}
+
+// The face-selection verdict both stage kernels branch on. `keepFace == false`
+// ⇒ the caller returns without emitting. `isCutFace` marks a non-exposed
+// VERTICAL face kept ONLY by the fog cut rule — the object's interior
+// cross-section wall; stage 2 folds it into the stored entity id (bit 29) so
+// LIGHTING_TO_TRIXEL force-lights it (#2124), stage 1 ignores it.
+struct VoxelFaceSelect {
+    int faceId;                 // possibly riser-flipped (#2207)
+    int riserFlip;              // 1 = opposite polarity of the slot's triplet face
+    bool rotatedEmit;           // rotated-content gate (re-voxelize OR kRotatedEmit)
+    bool bothPolaritiesExposed; // #2157 dual-emit predicate (cardinal subdivided path)
+    bool fogActive;             // world fog route gate (#2125/#2127/#2128)
+    ivec2 worldColumn;          // world fog column (valid iff fogActive)
+    bool keepFace;
+    bool isCutFace;
+};
+
+// Face selection for one (voxel, slot) invocation — the visible-triplet ×
+// exposed-mask gate (#1278), the silhouette-riser flip (#2207) and dual-emit
+// predicate (#2157) for rotated content, and the fog cut-face widening
+// (#2125/#2126/#2127; per-axis #2128). Stage 1 keys its distance taps and
+// stage 2 its colour/entity-id taps off the SAME verdict, which is the
+// contract that keeps the two kernels' face sets identical.
+//
+// The `perAxisRouteIn <= 2` comparison term in `fogActive` is load-bearing for
+// byte-identity: it makes the GLSL/MSL compiler schedule the non-fog per-axis
+// store identically to the pre-#2128 `== 0` gate (a bare-removed term
+// reshuffled the Metal per-axis tie-winner resolution). A world-placed
+// re-voxelize detached canvas rasters in the pool-centered MODEL frame, so its
+// world column is model + detachedWorldReceiveIn.xy — the same recovery
+// c_lighting_to_trixel uses. ±Z faces are never cut (the vision region is a
+// vertical cylinder), hence the `faceId < kFaceZNeg` bound.
+VoxelFaceSelect selectVoxelFace(
+    const int faceIdIn,
+    const bool reVoxelize,
+    const uint reserved,
+    const uint flagsByte,
+    const vec4 voxelPosition,
+    const int perAxisRouteIn,
+    const float isDetachedCanvasIn,
+    const vec4 detachedWorldReceiveIn
+) {
+    VoxelFaceSelect sel;
+    sel.faceId = faceIdIn;
+    // Silhouette-riser face selection (rotated-footprint gap fix): if this
+    // slot's triplet face is occluded but the opposite same-axis face is
+    // exposed, emit that opposite face — the missing silhouette riser on a
+    // rotated staircase edge. Gated to ROTATED content (the re-voxelize
+    // uniform OR the per-voxel kRotatedEmit marker, reserved bit 2), so
+    // axis-aligned fast paths never flip and stay byte-identical.
+    sel.rotatedEmit = reVoxelize || (reserved & 4u) != 0u;
+    sel.riserFlip = 0;
+    if (sel.rotatedEmit && !faceIsExposed(flagsByte, sel.faceId) &&
+        faceIsExposed(flagsByte, sel.faceId ^ 1)) {
+        sel.faceId = sel.faceId ^ 1;
+        sel.riserFlip = 1;
+    }
+    // Both-exposed silhouette-riser dual emit (#2157): a rotated staircase
+    // EDGE cell can have BOTH polarities of a slot's axis exposed; the flip
+    // above never fires there, so the cardinal subdivided path emits both
+    // planes (the per-axis store takes NO second tap — measured net-worse,
+    // see #2207).
+    sel.bothPolaritiesExposed = sel.rotatedEmit && faceIsExposed(flagsByte, sel.faceId) &&
+        faceIsExposed(flagsByte, sel.faceId ^ 1);
+    // World fog route: fires on the world fog route (perAxisRoute==0 — the
+    // GRID world canvas or a world-placed re-voxelize detached canvas, #2127)
+    // AND the X/Y per-axis rotation routes (1/2, #2128 — a cut face is a
+    // vertical X/Y face that rides the matching axis canvas under continuous
+    // yaw). Plain octahedral DETACHED and the Z route (3, no cut faces) stay
+    // on the no-fog placeholder.
+    sel.fogActive = visionCircleCount > 0 && perAxisRouteIn <= 2 &&
+        (isDetachedCanvasIn < 0.5 ||
+         (perAxisRouteIn == 0 && detachedWorldReceiveIn.w != 0.0));
+    sel.worldColumn = ivec2(0);
+    if (sel.fogActive) {
+        sel.worldColumn = roundHalfUp(voxelPosition.xyz).xy +
+            (isDetachedCanvasIn > 0.5 ? roundHalfUp(detachedWorldReceiveIn.xy) : ivec2(0));
+    }
+    // Exposed-face gate (#1278) widened with the fog CUT-FACE rule: at the fog
+    // boundary a non-exposed VERTICAL face becomes the interior cross-section
+    // wall when the solid neighbor COLUMN it faces is not fully revealed
+    // (`reveal < 1.0`, #2126 P2 — the cut exists across the whole soft band and
+    // the per-pixel FOG_TO_TRIXEL mask owns the smooth silhouette; a hard disc
+    // collapses to the binary boundary, byte-identical).
+    sel.keepFace = faceIsExposed(flagsByte, sel.faceId);
+    sel.isCutFace = false;
+    if (!sel.keepFace && sel.faceId < kFaceZNeg && sel.fogActive) {
+        sel.keepFace =
+            fogColumnReveal(sel.worldColumn + faceOutwardNormal6I(sel.faceId).xy) < 1.0;
+        sel.isCutFace = sel.keepFace;
+    }
+    return sel;
+}
+
+// Per-axis base-resolution store position + encoded key (#1458 encoding,
+// #1944 un-yawed cardinal iso key). Returns the face-plane position whose
+// projection `perAxisBase + pos3DtoPos2DIso(facePos)` is the store cell;
+// writes the encoded distance key through `encodedDistance`. Stage 1's
+// distance/mask/append/election taps and stage 2's colour tap all derive the
+// cell + key through this one definition — the "stage 2 MUST mirror stage 1's
+// store exactly" contract in code. Full sub-cell fracs (u/v in-plane + w
+// out-of-plane) ride the encoding so a fractionally-positioned face
+// reconstructs on its TRUE plane; integer content encodes 8/8/8 (zero
+// offsets). The 4-bit frac quantization here is where equal keys arise — two
+// sub-cell offsets in one 1/16 bucket encode byte-identically — which is why
+// the #2255 winner election exists downstream.
+ivec3 perAxisStoreFacePos(
+    const vec4 voxelPosition,
+    const int faceId,
+    const int slot,
+    const int axis,
+    const int riserFlip,
+    out int encodedDistance
+) {
+    const vec3 worldAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
+    const ivec3 worldPos = roundHalfUp(worldAligned);
+    const ivec3 facePos = faceMicroPositionFixed6(faceId, worldPos, 0, 0, 1);
+    const vec3 fracInCell = worldAligned - vec3(worldPos);
+    encodedDistance =
+        encodeDepthWithFaceFrac(pos3DtoDistance(facePos), slot, axis, fracInCell, riserFlip);
+    return facePos;
+}

--- a/engine/render/src/shaders/ir_voxel_face_select.glsl
+++ b/engine/render/src/shaders/ir_voxel_face_select.glsl
@@ -111,7 +111,6 @@ float fogColumnRevealNearest(ivec2 col) {
 struct VoxelFaceSelect {
     int faceId;                 // possibly riser-flipped (#2207)
     int riserFlip;              // 1 = opposite polarity of the slot's triplet face
-    bool rotatedEmit;           // rotated-content gate (re-voxelize OR kRotatedEmit)
     bool bothPolaritiesExposed; // #2157 dual-emit predicate (cardinal subdivided path)
     bool fogActive;             // world fog route gate (#2125/#2127/#2128)
     ivec2 worldColumn;          // world fog column (valid iff fogActive)
@@ -151,10 +150,12 @@ VoxelFaceSelect selectVoxelFace(
     // exposed, emit that opposite face — the missing silhouette riser on a
     // rotated staircase edge. Gated to ROTATED content (the re-voxelize
     // uniform OR the per-voxel kRotatedEmit marker, reserved bit 2), so
-    // axis-aligned fast paths never flip and stay byte-identical.
-    sel.rotatedEmit = reVoxelize || (reserved & 4u) != 0u;
+    // axis-aligned fast paths never flip and stay byte-identical. Kept a
+    // function-local intermediate — only the riserFlip gate and
+    // bothPolaritiesExposed predicate read it, so it stays off the verdict struct.
+    const bool rotatedEmit = reVoxelize || (reserved & 4u) != 0u;
     sel.riserFlip = 0;
-    if (sel.rotatedEmit && !faceIsExposed(flagsByte, sel.faceId) &&
+    if (rotatedEmit && !faceIsExposed(flagsByte, sel.faceId) &&
         faceIsExposed(flagsByte, sel.faceId ^ 1)) {
         sel.faceId = sel.faceId ^ 1;
         sel.riserFlip = 1;
@@ -164,7 +165,7 @@ VoxelFaceSelect selectVoxelFace(
     // above never fires there, so the cardinal subdivided path emits both
     // planes (the per-axis store takes NO second tap — measured net-worse,
     // see #2207).
-    sel.bothPolaritiesExposed = sel.rotatedEmit && faceIsExposed(flagsByte, sel.faceId) &&
+    sel.bothPolaritiesExposed = rotatedEmit && faceIsExposed(flagsByte, sel.faceId) &&
         faceIsExposed(flagsByte, sel.faceId ^ 1);
     // World fog route: fires on the world fog route (perAxisRoute==0 — the
     // GRID world canvas or a world-placed re-voxelize detached canvas, #2127)

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -11,4 +11,5 @@
 #define IR_FEEDER_PASS 0
 #define IR_STORE_WINNER_ELECTION 0
 #define IR_STAGE1_KERNEL_NAME c_voxel_to_trixel_stage_1
+#include "ir_voxel_face_select.metal"
 #include "c_voxel_to_trixel_stage_1_body.metal"

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_body.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_body.metal
@@ -306,106 +306,12 @@ struct Voxel {
 // exposed-face test (visible-triplet × exposed-mask, #1278) is centralized
 // in `faceIsExposed(flagsByte, faceId)` from ir_iso_common.metal.
 
-// Per-voxel analytic fog clip inputs (#2102), mirroring c_voxel_visibility_compact
-// + c_fog_to_trixel. The world fog canvas binds its 256² grid texture at
-// [[texture(0)]] and the live vision circles at [[buffer(27)]]; every non-fog /
-// detached canvas binds a 1×1 all-visible placeholder + a count-0 observer
-// buffer, so fogColumnReveal short-circuits to "fully visible" and those
-// scenes stay byte-identical.
-constant int kFogOfWarHalfExtent = 128;
-constant float kFogExploredThreshold = 0.25f;
-constant int kMaxFogVisionCircles = 8; // mirror of component_canvas_fog_of_war.hpp kMaxFogVisionCircles
-struct FogObserverData {
-    float4 visionCircles[kMaxFogVisionCircles]; // (centerX, centerY, radius, edgeSoftness)
-    int visionCircleCount;
-    int _fogObsPad0;
-    int _fogObsPad1;
-    int _fogObsPad2;
-};
-
-// Fog reveal of world grid COLUMN `col` (xy world units) in [0,1]: the strongest
-// live vision-disc reveal at the column center (aa = 0), or 1.0 for explored grid
-// memory / OOB / the 1×1 placeholder. See the GLSL twin
-// (c_voxel_to_trixel_stage_1.glsl::fogColumnReveal) for the full rationale: the
-// compact keeps a permissive margin for the smooth per-pixel floor edge, and
-// STAGE_1 tightens it for the voxel object. Two callers threshold this — the #2102
-// own-column drop (drop reveal <= 0, FULLY hidden; a partially-revealed boundary
-// column rasterizes so FOG_TO_TRIXEL fades it like the floor, #2126 Mode B) and
-// the #2125/#2126 neighbor cut-face test (cut reveal < 1.0, "not fully revealed").
-// For a hard disc reveal is binary {0,1} so all thresholds collapse to "outside
-// radius" → Mode A + non-fog byte-identical. Duplicated byte-identically in
-// c_voxel_to_trixel_stage_2.metal (fog grid on [[texture(3)]] there); keep in sync.
-static float fogColumnReveal(
-    texture2d<float, access::read> fog, constant FogObserverData& obs, int2 col
-) {
-    const int2 fogSize = int2(int(fog.get_width()), int(fog.get_height()));
-    if (fogSize.x <= 1) {
-        return 1.0f; // 1×1 all-visible placeholder (non-fog / detached canvas)
-    }
-    const int2 cell = col + int2(kFogOfWarHalfExtent);
-    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
-        return 1.0f; // out-of-range column reads as visible
-    }
-    if (fog.read(uint2(cell)).r >= kFogExploredThreshold) {
-        return 1.0f; // explored / visible grid memory — keep
-    }
-    float reveal = 0.0f;
-    for (int i = 0; i < obs.visionCircleCount; ++i) {
-        reveal = max(reveal, fogVisionCircleReveal(float2(col), obs.visionCircles[i], 0.0f));
-    }
-    return reveal;
-}
-
-// Own-column DROP reveal, evaluated at the cell point NEAREST each vision-circle
-// center rather than the cell center (#2124 screen-space cross-section). The drop
-// keeps a column iff this is > 0, so a column the disc merely CLIPS (center
-// outside R, but the unit cell still overlaps the reveal region) is KEPT and
-// rasters its full footprint — FOG_TO_TRIXEL then trims it per pixel at the exact
-// analytic edge (a game-resolution silhouette) instead of the geometry ending on
-// the voxel lattice (the #2102 voxel-jagged edge). Evaluating at the nearest cell
-// point keeps ONLY the one-cell ring the disc crosses (tight, not a blanket
-// margin); kFogColumnKeepAa is a small rim so the hard-disc smoothstep is
-// non-degenerate and the AA rim / reconstruction skew never notches the edge.
-// Grid-memory / OOB / placeholder short-circuits match fogColumnReveal.
-constant float kFogColumnCellHalf = 0.5f;
-constant float kFogColumnKeepAa = 0.5f;
-// kFogHiddenKeepCells widens the keep into a RING of fog-hidden columns
-// around the disc (#2124 analytic cross-section): FOG_TO_TRIXEL's image-space
-// cut repaints a hidden pixel as the cylinder's cut surface, so hidden matter
-// near the rim must still RENDER for the cut to have colour to work from.
-// See the GLSL twin for the full rationale; mirrored in the compact's
-// kCullSafetyCells (keep superset).
-constant float kFogHiddenKeepCells = 8.0f;
-static float fogColumnRevealNearest(
-    texture2d<float, access::read> fog, constant FogObserverData& obs, int2 col
-) {
-    const int2 fogSize = int2(int(fog.get_width()), int(fog.get_height()));
-    if (fogSize.x <= 1) {
-        return 1.0f;
-    }
-    const int2 cell = col + int2(kFogOfWarHalfExtent);
-    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
-        return 1.0f;
-    }
-    if (fog.read(uint2(cell)).r >= kFogExploredThreshold) {
-        return 1.0f;
-    }
-    float reveal = 0.0f;
-    for (int i = 0; i < obs.visionCircleCount; ++i) {
-        const float2 nearest = clamp(
-            obs.visionCircles[i].xy,
-            float2(col) - kFogColumnCellHalf,
-            float2(col) + kFogColumnCellHalf
-        );
-        reveal = max(
-            reveal,
-            fogVisionCircleReveal(
-                nearest, obs.visionCircles[i], kFogColumnKeepAa + kFogHiddenKeepCells
-            )
-        );
-    }
-    return reveal;
-}
+// Fog constants/struct + fogColumnReveal/Nearest and the shared
+// face-selection / per-axis store-key math live in ir_voxel_face_select.metal
+// (the wrapper includes it before this body). STAGE_1's fog grid rides
+// [[texture(0)]] — free here, the distance store goes through the atomic
+// scratch buffer; Metal passes the texture + observers into the shared
+// functions as arguments.
 
 kernel void IR_STAGE1_KERNEL_NAME(
     constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
@@ -483,101 +389,34 @@ kernel void IR_STAGE1_KERNEL_NAME(
     // the full rationale.
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
 
-    // Silhouette-riser face selection (rotated-footprint gap fix) — see the GLSL
-    // twin for the full rationale. A rotated voxel staircase's camera-side grazing
-    // edge presents the OPPOSITE polarity of an axis from the convex-cardinal
-    // triplet; emit it when the triplet face is occluded but the opposite is
-    // exposed. GATED to rotated content (detached re-voxelize uniform OR the
-    // per-voxel kRotatedEmit marker, reserved bit 2) so static / axis-aligned
-    // content keeps the strict triplet and stays byte-identical. Stage 2 mirrors
-    // this flip + gate exactly.
-    const bool rotatedEmit = reVoxelize || (voxels[voxelIndex].reserved & 4u) != 0u;
-    // Polarity carrier (#2207) — riserFlip marks every emit below as the
-    // opposite polarity of this slot's triplet face. See the GLSL twin.
-    int riserFlip = 0;
-    if (rotatedEmit && !faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1)) {
-        faceId = faceId ^ 1;
-        riserFlip = 1;
-    }
-    // Both-exposed silhouette-riser dual emit (#2157) — see the GLSL twin for
-    // the full rationale. Stage 2 mirrors this predicate + the emit site.
-    const bool bothPolaritiesExposed = rotatedEmit && faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1);
-    // Re-voxelize now authors the ROTATED-frame exposed mask on the GPU
-    // (c_revoxelize_detached) like the GRID path's #1720, so it gates on
-    // faceIsExposed too (no all-3-face bypass → no slot-tie AO hatching). The
-    // reVoxelize flag still drives the ±1px dilation in emitDeformedFace.
-    //
-    // World fog route + world-column recovery (#2125 GRID, #2127 detached; per-axis
-    // #2128) — see the GLSL twin. `fogActive` is the single cheap (uniform-only)
-    // gate that keeps every non-fog / plain-DETACHED / Z-route voxel byte-identical
-    // to master AND free of the world-column rounding below. It fires on the world
-    // fog route (perAxisRoute==0, GRID or world-placed re-voxelize detached, #2127)
-    // AND the X/Y per-axis rotation routes (1/2, #2128). The GRID world canvas + the
-    // X/Y per-axis canvases raster in world space (offset 0); a world-placed detached
-    // re-voxelize canvas rasters in the pool-centered MODEL frame, so recover its
-    // world column as model + the published cell origin (the SAME model+offset
-    // recovery c_lighting_to_trixel uses; the re-voxelize bake is a pure translation
-    // off world, so the model-frame face normal equals the world-frame one).
-    const bool fogActive = fogObservers.visionCircleCount > 0 &&
-        frameData.perAxisRoute <= 2 &&
-        (frameData.isDetachedCanvas < 0.5f ||
-         (frameData.perAxisRoute == 0 && frameData.detachedWorldReceive.w != 0.0f));
-    int2 worldColumn = int2(0);
-    if (fogActive) {
-        worldColumn = roundHalfUp(voxelPosition.xyz).xy +
-            (frameData.isDetachedCanvas > 0.5f
-                 ? roundHalfUp(frameData.detachedWorldReceive.xy)
-                 : int2(0));
-    }
+    // Face selection — the visible-triplet × exposed-mask gate (#1278), the
+    // silhouette-riser flip (#2207) + dual-emit predicate (#2157) for rotated
+    // content, and the fog cut-face widening (#2125/#2126/#2127; per-axis
+    // #2128) — is shared with stage 2 via ir_voxel_face_select.metal: both
+    // stages key their taps off ONE definition, so the colour tap cannot
+    // desync from the distance tap.
+    const VoxelFaceSelect sel = selectVoxelFace(
+        canvasFogOfWar, fogObservers, faceId, reVoxelize,
+        voxels[voxelIndex].reserved, flagsByte, voxelPosition,
+        frameData.perAxisRoute, frameData.isDetachedCanvas,
+        frameData.detachedWorldReceive
+    );
+    if (!sel.keepFace) return;
+    faceId = sel.faceId;
+    const int riserFlip = sel.riserFlip;
+    const bool bothPolaritiesExposed = sel.bothPolaritiesExposed;
 
-    // Exposed-face gate widened with the fog CUT-FACE rule (#2125/#2127; per-axis
-    // #2128) — see the GLSL twin. A non-exposed VERTICAL face (faceId 0..3 = ±X/±Y)
-    // becomes the object's interior cross-section wall when its solid neighbor world
-    // COLUMN is NOT fully revealed; world fog route (perAxisRoute==0, GRID or
-    // world-placed re-voxelize detached via `fogActive`) plus the per-axis rotation
-    // routes. `fogActive` carries the per-axis route selection (routes 0/1/2): under
-    // yaw the cut face rides the matching axis canvas via the `(faceId>>1)!=axis`
-    // store filter below; the Z route (3) carries no cut faces. Keeping a
-    // `perAxisRoute` comparison term in `fogActive` makes the Metal compiler schedule
-    // the non-fog per-axis store the SAME as the pre-#2128 `== 0` gate → byte-
-    // identical. Keep byte-identical to stage 2's gate so distance + colour agree.
-    // P2 (#2126) cuts when the neighbor is "not fully revealed" (reveal < 1.0) so the
-    // cut wall fills the whole soft band; a hard disc collapses it to the binary
-    // boundary (Mode A byte-identical, so #2127's re-voxelize detached cut keeps its
-    // merged behaviour at the default).
-    bool keepFace = faceIsExposed(flagsByte, faceId);
-    if (!keepFace && faceId < kFaceZNeg && fogActive) {
-        keepFace = fogColumnReveal(
-            canvasFogOfWar, fogObservers,
-            worldColumn + faceOutwardNormal6I(faceId).xy) < 1.0f;
-    }
-    if (!keepFace) return;
-
-    // Per-voxel analytic fog clip (#2102 + #2126 P2 + #2127; per-axis split #2128) —
-    // see the GLSL twin. On the single-canvas world route (perAxisRoute==0) drop a
-    // voxel whose OWN world column is FULLY fog-hidden (reveal <= 0) so FOG_TO_TRIXEL
-    // can't hard-black its faces; STAGE_2 inherits the drop via its depth re-test. A
-    // partially-revealed boundary column rasterizes so FOG_TO_TRIXEL fades the
-    // silhouette like the floor (Mode B). The per-axis rotation routes run the SAME
-    // reveal<=0 clip inside their branch below (#2128) rather than here, so the shared
-    // pre-split code stays byte-identical to the pre-#2128 per-axis store (a
-    // perAxisRoute!=0 early-return here reshuffles the Metal compiler's per-axis store
-    // scheduling → tie-winner drift); the explicit perAxisRoute==0 term keeps this an
-    // unconditional no-op on routes 1/2/3. `fogActive` covers the GRID + world-placed
-    // re-voxelize detached canvas and short-circuits every other route, keeping
-    // non-fog scenes byte-identical.
-    // The GRID canvas keeps a disc-adjacent RING of hidden columns
-    // (fogColumnRevealNearest's kFogHiddenKeepCells) so FOG_TO_TRIXEL's image-space
-    // cut (#2124) has hidden matter to repaint per pixel. A world-placed DETACHED
-    // canvas carries no fog pass, so nothing reclaims those kept columns — it clips
-    // tight at the voxel lattice (fogColumnReveal <= 0), the #2137-era behaviour the
-    // per-axis routes also apply. See #2248.
+    // Per-voxel analytic fog clip (#2102 + #2126 P2 + #2127; per-axis split
+    // #2128) — STAGE-1-ONLY (stage 2 never repeats it: with the distances
+    // dropped, its colour taps are rejected by the depth re-test). See the
+    // GLSL twin for the full rationale (Mode B partial-reveal keep, the
+    // #2124 hidden-ring via fogColumnRevealNearest, the #2248 detached
+    // lattice clip, and why the per-axis routes run their own clip inside
+    // their branch below).
     const bool ownColumnHidden = frameData.isDetachedCanvas > 0.5f
-        ? fogColumnReveal(canvasFogOfWar, fogObservers, worldColumn) <= 0.0f
-        : fogColumnRevealNearest(canvasFogOfWar, fogObservers, worldColumn) <= 0.0f;
-    if (fogActive && frameData.perAxisRoute == 0 && ownColumnHidden) {
+        ? fogColumnReveal(canvasFogOfWar, fogObservers, sel.worldColumn) <= 0.0f
+        : fogColumnRevealNearest(canvasFogOfWar, fogObservers, sel.worldColumn) <= 0.0f;
+    if (sel.fogActive && frameData.perAxisRoute == 0 && ownColumnHidden) {
         return;
     }
 
@@ -624,74 +463,37 @@ kernel void IR_STAGE1_KERNEL_NAME(
         // keep trixelFrameOffset.
         const int2 perAxisBase = trixelOriginOffsetZ1(frameData.canvasSizePixels) +
                                  int2(floor(frameData.frameCanvasOffset));
-        if (frameData.voxelRenderOptions.x == 0) {
-            const float3 worldAlignedBase = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-            const int3 worldPos = roundHalfUp(worldAlignedBase);
-            const int3 facePos = faceMicroPositionFixed6(faceId, worldPos, 0, 0, 1);
-            // Full sub-cell fracs (u/v in-plane + w out-of-plane) so a
-            // fractionally-positioned face reconstructs on its TRUE plane,
-            // not the integer lattice plane. Integer content encodes 8/8/8
-            // (zero offsets) — byte-identical to the old centre-frac store.
-            const float3 fracInCellBase = worldAlignedBase - float3(worldPos);
-            const int voxelDistance = encodeDepthWithFaceFrac(
-                pos3DtoDistance(facePos), slot, axis, fracInCellBase, riserFlip
-            );
-            if (frameData.resolveMode == 2) {
-                viewMaskTap(perAxisBase, facePos, frameData, perAxisWinnerIds);
-                return;
-            }
-            if (frameData.resolveMode == 3) {
-                overflowAppendTap(
-                    perAxisBase, facePos, voxelDistance, voxels[voxelIndex].colorPacked,
-                    frameData, distanceScratch, perAxisWinnerIds, canvasSize
-                );
-                return;
-            }
-            if (frameData.resolveMode != 0) {
-                resolveWinnerTap(
-                    perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance, voxelIndex,
-                    distanceScratch, perAxisWinnerIds, canvasSize
-                );
-                return;
-            }
-            writeDistanceTap(
-                perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance,
-                distanceScratch, canvasSize
-            );
-            return;
-        }
-        // #1458: store at BASE (world-unit) resolution regardless of effSub.
-        // Only the z=0 invocation writes; higher z-slices return early.
-        if (zIdx != 0) return;
-        const float3 worldAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-        const int3 worldPos_sub = roundHalfUp(worldAligned);
-        const int3 facePos_sub = faceMicroPositionFixed6(faceId, worldPos_sub, 0, 0, 1);
-        const float3 fracInCell = worldAligned - float3(worldPos_sub);
-        const int voxelDistance =
-            encodeDepthWithFaceFrac(pos3DtoDistance(facePos_sub), slot, axis, fracInCell, riserFlip);
+        // #1458: store at BASE (world-unit) resolution regardless of effSub —
+        // on the subdivided path only the z=0 invocation writes (the voxel's
+        // continuous sub-cell offset rides the encoding so the scatter can
+        // sub-pixel-shift the face quad).
+        if (frameData.voxelRenderOptions.x != 0 && zIdx != 0) return;
+        int voxelDistance;
+        const int3 facePos =
+            perAxisStoreFacePos(voxelPosition, faceId, slot, axis, riserFlip, voxelDistance);
         if (frameData.resolveMode == 2) {
-            viewMaskTap(perAxisBase, facePos_sub, frameData, perAxisWinnerIds);
+            viewMaskTap(perAxisBase, facePos, frameData, perAxisWinnerIds);
             return;
         }
         if (frameData.resolveMode == 3) {
             overflowAppendTap(
-                perAxisBase, facePos_sub, voxelDistance, voxels[voxelIndex].colorPacked,
+                perAxisBase, facePos, voxelDistance, voxels[voxelIndex].colorPacked,
                 frameData, distanceScratch, perAxisWinnerIds, canvasSize
             );
             return;
         }
-        // #2255: the 4-bit frac quantization above is where equal keys arise —
-        // see the GLSL twin. The winner election keeps stage 2's color tap
-        // deterministic among the tied faces.
+        // #2255: equal keys arise from the 4-bit frac quantization (see
+        // perAxisStoreFacePos) — the winner election here is what keeps the
+        // stage-2 color tap deterministic among them.
         if (frameData.resolveMode != 0) {
             resolveWinnerTap(
-                perAxisBase + pos3DtoPos2DIso(facePos_sub), voxelDistance, voxelIndex,
+                perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance, voxelIndex,
                 distanceScratch, perAxisWinnerIds, canvasSize
             );
             return;
         }
         writeDistanceTap(
-            perAxisBase + pos3DtoPos2DIso(facePos_sub), voxelDistance,
+            perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance,
             distanceScratch, canvasSize
         );
         return;

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_feeder.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_feeder.metal
@@ -14,4 +14,5 @@
 #define IR_FEEDER_PASS 1
 #define IR_STORE_WINNER_ELECTION 0
 #define IR_STAGE1_KERNEL_NAME c_voxel_to_trixel_stage_1_feeder
+#include "ir_voxel_face_select.metal"
 #include "c_voxel_to_trixel_stage_1_body.metal"

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_winner_resolve.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_winner_resolve.metal
@@ -18,4 +18,5 @@
 #define IR_FEEDER_PASS 0
 #define IR_STORE_WINNER_ELECTION 1
 #define IR_STAGE1_KERNEL_NAME c_voxel_to_trixel_stage_1_winner_resolve
+#include "ir_voxel_face_select.metal"
 #include "c_voxel_to_trixel_stage_1_body.metal"

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
@@ -10,4 +10,5 @@
 
 #define IR_STORE_WINNER_ELECTION 0
 #define IR_STAGE2_KERNEL_NAME c_voxel_to_trixel_stage_2
+#include "ir_voxel_face_select.metal"
 #include "c_voxel_to_trixel_stage_2_body.metal"

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal
@@ -254,47 +254,12 @@ struct Voxel {
     uint reserved;
 };
 
-// Fog cut-face inputs (#2125). STAGE_1 binds the fog grid at [[texture(0)]] (free
-// there), but [[texture(0)]] is the colour output here, so the fog grid binds at
-// [[texture(3)]] instead. Every non-fog / detached canvas binds a 1×1 all-visible
-// placeholder + count-0 observers, so fogColumnReveal short-circuits to "fully
-// visible" and those scenes stay byte-identical.
-constant int kFogOfWarHalfExtent = 128;
-constant float kFogExploredThreshold = 0.25f;
-constant int kMaxFogVisionCircles = 8; // mirror of component_canvas_fog_of_war.hpp kMaxFogVisionCircles
-struct FogObserverData {
-    float4 visionCircles[kMaxFogVisionCircles]; // (centerX, centerY, radius, edgeSoftness)
-    int visionCircleCount;
-    int _fogObsPad0;
-    int _fogObsPad1;
-    int _fogObsPad2;
-};
-
-// Fog reveal of world grid COLUMN `col` in [0,1]. MUST stay byte-identical to
-// c_voxel_to_trixel_stage_1.metal::fogColumnReveal (and the GLSL twin) — stage 1
-// emits the cut face's DISTANCE for `reveal < 1.0` (#2126 P2), and stage 2 must
-// paint colour on the same set of faces or the cut wall reads as cleared
-// background.
-static float fogColumnReveal(
-    texture2d<float, access::read> fog, constant FogObserverData& obs, int2 col
-) {
-    const int2 fogSize = int2(int(fog.get_width()), int(fog.get_height()));
-    if (fogSize.x <= 1) {
-        return 1.0f; // 1×1 all-visible placeholder (non-fog / detached canvas)
-    }
-    const int2 cell = col + int2(kFogOfWarHalfExtent);
-    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
-        return 1.0f; // out-of-range column reads as visible
-    }
-    if (fog.read(uint2(cell)).r >= kFogExploredThreshold) {
-        return 1.0f; // explored / visible grid memory — keep
-    }
-    float reveal = 0.0f;
-    for (int i = 0; i < obs.visionCircleCount; ++i) {
-        reveal = max(reveal, fogVisionCircleReveal(float2(col), obs.visionCircles[i], 0.0f));
-    }
-    return reveal;
-}
+// Fog constants/struct + fogColumnReveal and the shared face-selection /
+// per-axis store-key math live in ir_voxel_face_select.metal (the wrapper
+// includes it before this body). STAGE_2's [[texture(0)]] is the colour
+// output, so the fog grid binds at [[texture(3)]] here (1/2 are the distance +
+// entity-id outputs); Metal passes the texture + observers into the shared
+// functions as arguments.
 
 kernel void IR_STAGE2_KERNEL_NAME(
     constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
@@ -363,64 +328,29 @@ kernel void IR_STAGE2_KERNEL_NAME(
     // winner among the emitted faces.
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
 
-    // Silhouette-riser face selection — MUST mirror stage 1's flip + rotated-content
-    // gate exactly so the colour tap lands on the same (possibly opposite-polarity)
-    // face stage 1 wrote the distance for. See c_voxel_to_trixel_stage_1.glsl.
-    const bool rotatedEmit = reVoxelize || (voxels[voxelIndex].reserved & 4u) != 0u;
-    // Polarity carrier (#2207) — mirror of stage 1's riserFlip: the colour tap
-    // must re-derive the identical encoding (flip bit included) or the depth
-    // re-test rejects every flipped-face tap.
-    int riserFlip = 0;
-    if (rotatedEmit && !faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1)) {
-        faceId = faceId ^ 1;
-        riserFlip = 1;
-    }
-    // Both-exposed silhouette-riser dual emit (#2157) — MUST mirror stage 1's
-    // predicate + emit site so the colour taps land on the dual-emitted
-    // distance taps. See the GLSL twin for the full rationale.
-    const bool bothPolaritiesExposed = rotatedEmit && faceIsExposed(flagsByte, faceId) &&
-        faceIsExposed(flagsByte, faceId ^ 1);
-
-    // Exposed-face gate + fog CUT-FACE widening (#2125/#2127; per-axis #2128) —
-    // MUST mirror stage 1's predicate EXACTLY so the colour tap lands on the same
-    // face set stage 1 wrote distances for, on the single-canvas (0) and X/Y
-    // per-axis routes (1/2) alike (a cut face is non-exposed; without this it'd read
-    // as cleared background). The world-column recovery handles a world-placed
-    // detached re-voxelize canvas (model + detachedWorldReceive.xy); see the GLSL
-    // twin (incl. why a `perAxisRoute` comparison term is kept in `fogActive` for
-    // non-fog byte-identity). The own-column drop (#2102/#2127) is NOT repeated here
-    // — stage 1 already dropped those voxels' distances on every route, so
-    // writeColorTap's depth re-test rejects their colour taps.
-    const bool fogActive = fogObservers.visionCircleCount > 0 &&
-        frameData.perAxisRoute <= 2 &&
-        (frameData.isDetachedCanvas < 0.5f ||
-         (frameData.perAxisRoute == 0 && frameData.detachedWorldReceive.w != 0.0f));
-    int2 worldColumn = int2(0);
-    if (fogActive) {
-        worldColumn = roundHalfUp(voxelPosition.xyz).xy +
-            (frameData.isDetachedCanvas > 0.5f
-                 ? roundHalfUp(frameData.detachedWorldReceive.xy)
-                 : int2(0));
-    }
-    bool keepFace = faceIsExposed(flagsByte, faceId);
-    bool isCutFace = false;
-    if (!keepFace && faceId < kFaceZNeg && fogActive) {
-        // P2 (#2126): cut iff the neighbor column is not fully revealed (reveal <
-        // 1.0) — mirrors stage 1 exactly. Mode A (edgeSoftness 0) reveal is binary so
-        // this collapses to the #2125/#2127 boolean boundary (byte-identical).
-        keepFace = fogColumnReveal(
-            canvasFogOfWar, fogObservers,
-            worldColumn + faceOutwardNormal6I(faceId).xy) < 1.0f;
-        // A non-exposed VERTICAL face kept ONLY by the fog cut rule is the interior
-        // cross-section wall — flag it so LIGHTING_TO_TRIXEL force-lights it as a
-        // clean exposed face (#2124 lit-cross-section follow-up). GLSL twin.
-        isCutFace = keepFace;
-    }
-    if (!keepFace) return;
-    // Fold the cut-face flag into the id AFTER the priority encode (which strips it
-    // via kEntityIdHighWordMask). Non-cut ⇒ id unchanged (byte-identical).
-    packedEntityId = encodeEntityIdCutFace(packedEntityId, isCutFace);
+    // Face selection — the visible-triplet × exposed-mask gate (#1278), the
+    // silhouette-riser flip (#2207) + dual-emit predicate (#2157), and the fog
+    // cut-face widening (#2125/#2126/#2127; per-axis #2128) — is shared with
+    // stage 1 via ir_voxel_face_select.metal: both stages key their taps off
+    // ONE definition, so the colour tap cannot desync from the distance tap.
+    // The own-column drop (#2102/#2127) is NOT repeated here — stage 1 already
+    // dropped those voxels' distances on every route, so the depth re-test in
+    // writeColorTap rejects their colour taps.
+    const VoxelFaceSelect sel = selectVoxelFace(
+        canvasFogOfWar, fogObservers, faceId, reVoxelize,
+        voxels[voxelIndex].reserved, flagsByte, voxelPosition,
+        frameData.perAxisRoute, frameData.isDetachedCanvas,
+        frameData.detachedWorldReceive
+    );
+    if (!sel.keepFace) return;
+    faceId = sel.faceId;
+    const int riserFlip = sel.riserFlip;
+    const bool bothPolaritiesExposed = sel.bothPolaritiesExposed;
+    // A face kept ONLY by the fog cut rule is the interior cross-section wall —
+    // fold the flag into the id (bit 29) AFTER the priority encode (which strips
+    // it via kEntityIdHighWordMask) so LIGHTING_TO_TRIXEL force-lights it
+    // (#2124). Non-cut ⇒ id unchanged, so non-fog scenes stay byte-identical.
+    packedEntityId = encodeEntityIdCutFace(packedEntityId, sel.isCutFace);
 
     // Per-slot deformation matrix — see stage 1 GLSL for the contract.
     const float2x2 D = float2x2(
@@ -442,33 +372,15 @@ kernel void IR_STAGE2_KERNEL_NAME(
         // Whole-iso base anchor (#1944) — MUST match stage 1's per-axis anchor.
         const int2 perAxisBase = trixelOriginOffsetZ1(frameData.canvasSizePixels) +
                                  int2(floor(frameData.frameCanvasOffset));
-        if (frameData.voxelRenderOptions.x == 0) {
-            const float3 worldAlignedBase = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-            const int3 worldPos = roundHalfUp(worldAlignedBase);
-            const int3 facePos = faceMicroPositionFixed6(faceId, worldPos, 0, 0, 1);
-            // Full sub-cell fracs — MUST mirror stage 1's base-resolution
-            // store exactly or the colour tap desyncs from the distance.
-            const float3 fracInCellBase = worldAlignedBase - float3(worldPos);
-            const int voxelDistance = encodeDepthWithFaceFrac(
-                pos3DtoDistance(facePos), slot, axis, fracInCellBase, riserFlip
-            );
-            writeColorTapPerAxis(
-                perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance, voxelColor,
-                packedEntityId, voxelIndex, canvasSize, distanceScratch, perAxisWinnerIds,
-                triangleCanvasColors, triangleCanvasDistances, triangleCanvasEntityIds
-            );
-            return;
-        }
-        // #1458: mirror stage 1's base-resolution store (z=0 only).
-        if (zIdx != 0) return;
-        const float3 worldAligned_s2 = snapNearIntegerVoxelPosition(voxelPosition.xyz);
-        const int3 worldPos_s2 = roundHalfUp(worldAligned_s2);
-        const int3 facePos_s2 = faceMicroPositionFixed6(faceId, worldPos_s2, 0, 0, 1);
-        const float3 fracInCell_s2 = worldAligned_s2 - float3(worldPos_s2);
-        const int voxelDistance_s2 =
-            encodeDepthWithFaceFrac(pos3DtoDistance(facePos_s2), slot, axis, fracInCell_s2, riserFlip);
+        // #1458: store at BASE (world-unit) resolution regardless of effSub —
+        // on the subdivided path only the z=0 invocation writes. The cell + key
+        // derive through the SAME shared helper stage 1's taps used.
+        if (frameData.voxelRenderOptions.x != 0 && zIdx != 0) return;
+        int voxelDistance;
+        const int3 facePos =
+            perAxisStoreFacePos(voxelPosition, faceId, slot, axis, riserFlip, voxelDistance);
         writeColorTapPerAxis(
-            perAxisBase + pos3DtoPos2DIso(facePos_s2), voxelDistance_s2, voxelColor,
+            perAxisBase + pos3DtoPos2DIso(facePos), voxelDistance, voxelColor,
             packedEntityId, voxelIndex, canvasSize, distanceScratch, perAxisWinnerIds,
             triangleCanvasColors, triangleCanvasDistances, triangleCanvasEntityIds
         );

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_winner.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_winner.metal
@@ -16,4 +16,5 @@
 
 #define IR_STORE_WINNER_ELECTION 1
 #define IR_STAGE2_KERNEL_NAME c_voxel_to_trixel_stage_2_winner
+#include "ir_voxel_face_select.metal"
 #include "c_voxel_to_trixel_stage_2_body.metal"

--- a/engine/render/src/shaders/metal/ir_voxel_face_select.metal
+++ b/engine/render/src/shaders/metal/ir_voxel_face_select.metal
@@ -1,0 +1,187 @@
+// Shared voxel face-selection + per-axis store-key math for the
+// c_voxel_to_trixel stage-1 / stage-2 kernel family — Metal twin of
+// ../ir_voxel_face_select.glsl (keep byte-identical math). Both stage BODIES
+// used to carry byte-identical copies of everything here under "MUST mirror
+// stage 1 EXACTLY" comments; one definition makes a one-sided edit
+// unrepresentable. Included by the kernel wrappers AFTER ir_iso_common.metal /
+// ir_constants.metal and BEFORE the stage body. Metal passes the fog texture +
+// observer buffer as function arguments (no global bindings), so no
+// fog-binding macro is needed here — the GLSL side #defines
+// IR_VOXEL_FOG_GRID_BINDING instead.
+
+// Prerequisite helpers (faceIsExposed, roundHalfUp, fogVisionCircleReveal,
+// faceMicroPositionFixed6, encodeDepthWithFaceFrac, …). The runtime include
+// resolver is recursive with a visited set, so the wrapper's own earlier
+// include of ir_iso_common.metal makes this a suppressed duplicate — the
+// ir_per_axis_lighting.metal idiom.
+#include "ir_iso_common.metal"
+
+// Per-voxel analytic fog clip inputs (#2102), mirroring
+// c_voxel_visibility_compact + c_fog_to_trixel. The world fog canvas binds its
+// 256² grid + live vision circles; every non-fog / detached canvas binds a 1×1
+// all-visible placeholder + count-0 observers, so `fogColumnReveal`
+// short-circuits to "fully visible" and those scenes stay byte-identical.
+constant int kFogOfWarHalfExtent = 128;
+constant float kFogExploredThreshold = 0.25f;
+constant int kMaxFogVisionCircles = 8; // mirror of component_canvas_fog_of_war.hpp kMaxFogVisionCircles
+struct FogObserverData {
+    float4 visionCircles[kMaxFogVisionCircles]; // (centerX, centerY, radius, edgeSoftness)
+    int visionCircleCount;
+    int _fogObsPad0;
+    int _fogObsPad1;
+    int _fogObsPad2;
+};
+
+// Fog reveal of world grid COLUMN `col` in [0,1]. Stage 1 emits the cut face's
+// DISTANCE for `reveal < 1.0` (#2126 P2) and stage 2 paints colour on the same
+// set of faces — both through this one definition, so the cut wall's depth and
+// colour cannot desync. GLSL twin: fogColumnReveal in
+// ../ir_voxel_face_select.glsl.
+static float fogColumnReveal(
+    texture2d<float, access::read> fog, constant FogObserverData& obs, int2 col
+) {
+    const int2 fogSize = int2(int(fog.get_width()), int(fog.get_height()));
+    if (fogSize.x <= 1) {
+        return 1.0f; // 1×1 all-visible placeholder (non-fog / detached canvas)
+    }
+    const int2 cell = col + int2(kFogOfWarHalfExtent);
+    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
+        return 1.0f; // out-of-range column reads as visible
+    }
+    if (fog.read(uint2(cell)).r >= kFogExploredThreshold) {
+        return 1.0f; // explored / visible grid memory — keep
+    }
+    float reveal = 0.0f;
+    for (int i = 0; i < obs.visionCircleCount; ++i) {
+        reveal = max(reveal, fogVisionCircleReveal(float2(col), obs.visionCircles[i], 0.0f));
+    }
+    return reveal;
+}
+
+// Own-column DROP reveal, evaluated at the cell point NEAREST each
+// vision-circle center (#2124 screen-space cross-section). The drop keeps a
+// column iff this is > 0; kFogHiddenKeepCells widens the keep into a ring of
+// fog-hidden columns so FOG_TO_TRIXEL's image-space cut has hidden matter to
+// repaint. Grid-memory / OOB / placeholder short-circuits match
+// fogColumnReveal. GLSL twin in ../ir_voxel_face_select.glsl.
+constant float kFogColumnCellHalf = 0.5f;
+constant float kFogColumnKeepAa = 0.5f;
+constant float kFogHiddenKeepCells = 8.0f;
+static float fogColumnRevealNearest(
+    texture2d<float, access::read> fog, constant FogObserverData& obs, int2 col
+) {
+    const int2 fogSize = int2(int(fog.get_width()), int(fog.get_height()));
+    if (fogSize.x <= 1) {
+        return 1.0f;
+    }
+    const int2 cell = col + int2(kFogOfWarHalfExtent);
+    if (cell.x < 0 || cell.x >= fogSize.x || cell.y < 0 || cell.y >= fogSize.y) {
+        return 1.0f;
+    }
+    if (fog.read(uint2(cell)).r >= kFogExploredThreshold) {
+        return 1.0f;
+    }
+    float reveal = 0.0f;
+    for (int i = 0; i < obs.visionCircleCount; ++i) {
+        const float2 nearest = clamp(
+            obs.visionCircles[i].xy,
+            float2(col) - kFogColumnCellHalf,
+            float2(col) + kFogColumnCellHalf
+        );
+        reveal = max(
+            reveal,
+            fogVisionCircleReveal(
+                nearest, obs.visionCircles[i], kFogColumnKeepAa + kFogHiddenKeepCells
+            )
+        );
+    }
+    return reveal;
+}
+
+// The face-selection verdict both stage kernels branch on. `keepFace == false`
+// ⇒ the caller returns without emitting. `isCutFace` marks a non-exposed
+// VERTICAL face kept ONLY by the fog cut rule — stage 2 folds it into the
+// stored entity id (bit 29, #2124), stage 1 ignores it.
+struct VoxelFaceSelect {
+    int faceId;                 // possibly riser-flipped (#2207)
+    int riserFlip;              // 1 = opposite polarity of the slot's triplet face
+    bool rotatedEmit;           // rotated-content gate (re-voxelize OR kRotatedEmit)
+    bool bothPolaritiesExposed; // #2157 dual-emit predicate (cardinal subdivided path)
+    bool fogActive;             // world fog route gate (#2125/#2127/#2128)
+    int2 worldColumn;           // world fog column (valid iff fogActive)
+    bool keepFace;
+    bool isCutFace;
+};
+
+// Face selection for one (voxel, slot) invocation — the visible-triplet ×
+// exposed-mask gate (#1278), the silhouette-riser flip (#2207) and dual-emit
+// predicate (#2157) for rotated content, and the fog cut-face widening
+// (#2125/#2126/#2127; per-axis #2128). Stage 1 keys its distance taps and
+// stage 2 its colour/entity-id taps off the SAME verdict. See the GLSL twin
+// for the full per-rule rationale (incl. why the `perAxisRouteIn <= 2`
+// comparison term is load-bearing for non-fog byte-identity).
+static VoxelFaceSelect selectVoxelFace(
+    texture2d<float, access::read> fog,
+    constant FogObserverData& obs,
+    const int faceIdIn,
+    const bool reVoxelize,
+    const uint reserved,
+    const uint flagsByte,
+    const float4 voxelPosition,
+    const int perAxisRouteIn,
+    const float isDetachedCanvasIn,
+    const float4 detachedWorldReceiveIn
+) {
+    VoxelFaceSelect sel;
+    sel.faceId = faceIdIn;
+    sel.rotatedEmit = reVoxelize || (reserved & 4u) != 0u;
+    sel.riserFlip = 0;
+    if (sel.rotatedEmit && !faceIsExposed(flagsByte, sel.faceId) &&
+        faceIsExposed(flagsByte, sel.faceId ^ 1)) {
+        sel.faceId = sel.faceId ^ 1;
+        sel.riserFlip = 1;
+    }
+    sel.bothPolaritiesExposed = sel.rotatedEmit && faceIsExposed(flagsByte, sel.faceId) &&
+        faceIsExposed(flagsByte, sel.faceId ^ 1);
+    sel.fogActive = obs.visionCircleCount > 0 && perAxisRouteIn <= 2 &&
+        (isDetachedCanvasIn < 0.5f ||
+         (perAxisRouteIn == 0 && detachedWorldReceiveIn.w != 0.0f));
+    sel.worldColumn = int2(0);
+    if (sel.fogActive) {
+        sel.worldColumn = roundHalfUp(voxelPosition.xyz).xy +
+            (isDetachedCanvasIn > 0.5f
+                 ? roundHalfUp(detachedWorldReceiveIn.xy)
+                 : int2(0));
+    }
+    sel.keepFace = faceIsExposed(flagsByte, sel.faceId);
+    sel.isCutFace = false;
+    if (!sel.keepFace && sel.faceId < kFaceZNeg && sel.fogActive) {
+        sel.keepFace = fogColumnReveal(
+            fog, obs, sel.worldColumn + faceOutwardNormal6I(sel.faceId).xy) < 1.0f;
+        sel.isCutFace = sel.keepFace;
+    }
+    return sel;
+}
+
+// Per-axis base-resolution store position + encoded key (#1458 encoding,
+// #1944 un-yawed cardinal iso key). Returns the face-plane position whose
+// projection `perAxisBase + pos3DtoPos2DIso(facePos)` is the store cell;
+// writes the encoded distance key through `encodedDistance`. The "stage 2
+// MUST mirror stage 1's store exactly" contract in code — see the GLSL twin
+// for the full rationale (frac carrier, #2255 equal-key source).
+static int3 perAxisStoreFacePos(
+    const float4 voxelPosition,
+    const int faceId,
+    const int slot,
+    const int axis,
+    const int riserFlip,
+    thread int& encodedDistance
+) {
+    const float3 worldAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
+    const int3 worldPos = roundHalfUp(worldAligned);
+    const int3 facePos = faceMicroPositionFixed6(faceId, worldPos, 0, 0, 1);
+    const float3 fracInCell = worldAligned - float3(worldPos);
+    encodedDistance =
+        encodeDepthWithFaceFrac(pos3DtoDistance(facePos), slot, axis, fracInCell, riserFlip);
+    return facePos;
+}

--- a/engine/render/src/shaders/metal/ir_voxel_face_select.metal
+++ b/engine/render/src/shaders/metal/ir_voxel_face_select.metal
@@ -8,6 +8,14 @@
 // observer buffer as function arguments (no global bindings), so no
 // fog-binding macro is needed here — the GLSL side #defines
 // IR_VOXEL_FOG_GRID_BINDING instead.
+//
+// No `#ifndef ..._INCLUDED` self-guard (unlike the ir_per_axis_lighting.metal
+// precedent) is needed: every function here is `static` (internal linkage) and
+// each wrapper includes this file exactly once, so neither in-TU re-inclusion
+// nor a standalone glob-compile can raise a duplicate-symbol conflict.
+// ir_per_axis_lighting.metal carries its guard only because it uses
+// external-linkage `inline` functions — do NOT "fix" this file by switching
+// its functions to `inline` and reintroducing that hazard.
 
 // Prerequisite helpers (faceIsExposed, roundHalfUp, fogVisionCircleReveal,
 // faceMicroPositionFixed6, encodeDepthWithFaceFrac, …). The runtime include
@@ -105,7 +113,6 @@ static float fogColumnRevealNearest(
 struct VoxelFaceSelect {
     int faceId;                 // possibly riser-flipped (#2207)
     int riserFlip;              // 1 = opposite polarity of the slot's triplet face
-    bool rotatedEmit;           // rotated-content gate (re-voxelize OR kRotatedEmit)
     bool bothPolaritiesExposed; // #2157 dual-emit predicate (cardinal subdivided path)
     bool fogActive;             // world fog route gate (#2125/#2127/#2128)
     int2 worldColumn;           // world fog column (valid iff fogActive)
@@ -134,14 +141,16 @@ static VoxelFaceSelect selectVoxelFace(
 ) {
     VoxelFaceSelect sel;
     sel.faceId = faceIdIn;
-    sel.rotatedEmit = reVoxelize || (reserved & 4u) != 0u;
+    // Function-local intermediate — only the riserFlip gate and
+    // bothPolaritiesExposed predicate read it, so it stays off the verdict struct.
+    const bool rotatedEmit = reVoxelize || (reserved & 4u) != 0u;
     sel.riserFlip = 0;
-    if (sel.rotatedEmit && !faceIsExposed(flagsByte, sel.faceId) &&
+    if (rotatedEmit && !faceIsExposed(flagsByte, sel.faceId) &&
         faceIsExposed(flagsByte, sel.faceId ^ 1)) {
         sel.faceId = sel.faceId ^ 1;
         sel.riserFlip = 1;
     }
-    sel.bothPolaritiesExposed = sel.rotatedEmit && faceIsExposed(flagsByte, sel.faceId) &&
+    sel.bothPolaritiesExposed = rotatedEmit && faceIsExposed(flagsByte, sel.faceId) &&
         faceIsExposed(flagsByte, sel.faceId ^ 1);
     sel.fogActive = obs.visionCircleCount > 0 && perAxisRouteIn <= 2 &&
         (isDetachedCanvasIn < 0.5f ||


### PR DESCRIPTION
## Summary
- **The stage-1/stage-2 "MUST mirror EXACTLY" blocks now have one definition.** New shared include-fragments `ir_voxel_face_select.{glsl,metal}` carry the fog reveal functions (`fogColumnReveal` / `fogColumnRevealNearest`), the face-selection verdict (`selectVoxelFace`: visible-triplet × exposed-mask gate #1278, silhouette-riser flip #2207, dual-emit predicate #2157, fog cut-face widening #2125/#2126/#2127/#2128), and the per-axis store cell+key derivation (`perAxisStoreFacePos`, the #1458 encoding). Both stage bodies — all **five** kernel wrappers (visible / feeder / winner-resolve / stage-2 default / stage-2 winner) — now key their taps off the same definitions, so a one-sided edit desyncing the colour tap from the distance tap is unrepresentable.
- **The documented "impossible" duplication is retired**: the fog functions were duplicated per stage because "slot-parameterized images are not possible in GLSL/MSL" — true at runtime, but the wrapper-`#define` idiom this kernel family already uses makes it a compile-time parameter (`IR_VOXEL_FOG_GRID_BINDING` 0 in the three stage-1 wrappers, 3 in the two stage-2 wrappers). Metal needed no macro (its fog functions already took the texture as an argument — they were pure text duplicates).
- **Intra-body collapse**: each body's per-axis base/subdivided branches were themselves near-identical copies (differing only by the `zIdx != 0` guard) — collapsed to one copy each. Net **−609 lines** across the bodies; the extraction is textual (the compiler inlines), following the established wrapper-over-shared-body idiom (#2258 a′, #2346).
- Body headers' include-order contracts + `engine/render/CLAUDE.md` shared-includes list updated.

## Verification (macOS/Metal, M4 Max — A/B vs base with per-side rebuilds)
| surface | result |
|---|---|
| shape_debug full shot table (28 shots: cardinals, yaw-45 rotating poses, pan pivots, LOD swaps) | **byte-identical** (max_delta 0) |
| fog demo (13 checks vs committed master refs — cut faces, own-column drop, detached edge, SDF blocker, smooth edge) | **all PASS, 100% / max_delta 0** — the moved fog path is byte-exact end-to-end |
| canvas_stress (12 shots) | 11 byte-identical; `so3_offsnap_disc` (yaw=π/4) differs by 8px @ ≤9/255 — **within that pose's own run-to-run noise** (re-running the same binary reproduces the same delta magnitude; the open #2479 class), carries no signal |
| jitter floor (#2469): `--yaw-sweep` zoom 4 voxel cylinder | x rev=2, max_residual=1.01px — **exactly the documented accepted floor** |
| all runs | `ir-run: RESULT=CLEAN` |

## Test plan
- [x] macOS/Metal: suite above (runtime Metal compile validates the MSL twins)
- [ ] Linux/GL smoke: `fleet-build --target IRShapeDebug` + `fleet-run IRShapeDebug --auto-screenshot 10`, ideally also `IRFogDemo` render-verify (validates the GLSL twins — no GLSL validator on the authoring host)

## Notes for reviewer
- GLSL's include resolver is non-recursive, so the fragment is included by the **wrappers** (before the bodies) and the extracted code is parameter-passing functions — the bodies keep their own UBO/SSBO declarations. The Metal fragment includes `ir_iso_common.metal` itself (recursive resolver + visited set — the `ir_per_axis_lighting.metal` idiom).
- `c_voxel_visibility_compact` and `c_fog_to_trixel` keep their own fog variants deliberately (different margins/semantics — permissive cull margin vs exact reveal; documented in their headers). Not folded.
- No screenshots attached: every deterministic surface is byte-identical (tables above quantify the one noise-class delta) — the `render-debug-loop` "provably no runtime effect" carve-out with the proof attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6v8rYcLosaHJghwGqBCRp
