### PR TITLE
render: RAII per-axis lighting route scope + one occupied-cell dispatch loop

### DIFF
--- a/engine/prefabs/irreden/render/per_axis_canvas.hpp
+++ b/engine/prefabs/irreden/render/per_axis_canvas.hpp
@@ -17,6 +17,7 @@
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 
 #include <cstddef>
+#include <cstdint>
 
 namespace IRPrefab::PerAxisCanvas {
 
@@ -149,8 +150,7 @@ inline void setUboSubdivisionDensity(IRRender::Buffer *frameDataUbo, int density
 // caching pattern) and pass them by reference so the named-resource lookup
 // only runs once per system.
 inline void restoreVoxelCompactionSlots(
-    IRRender::Buffer *&voxelCompactedBuf,
-    IRRender::Buffer *&voxelIndirectBuf
+    IRRender::Buffer *&voxelCompactedBuf, IRRender::Buffer *&voxelIndirectBuf
 ) {
     if (voxelCompactedBuf == nullptr) {
         voxelCompactedBuf = IRRender::getNamedResource<IRRender::Buffer>("CompactedVoxelIndices");
@@ -168,6 +168,97 @@ inline void restoreVoxelCompactionSlots(
         voxelIndirectBuf->bindBase(
             IRRender::BufferTarget::SHADER_STORAGE,
             IRRender::kBufferIndex_PerAxisCellIndirect
+        );
+    }
+}
+
+// RAII scope for the per-axis lighting-family dispatches (AO / sun-shadow /
+// lighting): flips the shared voxel frame-data UBO onto the per-axis decode
+// route (perAxisRoute_ = 1 — a boolean route flag on the lighting path; the
+// shader recovers the axis per-pixel from faceId, distinct from stage-1's
+// 1/2/3 axis selector) at the #1431-capped lattice density the store wrote,
+// and restores the single-canvas state on destruction: route 0, the uncapped
+// effSub density, and the voxel-compaction slots 25/26 (see
+// restoreVoxelCompactionSlots — the loop below borrows them). One definition
+// of the patch/restore discipline those three dispatches each hand-rolled —
+// the FrameYawRestoreGuard idiom (system_bake_sun_shadow_map.hpp) applied to
+// the lighting family, so a new consumer cannot forget a restore.
+class LightingRouteScope {
+  public:
+    LightingRouteScope(
+        IRRender::Buffer *frameDataUbo,
+        IRRender::Buffer *&voxelCompactedBuf,
+        IRRender::Buffer *&voxelIndirectBuf
+    )
+        : m_frameDataUbo{frameDataUbo}
+        , m_voxelCompactedBuf{voxelCompactedBuf}
+        , m_voxelIndirectBuf{voxelIndirectBuf} {
+        const int kPerAxisRoute = 1;
+        m_frameDataUbo->subData(
+            offsetof(IRRender::FrameDataVoxelToCanvas, perAxisRoute_),
+            sizeof(int),
+            &kPerAxisRoute
+        );
+        setUboSubdivisionDensity(m_frameDataUbo, subdivisionDensity());
+    }
+
+    ~LightingRouteScope() {
+        const int kSingleCanvasRoute = 0;
+        m_frameDataUbo->subData(
+            offsetof(IRRender::FrameDataVoxelToCanvas, perAxisRoute_),
+            sizeof(int),
+            &kSingleCanvasRoute
+        );
+        setUboSubdivisionDensity(m_frameDataUbo, IRRender::getVoxelRenderEffectiveSubdivisions());
+        restoreVoxelCompactionSlots(m_voxelCompactedBuf, m_voxelIndirectBuf);
+    }
+
+    LightingRouteScope(const LightingRouteScope &) = delete;
+    LightingRouteScope &operator=(const LightingRouteScope &) = delete;
+    LightingRouteScope(LightingRouteScope &&) = delete;
+    LightingRouteScope &operator=(LightingRouteScope &&) = delete;
+
+  private:
+    IRRender::Buffer *m_frameDataUbo;
+    // References to the owning system's lazily-resolved members (the
+    // restoreVoxelCompactionSlots contract) — the scope is stack-local inside
+    // one tick, so the referents always outlive it.
+    IRRender::Buffer *&m_voxelCompactedBuf;
+    IRRender::Buffer *&m_voxelIndirectBuf;
+};
+
+// One indirect compute dispatch per axis over that axis's compacted OCCUPIED
+// cell list (#2256): calls @p bindAxis(axis) for the pass-specific image
+// bindings, binds the axis's region of the component-owned compacted-cell +
+// dispatch-args buffers onto slots 25/26 (borrowing them — the caller restores
+// via restoreVoxelCompactionSlots / LightingRouteScope), then issues the
+// indirect dispatch from the axis's args region. One definition of the loop
+// the per-axis AO / sun-shadow / lighting / screen-depth-resolve dispatches
+// each hand-rolled.
+template <typename BindAxis>
+inline void dispatchPerAxisCells(IRComponents::C_PerAxisTrixelCanvases &axes, BindAxis &&bindAxis) {
+    IRRender::Buffer *cellCompacted = axes.cellCompacted_.second;
+    IRRender::Buffer *cellIndirect = axes.cellIndirect_.second;
+    const int regionStride = axes.cellRegionStride_;
+    for (int axis = 0; axis < IRComponents::C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+        bindAxis(axis);
+        cellCompacted->bindRange(
+            IRRender::BufferTarget::SHADER_STORAGE,
+            IRRender::kBufferIndex_PerAxisCellCompacted,
+            static_cast<std::ptrdiff_t>(axis) * regionStride *
+                static_cast<int>(sizeof(std::uint32_t)),
+            static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
+        );
+        cellIndirect->bindRange(
+            IRRender::BufferTarget::SHADER_STORAGE,
+            IRRender::kBufferIndex_PerAxisCellIndirect,
+            static_cast<std::ptrdiff_t>(axis) * IRRender::kPerAxisCellIndirectStrideBytes,
+            IRRender::kPerAxisCellIndirectStrideBytes
+        );
+        IRRender::device()->dispatchComputeIndirect(
+            cellIndirect,
+            static_cast<std::ptrdiff_t>(axis) * IRRender::kPerAxisCellIndirectStrideBytes +
+                IRRender::kPerAxisCellDispatchArgsOffsetBytes
         );
     }
 }

--- a/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
@@ -27,7 +27,6 @@
 #include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <cstddef>
-#include <cstdint>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -88,75 +87,35 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
         }
     }
 
-    // Resolve the sun-shadow factor for each per-axis canvas. Flips the shared
-    // UBO's perAxisRoute so the shader reconstructs world-pos face-locally, then
-    // restores it. The sun depth map (binding 28) and FrameDataSun stay bound.
+    // Resolve the sun-shadow factor for each per-axis canvas. The
+    // LightingRouteScope flips the shared UBO onto the per-axis decode route
+    // (the shader reconstructs world-pos face-locally) and restores route /
+    // density / compaction slots on exit. The sun depth map (binding 28) and
+    // FrameDataSun stay bound.
     void dispatchPerAxisSunShadow(
         C_PerAxisTrixelCanvases &axes,
         const C_TriangleCanvasTextures &mainTextures,
         const C_CanvasSunShadow &mainShadow
     ) {
-        // perAxisRoute is a boolean route flag on the lighting path (any nonzero
-        // = per-axis canvas); the shader recovers the axis per-pixel from faceId,
-        // NOT from this field — distinct from stage-1's 1/2/3 = X/Y/Z axis selector.
-        const int kPerAxisRoute = 1;
-        voxelFrameDataBuf_
-            ->subData(offsetof(FrameDataVoxelToCanvas, perAxisRoute_), sizeof(int), &kPerAxisRoute);
-        // Recover world-pos with the SAME #1431-capped lattice density the store
-        // wrote (perAxisCellToWorld3D reads voxelRenderOptions.y); restored below.
-        IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
-            voxelFrameDataBuf_,
-            IRPrefab::PerAxisCanvas::subdivisionDensity()
-        );
-        // #2256: dispatch indirectly over only each axis's compacted OCCUPIED
-        // cells (filled by the STAGE_1 per-axis compaction) instead of sweeping
-        // the full worst-case grid — mirrors RESOLVE_PER_AXIS_SCREEN_DEPTH.
-        Buffer *cellCompacted = axes.cellCompacted_.second;
-        Buffer *cellIndirect = axes.cellIndirect_.second;
-        const int regionStride = axes.cellRegionStride_;
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            auto &tex = axes.axes_[axis];
-            tex.distances_.second->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            tex.sunShadow_.second->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-            cellCompacted->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellCompacted,
-                static_cast<std::ptrdiff_t>(axis) * regionStride *
-                    static_cast<int>(sizeof(std::uint32_t)),
-                static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
+        {
+            IRPrefab::PerAxisCanvas::LightingRouteScope route(
+                voxelFrameDataBuf_,
+                voxelCompactedBuf_,
+                voxelIndirectBuf_
             );
-            cellIndirect->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                kPerAxisCellIndirectStrideBytes
-            );
-            IRRender::device()->dispatchComputeIndirect(
-                cellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
-                    kPerAxisCellDispatchArgsOffsetBytes
-            );
+            IRPrefab::PerAxisCanvas::dispatchPerAxisCells(axes, [&](int axis) {
+                auto &tex = axes.axes_[axis];
+                tex.distances_.second
+                    ->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                tex.sunShadow_.second
+                    ->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+            });
+            // One barrier after the 3 independent per-axis dispatches (each axis
+            // writes its own sun-shadow image texture — disjoint outputs, so
+            // dispatch order doesn't matter) so they overlap on the GPU instead
+            // of serializing per axis (#1311).
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
         }
-        // One barrier after the 3 independent per-axis dispatches (each axis
-        // writes its own sun-shadow image texture — disjoint outputs, so dispatch
-        // order doesn't matter) so they overlap on the GPU instead of serializing
-        // per axis (#1311).
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-        const int kSingleCanvasRoute = 0;
-        voxelFrameDataBuf_->subData(
-            offsetof(FrameDataVoxelToCanvas, perAxisRoute_),
-            sizeof(int),
-            &kSingleCanvasRoute
-        );
-        // Restore the uncapped density for downstream single-canvas passes.
-        IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
-            voxelFrameDataBuf_,
-            IRRender::getVoxelRenderEffectiveSubdivisions()
-        );
-        // Restore slots 25/26 to the voxel-compaction buffers (#1961/#2256) the
-        // per-axis loop above borrowed via bindRange — see the restore-slots
-        // note in system_compute_voxel_ao.hpp for the corruption mode this avoids.
-        IRPrefab::PerAxisCanvas::restoreVoxelCompactionSlots(voxelCompactedBuf_, voxelIndirectBuf_);
         // Restore the main-canvas image bindings (see the #1311 note in
         // system_compute_voxel_ao.hpp — the persistent Metal image-binding table
         // would otherwise dangle when release() frees the per-axis textures).

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -27,7 +27,6 @@
 #include <irreden/render/gpu_substage_timing.hpp>
 
 #include <cstddef>
-#include <cstdint>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -133,79 +132,35 @@ template <> struct System<COMPUTE_VOXEL_AO> {
         }
     }
 
-    // Run the AO compute over each of the three per-axis canvases. Flips the
-    // shared UBO's perAxisRoute selector so the shader reconstructs world-pos
-    // face-locally (perAxisCellToWorld3D), then restores it to 0 so downstream
-    // single-canvas passes are unaffected. The world AO band is per-axis-correct
-    // because the canvas is a same-axis cardinal-iso lattice.
+    // Run the AO compute over each of the three per-axis canvases. The
+    // LightingRouteScope flips the shared UBO onto the per-axis decode route
+    // (the shader reconstructs world-pos face-locally, perAxisCellToWorld3D)
+    // and restores route / density / compaction slots on exit. The world AO
+    // band is per-axis-correct because the canvas is a same-axis cardinal-iso
+    // lattice.
     void dispatchPerAxisAO(
         C_PerAxisTrixelCanvases &axes,
         const C_TriangleCanvasTextures &mainTextures,
         const C_CanvasAOTexture &mainAO
     ) {
-        // perAxisRoute is a boolean route flag on the lighting path (any nonzero
-        // = per-axis canvas); the shader recovers the axis per-pixel from faceId,
-        // NOT from this field — distinct from stage-1's 1/2/3 = X/Y/Z axis selector.
-        const int kPerAxisRoute = 1;
-        voxelFrameDataBuf_
-            ->subData(offsetof(FrameDataVoxelToCanvas, perAxisRoute_), sizeof(int), &kPerAxisRoute);
-        // Recover world-pos with the SAME #1431-capped lattice density the store
-        // wrote (perAxisCellToWorld3D reads voxelRenderOptions.y); restored below.
-        IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
-            voxelFrameDataBuf_,
-            IRPrefab::PerAxisCanvas::subdivisionDensity()
-        );
-        // #2256: dispatch indirectly over only each axis's compacted occupied
-        // cells (filled by the STAGE_1 per-axis compaction into these
-        // component-owned buffers) instead of sweeping the full worst-case grid.
-        Buffer *cellCompacted = axes.cellCompacted_.second;
-        Buffer *cellIndirect = axes.cellIndirect_.second;
-        const int regionStride = axes.cellRegionStride_;
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-            auto &tex = axes.axes_[axis];
-            tex.distances_.second->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            tex.ao_.second->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-            cellCompacted->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellCompacted,
-                static_cast<std::ptrdiff_t>(axis) * regionStride *
-                    static_cast<int>(sizeof(std::uint32_t)),
-                static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
+        {
+            IRPrefab::PerAxisCanvas::LightingRouteScope route(
+                voxelFrameDataBuf_,
+                voxelCompactedBuf_,
+                voxelIndirectBuf_
             );
-            cellIndirect->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                kPerAxisCellIndirectStrideBytes
-            );
-            IRRender::device()->dispatchComputeIndirect(
-                cellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
-                    kPerAxisCellDispatchArgsOffsetBytes
-            );
+            IRPrefab::PerAxisCanvas::dispatchPerAxisCells(axes, [&](int axis) {
+                auto &tex = axes.axes_[axis];
+                tex.distances_.second
+                    ->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                tex.ao_.second->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+            });
+            // One barrier after the 3 independent per-axis dispatches (each axis
+            // writes its own AO image texture — disjoint outputs, so dispatch
+            // order doesn't matter) so they overlap on the GPU instead of
+            // serializing per axis (#1311).
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
         }
-        // One barrier after the 3 independent per-axis dispatches (each axis
-        // writes its own AO image texture — disjoint outputs, so dispatch order
-        // doesn't matter) so they overlap on the GPU instead of serializing per
-        // axis (#1311).
-        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-        const int kSingleCanvasRoute = 0;
-        voxelFrameDataBuf_->subData(
-            offsetof(FrameDataVoxelToCanvas, perAxisRoute_),
-            sizeof(int),
-            &kSingleCanvasRoute
-        );
-        // Restore the uncapped density for downstream single-canvas passes.
-        IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
-            voxelFrameDataBuf_,
-            IRRender::getVoxelRenderEffectiveSubdivisions()
-        );
-        // Restore slots 25/26 to the voxel-compaction buffers (#1961/#2256) the
-        // per-axis loop above borrowed via bindRange — VOXEL_TO_TRIXEL_STAGE_1's
-        // single-canvas compact binds them once at create() and trusts sticky
-        // global state thereafter, so a leaked borrow re-reads the cell list as
-        // the voxel index list next frame and corrupts world voxels.
-        IRPrefab::PerAxisCanvas::restoreVoxelCompactionSlots(voxelCompactedBuf_, voxelIndirectBuf_);
         // Restore the main-canvas image bindings the loop overwrote. The Metal
         // backend's image-binding table persists across frames and is read on
         // every dispatch; leaving the per-axis textures bound here would dangle

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -280,88 +280,44 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
         const C_CanvasAOTexture &mainAO,
         const C_CanvasSunShadow &mainShadow
     ) {
-        // Sub-scope (#2281): the 3 per-axis relight dispatches; the overflow
-        // relight below gets its own row.
+        // The LightingRouteScope flips the shared UBO onto the per-axis decode
+        // route at the #1431-capped store density and restores route / density /
+        // compaction slots on exit; it spans the overflow relight below, which
+        // reads the same per-axis frame state. The GpuSubStageScope (#2281)
+        // brackets only the 3 per-axis relight dispatches — the overflow
+        // relight owns its own row.
         {
-            GpuSubStageScope perAxisScope("lightingPerAxis");
-            // perAxisRoute is a boolean route flag on the lighting path (any nonzero
-            // = per-axis canvas); the shader recovers the axis per-pixel from faceId,
-            // NOT from this field — distinct from stage-1's 1/2/3 = X/Y/Z axis selector.
-            const int kPerAxisRoute = 1;
-            voxelFrameDataBuf_->subData(
-                offsetof(FrameDataVoxelToCanvas, perAxisRoute_),
-                sizeof(int),
-                &kPerAxisRoute
-            );
-            // Recover world-pos with the SAME #1431-capped lattice density the store
-            // wrote (perAxisCellToWorld3D reads voxelRenderOptions.y); restored below.
-            IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
+            IRPrefab::PerAxisCanvas::LightingRouteScope route(
                 voxelFrameDataBuf_,
-                IRPrefab::PerAxisCanvas::subdivisionDensity()
+                voxelCompactedBuf_,
+                voxelIndirectBuf_
             );
-            // #2256: dispatch indirectly over only each axis's OCCUPIED cells
-            // (compacted by the STAGE_1 per-axis pre-pass) instead of sweeping the
-            // full worst-case per-axis grid. Each kernel recovers its cell from the
-            // compacted list (slot 25) and reads visibleCount for its 1-D bound guard
-            // from the indirect-args region (slot 26).
-            Buffer *cellCompacted = axes.cellCompacted_.second;
-            Buffer *cellIndirect = axes.cellIndirect_.second;
-            const int regionStride = axes.cellRegionStride_;
-            for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
-                auto &tex = axes.axes_[axis];
-                tex.colors_.second->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
-                tex.distances_.second
-                    ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-                tex.ao_.second->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-                tex.sunShadow_.second
-                    ->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-                cellCompacted->bindRange(
-                    BufferTarget::SHADER_STORAGE,
-                    kBufferIndex_PerAxisCellCompacted,
-                    static_cast<std::ptrdiff_t>(axis) * regionStride *
-                        static_cast<int>(sizeof(std::uint32_t)),
-                    static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
-                );
-                cellIndirect->bindRange(
-                    BufferTarget::SHADER_STORAGE,
-                    kBufferIndex_PerAxisCellIndirect,
-                    static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                    kPerAxisCellIndirectStrideBytes
-                );
-                IRRender::device()->dispatchComputeIndirect(
-                    cellIndirect,
-                    static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
-                        kPerAxisCellDispatchArgsOffsetBytes
-                );
+            {
+                GpuSubStageScope perAxisScope("lightingPerAxis");
+                IRPrefab::PerAxisCanvas::dispatchPerAxisCells(axes, [&](int axis) {
+                    auto &tex = axes.axes_[axis];
+                    tex.colors_.second
+                        ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
+                    tex.distances_.second
+                        ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+                    tex.ao_.second->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                    tex.sunShadow_.second
+                        ->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+                });
+                // One barrier after the 3 independent per-axis dispatches (each
+                // axis writes its own colour image texture in place — disjoint
+                // outputs, so dispatch order doesn't matter) so they overlap on
+                // the GPU instead of serializing per axis (#1311).
+                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
             }
-            // One barrier after the 3 independent per-axis dispatches (each axis
-            // writes its own colour image texture in place — disjoint outputs, so
-            // dispatch order doesn't matter) so they overlap on the GPU instead of
-            // serializing per axis (#1311).
-            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+            // #2334: relight the overflow entries the C1 lane appended albedo-only,
+            // at their recovered world pos, while the sun-depth map (slot 28) + light
+            // volume are still bound from the cell pass above. Switches the compute
+            // program, so restore the lighting program for any remaining per-canvas
+            // ticks this frame (beginTick's program_->use() runs once per frame).
+            dispatchOverflowLighting(axes);
+            program_->use();
         }
-        // #2334: relight the overflow entries the C1 lane appended albedo-only,
-        // at their recovered world pos, while the sun-depth map (slot 28) + light
-        // volume are still bound from the cell pass above. Switches the compute
-        // program, so restore the lighting program for any remaining per-canvas
-        // ticks this frame (beginTick's program_->use() runs once per frame).
-        dispatchOverflowLighting(axes);
-        program_->use();
-        const int kSingleCanvasRoute = 0;
-        voxelFrameDataBuf_->subData(
-            offsetof(FrameDataVoxelToCanvas, perAxisRoute_),
-            sizeof(int),
-            &kSingleCanvasRoute
-        );
-        // Restore the uncapped density for downstream single-canvas passes.
-        IRPrefab::PerAxisCanvas::setUboSubdivisionDensity(
-            voxelFrameDataBuf_,
-            IRRender::getVoxelRenderEffectiveSubdivisions()
-        );
-        // Restore slots 25/26 to the voxel-compaction buffers (#1961/#2256) the
-        // per-axis loop above borrowed via bindRange — see the restore-slots
-        // note in system_compute_voxel_ao.hpp for the corruption mode this avoids.
-        IRPrefab::PerAxisCanvas::restoreVoxelCompactionSlots(voxelCompactedBuf_, voxelIndirectBuf_);
         // Restore slot 8 to the pool's active mask. dispatchOverflowLighting
         // bindBase'd the overflow scratch over kBufferIndex_OverflowLightingScratch,
         // which ALIASES kBufferIndex_VoxelActiveMask — the named

--- a/engine/prefabs/irreden/render/systems/system_resolve_per_axis_screen_depth.hpp
+++ b/engine/prefabs/irreden/render/systems/system_resolve_per_axis_screen_depth.hpp
@@ -38,6 +38,7 @@
 #include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 using namespace IRComponents;

--- a/engine/prefabs/irreden/render/systems/system_resolve_per_axis_screen_depth.hpp
+++ b/engine/prefabs/irreden/render/systems/system_resolve_per_axis_screen_depth.hpp
@@ -38,7 +38,6 @@
 #include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <cstddef>
-#include <cstdint>
 #include <vector>
 
 using namespace IRComponents;
@@ -148,31 +147,10 @@ template <> struct System<RESOLVE_PER_AXIS_SCREEN_DEPTH> {
         // STAGE_1 per-axis compaction) instead of sweeping the full worst-case grid.
         scatterProgram_->use();
         scratch_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_PerAxisResolveScratch);
-        Buffer *cellCompacted = perAxisCanvases_->cellCompacted_.second;
-        Buffer *cellIndirect = perAxisCanvases_->cellIndirect_.second;
-        const int regionStride = perAxisCanvases_->cellRegionStride_;
-        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+        IRPrefab::PerAxisCanvas::dispatchPerAxisCells(*perAxisCanvases_, [&](int axis) {
             perAxisCanvases_->axes_[axis]
                 .distances_.second->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
-            cellCompacted->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellCompacted,
-                static_cast<std::ptrdiff_t>(axis) * regionStride *
-                    static_cast<int>(sizeof(std::uint32_t)),
-                static_cast<size_t>(regionStride) * sizeof(std::uint32_t)
-            );
-            cellIndirect->bindRange(
-                BufferTarget::SHADER_STORAGE,
-                kBufferIndex_PerAxisCellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes,
-                kPerAxisCellIndirectStrideBytes
-            );
-            IRRender::device()->dispatchComputeIndirect(
-                cellIndirect,
-                static_cast<std::ptrdiff_t>(axis) * kPerAxisCellIndirectStrideBytes +
-                    kPerAxisCellDispatchArgsOffsetBytes
-            );
-        }
+        });
         IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
 
         // Pass 2 — blit the scratch into the resolve texture BAKE reads, and


### PR DESCRIPTION
## Summary
- **The per-axis lighting-family UBO patch/restore discipline is now RAII.** New `IRPrefab::PerAxisCanvas::LightingRouteScope` flips the shared voxel-frame UBO onto the per-axis decode route (`perAxisRoute_ = 1`) at the #1431-capped store density on construction, and restores the single-canvas state (route 0, uncapped density, compaction slots 25/26) on destruction — the `FrameYawRestoreGuard` idiom (`system_bake_sun_shadow_map.hpp`) applied to the three systems (`COMPUTE_VOXEL_AO`, `COMPUTE_SUN_SHADOW`, `LIGHTING_TO_TRIXEL`) that each hand-rolled the same `subData(offsetof(...))` + tail-restore sequence. A missed restore in that sequence is the #2412-segfault / #1961-corruption bug class; the destructor makes it unrepresentable.
- **The per-axis occupied-cell indirect-dispatch loop has one definition.** New `IRPrefab::PerAxisCanvas::dispatchPerAxisCells(axes, bindAxis)` owns the bindRange-25/26 + `dispatchComputeIndirect` loop (#2256) that AO, sun-shadow, lighting, and the screen-depth resolve each duplicated; each caller now supplies only its pass-specific image binds.
- Net **−150 lines** across the four systems; behavior-identical (same call order: per-axis image binds → cell-list ranges → indirect dispatch; same restore order: route → density → slots → main-canvas images).

## Verification (macOS/Metal, M4 Max — A/B vs base with per-side rebuilds)
| surface | result |
|---|---|
| shape_debug full shot table (28 shots — the yaw-45 rotating poses exercise all four converted per-axis paths) | **byte-identical** (max_delta 0) |
| fog demo (13 checks vs committed refs) | **all PASS, max_delta 0** |
| canvas_stress (12 shots, lit + SO(3)) | 11 byte-identical; `so3_offsnap_disc` within its own run-to-run noise (#2479 class) |
| jitter floor (#2469) zoom 4 | x rev=2, max_residual=1.01px — exactly the accepted floor |
| all runs | `ir-run: RESULT=CLEAN` |

## Test plan
- [x] macOS/Metal: suite above
- [ ] Linux/GL smoke: `fleet-build --target IRShapeDebug` + `fleet-run IRShapeDebug --auto-screenshot 10`

## Notes for reviewer
- The scope stores *references* to the owning system's lazily-resolved buffer members (the `restoreVoxelCompactionSlots` lazy-lookup contract) — it is stack-local inside one tick, so the referents always outlive it.
- Deliberately not converted: the bake's own guards (already RAII), the voxel system's `dispatchPerAxisCanvases` (wholesale per-axis/mode frame re-authoring, a different shape), the resolve's `canvasSizePixels` patch (documented as safe-to-leave-set — different contract; it now uses `dispatchPerAxisCells` for its loop but keeps its own density/slot restores), and the scatter draw loop (indirect *draw*, not compute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6v8rYcLosaHJghwGqBCRp
