### PR TITLE
build: gate the Metal AOT metallib build behind an opt-in + fix source list

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -121,6 +121,29 @@ ACES tonemap, shared by the world-lighting passes).
 Shader file paths are stored in `render/shader_names.hpp`. Update that
 header when you add or rename a shader.
 
+### Metal AOT metallib build (opt-in, no runtime consumer)
+
+`engine/render/CMakeLists.txt` can precompile every `.metal` file into
+`default.metallib` via `xcrun metal`/`metallib`, gated behind
+`IRREDEN_METAL_AOT_SHADERS` (default `OFF`). **This is a convention, not a
+build-time check**: kernel wrapper files (`c_voxel_to_trixel_stage_1.metal`,
+`_feeder`, `_winner_resolve`, `c_voxel_to_trixel_stage_2.metal`, `_winner`,
+and the other top-level kernel files) are the only standalone compile units
+— they `#define` the macros an include-fragment needs and then `#include`
+it. `*_body.metal` (the stage bodies) and `ir_*.metal` (shared helpers like
+`ir_iso_common.metal`, `ir_per_axis_lighting.metal`) are include-fragments:
+they reference wrapper-supplied macros or lack an entry point, so they
+cannot compile as standalone translation units. The AOT glob excludes both
+patterns by filename convention — a new include-fragment MUST match one of
+them or it silently re-breaks the opt-in AOT path.
+
+`default.metallib` currently has **no runtime consumer** — the live path is
+always `metal_pipeline.cpp`'s `loadAndPreprocessMetalSource`, which resolves
+`#include` recursively (with a visited-set cycle guard) and compiles from
+source at runtime. The AOT path exists for a future full-Xcode packaging
+step; enabling it costs an `xcrun`-not-found `WARNING` (correct once
+opted in) and produces an unloaded `.metallib` today.
+
 ## Backends
 
 `render/opengl/` and `render/metal/` each implement the `RenderImpl` /

--- a/engine/render/CMakeLists.txt
+++ b/engine/render/CMakeLists.txt
@@ -157,68 +157,86 @@ target_include_directories(
 
 )
 
+option(
+    IRREDEN_METAL_AOT_SHADERS
+    "Precompile Metal shaders to default.metallib via xcrun (requires full Xcode)"
+    OFF
+)
+
 if(IR_isDarwin)
-    set(METAL_SHADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/shaders/metal)
-    file(GLOB METAL_SHADER_SOURCES ${METAL_SHADER_DIR}/*.metal)
-    find_program(IRREDEN_XCRUN_BIN xcrun HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin)
+    if(IRREDEN_METAL_AOT_SHADERS)
+        set(METAL_SHADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/shaders/metal)
+        file(GLOB METAL_SHADER_SOURCES ${METAL_SHADER_DIR}/*.metal)
+        # Kernel wrapper files are the standalone compile units; *_body.metal
+        # and ir_*.metal are include-fragments (rely on macros/#includes from
+        # their wrapper) and cannot compile standalone. See engine/render/CLAUDE.md
+        # § Shaders.
+        list(FILTER METAL_SHADER_SOURCES EXCLUDE REGEX "_body\\.metal$")
+        list(FILTER METAL_SHADER_SOURCES EXCLUDE REGEX "/ir_[^/]*\\.metal$")
+        message(STATUS "Metal AOT shader precompilation sources: ${METAL_SHADER_SOURCES}")
 
-    unset(IRREDEN_METAL_COMPILER)
-    unset(IRREDEN_METALLIB_TOOL)
-    set(IRREDEN_METAL_COMPILER_RESULT 1)
-    set(IRREDEN_METALLIB_TOOL_RESULT 1)
-    if(IRREDEN_XCRUN_BIN)
-        execute_process(
-            COMMAND ${IRREDEN_XCRUN_BIN} --find metal
-            RESULT_VARIABLE IRREDEN_METAL_COMPILER_RESULT
-            OUTPUT_VARIABLE IRREDEN_METAL_COMPILER
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
-        )
-        execute_process(
-            COMMAND ${IRREDEN_XCRUN_BIN} --find metallib
-            RESULT_VARIABLE IRREDEN_METALLIB_TOOL_RESULT
-            OUTPUT_VARIABLE IRREDEN_METALLIB_TOOL
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
-        )
-    endif()
+        find_program(IRREDEN_XCRUN_BIN xcrun HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin)
 
-    if(
-        IRREDEN_XCRUN_BIN
-        AND IRREDEN_METAL_COMPILER_RESULT EQUAL 0
-        AND IRREDEN_METALLIB_TOOL_RESULT EQUAL 0
-        AND IRREDEN_METAL_COMPILER
-        AND IRREDEN_METALLIB_TOOL
-    )
-        file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/shaders)
-        unset(METAL_AIR_FILES)
-        foreach(SHADER ${METAL_SHADER_SOURCES})
-            get_filename_component(SHADER_NAME ${SHADER} NAME_WE)
-            set(AIR_FILE ${PROJECT_BINARY_DIR}/shaders/${SHADER_NAME}.air)
-            add_custom_command(
-                OUTPUT ${AIR_FILE}
-                COMMAND ${IRREDEN_XCRUN_BIN} -sdk macosx metal -c ${SHADER} -o ${AIR_FILE}
-                DEPENDS ${SHADER}
-                COMMENT "Compiling Metal shader ${SHADER_NAME}"
+        unset(IRREDEN_METAL_COMPILER)
+        unset(IRREDEN_METALLIB_TOOL)
+        set(IRREDEN_METAL_COMPILER_RESULT 1)
+        set(IRREDEN_METALLIB_TOOL_RESULT 1)
+        if(IRREDEN_XCRUN_BIN)
+            execute_process(
+                COMMAND ${IRREDEN_XCRUN_BIN} --find metal
+                RESULT_VARIABLE IRREDEN_METAL_COMPILER_RESULT
+                OUTPUT_VARIABLE IRREDEN_METAL_COMPILER
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
             )
-            list(APPEND METAL_AIR_FILES ${AIR_FILE})
-        endforeach()
+            execute_process(
+                COMMAND ${IRREDEN_XCRUN_BIN} --find metallib
+                RESULT_VARIABLE IRREDEN_METALLIB_TOOL_RESULT
+                OUTPUT_VARIABLE IRREDEN_METALLIB_TOOL
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+        endif()
 
-        add_custom_command(
-            OUTPUT ${PROJECT_BINARY_DIR}/shaders/default.metallib
-            COMMAND ${IRREDEN_XCRUN_BIN} -sdk macosx metallib ${METAL_AIR_FILES} -o ${PROJECT_BINARY_DIR}/shaders/default.metallib
-            DEPENDS ${METAL_AIR_FILES}
-            COMMENT "Linking Metal shader library"
+        if(
+            IRREDEN_XCRUN_BIN
+            AND IRREDEN_METAL_COMPILER_RESULT EQUAL 0
+            AND IRREDEN_METALLIB_TOOL_RESULT EQUAL 0
+            AND IRREDEN_METAL_COMPILER
+            AND IRREDEN_METALLIB_TOOL
         )
+            file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/shaders)
+            unset(METAL_AIR_FILES)
+            foreach(SHADER ${METAL_SHADER_SOURCES})
+                get_filename_component(SHADER_NAME ${SHADER} NAME_WE)
+                set(AIR_FILE ${PROJECT_BINARY_DIR}/shaders/${SHADER_NAME}.air)
+                add_custom_command(
+                    OUTPUT ${AIR_FILE}
+                    COMMAND ${IRREDEN_XCRUN_BIN} -sdk macosx metal -c ${SHADER} -o ${AIR_FILE}
+                    DEPENDS ${SHADER}
+                    COMMENT "Compiling Metal shader ${SHADER_NAME}"
+                )
+                list(APPEND METAL_AIR_FILES ${AIR_FILE})
+            endforeach()
 
-        add_custom_target(MetalShaders ALL DEPENDS ${PROJECT_BINARY_DIR}/shaders/default.metallib)
-        add_dependencies(IrredenEngineRendering MetalShaders)
+            add_custom_command(
+                OUTPUT ${PROJECT_BINARY_DIR}/shaders/default.metallib
+                COMMAND ${IRREDEN_XCRUN_BIN} -sdk macosx metallib ${METAL_AIR_FILES} -o ${PROJECT_BINARY_DIR}/shaders/default.metallib
+                DEPENDS ${METAL_AIR_FILES}
+                COMMENT "Linking Metal shader library"
+            )
+
+            add_custom_target(MetalShaders ALL DEPENDS ${PROJECT_BINARY_DIR}/shaders/default.metallib)
+            add_dependencies(IrredenEngineRendering MetalShaders)
+        else()
+            message(
+                WARNING
+                "IRREDEN_METAL_AOT_SHADERS=ON but xcrun cannot find metal/metallib; skipping .metallib precompilation. "
+                "Install full Xcode and select it with xcode-select."
+            )
+        endif()
     else()
-        message(
-            WARNING
-            "Metal shader compiler not found via xcrun; skipping .metallib precompilation on this machine. "
-            "Install full Xcode and select it with xcode-select if you need precompiled Metal shaders."
-        )
+        message(STATUS "Metal AOT shader precompilation disabled (IRREDEN_METAL_AOT_SHADERS=OFF); shaders compile at runtime.")
     endif()
 endif()
 

--- a/engine/render/src/shaders/metal/ir_per_axis_lighting.metal
+++ b/engine/render/src/shaders/metal/ir_per_axis_lighting.metal
@@ -3,9 +3,10 @@
 // Kept OUT of ir_iso_common.metal so adding it does not recompile the SDF /
 // voxel / scatter shaders that share ir_iso_common — which would perturb their
 // FP scheduling and drift SDF-edge pixels at the cardinal fast path (breaking
-// the residualYaw == 0 byte-identity guarantee). The metallib build globs every
-// *.metal and compiles it standalone, so this file includes ir_iso_common.metal
-// (guarded) to resolve its helpers when compiled on its own.
+// the residualYaw == 0 byte-identity guarantee). This file includes
+// ir_iso_common.metal (guarded) to resolve its helpers and stay self-contained
+// as an include-fragment; the runtime preprocessor's visited-set (metal_pipeline.cpp)
+// dedupes the include when a wrapper also pulls in ir_iso_common.metal directly.
 #ifndef IR_PER_AXIS_LIGHTING_METAL_INCLUDED
 #define IR_PER_AXIS_LIGHTING_METAL_INCLUDED
 


### PR DESCRIPTION
## Summary
- Gate the Metal AOT `default.metallib` build behind a new `IRREDEN_METAL_AOT_SHADERS` option (default OFF) — no fleet host has full Xcode, so the branch was permanently dead and firing a spurious WARNING on every CLT-only macOS configure.
- Inside the opt-in branch, filter the shader glob to exclude include-fragments (`*_body.metal`, `ir_*.metal`) that reference wrapper-supplied macros or lack an entry point and cannot compile standalone — this was a latent hard-break waiting for a full-Xcode host.
- Reworded a stale comment in `ir_per_axis_lighting.metal` that cited the old unconditional-glob rationale, and documented the wrapper-vs-fragment naming convention in `engine/render/CLAUDE.md § Shaders`.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Exclude fragments from AOT glob by convention (or standalone-compilable, or gate off) | `cmake -DIRREDEN_METAL_AOT_SHADERS=ON .` | Configure log prints the filtered source list — 36 kernel-wrapper files (45 total `.metal` minus 2 `_body.metal` + 7 `ir_*.metal` fragments), confirming `list(FILTER ... EXCLUDE REGEX ...)` bites; fires the "requested but xcrun cannot find metal" WARNING (no full-Xcode host) |
| Documented in `engine/render/CLAUDE.md` §Shaders | manual read | New "### Metal AOT metallib build (opt-in, no runtime consumer)" subsection inside `## Shaders` describes the gate and the wrapper/fragment naming convention |
| Validation requires full-Xcode host; if none in fleet, land glob fix + configure-time message + note untested path in PR | `cmake .` (default, option absent) | Prints only the single `STATUS "...disabled..."` line, no WARNING; full-Xcode `default.metallib` production is unverifiable on this host (no full-Xcode fleet host) — noted below |
| No regression to runtime shader path | `fleet-build --target IRShapeDebug` + `fleet-run IRShapeDebug --auto-screenshot 3` | Clean build; `RESULT=CLEAN`, runtime shader compilation intact (always source-compiles via `metal_pipeline.cpp`, unaffected by this gate) |

Full-Xcode host validation (`-DIRREDEN_METAL_AOT_SHADERS=ON` actually producing `default.metallib`) is unverifiable on this host: no full-Xcode host in the fleet, per the issue's own validation clause.

Closes #2515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
