### PR TITLE
fleet: host-gate the design-unblocked feedback tier (#2524)

### DIFF
--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -264,7 +264,10 @@ Do the work, then exit cleanly:
    class routing already sends those PRs to an opus+ dispatch). Skip
    any PR already carrying a `fleet:amending-*` label (another
    worker holds the atomic feedback claim and is handling it; step a
-   will reject your claim anyway).
+   will reject your claim anyway). Also skip any feedback PR carrying
+   `fleet:needs-gl-host` unless this host is GL-capable
+   (`{linux, windows}`) — its remaining work needs a GL host, and
+   `amending-claim` refuses the claim as a backstop (#2524).
 
    Follow [`docs/agents/FLEET-FEEDBACK-HANDLING.md`](../../docs/agents/FLEET-FEEDBACK-HANDLING.md) —
    it owns the priority order, the detached-HEAD checkout flow,

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -57,6 +57,17 @@ itself, so a PR that slips past this filter (claimed after your state
 snapshot) is still caught when your own `amending-claim` loses the
 lex-min in Step a.
 
+**Skip** PRs carrying `fleet:needs-gl-host` unless this host is
+GL-capable (`{linux, windows}` — macOS GL is 4.1, below the shaders'
+required 4.5). On a PR the label marks the **remaining** work as
+GL-host-only; the typical case is a `fleet:design-unblocked` resume
+whose architect reply leaves only GL gate runs (the architect applies
+the label at unblock time — see `architect-protocol.md`). A wrong-host
+pane can only burn the claim and release with zero commits (PR #2475
+collected five such iterations in 80 minutes — #2524). `fleet-claim
+amending-claim` refuses these claims as a backstop, but skip pre-claim
+so the iteration goes to work you can actually do.
+
 ## Step a — claim the PR atomically (before anything else)
 
 Feedback pickup fans out: the dispatcher can launch your role into

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -554,6 +554,16 @@ When working a `fleet:design-blocked` PR:
    Then verify the PR carries `fleet:design-unblocked` (and not
    `fleet:design-blocked`) before moving on. The reconcile guard for the
    stranded state is tracked in #1516.
+
+   **Host-gate the resume when the remaining work is GL-only (#2524).**
+   `fleet:design-unblocked` routes to every opus+ pane regardless of host.
+   If your unblock direction leaves only work a GL host can run (GL gate
+   runs, GL-only repro or verification), add `fleet:needs-gl-host` in the
+   **same** `gh pr edit` as the swap — otherwise Metal-only panes claim
+   the PR, find nothing runnable, and release, every dispatch cycle
+   (PR #2475 burned five opus iterations in 80 minutes this way). The
+   GL-capable pane that finishes the gated work removes the label with
+   its push.
 6. **Self-heal stale resume-state (do this every unblock).** A worker that
    escalated typically released its claim and reset/parked the branch
    ("releasing the claim so any worker can resume"), but two pieces of stale

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -265,17 +265,24 @@ Specifically, **never pass these via `--label` when filing**:
   **smoking agent** on a successful smoke run (Windows: a native-Windows
   smoke worker, or `platform-catchup` as fallback). Permanent audit trail;
   not used by the merge gate. Don't add to issues.
-- `fleet:needs-gl-host` — **issue/task** label marking a backend-specific
-  task that needs an OpenGL-4.5 host (`{linux, windows}`). macOS GL is 4.1, so
+- `fleet:needs-gl-host` — **issue/task and PR** label marking work that
+  needs an OpenGL-4.5 host (`{linux, windows}`). macOS GL is 4.1, so
   a Metal-only pane genuinely cannot build/run/verify the GL backend.
+  On an issue it marks the whole task; on a PR it marks the **remaining**
+  work (typical case: a `fleet:design-unblocked` resume whose architect
+  reply leaves only GL gate runs — the architect adds it in the same edit
+  as the unblock swap, see `architect-protocol.md`; the GL pane that
+  finishes the gated work removes it).
   **Applied by the human/architect** as a triage signal (like the model
   labels) — the scout can't reliably infer "GL-only" from a render task, so
-  it is never auto-derived. **Respected at two points:** the dispatcher's
+  it is never auto-derived. **Respected at three points:** the dispatcher's
   claimability filter (`fleet_task_class.py`) skips the task on a macOS pane
-  (a slice whose only open task is GL-only → `defer`, no churn), and a
+  (a slice whose only open task is GL-only → `defer`, no churn), a
   `fleet-claim claim` backstop gate refuses a GL-only claim from a non-GL
-  host (covers manual / raced / `--stackable-on` claims). No host online to
-  run it just means the task waits for a Linux/Windows pane — the correct
+  host (covers manual / raced / `--stackable-on` claims), and the feedback
+  tier skips + `fleet-claim amending-claim` refuses a labeled PR on a
+  non-GL host (#2524). No host online to
+  run it just means the work waits for a Linux/Windows pane — the correct
   behavior, not a loss. Once the GL task merges on a GL host, its blocked
   dependents resolve normally.
 - `fleet:in-progress` — generic "a worker has claimed this issue"

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -250,9 +250,9 @@
     },
     {
       "name": "fleet:needs-gl-host",
-      "scope": "issue",
+      "scope": "issue+pr",
       "color": "c5def5",
-      "description": "Task needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it (dispatcher filter + claim gate). Human/architect triage signal."
+      "description": "Remaining work needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it (dispatcher filter, claim + amending-claim gates, feedback-tier skip). Human/architect triage signal."
     },
     {
       "name": "fleet:stacked",

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -850,6 +850,11 @@ check_host_capability() {
     # backstop for a manual or raced claim, and it runs unconditionally so it
     # also covers --stackable-on GL claims. Fail-closed on an unrecognized
     # host (refuse) — a real dispatch host is always mac/linux/windows.
+    #
+    # Also runs on amending-claim (#2524): the label is valid on PRs too
+    # (remaining work is GL-host-only — e.g. a design-unblocked resume whose
+    # gates only run on GL), and PR numbers share the issues label namespace,
+    # so the same fetch works unchanged.
     local issue_num="$1"
 
     local info
@@ -1687,7 +1692,17 @@ cmd_review_claim()   { _cmd_pr_label_claim   "fleet:reviewing-" "review-claim"  
 cmd_review_release() { _cmd_pr_label_release "fleet:reviewing-" "review-release" "$@"; }
 cmd_resolving_claim()   { _cmd_pr_label_claim   "fleet:resolving-" "resolving-claim"   "$@"; }
 cmd_resolving_release() { _cmd_pr_label_release "fleet:resolving-" "resolving-release" "$@"; }
-cmd_amending_claim()   { _cmd_pr_label_claim   "fleet:amending-" "amending-claim"   "$@"; }
+cmd_amending_claim() {
+    # Host-capability backstop (#2524): refuse to amend-claim a PR whose
+    # remaining work is GL-host-gated (fleet:needs-gl-host) from a non-GL
+    # host — the pane can only burn the claim and release with zero commits.
+    # The load-bearing fix is the pickup-side skip in
+    # FLEET-FEEDBACK-HANDLING.md; this catches stale-docs / raced claims.
+    if [[ "${1:-}" =~ ^[0-9]+$ ]] && ! check_host_capability "$1"; then
+        return 1
+    fi
+    _cmd_pr_label_claim   "fleet:amending-" "amending-claim"   "$@"
+}
 cmd_amending_release() {
     # Remove the local amend-snapshot sidecar written by fleet-pr-claim-feedback
     # so R7's grace-period guard resets on clean release (#1650).

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -138,7 +138,7 @@ LABELS=(
     "fleet:verified-linux|0e8a16|Smoking agent set this on a successful Linux smoke run; audit trail, not a merge gate"
     "fleet:verified-macos|0e8a16|Smoking agent set this on a successful macOS smoke run; audit trail, not a merge gate"
     "fleet:verified-windows|0e8a16|Windows smoke worker or platform-catchup set this on a successful Windows smoke; audit trail"
-    "fleet:needs-gl-host|c5def5|Task needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it"
+    "fleet:needs-gl-host|c5def5|Remaining work needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it"
     "fleet:stacked|c5def5|PR's base is a feature branch (stacked PR)"
     "fleet:awaiting-base|c5def5|Stacked PR; merger is waiting for base PR to merge"
     "fleet:needs-base-update|fbca04|Stacked child PR; upstream force-pushed and cascade-rebase conflicted; author rebases manually"

--- a/scripts/fleet/tests/test_fleet_claim_host_gate.sh
+++ b/scripts/fleet/tests/test_fleet_claim_host_gate.sh
@@ -16,6 +16,8 @@
 #   - unknown host is fail-closed → refused (exit 1)
 #   - issue without the label passes on a mac host (gate is opt-in, exit 0)
 #   - gh failure soft-degrades to pass (exit 0)
+#   - amending-claim (#2524): mac host refuses a fleet:needs-gl-host PR,
+#     linux host passes it, an unlabeled PR passes on mac
 
 set -euo pipefail
 
@@ -59,10 +61,14 @@ export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
 mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR"
 
 # Stub `gh` so check_host_capability reads canned JSON instead of hitting
-# GitHub. Dispatches on the issue number passed via `gh issue view <N>`.
+# GitHub. Dispatches on the issue number passed via `gh issue view <N>`
+# (PR numbers share the issues label namespace, so PRs go through the same
+# arm).
 #   2001 — carries fleet:needs-gl-host (GL-only task)
 #   2002 — no host label (gate is opt-in)
 #   2003 — gh failure (soft-degrade contract)
+#   3001 — PR carrying fleet:needs-gl-host (GL-gated design-unblocked resume)
+#   3002 — PR without the label
 # The `api` arm emulates the cross-host fleet:claim-* lock acquire so a
 # gate-passing claim runs through to success (echo the requested label back
 # as the lex-min winner). All issues carry fleet:opus so a stray ambient
@@ -84,6 +90,12 @@ case "$1 $2" in
                 ;;
             2003)
                 exit 1
+                ;;
+            3001)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"},{"name":"fleet:needs-gl-host"}],"body":""}'
+                ;;
+            3002)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"}],"body":""}'
                 ;;
             *)
                 echo '{"state":"OPEN","labels":[],"body":""}'
@@ -162,6 +174,21 @@ echo "T6: gh failure soft-degrades to pass"
 actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2003 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 0 "gh failure → soft-pass exit 0"
 release_quiet 2003
+
+# --- T7: mac host refuses amending-claim on a fleet:needs-gl-host PR --------
+echo "T7: mac host refuses amending-claim on a fleet:needs-gl-host PR"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "mac + fleet:needs-gl-host PR → amending-claim exit 1"
+
+# --- T8: linux host passes amending-claim on the same PR --------------------
+echo "T8: linux host passes amending-claim on a fleet:needs-gl-host PR"
+actual=0; FLEET_TEST_HOST=linux FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "linux + fleet:needs-gl-host PR → amending-claim exit 0"
+
+# --- T9: unlabeled PR passes amending-claim on a mac host -------------------
+echo "T9: mac host passes amending-claim on a PR without the label"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3002 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "mac + no host label PR → amending-claim exit 0"
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- Close the host-routing gap that let `fleet:design-unblocked` PRs with GL-host-only remaining work churn wrong-host opus panes (PR #2475: five zero-commit macOS claim/release cycles in ~80 minutes on 07-22).
- Widen `fleet:needs-gl-host` from issue/task-only to **issue + PR** scope across the three catalog surfaces (`fleet-labels`, `fleet-state-machine.json`, `fleet-labels-reference.md`). On a PR it marks the *remaining* work as GL-host-only.
- `FLEET-FEEDBACK-HANDLING.md` + `role-worker.md` step 1: feedback-tier pickup now **skips** PRs carrying `fleet:needs-gl-host` on a non-GL host (`{linux, windows}` are GL-capable) — the load-bearing fix.
- `architect-protocol.md`: when a design-unblock leaves only GL-runnable work, the architect adds `fleet:needs-gl-host` in the **same** `gh pr edit` as the label swap; the GL pane that finishes the gated work removes it.
- `fleet-claim amending-claim`: runs `check_host_capability` against the PR before acquiring `fleet:amending-*` (backstop for stale-docs / raced claims; PR numbers share the issues label namespace so the existing fetch works unchanged; same soft-degrade-on-gh-failure semantics as the issue gate).

Live mitigation already applied: `fleet:needs-gl-host` is on PR #2475 now and becomes load-bearing when this merges. The GitHub label description was synced to the new catalog wording.

Touches gated self-config surfaces (`role-worker.md`, fleet flow docs) — authored in a human-cued session; human merges.

## Test plan
- [x] `scripts/fleet/tests/test_fleet_claim_host_gate.sh` — 9/9 (T1–T6 existing issue-gate cases unchanged; new T7 mac refuses amending-claim on a `fleet:needs-gl-host` PR, T8 linux passes it, T9 unlabeled PR passes on mac)
- [x] `scripts/fleet/fleet-labels --check` — catalog and state-machine agree (60 labels), all descriptions ≤100 chars
- [x] `fleet-state-machine.json` re-parsed as valid JSON after the scope/description edit

Closes #2524

🤖 Generated with [Claude Code](https://claude.com/claude-code)
