### PR TITLE
engine/system: populate the dormant SystemName registry; retire prefab wire-once system handles (#2526)

### DIFF
--- a/.fleet/plans/issue-2526.md
+++ b/.fleet/plans/issue-2526.md
@@ -1,0 +1,36 @@
+## Plan: engine/system: populate the dormant SystemName registry; retire prefab wire-once system handles
+
+- **Issue:** #2526
+- **Model:** opus
+- **Date:** 2026-07-22
+
+### Scope
+
+Make `SystemManager` the owner of the `SystemName -> SystemId` mapping by populating its existing dormant `m_engineSystemIds` member, and rewrite the two prefab wire-once handles over it. No behavior change for creations beyond deleting the now-unneeded wire-once calls.
+
+### Approach
+
+1. In the enum-templated registration path (`IRSystem::createSystem<SystemName type>` and `registerSystem<N, ...>` — both have the enum statically and funnel into the manager), record `m_engineSystemIds[N] = id`. `IR_ASSERT` on duplicate registration of the same `SystemName` (verified at plan time: no in-tree creation registers a `SystemName` twice; scene transitions re-register *pipelines*, not systems). Dynamic systems (`createSystemDynamic`, Lua-defined) have no enum and are out of scope.
+2. Expose `SystemManager::findEngineSystem(SystemName) const` returning `SystemId` or `kNullEntity`, plus an `IRSystem::findSystem(SystemName)` free-function wrapper in `ir_system.hpp`.
+3. Rewrite `IRPrefab::JointTransform::system()` and `IRPrefab::VoxelTransform::allocator()` to resolve via `findSystem(UPDATE_JOINT_MATRICES)` / `findSystem(UPDATE_VOXEL_POSITIONS_GPU)`; delete `g_jointMatrixSystem` / `g_allocatorSystem`.
+4. Keep `setSystem(SystemId)` / `setAllocatorSystem(SystemId)` as deprecated no-ops: `// DEPRECATED — registration self-wires via SystemManager; remove once out-of-tree creations migrate.` Add the matching `## Deprecated` entry to `engine/prefabs/irreden/render/CLAUDE.md`.
+5. Delete the six in-tree wire-once calls: `creations/demos/shape_debug/main.cpp`, `creations/demos/skeletal_demo/main.cpp`, `creations/editors/voxel_editor/main.cpp` (two each).
+
+### Affected files
+
+- `engine/system/include/irreden/system/system_manager.hpp` (populate map + `findEngineSystem`)
+- `engine/system/include/irreden/ir_system.hpp` (`findSystem` free function)
+- `engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp`
+- `engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp`
+- `engine/prefabs/irreden/render/CLAUDE.md` (`## Deprecated`)
+- `creations/demos/shape_debug/main.cpp`, `creations/demos/skeletal_demo/main.cpp`, `creations/editors/voxel_editor/main.cpp`
+
+### Acceptance criteria
+
+As in the issue body. Verification: `fleet-build --target IRShapeDebug` + `fleet-run IRShapeDebug --auto-screenshot`; same for `IRSkeletalDemo`; grep for mutable `inline` namespace-scope variables under `engine/prefabs/**/systems/`.
+
+### Gotchas
+
+- `findSystem` costs one hash lookup; `JointTransform::slotBase` / `VoxelTransform::acquireSlot` are per-rig-operation and per-set-allocation calls, not per-voxel — no hot-path concern. If a caller ever appears in a per-entity tick, cache the resolved pointer in that system's `beginTick`, per the ECS footgun rule.
+- The registry must NOT be cleared by `clearPipeline` — systems are never destroyed and pipelines re-register across scene transitions. It dies with the manager at World teardown, which is exactly the ownership the current globals lack.
+- `SystemId` is an entity-id alias; `kNullEntity` is the established "unwired" sentinel both handles already use — keep it as `findSystem`'s miss value so `system()` / `allocator()` null-return semantics are unchanged.

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -497,19 +497,16 @@ void initSystems() {
     // GPU voxel-position prepass (#1396) — writes binding 5 for
     // GPU-transform-indirected voxel sets before STAGE_1 reads it. A no-op (no
     // dispatch) unless a voxel set opts in via gpuTransformSlot_, so the default
-    // scene stays byte-identical. Created up-front so its SystemId can wire the
-    // transform-slot allocator; it keeps its pipeline position below (before
-    // STAGE_1).
+    // scene stays byte-identical. Created up-front so its SystemId can order the
+    // render pipeline below (before STAGE_1).
     const IRSystem::SystemId updateVoxelPositionsId =
         IRSystem::createSystem<IRSystem::UPDATE_VOXEL_POSITIONS_GPU>();
-    IRPrefab::VoxelTransform::setAllocatorSystem(updateVoxelPositionsId);
     // Joint skin-matrix upload (#1603) + per-voxel bone→slot seeding (#1605).
     // Before UPDATE_VOXEL_POSITIONS_GPU so binding 18 holds the skin matrices
     // when the prepass dispatches; a no-op (zero skeletons) unless --skin-smoke
     // rigs a set, so the default scene stays byte-identical.
     const IRSystem::SystemId updateJointMatricesId =
         IRSystem::createSystem<IRSystem::UPDATE_JOINT_MATRICES>();
-    IRPrefab::JointTransform::setSystem(updateJointMatricesId);
     // Captured for the culling minimap's light + caster domains (#2316, V2) —
     // the minimap reads these systems' per-frame gather state back rather
     // than re-running its own light/caster query. Assigned in-place inside

--- a/creations/demos/skeletal_demo/main.cpp
+++ b/creations/demos/skeletal_demo/main.cpp
@@ -104,10 +104,8 @@ void initSystems() {
     std::list<IRSystem::SystemId> renderPipeline = IRPrefab::Camera::standardControlSystems();
     const IRSystem::SystemId updateVoxelPositionsId =
         IRSystem::createSystem<IRSystem::UPDATE_VOXEL_POSITIONS_GPU>();
-    IRPrefab::VoxelTransform::setAllocatorSystem(updateVoxelPositionsId);
     const IRSystem::SystemId updateJointMatricesId =
         IRSystem::createSystem<IRSystem::UPDATE_JOINT_MATRICES>();
-    IRPrefab::JointTransform::setSystem(updateJointMatricesId);
     renderPipeline.insert(
         renderPipeline.end(),
         {

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2319,14 +2319,12 @@ void initSystems() {
     // UPDATE_VOXEL_POSITIONS_GPU so binding 18 holds the skin matrices when
     // the prepass dispatches. Both are no-ops until a voxel set opts in via
     // gpuTransformSlot_ (the seeded rig does), so an unrigged scene renders
-    // byte-identically. Created up-front so their SystemIds can wire the
-    // slot-allocator handles.
+    // byte-identically. Created up-front so their SystemIds can order the
+    // render pipeline below.
     const IRSystem::SystemId updateVoxelPositionsId =
         IRSystem::createSystem<IRSystem::UPDATE_VOXEL_POSITIONS_GPU>();
-    IRPrefab::VoxelTransform::setAllocatorSystem(updateVoxelPositionsId);
     const IRSystem::SystemId updateJointMatricesId =
         IRSystem::createSystem<IRSystem::UPDATE_JOINT_MATRICES>();
-    IRPrefab::JointTransform::setSystem(updateJointMatricesId);
 
     std::list<IRSystem::SystemId> renderPipeline = IRPrefab::Camera::standardControlSystems();
     renderPipeline.push_front(animPlaybackSystem);

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -618,6 +618,26 @@ sub-attribution is per-dispatch, CPU stays coarse. Sub-scopes are
 single-canvas-exact (last-sample on multi-canvas) and do not cover the
 rotating-only per-axis voxel dispatch.
 
+## Deprecated
+
+| Surface | Replacement | Marked |
+|---|---|---|
+| `IRPrefab::JointTransform::setSystem(SystemId)` | none needed — `IRPrefab::JointTransform::system()` resolves the id itself via `IRSystem::findSystem(UPDATE_JOINT_MATRICES)` | #2526, 2026-07-22 |
+| `IRPrefab::VoxelTransform::setAllocatorSystem(SystemId)` | none needed — `IRPrefab::VoxelTransform::allocator()` resolves the id itself via `IRSystem::findSystem(UPDATE_VOXEL_POSITIONS_GPU)` | #2526, 2026-07-22 |
+
+Both were **wire-once handles**: a creation had to call the setter once,
+immediately after `System<N>::create()`, or the feature silently degraded
+(`allocator()` / `system()` returned `nullptr`, so GPU-transform slots and
+skinning fell back to CPU-direct with no diagnostic). `SystemManager` now owns a
+`SystemName -> SystemId` registry populated by the enum-templated registration
+paths, so **registration self-wires** and the bookkeeping call is gone — see
+`.claude/rules/cpp-ecs.md` §"System-owned invariants: encapsulate, don't delegate
+to callers".
+
+Both setters remain as **no-ops** so out-of-tree creations keep compiling (engine
+API removal rule); every in-tree call site was deleted in #2526. Delete the
+setters once out-of-tree creations have migrated.
+
 ## Gotchas
 
 - **SQT transition complete (T-299/T-300/T-301a/T-302).** All render-side, update-side, and voxel-side readers/writers use `C_LocalTransform` + `C_WorldTransform`. The voxel pool's per-voxel SoA arrays are a dedicated 16-byte `IRRender::VoxelGpuPosition` POD (std430 stride contract). The legacy `C_Position3D` / `C_PositionGlobal3D` / `C_Rotation` components and `SYSTEM_GLOBAL_POSITION_3D` were deleted in T-302; consumers read `C_WorldTransform.translation_` and the SQT quat directly.

--- a/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
@@ -410,25 +410,23 @@ template <> struct System<UPDATE_JOINT_MATRICES> {
 
 namespace IRPrefab::JointTransform {
 
-// Wire-once-at-init handle to the UPDATE_JOINT_MATRICES skeleton slot blocks —
-// the same shape as `IRPrefab::VoxelTransform` (the entity-slot half of the
-// shared binding-18 budget). A creation that rigs voxel sets calls
-// `setSystem(systemId)` once, right after
-// `System<UPDATE_JOINT_MATRICES>::create()`.
-inline IRSystem::SystemId g_jointMatrixSystem = IREntity::kNullEntity;
-
-inline void setSystem(IRSystem::SystemId systemId) {
-    g_jointMatrixSystem = systemId;
-}
-
+// Handle to the UPDATE_JOINT_MATRICES skeleton slot blocks — the same shape as
+// `IRPrefab::VoxelTransform` (the entity-slot half of the shared binding-18
+// budget). The id is resolved from SystemManager's `SystemName` registry
+// (#2526), so creating the system is all the wiring there is; a creation that
+// rigs voxel sets needs no follow-up call.
 inline IRSystem::System<IRSystem::UPDATE_JOINT_MATRICES> *system() {
-    if (g_jointMatrixSystem == IREntity::kNullEntity) {
+    const IRSystem::SystemId systemId = IRSystem::findSystem(IRSystem::UPDATE_JOINT_MATRICES);
+    if (systemId == IREntity::kNullEntity) {
         return nullptr;
     }
-    return IRSystem::getSystemParams<IRSystem::System<IRSystem::UPDATE_JOINT_MATRICES>>(
-        g_jointMatrixSystem
-    );
+    return IRSystem::getSystemParams<IRSystem::System<IRSystem::UPDATE_JOINT_MATRICES>>(systemId);
 }
+
+// DEPRECATED — registration self-wires via SystemManager; remove once
+// out-of-tree creations migrate. Kept as a no-op so an existing call site
+// keeps compiling (engine API removal rule).
+inline void setSystem(IRSystem::SystemId) {}
 
 // Absolute binding-18 slot of joint 0 in `rigRoot`'s skeleton block —
 // per-voxel skinning slots are `slotBase + bone_id` (#605 Phase 2.3). Returns

--- a/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
@@ -300,29 +300,26 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
 
 namespace IRPrefab::VoxelTransform {
 
-// Wire-once-at-init handle to the UPDATE_VOXEL_POSITIONS_GPU transform-slot
-// allocator (#1396). A consumer reaches the system's free-list through this
-// rather than threading the SystemId through every call — the same shape as
-// `IRPrefab::Chunk::setMembershipMigrationManager` (which threads the id per
-// call; here the id is config so the slot API can stay id-free). Init-config: a
-// creation that opts voxel sets into the GPU prepass calls
-// `setAllocatorSystem(systemId)` once, right after
-// `System<UPDATE_VOXEL_POSITIONS_GPU>::create()`. `IREntity::kNullEntity` is the
-// "never wired" sentinel (system ids count up from 0, so they never collide).
-inline IRSystem::SystemId g_allocatorSystem = IREntity::kNullEntity;
-
-inline void setAllocatorSystem(IRSystem::SystemId systemId) {
-    g_allocatorSystem = systemId;
-}
-
+// Handle to the UPDATE_VOXEL_POSITIONS_GPU transform-slot allocator (#1396). A
+// consumer reaches the system's free-list through this rather than threading the
+// SystemId through every call, so the slot API stays id-free. The id is resolved
+// from SystemManager's `SystemName` registry (#2526): creating the system is all
+// the wiring there is, and `IREntity::kNullEntity` means "never created" —
+// callers treat that as "stay CPU-direct".
 inline IRSystem::System<IRSystem::UPDATE_VOXEL_POSITIONS_GPU> *allocator() {
-    if (g_allocatorSystem == IREntity::kNullEntity) {
+    const IRSystem::SystemId systemId = IRSystem::findSystem(IRSystem::UPDATE_VOXEL_POSITIONS_GPU);
+    if (systemId == IREntity::kNullEntity) {
         return nullptr;
     }
     return IRSystem::getSystemParams<IRSystem::System<IRSystem::UPDATE_VOXEL_POSITIONS_GPU>>(
-        g_allocatorSystem
+        systemId
     );
 }
+
+// DEPRECATED — registration self-wires via SystemManager; remove once
+// out-of-tree creations migrate. Kept as a no-op so an existing call site
+// keeps compiling (engine API removal rule).
+inline void setAllocatorSystem(IRSystem::SystemId) {}
 
 // Acquire an EntityTransformBuffer slot for a GPU-transform-indirected set.
 // Returns `IRRender::kVoxelTransformStatic` when the allocator was never wired

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -1522,9 +1522,10 @@ local w,  h  = IRRender.getGuiCanvasSize()            -- "gui" canvas size (trix
   in the INPUT pipeline **immediately after `WIDGET_INPUT`** (so `fireAction_`
   is fresh) before main.lua registers an `onClick` — the binding raises a Lua
   error naming the missing registration if it's absent. Because
-  `registerPrefabSystem` and a C++ `createSystem` would make two instances, the
-  creation passes the registered prefab id into the pipeline (so the binding
-  and the ticked instance are the same one).
+  `registerPrefabSystem` and a C++ `createSystem` would make two instances
+  (and, since the `SystemName` registry, now trips an `IR_ASSERT` on the
+  second registration), the creation passes the registered prefab id into the
+  pipeline (so the binding and the ticked instance are the same one).
 - **`IRGui` / `IRRender` are extended, never replaced** (`if (!valid())`
   guard), so the render-glue `drawDisc`/`drawLine` and setters bound earlier
   survive.

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -111,7 +111,8 @@ class LuaScript {
     // six modifier-resolver SystemIds and creates the singleton globals
     // entity in the same call. Calling
     // `registerPrefabSystem<MODIFIER_DECAY>()` after that would create a
-    // duplicate; this helper records the existing id without recreating.
+    // duplicate (and now trips an IR_ASSERT via the SystemName registry);
+    // this helper records the existing id without recreating.
     void registerPrefabSystemId(IRSystem::SystemName name, IRSystem::SystemId id) {
         m_prefabSystemIds[static_cast<int>(name)] = id;
     }

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -78,6 +78,43 @@ Schema-level changes (different include / exclude archetype) are out
 of scope — `replaceSystemBody` is the cheap path that avoids entity
 migration. To change the archetype, register a new system.
 
+## `findSystem` — resolve a `SystemName` to its `SystemId` (#2526)
+
+`SystemManager` owns a `SystemName -> SystemId` map populated by the two
+enum-templated registration paths (`createSystem<N>` and
+`registerSystem<N, ...>` — the only entry points that have the enum
+statically). Read it back with the free function:
+
+```cpp
+IRSystem::SystemId id = IRSystem::findSystem(IRSystem::UPDATE_JOINT_MATRICES);
+```
+
+Registration **self-wires**, so a feature that needs to reach its own
+system from a free function no longer needs a manual "wire-once" setter
+the consuming creation must remember to call after `create()`. That
+pattern (a mutable namespace-scope global in a prefab header plus a
+`setFooSystem(id)` call at init) is retired — see
+`engine/prefabs/irreden/render/CLAUDE.md` §Deprecated and
+`.claude/rules/cpp-ecs.md` §"System-owned invariants: encapsulate, don't
+delegate to callers".
+
+Contract:
+
+- Returns `IREntity::kNullEntity` when the name was never registered, and
+  when no `SystemManager` exists at all (headless unit tests that tick a
+  `System<N>` against a bare `EntityManager`) — so a prefab handle built
+  on it degrades to its "unwired" branch instead of dereferencing null.
+- Dynamic systems (`createSystemDynamic`, Lua-defined) carry no enum and
+  are absent from the registry.
+- Registering the same `SystemName` twice is an `IR_ASSERT` (debug only).
+  The two entry points nest, so one registration recording itself twice
+  with the *same* id is expected and does not trip it.
+- Costs one hash lookup. Fine per-operation; a per-entity tick should
+  resolve once in `beginTick` and cache the pointer (the ECS footgun
+  rule), not call it per row.
+- Caveat: ids count up from 0 and `kNullEntity` is 0, so the first system
+  created in a process is indistinguishable from "unregistered" — #2540.
+
 ## Three valid TICK function signatures
 
 `createSystem<Components...>` detects the signature at compile time via

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -104,6 +104,10 @@ Contract:
   when no `SystemManager` exists at all (headless unit tests that tick a
   `System<N>` against a bare `EntityManager`) — so a prefab handle built
   on it degrades to its "unwired" branch instead of dereferencing null.
+  Note: a `System<N>::create()` called directly (bypassing the
+  `createSystem<N>` wrapper) only records if its spec routes through
+  `registerSystem<N, ...>` — direct-`create()` alone does not populate the
+  registry.
 - Dynamic systems (`createSystemDynamic`, Lua-defined) carry no enum and
   are absent from the registry.
 - Registering the same `SystemName` twice is an `IR_ASSERT` (debug only).

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -211,8 +211,16 @@ constexpr SystemId createSystem(
 }
 
 // Create a prefab system
+//
+// #2526: this and `registerSystem<N, ...>` below are the only registration
+// entry points that have the `SystemName` statically, so both record the
+// resulting id in SystemManager's registry. They nest — `System<type>::create()`
+// often calls `registerSystem<type, ...>` — and re-recording the same id is a
+// deliberate no-op; see `SystemManager::recordEngineSystemId`.
 template <SystemName type, typename... Args> SystemId createSystem(Args &&...args) {
-    return System<type>::create(args...);
+    const SystemId id = System<type>::create(args...);
+    getSystemManager().recordEngineSystemId(type, id);
+    return id;
 }
 
 namespace detail {
@@ -434,7 +442,22 @@ registerSystem(std::string name, RelationParams<RelationComponents...> relationP
         cadenceOffset
     );
     setSystemParams(id, std::move(instance));
+    getSystemManager().recordEngineSystemId(N, id);
     return id;
+}
+
+// #2526: resolve a `SystemName` to the id it was registered under, or
+// `IREntity::kNullEntity` if no enum-templated registration recorded it.
+// This is the manager-owned replacement for the wire-once
+// `setSystem(id)` / `setAllocatorSystem(id)` handles prefab headers used to
+// carry: registration self-wires, so a creation no longer has to remember a
+// bookkeeping call after `create()`.
+//
+// Costs one hash lookup. Fine for per-operation callers; a per-entity tick
+// should resolve once in `beginTick` and cache the pointer (the ECS footgun
+// rule) rather than calling this per row.
+inline SystemId findSystem(SystemName name) {
+    return getSystemManager().findEngineSystem(name);
 }
 
 // Free-function wrapper around `SystemManager::createSystemDynamic`. Used by

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -212,10 +212,10 @@ constexpr SystemId createSystem(
 
 // Create a prefab system
 //
-// #2526: this and `registerSystem<N, ...>` below are the only registration
-// entry points that have the `SystemName` statically, so both record the
-// resulting id in SystemManager's registry. They nest — `System<type>::create()`
-// often calls `registerSystem<type, ...>` — and re-recording the same id is a
+// #2526: this and `registerSystem<N, ...>` are the only registration entry
+// points that have the `SystemName` statically, so both record the resulting
+// id in SystemManager's registry. They nest — `System<type>::create()` often
+// calls `registerSystem<type, ...>` — and re-recording the same id is a
 // deliberate no-op; see `SystemManager::recordEngineSystemId`.
 template <SystemName type, typename... Args> SystemId createSystem(Args &&...args) {
     const SystemId id = System<type>::create(args...);
@@ -456,8 +456,17 @@ registerSystem(std::string name, RelationParams<RelationComponents...> relationP
 // Costs one hash lookup. Fine for per-operation callers; a per-entity tick
 // should resolve once in `beginTick` and cache the pointer (the ECS footgun
 // rule) rather than calling this per row.
+// Null-manager-safe on purpose. This is a *query*, and the prefab handles
+// built on it (`IRPrefab::VoxelTransform::allocator()`,
+// `IRPrefab::JointTransform::system()`) are reached from headless contexts
+// with no `World` — the ECS unit tests construct a bare `EntityManager` and
+// tick a `System<N>` directly, so `g_systemManager` is null there. "No
+// manager" is answered the same as "never registered" rather than
+// dereferencing null; the sentinel check the wire-once globals did before
+// touching the manager is what this preserves.
 inline SystemId findSystem(SystemName name) {
-    return getSystemManager().findEngineSystem(name);
+    return g_systemManager == nullptr ? IREntity::kNullEntity
+                                      : g_systemManager->findEngineSystem(name);
 }
 
 // Free-function wrapper around `SystemManager::createSystemDynamic`. Used by

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -312,9 +312,8 @@ class SystemManager {
     /// ...>`), so a single registration legitimately reports itself from
     /// both. `m_nextSystemId` is monotonic, so a genuinely duplicate
     /// registration always carries a *different* id — which is what the
-    /// assert catches. In release (assert stripped) the newest id wins,
-    /// matching the last-call-wins behavior of the wire-once setters this
-    /// registry replaces.
+    /// assert catches. In release (assert stripped) the newest id wins, so a
+    /// duplicate degrades to last-call-wins rather than to a stale mapping.
     void recordEngineSystemId(SystemName name, SystemId id) {
         SystemId &slot = m_engineSystemIds.try_emplace(name, id).first->second;
         IR_ASSERT(
@@ -335,10 +334,9 @@ class SystemManager {
     ///
     /// Caveat: `kNullEntity` is 0 and system ids also count up from 0, so
     /// the *first* system created in a process is indistinguishable from
-    /// "not registered" through this return value. That ambiguity predates
-    /// this registry (it is the same sentinel the wire-once globals used)
-    /// and is harmless for the current consumers, which are never the first
-    /// system a creation registers. Tracked separately.
+    /// "not registered" through this return value. Harmless for the current
+    /// consumers, which are never the first system a creation registers —
+    /// see #2540 for the sentinel fix.
     SystemId findEngineSystem(SystemName name) const {
         const auto it = m_engineSystemIds.find(name);
         return it == m_engineSystemIds.end() ? IREntity::kNullEntity : it->second;

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -298,6 +298,51 @@ class SystemManager {
     SystemId getSystemCount() const {
         return m_nextSystemId;
     }
+
+    /// #2526: record `name -> id` in the engine-system registry. Called by
+    /// the enum-templated registration paths (`IRSystem::createSystem<N>` /
+    /// `IRSystem::registerSystem<N, ...>`), the only two entry points that
+    /// have the `SystemName` statically. Dynamic systems
+    /// (`createSystemDynamic`, Lua-defined) carry no enum and are absent
+    /// from the registry.
+    ///
+    /// Recording the same id twice is expected, not an error: the two
+    /// enum-aware entry points nest (`createSystem<N>` calls
+    /// `System<N>::create()`, whose body often calls `registerSystem<N,
+    /// ...>`), so a single registration legitimately reports itself from
+    /// both. `m_nextSystemId` is monotonic, so a genuinely duplicate
+    /// registration always carries a *different* id — which is what the
+    /// assert catches. In release (assert stripped) the newest id wins,
+    /// matching the last-call-wins behavior of the wire-once setters this
+    /// registry replaces.
+    void recordEngineSystemId(SystemName name, SystemId id) {
+        SystemId &slot = m_engineSystemIds.try_emplace(name, id).first->second;
+        IR_ASSERT(
+            slot == id,
+            "SystemName is already registered as system '{}' (id {}) and is now being "
+            "registered again as '{}' (id {}). A SystemName maps to exactly one system; "
+            "create it once and share the id.",
+            getSystemName(slot),
+            slot,
+            getSystemName(id),
+            id
+        );
+        slot = id;
+    }
+
+    /// #2526: resolve a `SystemName` to the `SystemId` it was registered
+    /// under, or `IREntity::kNullEntity` when it was never registered.
+    ///
+    /// Caveat: `kNullEntity` is 0 and system ids also count up from 0, so
+    /// the *first* system created in a process is indistinguishable from
+    /// "not registered" through this return value. That ambiguity predates
+    /// this registry (it is the same sentinel the wire-once globals used)
+    /// and is harmless for the current consumers, which are never the first
+    /// system a creation registers. Tracked separately.
+    SystemId findEngineSystem(SystemName name) const {
+        const auto it = m_engineSystemIds.find(name);
+        return it == m_engineSystemIds.end() ? IREntity::kNullEntity : it->second;
+    }
     const TimingAccum &getTimingAccum(SystemId id) const {
         return m_timingAccum[id];
     }
@@ -330,6 +375,11 @@ class SystemManager {
     std::vector<C_SystemEvent<RELATION_TICK>> m_relationTicks;
     std::vector<C_SystemRelation> m_relations;
     std::vector<ErasedParamsPtr> m_systemParams;
+    /// `SystemName -> SystemId` for enum-registered engine systems.
+    /// Written by `recordEngineSystemId`, read by `findEngineSystem`.
+    /// Owned by the manager, so it dies with the World — never cleared by
+    /// `clearPipeline`, since systems outlive pipeline registration and
+    /// scene transitions re-register pipelines, not systems.
     std::unordered_map<SystemName, SystemId> m_engineSystemIds;
 
     /// T-224: canonical pipeline storage is per-group. The legacy

--- a/test/system/register_system_test.cpp
+++ b/test/system/register_system_test.cpp
@@ -154,4 +154,37 @@ TEST_F(RegisterSystemTest, ParamsAccessibleAfterCreate) {
     EXPECT_EQ(params->scaleFromBegin_, 0);
 }
 
+// #2526 — the SystemName registry. Registration self-wires, which is what lets
+// the prefab handles drop their manual wire-once setters.
+TEST_F(RegisterSystemTest, FindSystemResolvesEachRegisteredName) {
+    auto sysA = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    auto sysB = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_B>();
+    ASSERT_NE(sysA, sysB);
+
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_A), sysA);
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_B), sysB);
+}
+
+TEST_F(RegisterSystemTest, FindSystemReportsANameThatWasNeverCreated) {
+    // Only A is created, so B has no entry — the miss value is the same
+    // `kNullEntity` the wire-once globals used as their "unwired" sentinel, so
+    // `system()` / `allocator()` null-return semantics are unchanged.
+    IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_B), IREntity::kNullEntity);
+}
+
+// Deliberately NOT a RegisterSystemTest fixture case: the guard under test is
+// that `findSystem` tolerates a null `g_systemManager`. The prefab handles are
+// reached from headless contexts that tick a `System<N>` against a bare
+// `EntityManager` with no `World` (see test/ecs/voxel_bone_slot_seed_test.cpp),
+// and the wire-once globals this registry replaces checked their sentinel
+// BEFORE touching the manager. Without the guard this segfaults.
+TEST(FindSystemNoManagerTest, ReportsNullWhenNoSystemManagerExists) {
+    ASSERT_EQ(IRSystem::g_systemManager, nullptr)
+        << "precondition: no SystemManager is alive between fixtures";
+
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_A), IREntity::kNullEntity);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

`SystemManager::m_engineSystemIds` (a `SystemName -> SystemId` map) has been declared but never populated or read. Meanwhile two prefab headers worked around the missing registry with mutable namespace-scope `inline` globals plus a manual **wire-once setter** every consuming creation had to remember to call right after `System<N>::create()` — the only mutable header-scope globals in the engine outside the documented manager-global pattern.

This populates the registry and rewrites both handles over it, so **registration self-wires** and the bookkeeping call disappears.

- `SystemManager::recordEngineSystemId` / `findEngineSystem` populate and read the map; the two enum-templated registration paths (`IRSystem::createSystem<N>`, `IRSystem::registerSystem<N, ...>` — the only entry points that have the enum statically) record into it, and `IRSystem::findSystem(SystemName)` reads it back.
- `IRPrefab::JointTransform::system()` and `IRPrefab::VoxelTransform::allocator()` resolve via `findSystem`; `g_jointMatrixSystem` / `g_allocatorSystem` are deleted. Registry ownership also fixes the lifetime hole — it dies with the `World` instead of leaking across it.
- `setSystem` / `setAllocatorSystem` remain as **deprecated no-ops** for out-of-tree creations (engine API removal rule), marked `// DEPRECATED` at the declaration and in a new `## Deprecated` section in `engine/prefabs/irreden/render/CLAUDE.md`. All six in-tree call sites are deleted.

### Two things worth a reviewer's eye

**1. The two registration paths nest.** `createSystem<N>` calls `System<N>::create()`, whose body often calls `registerSystem<N, ...>` — so a *single* registration reports itself from both. `recordEngineSystemId` is therefore idempotent for the same id, and the duplicate-registration `IR_ASSERT` keys on a *different* id (`m_nextSystemId` is monotonic, so a genuine duplicate always has one). Both paths are hooked because not every `System<N>::create()` body goes through `registerSystem`.

**2. `findSystem` is null-manager-safe, and that is load-bearing.** The globals checked their `kNullEntity` sentinel *before* touching the manager; `getSystemManager()` is `return *g_systemManager;`. Routing the handles through it initially **segfaulted `VoxelBoneSlotSeedTest`**, which ticks a `System<N>` against a bare `EntityManager` with no `World`. `findSystem` now answers "no manager" the same as "never registered". Caught by the existing tests, fixed in `a969fba4`, and pinned by a new test.

## Test plan

- [x] `fleet-build` + `fleet-run` clean for `IRShapeDebug`, `IRSkeletalDemo` (the two demo consumers) and `IRVoxelEditor` — all `RESULT=CLEAN`; skeletal rig round-trips OK (30 / 4 / 9 joints).
- [x] **`render-verify --target IRShapeDebug`: 24/24 PASS, `max_delta 0`** (macos-debug).
- [x] **Behavioral A/B against `origin/master` on the path that actually exercises the handles.** Both systems are no-ops in the default scene, so render-verify alone would not prove the handles still resolve. `IRShapeDebug --skin-smoke` (which drives `VoxelTransform::acquireSlot` through `findSystem`) was captured on `origin/master` and on this branch: **28/28 screenshots byte-identical**. Since the setter calls are deleted here, a failed resolve would silently fall back to CPU-direct and the images *would* differ.
- [x] `IrredenEngineTest`: **1359 passed** (1356 pre-existing + 3 new).
- [x] Acceptance grep — no mutable namespace-scope `inline` variable remains under `engine/prefabs/**/systems/`.

## Notes

- **No screenshots attached deliberately.** The diff touches `engine/prefabs/irreden/render/`, but the change is a wiring indirection with no intended visual delta, and the byte-identical render-verify + `--skin-smoke` A/B above are strictly stronger evidence than a before/after pair (which would be identical by construction).
- **`optimize` skipped**: `findSystem` costs one hash lookup and both call sites are cold — `acquireSlot` fires only on first opt-in inside a block-realloc-only path, never per-frame or per-voxel.
- **GL/Windows smoke still owed** — authored and verified on macOS/Metal only.
- Filed **#2540**: `SystemId` 0 collides with the `kNullEntity` "no such system" sentinel (ids count from 0 and `kNullEntity` is 0, so the first system created — `LOD_UPDATE` in `shape_debug` — is indistinguishable from "unregistered"). Pre-existing and harmless for these consumers, but `findSystem` makes it reachable as general API. Not fixed here; the fix has options that want a planning pass.

Closes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
