### PR TITLE
docs: global-state rule catalog + header-global ban checks

### DIFF
--- a/.claude/rules/cpp-globals.md
+++ b/.claude/rules/cpp-globals.md
@@ -1,0 +1,78 @@
+# Global state: sanctioned patterns and the header-global ban
+
+Rule:
+
+> **Never** introduce a new mutable namespace-scope variable in a header
+> (`inline` or `extern`). Every process- or world-scoped mutable object lives
+> behind one of the sanctioned patterns below — each has an **owner**, a
+> **lifecycle**, and an **accessor**. A bare header global has none of the
+> three.
+
+Allowed at namespace scope in headers: `constexpr` / `const` compile-time
+constants. Those are program constants, not state.
+
+## Sanctioned patterns
+
+| State kind | Pattern | Owner / lifecycle |
+|---|---|---|
+| Module manager (process-singular subsystem) | `extern Manager *g_<x>` declared in the module's `ir_<module>.hpp` entry point, defined in the module `.cpp`; the manager's own ctor stamps `this`, its dtor clears-if-self; access via the asserting free function (`IREntity::getEntityManager()`) | `World` owns every manager as a member in dependency order — member order IS the set/clear order |
+| Engine process context | `inline` variables in `engine/include/irreden/ir_engine.hpp` (`g_world`, `g_scriptsDir`, ...), set once in `IREngine::init()`, wrapped by accessors | `IREngine` entry points |
+| Process infrastructure (logger, profiler, CLI args, GL dispatch table, Metal runtime) | Meyers singleton (`static X x; return x;`) or intentionally-leaked `instance()` where shutdown-order robustness demands it (leak documented at the site) | lazy first-use → process lifetime |
+| World-scoped settings / game state (mutate-once config, per-world globals) | singleton component via `IREntity::singleton<T>()` | ECS-owned; preserved across `resetGameplay`, torn down with the world — see `engine/entity/CLAUDE.md` §"Singleton components" |
+| System wiring (find a registered system by name) | the `SystemManager` `SystemName -> SystemId` registry (`IRSystem::findSystem`, #2526) | dies with `World` |
+| Per-thread identity | `thread_local` in a `.cpp` behind an accessor (`IRJob::workerId()`) | thread lifetime |
+| Module-internal state | anonymous-namespace variable in a `.cpp` | translation unit; never a header |
+
+Naming for the sanctioned forms: `g_` prefix at namespace/file scope, `t_`
+for `thread_local`. (This file is the canonical home for these two
+prefixes; the general naming table in `docs/agents/CLAUDE-BASELINE.md`
+covers members, components, and shaders.)
+
+## Why the ban
+
+- **No owner.** A header global is never cleared at `World` teardown, is
+  invisible to scene reset and save/load, and its mutation points are
+  unguarded and unfindable. Each one becomes its own mini-convention the
+  next reader has to reverse-engineer.
+- **Wire-once handles are delegated bookkeeping.** A header global plus a
+  "creation must call `setX(id)` once at init" contract makes every
+  consumer responsible for the subsystem's invariant — the exact failure
+  mode `.claude/rules/cpp-ecs.md` §"System-owned invariants: encapsulate,
+  don't delegate to callers" exists to prevent. The subsystem that owns
+  the state owns the wiring.
+- **The inline-variable trick is not an exemption.** "It's an `inline`
+  variable, not a function-local static" does not satisfy the system-state
+  rule (`.claude/rules/cpp-systems.md`) — it relocates the unowned state,
+  it doesn't give it an owner.
+
+The manager-global pattern itself is deliberate and stays: the globals are
+private implementation detail behind free-function module APIs, which is
+what keeps the storage mechanism swappable (a future multi-world would
+change `ir_<module>.cpp` internals, not call sites).
+
+## Detection
+
+Grep new diff hunks in headers for namespace-scope `inline` / `extern`
+declarations that are not `constexpr` / `const`:
+
+```
+pattern: '^\s*(inline|extern)\s+(?!(constexpr|const|void)\b)[^(]*[;={]'
+glob:    '**/*.{hpp,h}'
+```
+
+The `[^(]*` guard drops function declarations; classify surviving hits by
+hand. Allowlisted paths (the sanctioned patterns above): module entry
+points `engine/*/include/irreden/ir_*.hpp` and
+`engine/include/irreden/ir_engine.hpp`. Everything else that matches is a
+violation — route it to the pattern that fits the state kind per the table.
+
+## Live deviations
+
+- `system_update_joint_matrices.hpp::g_jointMatrixSystem` and
+  `system_update_voxel_positions_gpu.hpp::g_allocatorSystem` — wire-once
+  system handles; migrate to the `SystemManager` registry (#2526).
+- `widget_theme.hpp::g_defaultTheme` — mutate-once widget theme; migrate
+  to a `C_WidgetTheme` singleton component (#2527).
+
+Don't add new violations; these migrate via the tracked issues. Don't
+migrate them in an unrelated PR — the issues carry the plans.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -53,6 +53,12 @@ issue.
 - Stored `g_*Manager` pointer or reference in any object whose lifetime can
   outlive `World` (background threads, sol2 callback closures, long-lived
   caches) — see `engine/world/CLAUDE.md` and `engine/CLAUDE.md`.
+- New mutable namespace-scope variable in a header (`inline` or `extern`)
+  outside a module `ir_*.hpp` entry point — state with no owner, teardown,
+  or reset participation. Belongs on a manager, a singleton component
+  (`IREntity::singleton<T>`), or a `.cpp` anonymous namespace; sanctioned
+  patterns + detection grep in
+  [`.claude/rules/cpp-globals.md`](../../rules/cpp-globals.md).
 
 **Render pipeline**
 - CPU frame-data struct out of sync with its GLSL `layout(std140)`

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -120,9 +120,10 @@ Check the diff against every item in [`.claude/rules/cpp-ecs-smells.md`](../../r
 
 ### 2b. Math primitives + system-state smells (mechanically detectable)
 
-Two convention slips that are pure regex catches. Both are documented in
-[`.claude/rules/cpp-math.md`](../../rules/cpp-math.md) and
-[`.claude/rules/cpp-systems.md`](../../rules/cpp-systems.md) — those rules
+Convention slips that are pure regex catches. The core ones are documented
+in [`.claude/rules/cpp-math.md`](../../rules/cpp-math.md),
+[`.claude/rules/cpp-systems.md`](../../rules/cpp-systems.md), and
+[`.claude/rules/cpp-globals.md`](../../rules/cpp-globals.md) — those rules
 auto-load whenever an agent opens a C++ file, but agents still slip.
 This pass catches what slipped through.
 
@@ -333,6 +334,33 @@ Flag: "extract to a `scripts/fleet/*.sh` executable with a hermetic
 `tests/test_*.sh` and call it from the workflow" — inline `run:` logic
 ships with zero CI signal and no local-sandbox test (#2290's `net_patch_id`
 classify bug). Report, don't auto-fix.
+
+**Check 11: mutable namespace-scope variables in headers.**
+
+A new `inline` / `extern` variable at namespace scope in a header is state
+with no owner — never cleared at World teardown, invisible to scene reset
+and save/load. Full rule, sanctioned-pattern table, and rationale:
+[`.claude/rules/cpp-globals.md`](../../rules/cpp-globals.md).
+
+```
+Grep tool with:
+  pattern: '^\s*(inline|extern)\s+(?!(constexpr|const|void)\b)[^(]*[;={]'
+  glob:    '**/*.{hpp,h}'
+  output_mode: 'content'
+  -n: true
+```
+
+The `[^(]*` guard drops function declarations; classify surviving hits by
+hand and cross-reference against added (`+`) diff lines — only flag newly
+introduced variables. Allowlisted paths (the sanctioned manager-global and
+engine-context patterns): `engine/*/include/irreden/ir_*.hpp` and
+`engine/include/irreden/ir_engine.hpp`. For everything else, flag with the
+migration target from the cpp-globals.md table: world-scoped mutate-once
+state → singleton component; system wiring → the `SystemManager` registry
+(`IRSystem::findSystem`); module-internal state → anonymous namespace in
+the `.cpp`. Live deviations (don't re-flag): `g_jointMatrixSystem` /
+`g_allocatorSystem` (#2526), `g_defaultTheme` (#2527). Report, don't
+auto-fix — the right owner is a design call.
 
 ### 2c. Serialized-struct version-bump check
 

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -117,6 +117,14 @@ path, or the API keeps signalling "experimental" when it's the production code
   that isn't in `IRMath` yet, add a wrapper in `engine/math/` first,
   then call it. The math library may itself wrap `glm::*` / `std::*`
   internally — that is the **only** place those names should appear.
+- **No new mutable namespace-scope variables in headers** (`inline` or
+  `extern`). Every process- or world-scoped mutable object lives behind an
+  owner with a lifecycle and an accessor: process-singular subsystems use
+  the manager-global + free-function pattern (module `ir_*.hpp` entry
+  points only); world-scoped mutate-once state is a singleton component
+  (`IREntity::singleton<T>`); system wiring is `SystemManager`-owned.
+  Full pattern catalog, rationale, and detection grep:
+  [`.claude/rules/cpp-globals.md`](../../.claude/rules/cpp-globals.md).
 - **"Set above" is code narration, not a WHY.** Comments that point at
   *where* code is — `// set above`, `// see below`, `// defined above`,
   `// called from X` — narrate location instead of explaining intent.
@@ -253,6 +261,7 @@ agent-facing doc, link to the canonical home rather than restating.
 | ECS smell diagnostics (machine-checkable) | `.claude/rules/cpp-ecs-smells.md` |
 | Math substitution rules (machine-checkable) | `.claude/rules/cpp-math.md` |
 | System-state smells (machine-checkable) | `.claude/rules/cpp-systems.md` |
+| Global-state patterns · header-global ban (machine-checkable) | `.claude/rules/cpp-globals.md` |
 | Tick-function signatures · INPUT → UPDATE → RENDER ordering | `engine/system/CLAUDE.md` |
 | Component-method tier rules | `engine/prefabs/CLAUDE.md` |
 | Asset serialization version-bump | `engine/asset/CLAUDE.md` |

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -110,8 +110,12 @@ T-300 Phase 2.
 ## Manager globals
 
 Each manager (`EntityManager`, `SystemManager`, `RenderManager`, etc.) is
-stored as a global pointer (`g_entityManager`, `g_systemManager`, ...) set by
-`World`'s constructor and cleared by its destructor. The `ir_<module>.hpp`
+stored as a global pointer (`g_entityManager`, `g_systemManager`, ...). The
+manager's own constructor stamps it (`g_entityManager = this;`) and its
+destructor clears it if still pointing at itself; `World` assigns nothing —
+it owns every manager as a member in dependency order, so member order IS
+the deterministic set/clear order. The `ir_<module>.hpp`
 entry points wrap access via free functions (`IREntity::getEntityManager()`).
 **Do not hold references or raw pointers to managers across frames outside
-of World's lifetime.**
+of World's lifetime.** Full global-state pattern catalog + the
+header-global ban: [`.claude/rules/cpp-globals.md`](../.claude/rules/cpp-globals.md).

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -127,8 +127,9 @@ section is the reciprocal pointer for renderer-side authors.
 
 Most code never touches `World` directly. It accesses managers via the
 `IR<Module>::get*Manager()` free functions in each module's `ir_*.hpp`
-header, which reach through the global pointers `World` sets up at
-construction time.
+header, which reach through the global pointers established during
+`World` construction (each manager's own ctor stamps its global — see
+Responsibilities below).
 
 ## Save-trait policy layer (persist P1, #2212, epic #667)
 
@@ -406,7 +407,10 @@ flag-off (W-8 parity holds). It is distinct from the always-on lightweight
    (renderer, input, video) and consumes only `WorldConfig` —
    see `engine/job/CLAUDE.md` for the IRJob surface and lifetime
    contract (Phase 1 of the multithreading epic #226).
-3. Sets the globals: `g_entityManager = &m_entityManager;`, etc.
+3. Each manager's constructor stamps its module global as it is
+   constructed (`g_entityManager = this;` in `EntityManager`'s ctor, and
+   so on) — `World` itself assigns none of them; the member order above
+   IS the set order.
 4. Calls `initEngineSystems()`, `initIRInputSystems()`,
    `initIRUpdateSystems()`, `initIRRenderSystems()` to register the
    engine-provided prefab systems and assign them to pipelines.
@@ -423,8 +427,8 @@ flag-off (W-8 parity holds). It is distinct from the always-on lightweight
 
 Destructor:
 
-- Clears the global pointers.
-- Destroys managers in reverse order of construction.
+- Destroys managers in reverse declaration order; each manager's
+  destructor clears its own module global (if it still points at itself).
 
 ## Lua wiring
 


### PR DESCRIPTION
## Summary
- New `.claude/rules/cpp-globals.md` — the canonical catalog of the engine's sanctioned global-state patterns (manager globals, engine context, process-infrastructure singletons, singleton components, `thread_local` worker ids, `.cpp`-internal state) and the ban on new mutable namespace-scope variables in headers, with rationale, a detection grep, and the live-deviation list (#2526, #2527).
- `docs/agents/CLAUDE-BASELINE.md` — Style bullet stating the header-global ban + canonical-home map row pointing at the new rule file.
- `simplify` Check 11 — mechanical grep over new header hunks for `inline` / `extern` mutable variables, with the allowlist (module `ir_*.hpp` entry points) and per-kind migration targets; §2b intro's stale "Two convention slips / Both" count fixed in passing.
- `review-pr` — ownership/lifetime checklist bullet so reviewers catch reintroductions the author's simplify pass missed.
- Doc-drift fix in `engine/CLAUDE.md` + `engine/world/CLAUDE.md`: both claimed `World`'s constructor sets and its destructor clears the `g_*` manager globals; in reality each manager self-stamps `this` in its own constructor and clears-if-self in its destructor — `World` contributes the deterministic ordering via member declaration order.

## Test plan
- [x] All new/changed markdown cross-refs verified to resolve (link paths checked against sibling links in the same files; cited headings `§"System-owned invariants…"`, `§"Singleton components"` grepped).
- [x] Detection grep validated against the three known live deviations (`g_jointMatrixSystem`, `g_allocatorSystem`, `g_defaultTheme` all match; manager `extern` declarations fall under the entry-point allowlist).
- [x] Doc-drift claim verified against source: `entity_manager.cpp::EntityManager` ctor stamps `g_entityManager = this;` (mirrored in every manager); no `g_*` assignment exists in `world.cpp`.
- [x] Final-newline check clean on all six files; no build needed (docs + agent-config only).

## Notes for reviewer
The three live deviations named in the rule file are deliberately NOT migrated here — #2526 (SystemName registry) and #2527 (widget-theme singleton) carry the plans, filed and approved in the same session. This PR is the guard-rail + doc-truth half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
