### PR TITLE
render: residual shader dedup — resolve emit, feeder predicate, Metal lighting UBOs, clear-volume constant (#2513)

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -120,7 +120,12 @@ Shared includes: `ir_iso_common.glsl`, `ir_constants.glsl`,
 ACES tonemap, shared by the world-lighting passes),
 `ir_voxel_face_select.glsl` (fog reveal + face selection + per-axis
 store key, shared by the stage-1/stage-2 kernel family — the fog grid
-image slot is wrapper-supplied via `IR_VOXEL_FOG_GRID_BINDING`).
+image slot is wrapper-supplied via `IR_VOXEL_FOG_GRID_BINDING`),
+`ir_resolve_cardinal_emit.glsl` (the cardinal-layout micro-cell diamond
+emit shared by the two sun-shadow RESOLVE scatter kernels — on the GLSL
+side it writes through the wrapper's own `resolveScratch` SSBO, since
+GLSL cannot pass a buffer as an argument; the Metal twin takes it as a
+parameter).
 Shader file paths are stored in `render/shader_names.hpp`. Update that
 header when you add or rename a shader.
 

--- a/engine/render/src/shaders/c_clear_light_volume.glsl
+++ b/engine/render/src/shaders/c_clear_light_volume.glsl
@@ -13,6 +13,12 @@
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 
+// Integer mirror of `kLightVolumeSize` in component_canvas_light_volume.hpp —
+// the same extent ir_world_lighting.glsl publishes as a float for the sampling
+// passes (which divide by it to reach texel centers). Deliberately NOT folded
+// into that fragment: this kernel needs one integer bound for a loop guard, and
+// including ir_world_lighting.glsl would declare its binding-4 LightSourceBuffer
+// SSBO in a clear pass that binds nothing at slot 4. Keep the two in lockstep.
 const int kLightVolumeSize = 128;
 
 layout(rgba8, binding = 0) writeonly uniform image3D lightVolume;

--- a/engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl
+++ b/engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl
@@ -54,6 +54,11 @@ layout(std430, binding = 28) restrict buffer PerAxisResolveScratch {
     int resolveScratch[];
 };
 
+// The cardinal-layout micro-cell emit shared with c_resolve_world_placed_depth.
+// Included AFTER ir_iso_common.glsl and AFTER the resolveScratch declaration it
+// writes through (the fragment's wrapper contract).
+#include "ir_resolve_cardinal_emit.glsl"
+
 // #2256: this stage is dispatched indirectly over only this axis's OCCUPIED
 // cells (compacted by the STAGE_1 per-axis pre-pass) instead of sweeping the
 // full worst-case grid. compactedCells holds the occupied linear cell indices;
@@ -145,24 +150,12 @@ void main() {
     for (int v = 0; v < scale; ++v) {
         for (int u = 0; u < scale; ++u) {
             const ivec3 microView = viewPos + stepU * u + stepV * v;
-            // Per-micro-cell depth, shared by the region's two pixels — the
-            // exact encode a real cardinal store would hold here, so BAKE's
-            // pixel+depth inverse recovers points on the face plane.
-            const int encoded = encodeDepthWithFace(pos3DtoDistance(microView), slot, flip);
-            const ivec2 cellBase = mainBase + pos3DtoPos2DIso(microView);
-            for (int k = 0; k < 2; ++k) {
-                const ivec2 mainPixel = cellBase + faceOffset_2x3(slot, k);
-                if (!isInsideCanvas(mainPixel, canvasSizePixels)) {
-                    continue;
-                }
-                // Front-most per screen pixel: smallest encoded distance wins
-                // (depth dominates the 3 low bits — flip+slot), exactly like
-                // the main canvas atomicMin store.
-                atomicMin(
-                    resolveScratch[mainPixel.y * canvasSizePixels.x + mainPixel.x],
-                    encoded
-                );
-            }
+            // `slot` twice: the per-axis store is already view-frame, so the
+            // slot IS the region axis; the world-placed twin must rotate its
+            // model face to get one.
+            emitResolveCardinalDiamond(
+                microView, slot, slot, flip, mainBase, canvasSizePixels
+            );
         }
     }
 }

--- a/engine/render/src/shaders/c_resolve_world_placed_depth.glsl
+++ b/engine/render/src/shaders/c_resolve_world_placed_depth.glsl
@@ -63,6 +63,12 @@ layout(std430, binding = 28) restrict buffer PerAxisResolveScratch {
     int resolveScratch[];
 };
 
+// The cardinal-layout micro-cell emit shared with
+// c_resolve_per_axis_screen_depth. Included AFTER ir_iso_common.glsl and AFTER
+// the resolveScratch declaration it writes through (the fragment's wrapper
+// contract).
+#include "ir_resolve_cardinal_emit.glsl"
+
 void main() {
     const ivec2 cell = ivec2(gl_GlobalInvocationID.xy);
     const ivec2 detachedSize = imageSize(detachedDistances);
@@ -111,7 +117,6 @@ void main() {
         viewPos = rotateCardinalZ(worldPos, cardinalIndex);
         viewPos += cardinalLowerCornerShift(cardinalIndex) * scale;
     }
-    const int encoded = encodeDepthWithFace(pos3DtoDistance(viewPos), slot, flip);
 
     const ivec2 mainBase = trixelFrameOffset(
         trixelOriginOffsetZ1(canvasSizePixels), frameCanvasOffset, voxelRenderOptions
@@ -128,15 +133,7 @@ void main() {
         rotateCardinalZ(faceOutwardNormal6I(slot << 1), cardinalIndex);
     const int viewAxis =
         (viewNormal.x != 0) ? kXFace : ((viewNormal.y != 0) ? kYFace : kZFace);
-    const ivec2 cellBase = mainBase + pos3DtoPos2DIso(viewPos);
-    for (int k = 0; k < 2; ++k) {
-        const ivec2 mainPixel = cellBase + faceOffset_2x3(viewAxis, k);
-        if (!isInsideCanvas(mainPixel, canvasSizePixels)) {
-            continue;
-        }
-        // Front-most per screen pixel: smallest encoded distance wins (depth
-        // dominates the 2 slot bits), exactly like the main canvas atomicMin
-        // store.
-        atomicMin(resolveScratch[mainPixel.y * canvasSizePixels.x + mainPixel.x], encoded);
-    }
+    emitResolveCardinalDiamond(
+        viewPos, viewAxis, slot, flip, mainBase, canvasSizePixels
+    );
 }

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
@@ -384,9 +384,14 @@ void main() {
             feederPos = rotateCardinalZ(feederPos, cardinalIndex);
             feederPos += cardinalLowerCornerShift(cardinalIndex);
         }
-        const ivec2 feederIso = pos3DtoPos2DIso(feederPos);
-        if (feederIso.x < visibleIsoBounds.x || feederIso.x > visibleIsoBounds.z ||
-            feederIso.y < visibleIsoBounds.y || feederIso.y > visibleIsoBounds.w) {
+        // One definition with the compact cull's Step-B classify
+        // (isShadowFeederIso, ir_iso_common.glsl) so the skip and the
+        // classification cannot drift. The predicate re-tests the two route
+        // terms — provably true inside this gate; the gate itself stays as the
+        // cheap early-out that avoids the cardinal projection above.
+        if (isShadowFeederIso(
+                pos3DtoPos2DIso(feederPos), visibleIsoBounds, residualYaw, isDetachedCanvas
+        )) {
             return;
         }
     }

--- a/engine/render/src/shaders/c_voxel_visibility_compact.glsl
+++ b/engine/render/src/shaders/c_voxel_visibility_compact.glsl
@@ -400,10 +400,11 @@ void main() {
                             // Feeders are off-screen by construction, so their
                             // coarser trixel depth reaches only the sun-shadow
                             // bake, never a visible pixel.
-                            bool isFeeder =
-                                residualYaw == 0.0 && isDetachedCanvas < 0.5 &&
-                                (isoPos.x < visibleIsoBounds.x || isoPos.x > visibleIsoBounds.z ||
-                                 isoPos.y < visibleIsoBounds.y || isoPos.y > visibleIsoBounds.w);
+                            // One definition with stage 2's skip
+                            // (isShadowFeederIso, ir_iso_common.glsl).
+                            bool isFeeder = isShadowFeederIso(
+                                isoPos, visibleIsoBounds, residualYaw, isDetachedCanvas
+                            );
                             if (isFeeder) {
                                 // Tail-append: feeder slot i lands at
                                 // voxelCount-1-i, growing down from the top of the

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -450,6 +450,36 @@ bool isInsideCanvas(ivec2 pixel, ivec2 canvasSize) {
            pixel.y >= 0 && pixel.y < canvasSize.y;
 }
 
+// Shadow-feeder classification (#1740): on the cardinal single-canvas world
+// route, a voxel whose cardinal iso position lies outside the UN-widened
+// visible viewport but inside the shadow-feeder-widened cull exists only to
+// cast sun shadows onto on-screen pixels through stage 1's distance bake — it
+// is never displayed, lit, or picked.
+//
+// Two kernels ask this same question and must agree: c_voxel_visibility_compact
+// partitions survivors into the visible list vs the strided off-screen feeder
+// list (#2258 Step B), and c_voxel_to_trixel_stage_2 skips a feeder's colour +
+// entity-id taps. They re-derived the predicate independently; one definition
+// is what keeps the classification and the skip from drifting (a compact that
+// called a voxel VISIBLE while stage 2 skipped it would drop an on-screen
+// pixel's colour). Over-classifying VISIBLE is the only safe failure direction.
+//
+// The route terms are part of the predicate, not a caller-side gate: the
+// widened cull only exists on the cardinal (residualYaw == 0) world
+// (isDetachedCanvas < 0.5) route, so both terms must hold before an
+// out-of-bounds iso means "feeder". When sun shadows are off,
+// visibleIsoBounds == cullIsoMin/Max and this never fires — byte-identical.
+bool isShadowFeederIso(
+    ivec2 isoPos,
+    ivec4 visibleIsoBounds,
+    float residualYaw,
+    float isDetachedCanvas
+) {
+    return residualYaw == 0.0 && isDetachedCanvas < 0.5 &&
+        (isoPos.x < visibleIsoBounds.x || isoPos.x > visibleIsoBounds.z ||
+         isoPos.y < visibleIsoBounds.y || isoPos.y > visibleIsoBounds.w);
+}
+
 // Hardware round() is safe here: the 1e-4 near-grid gate excludes
 // half-integer inputs, so the tie direction — the only point where
 // round() is implementation-defined — is unobservable.

--- a/engine/render/src/shaders/ir_resolve_cardinal_emit.glsl
+++ b/engine/render/src/shaders/ir_resolve_cardinal_emit.glsl
@@ -1,0 +1,64 @@
+// Shared cardinal-layout micro-cell emit for the sun-shadow RESOLVE scatter
+// kernels (c_resolve_per_axis_screen_depth, c_resolve_world_placed_depth).
+// Both kernels re-project a foreign R32I distance canvas into the SCREEN-SPACE
+// scratch buffer laid out exactly like the main canvas distance texture. Their
+// decodes differ, but the emit that ends each — encode the micro-cell's depth
+// key, project it to its iso pixel, atomicMin it into the region's two-pixel
+// diamond — is the same math. One definition keeps a one-sided edit from
+// desyncing the two resolve routes' footprints against the BAKE recovery that
+// reads them (the ir_voxel_face_select.glsl idiom).
+//
+// This is an include-FRAGMENT, not a standalone shader: the kernel wrappers
+// include it AFTER ir_iso_common.glsl (prerequisite helpers: pos3DtoDistance,
+// pos3DtoPos2DIso, encodeDepthWithFace, faceOffset_2x3, isInsideCanvas) and
+// AFTER their own `resolveScratch` SSBO declaration, which this function
+// writes through. GLSL has no way to pass an SSBO as an argument, so the
+// scratch binding is a wrapper-supplied contract rather than a parameter —
+// the same reason the fog grid's image slot is a wrapper #define in
+// ir_voxel_face_select.glsl. The fragment includes nothing itself: the GLSL
+// include resolver is non-recursive (#2514), so every prerequisite must be
+// pulled in by the wrapper ahead of this file.
+// Metal twin: metal/ir_resolve_cardinal_emit.metal — keep byte-identical math.
+
+// Emit one micro-cell's two-pixel diamond region (#1724) into the resolve
+// scratch, in the MAIN-canvas cardinal distance layout.
+//
+// `viewPos` is the micro-cell already rotated into the cardinal VIEW frame and
+// expressed in subdivision units; `slot`/`flip` are the stored key bits, which
+// ride the encode so polarity survives the resolve bridge (#2207). Emitting the
+// two-pixel region rather than the single origin pixel is load-bearing:
+// roundHalfUp collapses a region's input pixels onto one recovered cell, so a
+// single-pixel write left the resolve texture ~50% sparse — pinhole casters
+// whose shadows dithered with interior gaps.
+//
+// `regionAxis` is the VIEW-frame face axis that picks the diamond region, and
+// is NOT always derivable from `slot`: the per-axis store is already in the
+// view frame (visibleFaceTripletCardinal orders the triplet so slot s lands on
+// view axis s), while the world-placed store is model-frame and must rotate
+// its face normal into the view frame first. Passing it in keeps both callers
+// on this one emit. faceOffset_2x3 is polarity-blind (axis only), so the flip
+// never reaches the region choice.
+void emitResolveCardinalDiamond(
+    const ivec3 viewPos,
+    const int regionAxis,
+    const int slot,
+    const int flip,
+    const ivec2 mainBase,
+    const ivec2 canvasSize
+) {
+    // Per-micro-cell depth, shared by the region's two pixels — the exact
+    // encode a real cardinal store would hold here, so BAKE's pixel+depth
+    // inverse recovers points on the face plane.
+    const int encoded = encodeDepthWithFace(pos3DtoDistance(viewPos), slot, flip);
+    const ivec2 cellBase = mainBase + pos3DtoPos2DIso(viewPos);
+    for (int k = 0; k < 2; ++k) {
+        const ivec2 mainPixel = cellBase + faceOffset_2x3(regionAxis, k);
+        if (!isInsideCanvas(mainPixel, canvasSize)) {
+            continue;
+        }
+        // Front-most per screen pixel: smallest encoded distance wins (depth
+        // dominates the low bits — flip+slot), exactly like the main canvas
+        // atomicMin store.
+        atomicMin(resolveScratch[mainPixel.y * canvasSize.x + mainPixel.x], encoded);
+    }
+}

--- a/engine/render/src/shaders/metal/c_clear_light_volume.metal
+++ b/engine/render/src/shaders/metal/c_clear_light_volume.metal
@@ -6,6 +6,13 @@ using namespace metal;
 // The parallel winning-light ID read texture (#2318) is cleared to 0 in
 // the same pass so an unreached cell reports "no winning light" (id 0).
 
+// Integer mirror of `kLightVolumeSize` in component_canvas_light_volume.hpp —
+// the same extent ir_world_lighting.metal publishes as a float for the sampling
+// passes (which divide by it to reach texel centers). Deliberately NOT folded
+// into that fragment: this kernel needs one integer bound for a loop guard, and
+// including it would pull the light-source list + SPOT/ACES helpers into a pass
+// that clears two textures. Mirrors the GLSL twin, whose fold would additionally
+// declare an unbound binding-4 SSBO here. Keep the two in lockstep.
 constant int kLightVolumeSize = 128;
 
 kernel void c_clear_light_volume(

--- a/engine/render/src/shaders/metal/c_light_overflow_faces.metal
+++ b/engine/render/src/shaders/metal/c_light_overflow_faces.metal
@@ -2,7 +2,8 @@
                                      // FrameDataVoxelToTrixel (with overflowScratchLayout)
 #include "ir_per_axis_lighting.metal" // perAxisCellToWorld3D
 #include "ir_sun_shadow_sample.metal" // FrameDataSun + worldSunShadowFactor()
-#include "ir_world_lighting.metal"    // GPULightSource layout, spotConeFactor, ACESFilm
+#include "ir_world_lighting.metal"    // GPULightSource layout, spotConeFactor, ACESFilm,
+                                     // FrameDataLightingToTrixel + LightVolumeParams
 
 // Mirrors shaders/c_light_overflow_faces.glsl — view-visibility overflow-face
 // lighting (#2334, epic #2331 phase C2). Dispatched inside LIGHTING_TO_TRIXEL
@@ -11,26 +12,6 @@
 // AO = 1.0 — same world sample as c_lighting_to_trixel) and rewrites the entry's
 // stored colorPacked in place, so the unchanged scatter draws LIT slivers while
 // rotating. Runs ONLY while rotating; the cardinal fast path is byte-identical.
-
-struct FrameDataLightingToTrixel {
-    int   lightingEnabled;
-    int   lutEnabled;
-    int   lightVolumeEnabled;
-    float debugLightLevel;
-    int   debugOverlayMode;
-    int   hdrEnabled;
-    float exposure;
-    float skyIntensity;
-    float4 skyColor;
-};
-
-struct LightVolumeParams {
-    int   _gridSize;
-    int   _halfExtent;
-    int   _lightCount;
-    float _stepFalloff;
-    int4  worldOriginVoxel;
-};
 
 kernel void c_light_overflow_faces(
     constant FrameDataLightingToTrixel& frameData [[buffer(27)]],

--- a/engine/render/src/shaders/metal/c_lighting_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_lighting_to_trixel.metal
@@ -4,7 +4,9 @@
 // for the opt-in detached re-voxelize world-receive path (#1576 P4b-2). Shared
 // with c_compute_sun_shadow; replaces this kernel's former local FrameDataSun.
 #include "ir_sun_shadow_sample.metal"
-// GPULightSource layout, light-volume extents, spotConeFactor, ACESFilm.
+// GPULightSource layout, light-volume extents, spotConeFactor, ACESFilm, plus
+// the FrameDataLightingToTrixel + LightVolumeParams UBO layouts this kernel and
+// c_light_overflow_faces both bind.
 #include "ir_world_lighting.metal"
 
 // Mirrors shaders/c_lighting_to_trixel.glsl. Screen-space lighting
@@ -15,29 +17,6 @@
 // float precision, adds the sky-term contribution, applies exposure,
 // and tonemaps via the ACES Filmic curve before writing back to the
 // canvas.
-
-struct FrameDataLightingToTrixel {
-    int   lightingEnabled;
-    int   lutEnabled;
-    int   lightVolumeEnabled;
-    float debugLightLevel;
-    int   debugOverlayMode;
-    int   hdrEnabled;
-    float exposure;
-    float skyIntensity;
-    float4 skyColor;
-};
-
-// Layout must match the propagate/seed UBO layout so the shared buffer
-// binding works. Lighting reads `worldOriginVoxel.xyz` (volume origin) and
-// `.w` (has-SPOT flag, #2318).
-struct LightVolumeParams {
-    int   _gridSize;
-    int   _halfExtent;
-    int   _lightCount;
-    float _stepFalloff;
-    int4  worldOriginVoxel;
-};
 
 // Per-axis empty-cell compaction (#2256): on the per-axis route
 // (perAxisRoute != 0) this kernel is dispatched indirectly over only each axis's

--- a/engine/render/src/shaders/metal/c_propagate_light_volume.metal
+++ b/engine/render/src/shaders/metal/c_propagate_light_volume.metal
@@ -29,6 +29,11 @@ constant uint kLightOcclusionBitfieldUintCount =
     uint(kLightOcclusionGridSize) * uint(kLightOcclusionGridSize) *
     uint(kLightOcclusionGridSize) / 32u;
 
+// Deliberate local copy of the shared layout in ir_world_lighting.metal (which
+// the seed / lighting / overflow passes bind through): this is the one
+// light-volume consumer that does not include that fragment, and pulling the
+// light-source list + SPOT/ACES helpers into a kernel dispatched 32× a frame
+// just to share a struct declaration is not worth it. Keep the two in lockstep.
 struct LightVolumeParams {
     int gridSize;
     int halfExtent;

--- a/engine/render/src/shaders/metal/c_resolve_per_axis_screen_depth.metal
+++ b/engine/render/src/shaders/metal/c_resolve_per_axis_screen_depth.metal
@@ -1,5 +1,7 @@
 #include "ir_iso_common.metal"
 #include <metal_atomic>
+// The cardinal-layout micro-cell emit shared with c_resolve_world_placed_depth.
+#include "ir_resolve_cardinal_emit.metal"
 
 // Mirrors shaders/c_resolve_per_axis_screen_depth.glsl. Re-projects one
 // face-local per-axis voxel canvas into a screen-space front-most iso-depth
@@ -106,23 +108,9 @@ kernel void c_resolve_per_axis_screen_depth(
     for (int v = 0; v < scale; ++v) {
         for (int u = 0; u < scale; ++u) {
             const int3 microView = viewPos + stepU * u + stepV * v;
-            // Per-micro-cell depth, shared by the region's two pixels — the
-            // exact encode a real cardinal store would hold here, so BAKE's
-            // pixel+depth inverse recovers points on the face plane.
-            const int encoded = encodeDepthWithFace(pos3DtoDistance(microView), slot, flip);
-            const int2 cellBase = mainBase + pos3DtoPos2DIso(microView);
-            for (int k = 0; k < 2; ++k) {
-                const int2 mainPixel = cellBase + faceOffset_2x3(slot, k);
-                if (!isInsideCanvas(mainPixel, canvasSize)) {
-                    continue;
-                }
-                // Front-most per screen pixel: smallest encoded distance wins
-                // (depth dominates the 2 slot bits), exactly like the main
-                // canvas atomicMin store.
-                const uint idx =
-                    uint(mainPixel.y) * uint(canvasSize.x) + uint(mainPixel.x);
-                atomic_fetch_min_explicit(&resolveScratch[idx], encoded, memory_order_relaxed);
-            }
+            emitResolveCardinalDiamond(
+                resolveScratch, microView, slot, slot, flip, mainBase, canvasSize
+            );
         }
     }
 }

--- a/engine/render/src/shaders/metal/c_resolve_world_placed_depth.metal
+++ b/engine/render/src/shaders/metal/c_resolve_world_placed_depth.metal
@@ -1,5 +1,8 @@
 #include "ir_iso_common.metal"
 #include <metal_atomic>
+// The cardinal-layout micro-cell emit shared with
+// c_resolve_per_axis_screen_depth.
+#include "ir_resolve_cardinal_emit.metal"
 
 // Mirrors shaders/c_resolve_world_placed_depth.glsl. Re-projects one opt-in
 // world-placed detached re-voxelize canvas (model-frame R32I distance texture)
@@ -60,7 +63,6 @@ kernel void c_resolve_world_placed_depth(
         viewPos = rotateCardinalZ(worldPos, cardinalIndex);
         viewPos += cardinalLowerCornerShift(cardinalIndex) * scale;
     }
-    const int encoded = encodeDepthWithFace(pos3DtoDistance(viewPos), slot, flip);
 
     const int2 canvasSize = frameData.canvasSizePixels; // MAIN canvas size
     const int2 mainBase = trixelFrameOffset(
@@ -80,16 +82,7 @@ kernel void c_resolve_world_placed_depth(
         rotateCardinalZ(faceOutwardNormal6I(slot << 1), cardinalIndex);
     const int viewAxis =
         (viewNormal.x != 0) ? kXFace : ((viewNormal.y != 0) ? kYFace : kZFace);
-    const int2 cellBase = mainBase + pos3DtoPos2DIso(viewPos);
-    for (int k = 0; k < 2; ++k) {
-        const int2 mainPixel = cellBase + faceOffset_2x3(viewAxis, k);
-        if (!isInsideCanvas(mainPixel, canvasSize)) {
-            continue;
-        }
-        // Front-most per screen pixel: smallest encoded distance wins (depth
-        // dominates the 2 slot bits), exactly like the main canvas atomicMin
-        // store.
-        const uint idx = uint(mainPixel.y) * uint(canvasSize.x) + uint(mainPixel.x);
-        atomic_fetch_min_explicit(&resolveScratch[idx], encoded, memory_order_relaxed);
-    }
+    emitResolveCardinalDiamond(
+        resolveScratch, viewPos, viewAxis, slot, flip, mainBase, canvasSize
+    );
 }

--- a/engine/render/src/shaders/metal/c_seed_light_volume.metal
+++ b/engine/render/src/shaders/metal/c_seed_light_volume.metal
@@ -9,19 +9,12 @@ using namespace metal;
 // window edge (see `gatherLightSources`). The propagate pass decrements
 // alpha by `stepFalloff` per step.
 
-// GPULightSource layout (the light-list entry this kernel seeds from).
+// GPULightSource layout (the light-list entry this kernel seeds from) and the
+// shared LightVolumeParams UBO layout. Phase 1c (#360): subtract
+// `worldOriginVoxel.xyz` — the camera-anchored window origin — before mapping a
+// light's world origin into a local texel index; `.w` is the has-SPOT flag
+// (#2318), unused by the seed.
 #include "ir_world_lighting.metal"
-
-struct LightVolumeParams {
-    int gridSize;
-    int halfExtent;
-    int lightCount;
-    float stepFalloff;
-    // Phase 1c (#360): camera-anchored window. Subtract this world voxel
-    // before mapping the light's world origin into a local texel index.
-    // `.w` carries the has-SPOT flag (#2318), unused by the seed.
-    int4 worldOriginVoxel;
-};
 
 kernel void c_seed_light_volume(
     device const GPULightSource *lights [[buffer(4)]],

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal
@@ -403,11 +403,17 @@ kernel void IR_STAGE2_KERNEL_NAME(
             feederPos = rotateCardinalZ(feederPos, cardinalIndex);
             feederPos += cardinalLowerCornerShift(cardinalIndex);
         }
-        const int2 feederIso = pos3DtoPos2DIso(feederPos);
-        if (feederIso.x < frameData.visibleIsoBounds.x ||
-            feederIso.x > frameData.visibleIsoBounds.z ||
-            feederIso.y < frameData.visibleIsoBounds.y ||
-            feederIso.y > frameData.visibleIsoBounds.w) {
+        // One definition with the compact cull's Step-B classify
+        // (isShadowFeederIso, ir_iso_common.metal) so the skip and the
+        // classification cannot drift. The predicate re-tests the two route
+        // terms — provably true inside this gate; the gate itself stays as the
+        // cheap early-out that avoids the cardinal projection above.
+        if (isShadowFeederIso(
+                pos3DtoPos2DIso(feederPos),
+                frameData.visibleIsoBounds,
+                frameData.residualYaw,
+                frameData.isDetachedCanvas
+        )) {
             return;
         }
     }

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -338,12 +338,14 @@ kernel void c_voxel_visibility_compact(
                             // the cardinal-snapped iso in that branch, so a voxel
                             // called feeder is exactly one stage 2 skips —
                             // over-classifying visible is the only failure mode.
-                            const bool isFeeder =
-                                frameData.residualYaw == 0.0f && frameData.isDetachedCanvas < 0.5f &&
-                                (isoPos.x < frameData.visibleIsoBounds.x ||
-                                 isoPos.x > frameData.visibleIsoBounds.z ||
-                                 isoPos.y < frameData.visibleIsoBounds.y ||
-                                 isoPos.y > frameData.visibleIsoBounds.w);
+                            // One definition with stage 2's skip
+                            // (isShadowFeederIso, ir_iso_common.metal).
+                            const bool isFeeder = isShadowFeederIso(
+                                isoPos,
+                                frameData.visibleIsoBounds,
+                                frameData.residualYaw,
+                                frameData.isDetachedCanvas
+                            );
                             if (isFeeder) {
                                 // Tail-append: feeder slot i lands at voxelCount-1-i
                                 // (grows down from the buffer top; nVisible +

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -417,6 +417,36 @@ inline bool isInsideCanvas(int2 pixel, int2 canvasSize) {
            pixel.y >= 0 && pixel.y < canvasSize.y;
 }
 
+// Shadow-feeder classification (#1740): on the cardinal single-canvas world
+// route, a voxel whose cardinal iso position lies outside the UN-widened
+// visible viewport but inside the shadow-feeder-widened cull exists only to
+// cast sun shadows onto on-screen pixels through stage 1's distance bake — it
+// is never displayed, lit, or picked.
+//
+// Two kernels ask this same question and must agree: c_voxel_visibility_compact
+// partitions survivors into the visible list vs the strided off-screen feeder
+// list (#2258 Step B), and c_voxel_to_trixel_stage_2 skips a feeder's colour +
+// entity-id taps. They re-derived the predicate independently; one definition
+// is what keeps the classification and the skip from drifting (a compact that
+// called a voxel VISIBLE while stage 2 skipped it would drop an on-screen
+// pixel's colour). Over-classifying VISIBLE is the only safe failure direction.
+//
+// The route terms are part of the predicate, not a caller-side gate: the
+// widened cull only exists on the cardinal (residualYaw == 0) world
+// (isDetachedCanvas < 0.5) route, so both terms must hold before an
+// out-of-bounds iso means "feeder". When sun shadows are off,
+// visibleIsoBounds == cullIsoMin/Max and this never fires — byte-identical.
+inline bool isShadowFeederIso(
+    int2 isoPos,
+    int4 visibleIsoBounds,
+    float residualYaw,
+    float isDetachedCanvas
+) {
+    return residualYaw == 0.0f && isDetachedCanvas < 0.5f &&
+        (isoPos.x < visibleIsoBounds.x || isoPos.x > visibleIsoBounds.z ||
+         isoPos.y < visibleIsoBounds.y || isoPos.y > visibleIsoBounds.w);
+}
+
 // Hardware round() is safe here: the 1e-4 near-grid gate excludes
 // half-integer inputs, so the tie direction — the only point where
 // round() can differ from the GLSL twin — is unobservable.

--- a/engine/render/src/shaders/metal/ir_resolve_cardinal_emit.metal
+++ b/engine/render/src/shaders/metal/ir_resolve_cardinal_emit.metal
@@ -1,0 +1,68 @@
+// Shared cardinal-layout micro-cell emit for the sun-shadow RESOLVE scatter
+// kernels — Metal twin of ../ir_resolve_cardinal_emit.glsl (keep byte-identical
+// math). c_resolve_per_axis_screen_depth and c_resolve_world_placed_depth decode
+// differently but end in the same emit; one definition keeps the two resolve
+// routes' footprints from drifting against the BAKE recovery that reads them.
+//
+// Included by the kernel wrappers AFTER ir_iso_common.metal. Unlike the GLSL
+// twin — which cannot pass an SSBO as an argument and so writes through a
+// wrapper-declared `resolveScratch` binding — Metal passes buffers as function
+// arguments, so the scratch pointer is an explicit parameter here.
+//
+// No `#ifndef ..._INCLUDED` self-guard: the function is `static` (internal
+// linkage) and each wrapper includes this file exactly once, so neither in-TU
+// re-inclusion nor a standalone glob-compile can raise a duplicate-symbol
+// conflict — the ir_voxel_face_select.metal idiom. Do NOT switch it to
+// external-linkage `inline`, which is what forces ir_per_axis_lighting.metal
+// to carry a guard.
+
+// Prerequisite helpers (pos3DtoDistance, pos3DtoPos2DIso, encodeDepthWithFace,
+// faceOffset_2x3, isInsideCanvas). The runtime include resolver is recursive
+// with a visited set, so the wrapper's own earlier include of ir_iso_common.metal
+// makes this a suppressed duplicate.
+#include "ir_iso_common.metal"
+#include <metal_atomic>
+
+// Emit one micro-cell's two-pixel diamond region (#1724) into the resolve
+// scratch, in the MAIN-canvas cardinal distance layout.
+//
+// `viewPos` is the micro-cell already rotated into the cardinal VIEW frame and
+// expressed in subdivision units; `slot`/`flip` are the stored key bits, which
+// ride the encode so polarity survives the resolve bridge (#2207). Emitting the
+// two-pixel region rather than the single origin pixel is load-bearing:
+// roundHalfUp collapses a region's input pixels onto one recovered cell, so a
+// single-pixel write left the resolve texture ~50% sparse — pinhole casters
+// whose shadows dithered with interior gaps.
+//
+// `regionAxis` is the VIEW-frame face axis that picks the diamond region, and
+// is NOT always derivable from `slot`: the per-axis store is already in the
+// view frame (visibleFaceTripletCardinal orders the triplet so slot s lands on
+// view axis s), while the world-placed store is model-frame and must rotate its
+// face normal into the view frame first. faceOffset_2x3 is polarity-blind (axis
+// only), so the flip never reaches the region choice.
+static void emitResolveCardinalDiamond(
+    device atomic_int* resolveScratch,
+    const int3 viewPos,
+    const int regionAxis,
+    const int slot,
+    const int flip,
+    const int2 mainBase,
+    const int2 canvasSize
+) {
+    // Per-micro-cell depth, shared by the region's two pixels — the exact
+    // encode a real cardinal store would hold here, so BAKE's pixel+depth
+    // inverse recovers points on the face plane.
+    const int encoded = encodeDepthWithFace(pos3DtoDistance(viewPos), slot, flip);
+    const int2 cellBase = mainBase + pos3DtoPos2DIso(viewPos);
+    for (int k = 0; k < 2; ++k) {
+        const int2 mainPixel = cellBase + faceOffset_2x3(regionAxis, k);
+        if (!isInsideCanvas(mainPixel, canvasSize)) {
+            continue;
+        }
+        // Front-most per screen pixel: smallest encoded distance wins (depth
+        // dominates the low bits — flip+slot), exactly like the main canvas
+        // atomicMin store.
+        const uint idx = uint(mainPixel.y) * uint(canvasSize.x) + uint(mainPixel.x);
+        atomic_fetch_min_explicit(&resolveScratch[idx], encoded, memory_order_relaxed);
+    }
+}

--- a/engine/render/src/shaders/metal/ir_world_lighting.metal
+++ b/engine/render/src/shaders/metal/ir_world_lighting.metal
@@ -30,6 +30,45 @@ struct GPULightSource {
     float4 trueOriginVoxel;
 };
 
+// LIGHTING_TO_TRIXEL's own frame UBO (`[[buffer(27)]]`), shared by the
+// composite pass and the overflow-face relight that runs at its tail — both
+// carried byte-identical copies of this layout. The GLSL twins declare the
+// equivalent as a per-kernel `layout(std140)` interface block, which cannot be
+// hoisted the same way, so this fold is Metal-only.
+struct FrameDataLightingToTrixel {
+    int   lightingEnabled;
+    int   lutEnabled;
+    int   lightVolumeEnabled;
+    float debugLightLevel;
+    int   debugOverlayMode;
+    int   hdrEnabled;
+    float exposure;
+    float skyIntensity;
+    float4 skyColor;
+};
+
+// The light-volume UBO (`[[buffer(23)]]`), written once by the CPU and read by
+// every light-volume stage — the seed, the lighting composite, and the
+// overflow relight all bind the SAME buffer, so this layout must stay in
+// lockstep across them; that is exactly why it is one definition here rather
+// than a copy per kernel.
+//
+// The seed reads all five fields; the lighting/overflow passes read only
+// `worldOriginVoxel` (`.xyz` = the volume's camera-anchored world origin,
+// #360 Phase 1c; `.w` = the has-SPOT flag, #2318) and ignore the other four.
+//
+// c_propagate_light_volume.metal keeps its own copy of this layout on purpose:
+// it is the one consumer that does not include this fragment, and pulling the
+// light-source list + SPOT/ACES helpers into a kernel dispatched 32× a frame
+// to share a struct declaration is not worth it. Keep the two in lockstep.
+struct LightVolumeParams {
+    int   gridSize;
+    int   halfExtent;
+    int   lightCount;
+    float stepFalloff;
+    int4  worldOriginVoxel;
+};
+
 // Analytic SPOT falloff at world position `pos3D` for the 0-based light
 // `lightIdx`. 1.0 inside the cone, smoothstep to 0.0 across the soft edge
 // band, 0.0 outside. Apex is the light's TRUE (unclamped) origin. Mirrors


### PR DESCRIPTION
## Summary
Four documented duplicates left over from the #2508 audit, each a textual extraction with no logic restructure.

- **Resolve-kernel cardinal-layout emit** → new `ir_resolve_cardinal_emit.{glsl,metal}`. `c_resolve_per_axis_screen_depth` and `c_resolve_world_placed_depth` decode different inputs but end in the same emit (encode depth key → iso pixel → `atomicMin` into the 2-pixel `faceOffset_2x3` diamond). Region axis is a parameter, not derived from the slot: the per-axis store is already view-frame, the world-placed store is model-frame and rotates its normal first. GLSL can't pass an SSBO as an argument, so the GLSL fragment writes through the wrapper's `resolveScratch` and is included after it; the Metal twin takes the pointer as a parameter.
- **Shadow-feeder predicate** → `isShadowFeederIso` in `ir_iso_common.{glsl,metal}`, consumed by the compact's Step-B partition (#2258) and stage 2's depth-only skip (#1740). The route terms live inside the predicate since the widened cull only exists on that route; stage 2 keeps its enclosing gate as the cheap early-out.
- **Metal lighting UBO structs** → `FrameDataLightingToTrixel` + `LightVolumeParams` folded into `ir_world_lighting.metal`. The live field names win (lighting/overflow never named the four they tombstoned), which lets the seed drop its copy too.
- **Clear-volume constant** → documented, not folded (see Notes).

## Test plan
- [x] macOS/Metal: full #2508 suite below (runtime Metal compile validates the MSL twins)
- [ ] Linux/GL smoke: `fleet-build --target IRShapeDebug` + `fleet-run IRShapeDebug --auto-screenshot 10`, ideally `IRFogDemo` render-verify — validates the GLSL twins, which have no validator on the authoring host

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| shape_debug 28-shot A/B byte-identical vs base | staged-shader-dir swap A/B (identical binary — diff is shaders-only), `md5` per shot | **28/28 byte-identical**; re-confirmed on the final committed tree |
| fog demo refs 13/13 | `render-verify.py --target IRFogDemo` | **13/13 PASS**, 100% match, max_delta 0 |
| canvas_stress within noise | `render-verify.py --target IRCanvasStress`, mine vs master shaders | **zero delta from this PR** — 8/10 FAIL identically on master's shaders (same match% to 4 dp); captures byte-identical mine vs master 12/12. Pre-existing stale refs, see Notes |
| jitter floor (#2469) exact | `--yaw-sweep` zoom 4 voxel cylinder → `jitter_probe` | **x rev=2, max_residual=1.01px** — exactly the documented floor |
| all runs RESULT=CLEAN | every run above | `ir-run: RESULT=CLEAN` throughout |
| one definition per hoisted symbol | tree-wide grep | `emitResolveCardinalDiamond` 1/backend; `isShadowFeederIso` 1/backend; `FrameDataLightingToTrixel` 1; `LightVolumeParams` 2 (shared + documented propagate copy); `kLightVolumeSize` documented pair |
| both backends in lockstep | every GLSL edit has its MSL twin | 4 twin pairs + 1 new fragment pair |

**Enabled-path proof (byte-identity alone would be vacuous here).** Both extracted symbols sit on paths gated off at cardinal / shadows-off, so I verified each actually executes by perturbing it in the staged shader dir and confirming output moves:
- `emitResolveCardinalDiamond` +4096 on the depth key → canvas_stress metrics shifted on all 8 rotating shots (e.g. `so3_offsnap_disc` 98.7363 → 98.4818).
- `isShadowFeederIso` bounds test inverted → perf_grid **7/7 shots changed**. (canvas_stress does *not* reach this path — inverting it there changed nothing — so the perf_grid scene is the one carrying this coverage. perf_grid needs `--wave-freeze` to be run-to-run deterministic; without it consecutive runs differ regardless of shaders.)
- perf_grid A/B on that same frozen feeder-exercising scene: **7/7 byte-identical** mine vs master.

## Notes for reviewer
- **No screenshots** — the `engine/render/CLAUDE.md` "internal refactors with provably no runtime effect" carve-out, with the proof attached above (four harnesses byte-identical). Same call #2508 made for the same class of change.
- **canvas_stress refs are stale on master, independent of this PR.** `origin/master` alone fails 8/10 checks with byte-for-byte the same metrics as this branch. Most likely #2509 (RAII per-axis lighting route) shifted output while #2516 refreshed only the shape_debug refs. Filing a ref-refresh follow-up; happy to fold it in here instead if preferred.
- **Item 2 deviates from the issue's suggested home.** `ir_voxel_face_select` was proposed, but `c_voxel_visibility_compact` declares its own `canvasFogOfWar` (binding 0) and `FogObserverData` (binding 27) — the same bindings that fragment declares — so including it there collides. `ir_iso_common` is already included by both call sites and needs no new include.
- **Item 3's plan caveat didn't trigger.** The plan said to leave seed/propagate out *if* the tombstone-vs-live naming couldn't merge cleanly. It merges cleanly (lighting/overflow reference only `worldOriginVoxel`), so the seed folds too. `c_propagate_light_volume` is the deliberate exception — it's the one consumer that doesn't include the fragment, and pulling the light list + SPOT/ACES helpers into a kernel dispatched 32× a frame to share a struct declaration isn't worth it. Both sides carry a pointer comment.
- **Item 4 documents rather than folds.** Including `ir_world_lighting.glsl` in the clear kernel would declare its binding-4 `LightSourceBuffer` SSBO in a pass that binds nothing at slot 4 (Metal side would drag in the light list + helpers). The issue sanctioned "fold or document".
- `c_voxel_visibility_compact.glsl:269` has a *similar* bounds test that is **not** folded into `isShadowFeederIso` — it's the #1812 Hi-Z coverage domain (no route terms, different semantics).
- **Perf is inconclusive, not clean.** On an alternating A/B series the spread within a single variant exceeded any between-variant delta (`voxelCompact` 0.069→0.789 for identical shaders), so this harness can't resolve a difference on this host. The change is a textual extraction the compiler inlines and output is byte-identical, but I'm not claiming a measured perf result.

Closes #2513

🤖 Generated with [Claude Code](https://claude.com/claude-code)