### PR TITLE
prefabs/render: widget theme becomes a C_WidgetTheme singleton component

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -355,8 +355,11 @@ kind-specific data component (`C_WidgetPanel` / `C_WidgetLabel` /
 `C_WidgetButton` / `C_WidgetSlider` / `C_WidgetCheckbox` /
 `C_WidgetList` / `C_WidgetDropdown` / `C_WidgetRadio` /
 `C_WidgetTextInput` / `C_WidgetScroll` / `C_WidgetColorSwatch`).
-Theme lives in `widget_theme.hpp::defaultTheme()` — a single inline
-header-level instance a creation mutates once at init.
+Theme lives on the `C_WidgetTheme` singleton component, read via
+`widget_theme.hpp::defaultTheme()` — a creation mutates it once at init
+before constructing widgets. Per-tick readers (`WIDGET_RENDER_*` systems)
+cache the theme in `beginTick` rather than reading the singleton per
+entity.
 
 `C_WidgetColorSwatch` (T-211) is a single solid-color clickable cell
 for palette panels and theme editors. Each swatch carries its own

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -356,10 +356,16 @@ kind-specific data component (`C_WidgetPanel` / `C_WidgetLabel` /
 `C_WidgetList` / `C_WidgetDropdown` / `C_WidgetRadio` /
 `C_WidgetTextInput` / `C_WidgetScroll` / `C_WidgetColorSwatch`).
 Theme lives on the `C_WidgetTheme` singleton component, read via
-`widget_theme.hpp::defaultTheme()` — a creation mutates it once at init
-before constructing widgets. Per-tick readers (`WIDGET_RENDER_*` systems)
-cache the theme in `beginTick` rather than reading the singleton per
-entity.
+`widget_theme.hpp::defaultTheme()` — a creation may mutate it once at init
+before constructing widgets. Every `WIDGET_RENDER_*` system's `create()`
+calls `widget_theme.hpp::ensureThemeSingleton()`, so the singleton
+reliably exists before frame 1 regardless of whether a creation
+customizes it — that main-thread registration-time touch keeps the
+lazy-create off the per-frame `beginTick` path (`singleton<T>()`'s first
+call must be main-thread; a non-main-thread `createEntity` defers the row
+insertion until `flushStructuralChanges`). Per-tick readers
+(`WIDGET_RENDER_*` systems) cache the theme in `beginTick` rather than
+reading the singleton per entity.
 
 `C_WidgetColorSwatch` (T-211) is a single solid-color clickable cell
 for palette panels and theme editors. Each swatch carries its own

--- a/engine/prefabs/irreden/render/components/component_widget_theme.hpp
+++ b/engine/prefabs/irreden/render/components/component_widget_theme.hpp
@@ -1,0 +1,86 @@
+#ifndef COMPONENT_WIDGET_THEME_H
+#define COMPONENT_WIDGET_THEME_H
+
+#include <irreden/ir_math.hpp>
+
+namespace IRPrefab::Widget {
+
+// Visual styling shared by every widget in a creation. Backs the
+// `C_WidgetTheme` singleton below; widgets read from it at render time. The
+// values lock in the look of the editor for every Phase 0 — Phase 10
+// implementation that builds on top, so additions should be additive
+// (new fields default to existing-color values) and renames are
+// breaking.
+struct WidgetTheme {
+    // Surfaces
+    IRMath::Color backgroundIdle_ = IRMath::Color{40, 44, 56, 255};
+    IRMath::Color backgroundHover_ = IRMath::Color{60, 68, 88, 255};
+    IRMath::Color backgroundPressed_ = IRMath::Color{90, 100, 124, 255};
+    IRMath::Color backgroundDisabled_ = IRMath::Color{32, 34, 40, 255};
+    IRMath::Color panelBackground_ = IRMath::Color{24, 26, 34, 220};
+    IRMath::Color panelTitleBackground_ = IRMath::Color{52, 58, 76, 255};
+
+    // Borders
+    IRMath::Color borderIdle_ = IRMath::Color{96, 108, 132, 255};
+    IRMath::Color borderHover_ = IRMath::Color{160, 200, 240, 255};
+    IRMath::Color borderPressed_ = IRMath::Color{220, 240, 255, 255};
+    IRMath::Color borderFocused_ = IRMath::Color{240, 200, 120, 255};
+    IRMath::Color borderDisabled_ = IRMath::Color{64, 68, 80, 255};
+
+    // Text
+    IRMath::Color textIdle_ = IRMath::Color{220, 224, 232, 255};
+    IRMath::Color textDisabled_ = IRMath::Color{120, 124, 132, 255};
+
+    // Slider track / thumb
+    IRMath::Color sliderTrack_ = IRMath::Color{72, 80, 96, 255};
+    IRMath::Color sliderThumbIdle_ = IRMath::Color{160, 168, 180, 255};
+    IRMath::Color sliderThumbHover_ = IRMath::Color{210, 220, 240, 255};
+
+    // Checkbox fill (when checked)
+    IRMath::Color checkboxFill_ = IRMath::Color{160, 200, 240, 255};
+
+    // List / dropdown row backgrounds (over the standard surface fill).
+    IRMath::Color listRowSelected_ = IRMath::Color{72, 96, 140, 255};
+    IRMath::Color listRowHover_ = IRMath::Color{52, 60, 80, 255};
+
+    // Radio button selected-fill (centre dot).
+    IRMath::Color radioFill_ = IRMath::Color{160, 200, 240, 255};
+
+    // Text input cursor color.
+    IRMath::Color textInputCursor_ = IRMath::Color{220, 224, 232, 255};
+
+    // Scroll bar visuals.
+    IRMath::Color scrollTrack_ = IRMath::Color{32, 36, 46, 255};
+    IRMath::Color scrollThumb_ = IRMath::Color{120, 132, 156, 255};
+    IRMath::Color scrollThumbHover_ = IRMath::Color{180, 200, 232, 255};
+
+    // Layout
+    int borderThickness_ = 2;
+    int padding_ = 4;
+    int fontSize_ = 2;
+    int sliderTrackThickness_ = 6;
+    int sliderThumbWidth_ = 8;
+    int checkboxBoxSize_ = 16;
+    int radioBoxSize_ = 16;
+    int textInputCursorWidth_ = 2;
+    int scrollBarThickness_ = 10;
+    int scrollThumbMinExtent_ = 16;
+    int textCursorBlinkPeriodFrames_ = 30;
+};
+
+} // namespace IRPrefab::Widget
+
+namespace IRComponents {
+
+// Singleton row backing `IRPrefab::Widget::defaultTheme()`
+// (`widget_theme.hpp`). Setup-time-only: a creation mutates the theme once
+// at init before constructing widgets. Per-tick readers must cache it in
+// `beginTick` rather than reading the singleton per entity (the ECS
+// footgun) — see the `WIDGET_RENDER_*` systems for the pattern.
+struct C_WidgetTheme {
+    IRPrefab::Widget::WidgetTheme theme_;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_WIDGET_THEME_H */

--- a/engine/prefabs/irreden/render/components/component_widget_theme.hpp
+++ b/engine/prefabs/irreden/render/components/component_widget_theme.hpp
@@ -73,10 +73,13 @@ struct WidgetTheme {
 namespace IRComponents {
 
 // Singleton row backing `IRPrefab::Widget::defaultTheme()`
-// (`widget_theme.hpp`). Setup-time-only: a creation mutates the theme once
-// at init before constructing widgets. Per-tick readers must cache it in
-// `beginTick` rather than reading the singleton per entity (the ECS
-// footgun) — see the `WIDGET_RENDER_*` systems for the pattern.
+// (`widget_theme.hpp`). Setup-time-only: a creation may mutate the theme
+// once at init before constructing widgets. Every `WIDGET_RENDER_*` system
+// touches the singleton from `create()` (`ensureThemeSingleton()`), so it
+// reliably exists before frame 1 whether or not a creation customizes it.
+// Per-tick readers must cache it in `beginTick` rather than reading the
+// singleton per entity (the ECS footgun) — see the `WIDGET_RENDER_*`
+// systems for the pattern.
 struct C_WidgetTheme {
     IRPrefab::Widget::WidgetTheme theme_;
 };

--- a/engine/prefabs/irreden/render/systems/system_widget_input_panel_drag.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_input_panel_drag.hpp
@@ -20,7 +20,7 @@ namespace IRSystem {
 // panel drag-to-dock flow in IRPrefab::Layout. Panels that are NOT
 // layout leaves are ignored (not part of the managed dockspace).
 //
-// Panel title-bar height is kGlyphStepY + 2*theme.padding_ (same value
+// Panel title-bar height is kGlyphStepY + 2*theme_.padding_ (same value
 // used by WIDGET_RENDER_PANEL to draw the title bar).
 //
 // Pipeline order requirement (INPUT pipeline):
@@ -30,6 +30,7 @@ template <> struct System<WIDGET_INPUT_PANEL_DRAG> {
     IRMath::vec2 mouseGuiTrixel_ = IRMath::vec2(0.0f);
     bool mouseLeftPressedThisFrame_ = false;
     bool mouseLeftDown_ = false;
+    IRPrefab::Widget::WidgetTheme theme_;
 
     void beginTick() {
         mouseGuiTrixel_ = IRPrefab::Layout::mousePositionInGuiTrixels();
@@ -43,6 +44,7 @@ template <> struct System<WIDGET_INPUT_PANEL_DRAG> {
             IRInput::ButtonStatuses::HELD
         );
         mouseLeftDown_ = heldThisFrame || mouseLeftPressedThisFrame_;
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -51,16 +53,13 @@ template <> struct System<WIDGET_INPUT_PANEL_DRAG> {
         const IRComponents::C_GuiPosition &guiPos,
         const IRComponents::C_LayoutLeaf &leaf
     ) {
-        const int padding = IRPrefab::Widget::defaultTheme().padding_;
-        const int titleBarH = IRRender::kGlyphStepY + padding * 2;
+        const int titleBarH = IRRender::kGlyphStepY + theme_.padding_ * 2;
 
-        const IRMath::ivec2 mouseI = IRMath::ivec2(
-            static_cast<int>(mouseGuiTrixel_.x),
-            static_cast<int>(mouseGuiTrixel_.y)
-        );
+        const IRMath::ivec2 mouseI =
+            IRMath::ivec2(static_cast<int>(mouseGuiTrixel_.x), static_cast<int>(mouseGuiTrixel_.y));
 
         const bool isDraggingThis = IRPrefab::Layout::isDraggingPanel() &&
-            IRPrefab::Layout::getDraggedPanelNodeIdx() == leaf.nodeIdx_;
+                                    IRPrefab::Layout::getDraggedPanelNodeIdx() == leaf.nodeIdx_;
 
         if (isDraggingThis) {
             if (!mouseLeftDown_) {
@@ -71,19 +70,16 @@ template <> struct System<WIDGET_INPUT_PANEL_DRAG> {
             return;
         }
 
-        if (IRPrefab::Layout::isDraggingPanel()) return;
+        if (IRPrefab::Layout::isDraggingPanel())
+            return;
 
         if (mouseLeftPressedThisFrame_) {
             const bool inTitleBar =
-                mouseI.x >= guiPos.pos_.x &&
-                mouseI.x < guiPos.pos_.x + widget.size_.x &&
-                mouseI.y >= guiPos.pos_.y &&
-                mouseI.y < guiPos.pos_.y + titleBarH;
+                mouseI.x >= guiPos.pos_.x && mouseI.x < guiPos.pos_.x + widget.size_.x &&
+                mouseI.y >= guiPos.pos_.y && mouseI.y < guiPos.pos_.y + titleBarH;
 
             if (inTitleBar) {
-                IRPrefab::Layout::beginPanelDrag(
-                    leaf.nodeIdx_, entityId, mouseI, guiPos.pos_
-                );
+                IRPrefab::Layout::beginPanelDrag(leaf.nodeIdx_, entityId, mouseI, guiPos.pos_);
             }
         }
     }
@@ -93,8 +89,7 @@ template <> struct System<WIDGET_INPUT_PANEL_DRAG> {
             WIDGET_INPUT_PANEL_DRAG,
             IRComponents::C_Widget,
             IRComponents::C_GuiPosition,
-            IRComponents::C_LayoutLeaf
-        >("WidgetInputPanelDrag");
+            IRComponents::C_LayoutLeaf>("WidgetInputPanelDrag");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_input_panel_drag.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_input_panel_drag.hpp
@@ -85,6 +85,7 @@ template <> struct System<WIDGET_INPUT_PANEL_DRAG> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_INPUT_PANEL_DRAG,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_button.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_button.hpp
@@ -16,12 +16,14 @@ namespace IRSystem {
 
 template <> struct System<WIDGET_RENDER_BUTTON> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -33,12 +35,11 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBackground(theme, widget, state),
+            IRPrefab::Widget::detail::stateBackground(theme_, widget, state),
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -46,9 +47,9 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetBorderDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
         IRPrefab::Widget::detail::queueCenteredText(
@@ -57,7 +58,7 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
             button.label_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateText(theme, widget)
+            IRPrefab::Widget::detail::stateText(theme_, widget)
         );
     }
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_button.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_button.hpp
@@ -67,6 +67,7 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_BUTTON,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_checkbox.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_checkbox.hpp
@@ -16,12 +16,14 @@ namespace IRSystem {
 
 template <> struct System<WIDGET_RENDER_CHECKBOX> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -33,15 +35,14 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
-        const int boxSize = theme.checkboxBoxSize_;
+        const int boxSize = theme_.checkboxBoxSize_;
         const int boxY = guiPos.pos_.y + (widget.size_.y - boxSize) / 2;
 
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(guiPos.pos_.x, boxY),
             IRMath::ivec2(boxSize, boxSize),
-            IRPrefab::Widget::detail::stateBackground(theme, widget, state),
+            IRPrefab::Widget::detail::stateBackground(theme_, widget, state),
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -49,19 +50,19 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
             *canvas_,
             IRMath::ivec2(guiPos.pos_.x, boxY),
             IRMath::ivec2(boxSize, boxSize),
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetBorderDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
 
         if (checkbox.checked_) {
-            const int inset = theme.borderThickness_ + 2;
+            const int inset = theme_.borderThickness_ + 2;
             IRRender::fillRect(
                 *canvas_,
                 IRMath::ivec2(guiPos.pos_.x + inset, boxY + inset),
                 IRMath::ivec2(boxSize - 2 * inset, boxSize - 2 * inset),
-                theme.checkboxFill_,
+                theme_.checkboxFill_,
                 IRRender::kWidgetLabelDistance,
                 scratch_
             );
@@ -72,9 +73,9 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
                 textCmds_,
                 canvas_->size_,
                 checkbox.label_,
-                IRMath::ivec2(guiPos.pos_.x + boxSize + theme.padding_ * 2, guiPos.pos_.y),
+                IRMath::ivec2(guiPos.pos_.x + boxSize + theme_.padding_ * 2, guiPos.pos_.y),
                 widget.size_.y,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
     }

--- a/engine/prefabs/irreden/render/systems/system_widget_render_checkbox.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_checkbox.hpp
@@ -85,6 +85,7 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_CHECKBOX,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_color_swatch.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_color_swatch.hpp
@@ -23,11 +23,13 @@ namespace IRSystem {
 // click feedback survives selection.
 template <> struct System<WIDGET_RENDER_COLOR_SWATCH> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -39,7 +41,6 @@ template <> struct System<WIDGET_RENDER_COLOR_SWATCH> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
             *canvas_,
             guiPos.pos_,
@@ -55,10 +56,10 @@ template <> struct System<WIDGET_RENDER_COLOR_SWATCH> {
         // theme call), which keeps click feedback consistent with the
         // other interactive widgets.
         const IRMath::Color borderColor =
-            swatch.selected_ ? theme.borderFocused_
-                             : IRPrefab::Widget::detail::stateBorder(theme, widget, state);
+            swatch.selected_ ? theme_.borderFocused_
+                             : IRPrefab::Widget::detail::stateBorder(theme_, widget, state);
         const int thickness =
-            swatch.selected_ ? theme.borderThickness_ + 1 : theme.borderThickness_;
+            swatch.selected_ ? theme_.borderThickness_ + 1 : theme_.borderThickness_;
         IRRender::drawBorder(
             *canvas_,
             guiPos.pos_,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_color_swatch.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_color_swatch.hpp
@@ -72,6 +72,7 @@ template <> struct System<WIDGET_RENDER_COLOR_SWATCH> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_COLOR_SWATCH,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_dropdown.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_dropdown.hpp
@@ -23,12 +23,14 @@ namespace IRSystem {
 // handled by WIDGET_APPLY_DROPDOWN (hitbox size mutation).
 template <> struct System<WIDGET_RENDER_DROPDOWN> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -42,7 +44,6 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
         if (widget.size_.x <= 0 || widget.size_.y <= 0)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         const int itemH = IRMath::max(1, dd.itemHeight_);
         const int n = static_cast<int>(dd.items_.size());
 
@@ -51,7 +52,7 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBackground(theme, widget, state),
+            IRPrefab::Widget::detail::stateBackground(theme_, widget, state),
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -59,9 +60,9 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetBorderDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
 
@@ -73,9 +74,9 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             textCmds_,
             canvas_->size_,
             headerText,
-            IRMath::ivec2(guiPos.pos_.x + theme.padding_ * 2, guiPos.pos_.y),
+            IRMath::ivec2(guiPos.pos_.x + theme_.padding_ * 2, guiPos.pos_.y),
             widget.size_.y,
-            IRPrefab::Widget::detail::stateText(theme, widget)
+            IRPrefab::Widget::detail::stateText(theme_, widget)
         );
 
         // Dropdown chevron — solid triangle approximated as a small stack of rects
@@ -83,13 +84,13 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
         // GUI canvas resolution this framework targets.
         const int chevronW = 8;
         const int chevronH = 4;
-        const int chevX = guiPos.pos_.x + widget.size_.x - chevronW - theme.padding_ * 2;
+        const int chevX = guiPos.pos_.x + widget.size_.x - chevronW - theme_.padding_ * 2;
         const int chevY = guiPos.pos_.y + (widget.size_.y - chevronH) / 2;
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(chevX, chevY),
             IRMath::ivec2(chevronW, 2),
-            IRPrefab::Widget::detail::stateText(theme, widget),
+            IRPrefab::Widget::detail::stateText(theme_, widget),
             IRRender::kWidgetBorderDistance,
             scratch_
         );
@@ -97,7 +98,7 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             *canvas_,
             IRMath::ivec2(chevX + 2, chevY + 2),
             IRMath::ivec2(chevronW - 4, 2),
-            IRPrefab::Widget::detail::stateText(theme, widget),
+            IRPrefab::Widget::detail::stateText(theme_, widget),
             IRRender::kWidgetBorderDistance,
             scratch_
         );
@@ -112,7 +113,7 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             *canvas_,
             panelPos,
             panelSize,
-            theme.backgroundIdle_,
+            theme_.backgroundIdle_,
             IRRender::kWidgetBorderDistance,
             scratch_
         );
@@ -129,7 +130,7 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
                     *canvas_,
                     rowPos,
                     rowSize,
-                    theme.listRowSelected_,
+                    theme_.listRowSelected_,
                     IRRender::kWidgetLabelDistance,
                     scratch_
                 );
@@ -138,7 +139,7 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
                     *canvas_,
                     rowPos,
                     rowSize,
-                    theme.listRowHover_,
+                    theme_.listRowHover_,
                     IRRender::kWidgetLabelDistance,
                     scratch_
                 );
@@ -147,9 +148,9 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
                 textCmds_,
                 canvas_->size_,
                 dd.items_[static_cast<std::size_t>(i)],
-                IRMath::ivec2(rowPos.x + theme.padding_ * 2, rowPos.y),
+                IRMath::ivec2(rowPos.x + theme_.padding_ * 2, rowPos.y),
                 itemH,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
 
@@ -157,9 +158,9 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             *canvas_,
             panelPos,
             panelSize,
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetLabelDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
     }

--- a/engine/prefabs/irreden/render/systems/system_widget_render_dropdown.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_dropdown.hpp
@@ -170,6 +170,7 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_DROPDOWN,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_label.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_label.hpp
@@ -16,11 +16,13 @@ namespace IRSystem {
 
 template <> struct System<WIDGET_RENDER_LABEL> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -32,9 +34,8 @@ template <> struct System<WIDGET_RENDER_LABEL> {
             return;
         if (label.text_.empty())
             return;
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         const IRMath::Color color = (label.colorOverride_.alpha_ == 0)
-                                        ? IRPrefab::Widget::detail::stateText(theme, widget)
+                                        ? IRPrefab::Widget::detail::stateText(theme_, widget)
                                         : label.colorOverride_;
         IRPrefab::GuiText::queueGuiText(
             textCmds_,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_label.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_label.hpp
@@ -52,6 +52,7 @@ template <> struct System<WIDGET_RENDER_LABEL> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_LABEL,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_list.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_list.hpp
@@ -22,12 +22,14 @@ namespace IRSystem {
 // by simply skipping rows that exceed it.
 template <> struct System<WIDGET_RENDER_LIST> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -41,7 +43,6 @@ template <> struct System<WIDGET_RENDER_LIST> {
         if (widget.size_.x <= 0 || widget.size_.y <= 0)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         const int itemH = IRMath::max(1, list.itemHeight_);
         const int rows = widget.size_.y / itemH;
         const int n = static_cast<int>(list.items_.size());
@@ -50,7 +51,11 @@ template <> struct System<WIDGET_RENDER_LIST> {
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBackground(theme, widget, IRComponents::C_WidgetState{}),
+            IRPrefab::Widget::detail::stateBackground(
+                theme_,
+                widget,
+                IRComponents::C_WidgetState{}
+            ),
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -72,7 +77,7 @@ template <> struct System<WIDGET_RENDER_LIST> {
                     *canvas_,
                     rowPos,
                     rowSize,
-                    theme.listRowSelected_,
+                    theme_.listRowSelected_,
                     IRRender::kWidgetBorderDistance,
                     scratch_
                 );
@@ -81,7 +86,7 @@ template <> struct System<WIDGET_RENDER_LIST> {
                     *canvas_,
                     rowPos,
                     rowSize,
-                    theme.listRowHover_,
+                    theme_.listRowHover_,
                     IRRender::kWidgetBorderDistance,
                     scratch_
                 );
@@ -91,9 +96,9 @@ template <> struct System<WIDGET_RENDER_LIST> {
                 textCmds_,
                 canvas_->size_,
                 list.items_[static_cast<std::size_t>(idx)],
-                IRMath::ivec2(rowPos.x + theme.padding_ * 2, rowPos.y),
+                IRMath::ivec2(rowPos.x + theme_.padding_ * 2, rowPos.y),
                 itemH,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
 
@@ -101,9 +106,9 @@ template <> struct System<WIDGET_RENDER_LIST> {
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetBorderDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
     }

--- a/engine/prefabs/irreden/render/systems/system_widget_render_list.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_list.hpp
@@ -118,6 +118,7 @@ template <> struct System<WIDGET_RENDER_LIST> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_LIST,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_panel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_panel.hpp
@@ -23,12 +23,14 @@ namespace IRSystem {
 // canvas clear into its own system; tracked as a follow-up.
 template <> struct System<WIDGET_RENDER_PANEL> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -40,23 +42,22 @@ template <> struct System<WIDGET_RENDER_PANEL> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            theme.panelBackground_,
+            theme_.panelBackground_,
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
 
         if (!panel.title_.empty()) {
-            const int titleBarH = IRRender::kGlyphStepY + theme.padding_ * 2;
+            const int titleBarH = IRRender::kGlyphStepY + theme_.padding_ * 2;
             IRRender::fillRect(
                 *canvas_,
                 guiPos.pos_,
                 IRMath::ivec2(widget.size_.x, titleBarH),
-                theme.panelTitleBackground_,
+                theme_.panelTitleBackground_,
                 IRRender::kWidgetBorderDistance,
                 scratch_
             );
@@ -66,7 +67,7 @@ template <> struct System<WIDGET_RENDER_PANEL> {
                 panel.title_,
                 guiPos.pos_,
                 IRMath::ivec2(widget.size_.x, titleBarH),
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
 
@@ -75,9 +76,9 @@ template <> struct System<WIDGET_RENDER_PANEL> {
                 *canvas_,
                 guiPos.pos_,
                 widget.size_,
-                IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+                IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
                 IRRender::kWidgetBorderDistance,
-                theme.borderThickness_,
+                theme_.borderThickness_,
                 scratch_
             );
         }

--- a/engine/prefabs/irreden/render/systems/system_widget_render_panel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_panel.hpp
@@ -89,6 +89,7 @@ template <> struct System<WIDGET_RENDER_PANEL> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_PANEL,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_radio.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_radio.hpp
@@ -24,12 +24,14 @@ namespace IRSystem {
 // reads identically once paired with the rest of the widget set.
 template <> struct System<WIDGET_RENDER_RADIO> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -41,15 +43,14 @@ template <> struct System<WIDGET_RENDER_RADIO> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
-        const int box = theme.radioBoxSize_;
+        const int box = theme_.radioBoxSize_;
         const int boxY = guiPos.pos_.y + (widget.size_.y - box) / 2;
 
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(guiPos.pos_.x, boxY),
             IRMath::ivec2(box, box),
-            IRPrefab::Widget::detail::stateBackground(theme, widget, state),
+            IRPrefab::Widget::detail::stateBackground(theme_, widget, state),
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -57,19 +58,19 @@ template <> struct System<WIDGET_RENDER_RADIO> {
             *canvas_,
             IRMath::ivec2(guiPos.pos_.x, boxY),
             IRMath::ivec2(box, box),
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetBorderDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
 
         if (radio.selected_) {
-            const int inset = theme.borderThickness_ + 2;
+            const int inset = theme_.borderThickness_ + 2;
             IRRender::fillRect(
                 *canvas_,
                 IRMath::ivec2(guiPos.pos_.x + inset, boxY + inset),
                 IRMath::ivec2(box - 2 * inset, box - 2 * inset),
-                theme.radioFill_,
+                theme_.radioFill_,
                 IRRender::kWidgetLabelDistance,
                 scratch_
             );
@@ -80,9 +81,9 @@ template <> struct System<WIDGET_RENDER_RADIO> {
                 textCmds_,
                 canvas_->size_,
                 radio.label_,
-                IRMath::ivec2(guiPos.pos_.x + box + theme.padding_ * 2, guiPos.pos_.y),
+                IRMath::ivec2(guiPos.pos_.x + box + theme_.padding_ * 2, guiPos.pos_.y),
                 widget.size_.y,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
     }

--- a/engine/prefabs/irreden/render/systems/system_widget_render_radio.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_radio.hpp
@@ -93,6 +93,7 @@ template <> struct System<WIDGET_RENDER_RADIO> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_RADIO,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_scroll.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_scroll.hpp
@@ -24,11 +24,13 @@ namespace IRSystem {
 // that content.
 template <> struct System<WIDGET_RENDER_SCROLL> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -37,12 +39,13 @@ template <> struct System<WIDGET_RENDER_SCROLL> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
-        if (widget.size_.x <= 0 || widget.size_.y <= 0) return;
+        if (!canvas_)
+            return;
+        if (widget.size_.x <= 0 || widget.size_.y <= 0)
+            return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         const bool vertical = (scroll.axis_ == IRComponents::C_WidgetScroll::Axis::VERTICAL);
-        const int bar = IRMath::max(1, theme.scrollBarThickness_);
+        const int bar = IRMath::max(1, theme_.scrollBarThickness_);
 
         IRMath::ivec2 trackPos = guiPos.pos_;
         IRMath::ivec2 trackSize = widget.size_;
@@ -58,7 +61,7 @@ template <> struct System<WIDGET_RENDER_SCROLL> {
             *canvas_,
             trackPos,
             trackSize,
-            theme.scrollTrack_,
+            theme_.scrollTrack_,
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -70,17 +73,14 @@ template <> struct System<WIDGET_RENDER_SCROLL> {
 
         // Thumb size proportional to viewExtent / contentExtent, clamped to a
         // minimum so it remains grabbable at extreme content sizes.
-        const int thumbExtentRaw = (contentExtent > 0)
-            ? (viewExtent * viewExtent) / contentExtent
-            : viewExtent;
-        const int thumbExtent = IRMath::clamp(
-            thumbExtentRaw, theme.scrollThumbMinExtent_, viewExtent
-        );
+        const int thumbExtentRaw =
+            (contentExtent > 0) ? (viewExtent * viewExtent) / contentExtent : viewExtent;
+        const int thumbExtent =
+            IRMath::clamp(thumbExtentRaw, theme_.scrollThumbMinExtent_, viewExtent);
 
         // Thumb offset proportional to scrollPos_ / maxScroll.
-        const int thumbOffset = (maxScroll > 0)
-            ? (clampedScroll * (viewExtent - thumbExtent)) / maxScroll
-            : 0;
+        const int thumbOffset =
+            (maxScroll > 0) ? (clampedScroll * (viewExtent - thumbExtent)) / maxScroll : 0;
 
         IRMath::ivec2 thumbPos = trackPos;
         IRMath::ivec2 thumbSize = trackSize;
@@ -92,11 +92,10 @@ template <> struct System<WIDGET_RENDER_SCROLL> {
             thumbSize.x = thumbExtent;
         }
 
-        const IRMath::Color thumbColor =
-            widget.disabled_   ? theme.backgroundDisabled_
-            : state.pressed_   ? theme.scrollThumbHover_
-            : state.hovered_   ? theme.scrollThumbHover_
-                               : theme.scrollThumb_;
+        const IRMath::Color thumbColor = widget.disabled_ ? theme_.backgroundDisabled_
+                                         : state.pressed_ ? theme_.scrollThumbHover_
+                                         : state.hovered_ ? theme_.scrollThumbHover_
+                                                          : theme_.scrollThumb_;
         IRRender::fillRect(
             *canvas_,
             thumbPos,
@@ -113,8 +112,7 @@ template <> struct System<WIDGET_RENDER_SCROLL> {
             IRComponents::C_Widget,
             IRComponents::C_WidgetScroll,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderScroll");
+            IRComponents::C_GuiPosition>("WidgetRenderScroll");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_scroll.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_scroll.hpp
@@ -107,6 +107,7 @@ template <> struct System<WIDGET_RENDER_SCROLL> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_SCROLL,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_slider.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_slider.hpp
@@ -20,12 +20,14 @@ namespace IRSystem {
 
 template <> struct System<WIDGET_RENDER_SLIDER> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -37,7 +39,6 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         const int W = widget.size_.x;
         const int H = widget.size_.y;
         if (W <= 0 || H <= 0)
@@ -45,7 +46,7 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
 
         // Top half is the optional label, bottom half is track + thumb.
         const int labelH = slider.label_.empty() ? 0 : IRRender::kGlyphStepY;
-        const int trackY = guiPos.pos_.y + labelH + (H - labelH - theme.sliderTrackThickness_) / 2;
+        const int trackY = guiPos.pos_.y + labelH + (H - labelH - theme_.sliderTrackThickness_) / 2;
         const int trackX = guiPos.pos_.x;
 
         if (!slider.label_.empty()) {
@@ -55,7 +56,7 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
                 slider.label_,
                 guiPos.pos_,
                 labelH,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
 
@@ -63,8 +64,8 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(trackX, trackY),
-            IRMath::ivec2(W, theme.sliderTrackThickness_),
-            theme.sliderTrack_,
+            IRMath::ivec2(W, theme_.sliderTrackThickness_),
+            theme_.sliderTrack_,
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -75,13 +76,13 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
                                 : 1.0f;
         const float t =
             IRMath::clamp((slider.currentValue_ - slider.minValue_) / range, 0.0f, 1.0f);
-        const int thumbW = theme.sliderThumbWidth_;
+        const int thumbW = theme_.sliderThumbWidth_;
         const int thumbH = H - labelH;
         const int thumbX = guiPos.pos_.x + static_cast<int>(t * static_cast<float>(W - thumbW));
         const int thumbY = guiPos.pos_.y + labelH;
-        const IRMath::Color thumbColor = widget.disabled_ ? theme.backgroundDisabled_
-                                         : state.hovered_ ? theme.sliderThumbHover_
-                                                          : theme.sliderThumbIdle_;
+        const IRMath::Color thumbColor = widget.disabled_ ? theme_.backgroundDisabled_
+                                         : state.hovered_ ? theme_.sliderThumbHover_
+                                                          : theme_.sliderThumbIdle_;
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(thumbX, thumbY),
@@ -100,7 +101,7 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
                 buf,
                 guiPos.pos_,
                 canvas_->size_,
-                IRPrefab::Widget::detail::stateText(theme, widget),
+                IRPrefab::Widget::detail::stateText(theme_, widget),
                 IRPrefab::Widget::detail::kWidgetTextFontSize,
                 IRComponents::TextAlignH::RIGHT,
                 IRComponents::TextAlignV::CENTER,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_slider.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_slider.hpp
@@ -116,6 +116,7 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_SLIDER,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_splitter.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_splitter.hpp
@@ -23,11 +23,13 @@ namespace IRSystem {
 //   LAYOUT_COMPUTE → ... → WIDGET_RENDER_SPLITTER → TRIXEL_TO_FRAMEBUFFER
 template <> struct System<WIDGET_RENDER_SPLITTER> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -35,15 +37,15 @@ template <> struct System<WIDGET_RENDER_SPLITTER> {
         const IRComponents::C_Widget &widget,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         const auto &ls = IRPrefab::Layout::getLayout();
         const bool active = IRPrefab::Layout::isDraggingSplitter() &&
-            ls.dragSplitterParent_ == splitter.parentNodeIdx_ &&
-            ls.dragSplitterChildIdx_ == splitter.childIdx_;
+                            ls.dragSplitterParent_ == splitter.parentNodeIdx_ &&
+                            ls.dragSplitterChildIdx_ == splitter.childIdx_;
 
-        IRMath::Color color = active ? theme.borderHover_ : theme.borderIdle_;
+        IRMath::Color color = active ? theme_.borderHover_ : theme_.borderIdle_;
         IRRender::fillRect(
             *canvas_,
             guiPos.pos_,
@@ -59,8 +61,7 @@ template <> struct System<WIDGET_RENDER_SPLITTER> {
             WIDGET_RENDER_SPLITTER,
             IRComponents::C_Splitter,
             IRComponents::C_Widget,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderSplitter");
+            IRComponents::C_GuiPosition>("WidgetRenderSplitter");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_splitter.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_splitter.hpp
@@ -57,6 +57,7 @@ template <> struct System<WIDGET_RENDER_SPLITTER> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_SPLITTER,
             IRComponents::C_Splitter,

--- a/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
@@ -24,6 +24,7 @@ namespace IRSystem {
 // holds keyboard focus.
 template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    IRPrefab::Widget::WidgetTheme theme_;
     IRRender::RectFillScratch scratch_;
     std::vector<IRRender::GlyphDrawCommand> textCmds_;
     int frameCounter_ = 0;
@@ -32,6 +33,7 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
         canvas_ = &IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
         ++frameCounter_;
+        theme_ = IRPrefab::Widget::defaultTheme();
     }
 
     void tick(
@@ -43,12 +45,11 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
         if (!canvas_)
             return;
 
-        const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBackground(theme, widget, state),
+            IRPrefab::Widget::detail::stateBackground(theme_, widget, state),
             IRRender::kWidgetBackgroundDistance,
             scratch_
         );
@@ -56,13 +57,13 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
             *canvas_,
             guiPos.pos_,
             widget.size_,
-            IRPrefab::Widget::detail::stateBorder(theme, widget, state),
+            IRPrefab::Widget::detail::stateBorder(theme_, widget, state),
             IRRender::kWidgetBorderDistance,
-            theme.borderThickness_,
+            theme_.borderThickness_,
             scratch_
         );
 
-        const int textX = guiPos.pos_.x + theme.padding_ * 2;
+        const int textX = guiPos.pos_.x + theme_.padding_ * 2;
         if (!textInput.text_.empty()) {
             IRPrefab::Widget::detail::queueLeftText(
                 textCmds_,
@@ -70,7 +71,7 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
                 textInput.text_,
                 IRMath::ivec2(textX, guiPos.pos_.y),
                 widget.size_.y,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+                IRPrefab::Widget::detail::stateText(theme_, widget)
             );
         }
 
@@ -80,7 +81,7 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
         // Blink: cursor visible during the first half of each blink
         // period, hidden during the second. textCursorBlinkPeriodFrames_
         // is the FULL period.
-        const int period = IRMath::max(2, theme.textCursorBlinkPeriodFrames_);
+        const int period = IRMath::max(2, theme_.textCursorBlinkPeriodFrames_);
         const bool cursorVisible = (frameCounter_ % period) < (period / 2);
         if (!cursorVisible)
             return;
@@ -89,15 +90,15 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
             IRMath::clamp(textInput.cursorPos_, 0, static_cast<int>(textInput.text_.size()));
         const int cursorX = IRMath::min(
             textX + cursorChars * IRRender::kGlyphStepX,
-            guiPos.pos_.x + widget.size_.x - theme.textInputCursorWidth_
+            guiPos.pos_.x + widget.size_.x - theme_.textInputCursorWidth_
         );
         const int cursorH = IRRender::kGlyphHeight;
         const int cursorY = guiPos.pos_.y + (widget.size_.y - cursorH) / 2;
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(cursorX, cursorY),
-            IRMath::ivec2(theme.textInputCursorWidth_, cursorH),
-            theme.textInputCursor_,
+            IRMath::ivec2(theme_.textInputCursorWidth_, cursorH),
+            theme_.textInputCursor_,
             IRRender::kWidgetBorderDistance,
             scratch_
         );

--- a/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
@@ -109,6 +109,7 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
     }
 
     static SystemId create() {
+        IRPrefab::Widget::ensureThemeSingleton();
         return registerSystem<
             WIDGET_RENDER_TEXT_INPUT,
             IRComponents::C_Widget,

--- a/engine/prefabs/irreden/render/widget_theme.hpp
+++ b/engine/prefabs/irreden/render/widget_theme.hpp
@@ -1,81 +1,19 @@
 #ifndef WIDGET_THEME_H
 #define WIDGET_THEME_H
 
-#include <irreden/ir_math.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <irreden/render/components/component_widget_theme.hpp>
 
 namespace IRPrefab::Widget {
 
-// Visual styling shared by every widget in a creation. A single instance
-// lives as `defaultTheme()`; widgets read from it at render time. The
-// values lock in the look of the editor for every Phase 0 — Phase 10
-// implementation that builds on top, so additions should be additive
-// (new fields default to existing-color values) and renames are
-// breaking.
-struct WidgetTheme {
-    // Surfaces
-    IRMath::Color backgroundIdle_ = IRMath::Color{40, 44, 56, 255};
-    IRMath::Color backgroundHover_ = IRMath::Color{60, 68, 88, 255};
-    IRMath::Color backgroundPressed_ = IRMath::Color{90, 100, 124, 255};
-    IRMath::Color backgroundDisabled_ = IRMath::Color{32, 34, 40, 255};
-    IRMath::Color panelBackground_ = IRMath::Color{24, 26, 34, 220};
-    IRMath::Color panelTitleBackground_ = IRMath::Color{52, 58, 76, 255};
-
-    // Borders
-    IRMath::Color borderIdle_ = IRMath::Color{96, 108, 132, 255};
-    IRMath::Color borderHover_ = IRMath::Color{160, 200, 240, 255};
-    IRMath::Color borderPressed_ = IRMath::Color{220, 240, 255, 255};
-    IRMath::Color borderFocused_ = IRMath::Color{240, 200, 120, 255};
-    IRMath::Color borderDisabled_ = IRMath::Color{64, 68, 80, 255};
-
-    // Text
-    IRMath::Color textIdle_ = IRMath::Color{220, 224, 232, 255};
-    IRMath::Color textDisabled_ = IRMath::Color{120, 124, 132, 255};
-
-    // Slider track / thumb
-    IRMath::Color sliderTrack_ = IRMath::Color{72, 80, 96, 255};
-    IRMath::Color sliderThumbIdle_ = IRMath::Color{160, 168, 180, 255};
-    IRMath::Color sliderThumbHover_ = IRMath::Color{210, 220, 240, 255};
-
-    // Checkbox fill (when checked)
-    IRMath::Color checkboxFill_ = IRMath::Color{160, 200, 240, 255};
-
-    // List / dropdown row backgrounds (over the standard surface fill).
-    IRMath::Color listRowSelected_ = IRMath::Color{72, 96, 140, 255};
-    IRMath::Color listRowHover_ = IRMath::Color{52, 60, 80, 255};
-
-    // Radio button selected-fill (centre dot).
-    IRMath::Color radioFill_ = IRMath::Color{160, 200, 240, 255};
-
-    // Text input cursor color.
-    IRMath::Color textInputCursor_ = IRMath::Color{220, 224, 232, 255};
-
-    // Scroll bar visuals.
-    IRMath::Color scrollTrack_ = IRMath::Color{32, 36, 46, 255};
-    IRMath::Color scrollThumb_ = IRMath::Color{120, 132, 156, 255};
-    IRMath::Color scrollThumbHover_ = IRMath::Color{180, 200, 232, 255};
-
-    // Layout
-    int borderThickness_ = 2;
-    int padding_ = 4;
-    int fontSize_ = 2;
-    int sliderTrackThickness_ = 6;
-    int sliderThumbWidth_ = 8;
-    int checkboxBoxSize_ = 16;
-    int radioBoxSize_ = 16;
-    int textInputCursorWidth_ = 2;
-    int scrollBarThickness_ = 10;
-    int scrollThumbMinExtent_ = 16;
-    int textCursorBlinkPeriodFrames_ = 30;
-};
-
-// Default theme. A creation that wants custom colors mutates this once
-// at init before constructing widgets. Inline header-level storage so
-// every translation unit shares one instance (C++17 inline variable;
-// not a function-local static, which is forbidden for mutable state by
-// the system-state rule).
-inline WidgetTheme g_defaultTheme;
+// Default theme accessor, backed by the `C_WidgetTheme` singleton
+// component. A creation that wants custom colors mutates this once at
+// init before constructing widgets — setup-time only; per-tick readers
+// must cache the returned reference in `beginTick` rather than calling
+// this per entity (the ECS footgun).
 inline WidgetTheme &defaultTheme() {
-    return g_defaultTheme;
+    return IREntity::singleton<IRComponents::C_WidgetTheme>().theme_;
 }
 
 } // namespace IRPrefab::Widget

--- a/engine/prefabs/irreden/render/widget_theme.hpp
+++ b/engine/prefabs/irreden/render/widget_theme.hpp
@@ -8,12 +8,23 @@
 namespace IRPrefab::Widget {
 
 // Default theme accessor, backed by the `C_WidgetTheme` singleton
-// component. A creation that wants custom colors mutates this once at
-// init before constructing widgets — setup-time only; per-tick readers
+// component. A creation that wants custom colors may mutate this once at
+// init before the first frame — setup-time only; per-tick readers
 // must cache the returned reference in `beginTick` rather than calling
 // this per entity (the ECS footgun).
 inline WidgetTheme &defaultTheme() {
     return IREntity::singleton<IRComponents::C_WidgetTheme>().theme_;
+}
+
+// Registration-time singleton touch. Every theme-reading widget system
+// calls this from `create()` so the lazy-create (a `createEntity`) runs on
+// the main thread during pipeline wiring, before frame 1 — never inside a
+// first-frame `beginTick`. `singleton<T>()`'s first call must be
+// main-thread: a worker-thread `createEntity` defers the row insertion
+// until `flushStructuralChanges`, so the immediately-following
+// `getComponent` would read a row that doesn't exist yet.
+inline void ensureThemeSingleton() {
+    defaultTheme();
 }
 
 } // namespace IRPrefab::Widget

--- a/engine/world/include/irreden/world/save_component_inventory.hpp
+++ b/engine/world/include/irreden/world/save_component_inventory.hpp
@@ -94,6 +94,7 @@
 #include <irreden/render/components/component_viewport.hpp>
 #include <irreden/render/components/component_voxel_selection.hpp>
 #include <irreden/render/components/component_widget.hpp>
+#include <irreden/render/components/component_widget_theme.hpp>
 #include <irreden/render/components/component_zoom_level.hpp>
 #include <irreden/render/systems/system_perf_stats_overlay.hpp>
 #include <irreden/spatial/components/component_spatial_index.hpp>
@@ -318,6 +319,11 @@ IR_SAVE_OPT_IN(IRComponents::C_WidgetScroll, 1)
 IR_SAVE_OPT_IN(IRComponents::C_WidgetSlider, 1)
 IR_SAVE_OPT_IN(IRComponents::C_WidgetTextInput, 1)
 IR_SAVE_OPT_IN(IRComponents::C_WidgetState, 1)
+
+// C_WidgetTheme: OPT-OUT — creation-authored init config re-established by
+// the creation's setup code on every run; persisting it in a world snapshot
+// would fight that init-time mutation on load.
+IR_SAVE_OPT_OUT(IRComponents::C_WidgetTheme)
 IR_SAVE_OPT_IN(IRComponents::C_Splitter, 1)
 IR_SAVE_OPT_IN(IRComponents::C_VoxelSelection, 1)
 IR_SAVE_OPT_IN(IRComponents::C_VoxelSelectionHighlight, 1)
@@ -498,6 +504,7 @@ using AllEngineComponents = std::tuple<
     IRComponents::C_WidgetSlider,
     IRComponents::C_WidgetTextInput,
     IRComponents::C_WidgetState,
+    IRComponents::C_WidgetTheme,
     IRComponents::C_Splitter,
     IRComponents::C_VoxelSelection,
     IRComponents::C_VoxelSelectionHighlight,
@@ -514,7 +521,7 @@ using AllEngineComponents = std::tuple<
     IRSystem::C_PerfStatsOverlayTag,
     IRComponents::C_SystemEvent<IRSystem::TICK>>;
 
-inline constexpr std::size_t kExpectedEngineComponentCount = 165;
+inline constexpr std::size_t kExpectedEngineComponentCount = 166;
 
 static_assert(
     detail::allExplicit<AllEngineComponents>(),

--- a/engine/world/include/irreden/world/save_component_inventory.hpp
+++ b/engine/world/include/irreden/world/save_component_inventory.hpp
@@ -320,9 +320,9 @@ IR_SAVE_OPT_IN(IRComponents::C_WidgetSlider, 1)
 IR_SAVE_OPT_IN(IRComponents::C_WidgetTextInput, 1)
 IR_SAVE_OPT_IN(IRComponents::C_WidgetState, 1)
 
-// C_WidgetTheme: OPT-OUT — creation-authored init config re-established by
-// the creation's setup code on every run; persisting it in a world snapshot
-// would fight that init-time mutation on load.
+// C_WidgetTheme: OPT-OUT — pure defaults every run; no creation mutates it
+// at runtime today, so a world snapshot would add nothing. Revisit if a
+// theme editor makes this user-authored state.
 IR_SAVE_OPT_OUT(IRComponents::C_WidgetTheme)
 IR_SAVE_OPT_IN(IRComponents::C_Splitter, 1)
 IR_SAVE_OPT_IN(IRComponents::C_VoxelSelection, 1)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(IrredenEngineTest
   render/sprite_animation_test.cpp
   render/sprite_components_test.cpp
   render/sprite_render_test.cpp
+  render/widget_theme_singleton_test.cpp
   script/lua_audio_midi_observer_test.cpp
   script/lua_collision_bindings_test.cpp
   script/lua_command_test.cpp

--- a/test/render/widget_theme_singleton_test.cpp
+++ b/test/render/widget_theme_singleton_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <irreden/ir_entity.hpp>
+
+#include <irreden/render/widget_theme.hpp>
+
+// Widget theme storage lives on the C_WidgetTheme singleton component
+// (see #2527). These tests pin the two invariants of component-backed
+// storage: the registration-time touch actually creates the row, and a
+// creation-customized theme survives the scene-transition teardown
+// (resetGameplay() preserves singleton rows).
+
+namespace {
+
+class WidgetThemeSingletonTest : public testing::Test {
+  protected:
+    IREntity::EntityManager m_entity_manager;
+};
+
+// Every WIDGET_RENDER_* system's create() calls ensureThemeSingleton() so the
+// singleton exists (main-thread) before frame 1 instead of lazy-creating
+// inside a first-frame beginTick.
+TEST_F(WidgetThemeSingletonTest, EnsureThemeSingletonCreatesTheRow) {
+    ASSERT_EQ(IREntity::singletonOrNull<IRComponents::C_WidgetTheme>(), nullptr);
+
+    IRPrefab::Widget::ensureThemeSingleton();
+
+    auto *row = IREntity::singletonOrNull<IRComponents::C_WidgetTheme>();
+    ASSERT_NE(row, nullptr);
+    EXPECT_EQ(row->theme_.borderThickness_, IRPrefab::Widget::WidgetTheme{}.borderThickness_);
+}
+
+TEST_F(WidgetThemeSingletonTest, MutatedDefaultThemeSurvivesSceneTransition) {
+    IRPrefab::Widget::ensureThemeSingleton();
+    IRPrefab::Widget::defaultTheme().borderThickness_ = 9;
+    IRPrefab::Widget::defaultTheme().textIdle_ = IRMath::Color{1, 2, 3, 255};
+
+    IREntity::resetGameplay();
+
+    EXPECT_EQ(IRPrefab::Widget::defaultTheme().borderThickness_, 9);
+    EXPECT_EQ(
+        IRPrefab::Widget::defaultTheme().textIdle_.toPackedRGBA(),
+        (IRMath::Color{1, 2, 3, 255}).toPackedRGBA()
+    );
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Retires `IRPrefab::Widget::g_defaultTheme` (a mutable header-scope inline global) in favor of a `C_WidgetTheme` singleton component, per the "per-world settings" pattern in `engine/entity/CLAUDE.md` §"Singleton components".
- `defaultTheme()` keeps its exact signature; the 13 widget-render/input systems that previously called it once per entity inside `tick()` now cache the theme once per frame in `beginTick()`.
- `C_WidgetTheme` opts OUT of world-snapshot save (creation-authored init config, re-established by setup code every run).

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `fleet-build --target IrredenEngineTest` — clean, 1356/1356 tests pass (including `SaveTrait.InventoryIsComplete`)
- [x] `python3 scripts/gui-verify.py IRVoxelEditor` — 14/14 assertions pass (hover/click/checkbox/slider/pick all still route through the widget framework correctly)
- [x] Visual spot-check of a GUI-heavy screenshot (voxel editor panels/sliders/dropdowns) — renders identically to before

Closes #2527

🤖 Generated with [Claude Code](https://claude.com/claude-code)