### PR TITLE
test: pivot-verify — deterministic rotation-pivot invariance harness (epic #2544 tooling)

### DIFF
--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -256,6 +256,76 @@ std::vector<std::array<char, 40>> g_pivotFocusShotLabels;
 // the focus exactly matches the rendered geometry.
 constexpr vec3 kPivotPillarCenter = vec3(8.0f, -8.0f, 10.0f);
 
+// --pivot-verify <block>: deterministic rotation-pivot invariance harness.
+// Each block spawns ONE vertical voxel cylinder (Z-yaw-invariant silhouette, so
+// its whole-silhouette centroid is immune to face-triplet changes) and sweeps
+// the camera yaw through cardinals + non-cardinals at a fixed pan; jitter_probe
+// --stationary then asserts the centroid holds its frame-0 position. Blocks:
+//   focus-ctr     — explicit focus on the probe center, probe at screen center.
+//   focus-off     — explicit focus on the probe center, probe panned off-center
+//                   (catches errors that vanish exactly at screen center).
+//   center-column — DEFAULT pivot; probe on the pinned vertical column (the
+//                   depth-0 focus's xy) at z > 0. Verifies the implemented
+//                   contract: the pivot correction pins the column
+//                   {W : W.xy == F.xy}, so this probe must hold even though it
+//                   renders below screen center.
+//   center-depth  — DEFAULT pivot; probe AT the viewport center but at z > 0:
+//                   on the center iso RAY, off the pinned column by (z, z) in
+//                   xy. Encodes the user-facing contract "what is at screen
+//                   center stays at screen center while rotating". DRIFT here
+//                   with center-column PINNED means the default pivot pins the
+//                   wrong DEPTH, not that the drift-cancel math is broken.
+// Requires --auto-screenshot (value = warmup frames per shot); score with
+// scripts/pivot-verify.py. Same stable-storage discipline as the other tables.
+std::string g_pivotVerifyBlock = "off";
+// --pivot-verify-sdf: probe via the SDF solver instead of the voxel pool, so
+// the two render paths' pivot conventions can be compared A/B — a layer that
+// pins while the other orbits means the paths disagree on the rendered-center
+// convention (invisible at yaw 0: a (0.5,0.5,0.5) offset rides the iso depth
+// axis and projects to zero until rotated).
+bool g_pivotVerifySdf = false;
+std::vector<IRVideo::AutoScreenshotShot> g_pivotVerifyShots;
+std::vector<std::array<char, 40>> g_pivotVerifyShotLabels;
+// Anchor of the DEFAULT-pivot blocks: an integer world point at iso depth 0
+// (x + y + z == 0) so `isoPixelToPos3D(viewCenterIso, 0)` — the default-pivot
+// focus derivation in getEffectiveCameraIso — recovers it EXACTLY when the pan
+// places it under the viewport center. Integer placement keeps the probe on
+// the voxel lattice (no displaced-pool tie noise in the measurement).
+constexpr vec3 kPivotVerifyDefaultAnchor = vec3(12.0f, -12.0f, 0.0f);
+// Probe z for the DEFAULT-pivot blocks. center-depth's xy displacement off the
+// pinned column equals this value in both axes (iso-ray geometry), so the
+// predicted master-drift scales with it.
+constexpr float kPivotVerifyProbeZ = 10.0f;
+// focus-off: iso offset of the pan away from probe-centered, so the pinned
+// probe holds a NON-center screen position.
+constexpr vec2 kPivotVerifyOffCenterIso = vec2(14.0f, 9.0f);
+
+// Camera pan that places kPivotVerifyDefaultAnchor under the exact viewport
+// center: inverts `viewCenterIso = canvasSize/2 - trixelOriginOffsetZ1 -
+// cameraIso` (getEffectiveCameraIso's default-focus derivation) at
+// `viewCenterIso == pos3DtoPos2DIso(anchor)`.
+vec2 pivotVerifyDefaultPan() {
+    const ivec2 canvasSize = ivec2(IRRender::getMainCanvasSizeTrixels());
+    return vec2(canvasSize) * 0.5f - vec2(IRMath::trixelOriginOffsetZ1(canvasSize)) -
+           IRMath::pos3DtoPos2DIso(kPivotVerifyDefaultAnchor);
+}
+
+// World center of the --pivot-verify probe cylinder for the active block.
+vec3 pivotVerifyProbeCenter() {
+    if (g_pivotVerifyBlock == "center-column") {
+        // On the pinned vertical column (anchor xy), shifted to z > 0.
+        return vec3(kPivotVerifyDefaultAnchor.x, kPivotVerifyDefaultAnchor.y, kPivotVerifyProbeZ);
+    }
+    if (g_pivotVerifyBlock == "center-depth") {
+        // On the viewport-center iso RAY at z = kPivotVerifyProbeZ: same screen
+        // position as the anchor, off the pinned column by (z, z) in xy.
+        return kPivotVerifyDefaultAnchor + vec3(kPivotVerifyProbeZ);
+    }
+    // focus-ctr / focus-off pin the same off-origin z>0 center the
+    // --pivot-focus-demo pillar uses.
+    return kPivotPillarCenter;
+}
+
 // --pan-sweep (#1944 diagnosis): hold yaw + zoom fixed and step the camera iso
 // position in fine sub-trixel increments across ~2 trixels, capturing one frame
 // per step. A static scene must translate SMOOTHLY across the sweep — any
@@ -303,6 +373,17 @@ void registerCliArgs() {
     args.flag("--skin-smoke", "Spawn one 2-bone rigged voxel bar skinned via binding-17 (#1605)");
     args.flag("--pan-sweep", "Fine fixed-yaw camera-pan jitter sweep (#1944)");
     args.flag("--yaw-sweep", "Fine fixed-position camera-yaw jitter sweep (#1944)");
+    args.enumValue(
+        "--pivot-verify",
+        "Rotation-pivot invariance sweep block "
+        "(off|focus-ctr|focus-off|center-column|center-depth)",
+        {"off", "focus-ctr", "focus-off", "center-column", "center-depth"},
+        "off"
+    );
+    args.flag(
+        "--pivot-verify-sdf",
+        "Render the --pivot-verify probe via the SDF solver instead of the voxel pool"
+    );
     args.number("--zoom", "Initial camera zoom (snapped to nearest power of two)", 0.0f);
     args.string("--debug-overlay", "Debug overlay mode (e.g. none, depth, normals)", "none");
     args.number("--yaw", "Initial camera Z-yaw in radians", 0.0f);
@@ -347,6 +428,8 @@ void readCliArgs() {
     g_skinSmoke = args.getFlag("--skin-smoke");
     g_panSweep = args.getFlag("--pan-sweep");
     g_yawSweep = args.getFlag("--yaw-sweep");
+    g_pivotVerifyBlock = args.getEnum("--pivot-verify");
+    g_pivotVerifySdf = args.getFlag("--pivot-verify-sdf");
 
     if (args.wasProvided("--zoom")) {
         const float zoom = args.getFloat("--zoom");
@@ -737,6 +820,71 @@ void initSystems() {
                 kPivotPillarCenter.x,
                 kPivotPillarCenter.y,
                 kPivotPillarCenter.z,
+                sweepZoom
+            );
+        } else if (g_pivotVerifyBlock != "off") {
+            // Pivot-invariance sweep (see the block comment on
+            // g_pivotVerifyBlock). One probe, fixed pan, yaw stepped through
+            // cardinals AND non-cardinals — both the cardinal gather and the
+            // per-axis residual path must hold the pin.
+            const float sweepZoom = g_initialZoom > 0.0f ? g_initialZoom : 4.0f;
+            const bool explicitFocus =
+                g_pivotVerifyBlock == "focus-ctr" || g_pivotVerifyBlock == "focus-off";
+            vec2 pan;
+            if (explicitFocus) {
+                pan = -IRMath::pos3DtoPos2DIso(kPivotPillarCenter);
+                if (g_pivotVerifyBlock == "focus-off") {
+                    pan += kPivotVerifyOffCenterIso;
+                }
+            } else {
+                pan = pivotVerifyDefaultPan();
+            }
+            const float yaws[] = {
+                0.0f,
+                IRMath::kPi / 6.0f,
+                IRMath::kQuarterPi,
+                IRMath::kHalfPi,
+                2.0f * IRMath::kPi / 3.0f,
+                IRMath::kPi,
+                IRMath::kPi + IRMath::kQuarterPi,
+                3.0f * IRMath::kHalfPi,
+                IRMath::kTwoPi - IRMath::kQuarterPi
+            };
+            constexpr int n = sizeof(yaws) / sizeof(yaws[0]);
+            g_pivotVerifyShotLabels.reserve(n);
+            g_pivotVerifyShots.reserve(n);
+            for (int i = 0; i < n; ++i) {
+                auto &label = g_pivotVerifyShotLabels.emplace_back();
+                std::snprintf(
+                    label.data(),
+                    label.size(),
+                    "pv_%s_yaw_%03d",
+                    g_pivotVerifyBlock.c_str(),
+                    i
+                );
+                IRVideo::AutoScreenshotShot shot{};
+                shot.zoom_ = sweepZoom;
+                shot.cameraIso_ = pan;
+                shot.yawRadians_ = yaws[i];
+                shot.label_ = label.data();
+                if (explicitFocus) {
+                    shot.pivotFocusWorld_ = kPivotPillarCenter;
+                    shot.hasPivotFocus_ = true;
+                }
+                g_pivotVerifyShots.push_back(shot);
+            }
+            cfg.shots_ = g_pivotVerifyShots.data();
+            cfg.numShots_ = static_cast<int>(g_pivotVerifyShots.size());
+            const vec3 probeCenter = pivotVerifyProbeCenter();
+            IR_LOG_INFO(
+                "Pivot-verify block '{}': {} yaw shots, pan ({},{}), probe ({},{},{}) at zoom={}",
+                g_pivotVerifyBlock,
+                cfg.numShots_,
+                pan.x,
+                pan.y,
+                probeCenter.x,
+                probeCenter.y,
+                probeCenter.z,
                 sweepZoom
             );
         } else if (g_panSweep) {
@@ -1174,6 +1322,41 @@ void initPivotFocusScene() {
     }
 }
 
+// Minimal scene for --pivot-verify: ONE bright vertical voxel cylinder centered
+// on the active block's probe point, nothing else. The scorer uses a
+// whole-frame THRESHOLD mask (any lit pixel), which is immune to the
+// shading-orientation bias that contaminates a color-locked mask: sun/AO
+// shading rotates with camera yaw, so a mask that keys on the lit base color
+// tracks the lit faces and fabricates an orbit-like centroid swing on
+// perfectly pinned geometry.
+void initPivotVerifyScene() {
+    const vec3 center = pivotVerifyProbeCenter();
+    if (g_pivotVerifySdf) {
+        createSDFShape(
+            center,
+            IRRender::ShapeType::CYLINDER,
+            vec4(4, 4, 17, 0),
+            Color{235, 235, 235, 255}
+        );
+    } else {
+        createVoxelPoolShape(
+            center,
+            IRRender::ShapeType::CYLINDER,
+            vec4(4, 4, 17, 0),
+            Color{235, 235, 235, 255},
+            ivec3(5, 5, 8)
+        );
+    }
+    IR_LOG_INFO(
+        "Pivot-verify scene: block '{}' probe {} cylinder at ({},{},{})",
+        g_pivotVerifyBlock,
+        g_pivotVerifySdf ? "SDF" : "voxel",
+        center.x,
+        center.y,
+        center.z
+    );
+}
+
 // Map a --spin-shape token to its ShapeType. Tokens match the lower-cased
 // fixture shapes below; returns false (leaving `out` untouched) on an unknown
 // name so the caller can diagnose it.
@@ -1225,6 +1408,11 @@ void setupCanvasLighting() {
 }
 
 void initEntities() {
+    if (g_pivotVerifyBlock != "off") {
+        IR_LOG_INFO("--- Pivot-verify probe scene ({}) ---", g_pivotVerifyBlock);
+        initPivotVerifyScene();
+        return;
+    }
     if (g_pivotFocusDemo) {
         IR_LOG_INFO("--- Camera pivot-focus demo scene (#1921) ---");
         initPivotFocusScene();

--- a/docs/design/camera-yaw-pivot.md
+++ b/docs/design/camera-yaw-pivot.md
@@ -84,6 +84,36 @@ out off-center** (not a pivot bug) — pin a focus (cursor mode, or a
 content-centroid focus) to rotate it in place. (Before this fix the default pivot
 itself swung a panned scene; that path is now correct.)
 
+## Known deviations (2026-07, epic #2544)
+
+The `scripts/pivot-verify.py` harness (isolated cylinder probe +
+`jitter_probe --stationary`; no reference images) measures three defects in
+the contract above on master — all invisible at cardinal yaw 0, so the
+"Empirically verified" section below remains true for what it measured while
+the pivot is still wrong under rotation:
+
+1. **Half-cell rotation-anchor mismatch (#2545).** The voxel raster rotates
+   content about `position + (0.5,0.5,0.5)` while the SDF path and the CPU
+   pivot/picking math rotate about the exact `position`. The offset rides the
+   iso depth axis (projects to zero at yaw 0); under yaw the voxel layer
+   orbits any pinned focus ~1 iso px and the voxel/SDF layers counter-rotate
+   apart.
+2. **Default focus pins the wrong depth (#2547).** The pinned set of the
+   drift-cancel offset is the vertical column `{W : W.xy == F.xy}`, and the
+   default `F` is the **iso-depth-0** point under the viewport center (this
+   doc's "z = 0 world point" wording is inaccurate — `isoPixelToPos3D`'s
+   third argument is iso depth `x+y+z`, not z). Content at screen center at
+   another depth sits on the center iso ray, off the pinned column by (t, t)
+   in xy, and orbits — 336 px measured at z=10, zoom 4.
+3. **Per-axis registration offset (#2546).** With (1) compensated, every
+   residual-yaw frame renders the voxel scene a constant ≈1 iso px off the
+   cardinal frames — the non-integer effective offset is rounded under a
+   different convention on the per-axis route than the cardinal gather.
+
+Fix chain and acceptance gates: epic #2544 (P1 #2545 → P2 #2546 → P3 #2547 →
+P4 #2548, cursor-pivot true-depth latch + indicator). Each child flips its
+pivot-verify block(s) to PINNED; this section shrinks as they land.
+
 ## History
 
 - #1352 / #1362 — first focus-pivot (panned-and-rotated correctness).

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -467,6 +467,19 @@ Three checks, in order:
 frames stay byte-identical (`img_diff`) *and* that motion is jitter-free
 (`jitter_probe`) — a change can pass one and fail the other.
 
+**Rotation-pivot invariance is a THIRD independent property** — a sweep can be
+SMOOTH and byte-identical at yaw 0 while the pivot pins the wrong point (a
+(0.5,0.5,0.5) anchor offset rides the iso depth axis: zero projection at
+cardinal 0, a visible orbit under yaw). Any change to `getEffectiveCameraIso`,
+`cameraYawPivotOffset`, the kernels' yawed reposition, or the per-axis anchor
+must also run `python3 scripts/pivot-verify.py` — it drives
+`IRShapeDebug --pivot-verify <block>` (isolated cylinder probe, explicit-focus
++ default-pivot blocks, voxel + SDF twins) and gates with
+`jitter_probe --stationary`. No reference images; the assertion is pure
+temporal invariance. Contract + known deviations:
+[`docs/design/camera-yaw-pivot.md`](../../docs/design/camera-yaw-pivot.md)
+(epic #2544).
+
 For changes that touch only one graphics backend (GLSL without MSL
 counterpart, or vice versa), follow up with the **`backend-parity`**
 skill on the lagging-side host — the rule is in [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md)

--- a/scripts/pivot-verify.py
+++ b/scripts/pivot-verify.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Rotation-pivot invariance harness (pivot-verify).
+
+Machine-checkable form of the camera Z-yaw pivot contract
+(``docs/design/camera-yaw-pivot.md``): a probe whose center the pivot pins
+must hold its frame-0 screen position across a full-circle yaw sweep. There
+are NO committed reference images — the assertion is pure temporal
+invariance, scored by ``tools/jitter_probe --stationary`` over the sweep
+captured by ``IRShapeDebug --pivot-verify <block>``.
+
+Blocks (see ``g_pivotVerifyBlock`` in ``creations/demos/shape_debug/main.cpp``):
+
+- ``focus-ctr`` / ``focus-off`` — explicit ``setRotationPivotFocus`` on the
+  probe center, probe at / off screen center.
+- ``center-column`` — default CAMERA_CENTER pivot, probe on the pinned
+  vertical column (the implemented contract).
+- ``center-depth`` — default pivot, probe AT the viewport center at z > 0
+  (the user-facing contract: what you are looking at stays put).
+
+``focus-ctr`` additionally runs an SDF-probe twin (``--pivot-verify-sdf``)
+so the voxel-pool and SDF render paths' pivot conventions are compared A/B.
+
+The harness asserts the CONTRACT, so it runs red while known pivot defects
+are open — each fix flips its block(s) to PINNED. The live defect list +
+fix chain is ``docs/design/camera-yaw-pivot.md`` §"Known deviations"
+(epic #2544).
+
+Exit: 0 = all requested passes PINNED; 1 = any DRIFT; 2 = harness error.
+
+Assumes this file lives at ``<repo>/scripts/pivot-verify.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import verify_common
+
+ALL_BLOCKS = ["focus-ctr", "focus-off", "center-column", "center-depth"]
+SDF_BLOCKS = ["focus-ctr"]
+
+
+def _jitter_probe_exe(build_dir: Path) -> Path:
+    for name in ("jitter_probe", "jitter_probe.exe"):
+        candidate = build_dir / "tools" / "jitter_probe" / name
+        if candidate.is_file():
+            return candidate
+    raise SystemExit(f"jitter_probe not found under {build_dir}/tools/jitter_probe "
+                     f"(build it: fleet-build --target jitter_probe)")
+
+
+def _score_pass(probe_exe: Path, frames: list[Path],
+                max_deviation: float) -> tuple[str, float, float, str]:
+    cmd = [str(probe_exe), "--stationary", "--verbose",
+           "--max-deviation", str(max_deviation)]
+    cmd.extend(str(f) for f in frames)
+    rc, output = verify_common.run_capture(cmd)
+    if rc == 2:
+        raise SystemExit(f"jitter_probe errored:\n{output}")
+    verdict = "PINNED" if rc == 0 else "DRIFT"
+    dev_x = dev_y = float("nan")
+    x_match = re.search(r"x: max_deviation=([0-9.]+)px", output)
+    y_match = re.search(r"y: max_deviation=([0-9.]+)px", output)
+    if x_match:
+        dev_x = float(x_match.group(1))
+    if y_match:
+        dev_y = float(y_match.group(1))
+    return verdict, dev_x, dev_y, output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Rotation-pivot invariance harness (jitter_probe --stationary "
+                    "over IRShapeDebug --pivot-verify sweeps).")
+    parser.add_argument("--target", default="IRShapeDebug",
+                        help="CMake target / executable to drive (default IRShapeDebug).")
+    parser.add_argument("--blocks", default=",".join(ALL_BLOCKS),
+                        help=f"Comma-separated block list (default {','.join(ALL_BLOCKS)}).")
+    parser.add_argument("--skip-sdf", action="store_true",
+                        help="Skip the SDF-probe twin passes.")
+    parser.add_argument("--zoom", type=float, action="append", default=None,
+                        help="Zoom level(s) to sweep (repeatable; default 4).")
+    parser.add_argument("--warmup", type=int, default=12,
+                        help="Warmup frames per shot (--auto-screenshot value).")
+    parser.add_argument("--max-deviation", type=float, default=1.5,
+                        help="PINNED threshold in px (jitter_probe --max-deviation).")
+    parser.add_argument("--timeout", type=int, default=180,
+                        help="Per-pass fleet-run timeout in seconds.")
+    parser.add_argument("--no-build", action="store_true",
+                        help="Skip fleet-build; assume targets are already built.")
+    args = parser.parse_args(argv)
+
+    blocks = [b.strip() for b in args.blocks.split(",") if b.strip()]
+    for block in blocks:
+        if block not in ALL_BLOCKS:
+            raise SystemExit(f"unknown block '{block}' (choose from {ALL_BLOCKS})")
+    zooms = args.zoom if args.zoom else [4.0]
+
+    worktree = verify_common.detect_worktree_root(Path.cwd())
+    build_dir = worktree / "build"
+    demo_name = "shape_debug"
+    shots_dir = (build_dir / "creations" / "demos" / demo_name /
+                 "save_files" / "screenshots")
+
+    if not args.no_build:
+        verify_common.run(["fleet-build", "--target", args.target], cwd=worktree)
+        verify_common.run(["fleet-build", "--target", "jitter_probe"], cwd=worktree)
+    probe_exe = _jitter_probe_exe(build_dir)
+
+    passes: list[tuple[str, bool, float]] = []
+    for zoom in zooms:
+        for block in blocks:
+            passes.append((block, False, zoom))
+            if not args.skip_sdf and block in SDF_BLOCKS:
+                passes.append((block, True, zoom))
+
+    results: list[tuple[str, str, float, float, int]] = []
+    for block, sdf, zoom in passes:
+        label = f"{block}{'-sdf' if sdf else ''}@z{zoom:g}"
+        cmd = ["fleet-run", "--timeout", str(args.timeout), args.target,
+               "--auto-screenshot", str(args.warmup),
+               "--pivot-verify", block, "--zoom", f"{zoom:g}"]
+        if sdf:
+            cmd.append("--pivot-verify-sdf")
+        rc, _output, frames = verify_common.run_pass(cmd, cwd=worktree,
+                                                     shots_dir=shots_dir,
+                                                     timeout=args.timeout + 60)
+        frames = [f for f in frames if "_crop_" not in f.name]
+        if rc != 0:
+            print(f"[pivot-verify] ({label}) fleet-run exited {rc}", file=sys.stderr)
+            results.append((label, "CRASH", float("nan"), float("nan"), len(frames)))
+            continue
+        if len(frames) < 3:
+            print(f"[pivot-verify] ({label}) only {len(frames)} frames captured",
+                  file=sys.stderr)
+            results.append((label, "NO-FRAMES", float("nan"), float("nan"),
+                            len(frames)))
+            continue
+        verdict, dev_x, dev_y, _ = _score_pass(probe_exe, frames,
+                                               args.max_deviation)
+        results.append((label, verdict, dev_x, dev_y, len(frames)))
+
+    print()
+    print(f"{'pass':<28} {'verdict':<10} {'dev_x(px)':>10} {'dev_y(px)':>10} "
+          f"{'frames':>7}")
+    failed = 0
+    for label, verdict, dev_x, dev_y, nframes in results:
+        print(f"{label:<28} {verdict:<10} {dev_x:>10.2f} {dev_y:>10.2f} "
+              f"{nframes:>7}")
+        if verdict != "PINNED":
+            failed += 1
+    print()
+    if failed:
+        print(f"pivot-verify: {failed}/{len(results)} passes FAILED "
+              f"(threshold {args.max_deviation}px)")
+        return 1
+    print(f"pivot-verify: all {len(results)} passes PINNED "
+          f"(threshold {args.max_deviation}px)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pivot-verify.py
+++ b/scripts/pivot-verify.py
@@ -43,15 +43,6 @@ ALL_BLOCKS = ["focus-ctr", "focus-off", "center-column", "center-depth"]
 SDF_BLOCKS = ["focus-ctr"]
 
 
-def _jitter_probe_exe(build_dir: Path) -> Path:
-    for name in ("jitter_probe", "jitter_probe.exe"):
-        candidate = build_dir / "tools" / "jitter_probe" / name
-        if candidate.is_file():
-            return candidate
-    raise SystemExit(f"jitter_probe not found under {build_dir}/tools/jitter_probe "
-                     f"(build it: fleet-build --target jitter_probe)")
-
-
 def _score_pass(probe_exe: Path, frames: list[Path],
                 max_deviation: float) -> tuple[str, float, float, str]:
     cmd = [str(probe_exe), "--stationary", "--verbose",
@@ -108,7 +99,7 @@ def main(argv: list[str] | None = None) -> int:
     if not args.no_build:
         verify_common.run(["fleet-build", "--target", args.target], cwd=worktree)
         verify_common.run(["fleet-build", "--target", "jitter_probe"], cwd=worktree)
-    probe_exe = _jitter_probe_exe(build_dir)
+    probe_exe = verify_common.find_exe(build_dir, "jitter_probe", "jitter_probe")
 
     passes: list[tuple[str, bool, float]] = []
     for zoom in zooms:

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -24,11 +24,28 @@ jitter_probe <frame_0.png> <frame_1.png> ... <frame_N.png>   # >=3, in capture o
     [--color R,G,B,T]    instead, foreground = pixels within T of color R,G,B
     [--reversal-eps PX]  per-frame deltas under this count as 0 (default 0.10)
     [--max-residual PX]  SMOOTH verdict requires residual <= this (default 1.50)
+    [--stationary]       assert the centroid does NOT move (pivot-pin check)
+    [--max-deviation PX] PINNED verdict requires deviation <= this (default 1.50)
     [--verbose]          print the per-frame centroid + residual table
 ```
 
-Exit code: `0` = SMOOTH, `1` = JITTER detected, `2` = argument / IO error (same
-convention as `img_diff`, so it drops into the same verification scripts).
+Exit code: `0` = SMOOTH/PINNED, `1` = JITTER/DRIFT detected, `2` = argument / IO
+error (same convention as `img_diff`, so it drops into the same verification
+scripts).
+
+## `--stationary` — the rotation-pivot pin check
+
+The default verdict asserts smooth LINEAR motion; `--stationary` asserts NO
+motion: verdict `PINNED` iff every frame's centroid stays within
+`--max-deviation` px of frame 0 on both axes, else `DRIFT`. This is the
+rotation-pivot contract (a probe centered on the pivot must hold its screen
+position through a yaw sweep), and the line-fit cannot express it — a slow
+orbital arc fits a line well enough to pass SMOOTH while being exactly the
+pivot-drift bug. Use a Z-yaw-invariant probe (vertical cylinder) and a
+THRESHOLD mask, not `--color`: directional shading rotates with camera yaw, so
+a color-locked mask tracks the lit faces and fabricates an orbit on pinned
+geometry. Driven end-to-end by `scripts/pivot-verify.py` over the
+`IRShapeDebug --pivot-verify <block>` sweeps.
 
 ## Capturing a clean sweep
 

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -223,9 +223,7 @@ int main(int argc, char **argv) {
     parser.string("--color", "Foreground = pixels within T of color R,G,B (format: R,G,B,T)", "");
     parser.number("--reversal-eps", "Per-frame deltas under this (px) are treated as 0", 0.10f);
     parser.number("--max-residual", "SMOOTH verdict requires residual <= this (px)", 1.50f);
-    parser.flag(
-        "--stationary", "Assert the centroid does NOT move (rotation-pivot pin check)"
-    );
+    parser.flag("--stationary", "Assert the centroid does NOT move (rotation-pivot pin check)");
     parser.number("--max-deviation", "PINNED verdict requires deviation <= this (px)", 1.50f);
     parser.flag("--verbose", "Print the per-frame centroid + residual table");
     parser.variadic("frames", "Frame PNGs in capture order (>= 3)", 3);
@@ -287,7 +285,12 @@ int main(int argc, char **argv) {
                     continue;
                 }
                 std::printf(
-                    "%5zu    %9.2f  %+7.2f    %9.2f  %+7.2f\n", i, cx[i], dx[i], cy[i], dy[i]
+                    "%5zu    %9.2f  %+7.2f    %9.2f  %+7.2f\n",
+                    i,
+                    cx[i],
+                    dx[i],
+                    cy[i],
+                    dy[i]
                 );
             }
         }

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -16,6 +16,8 @@
 //     [--color R,G,B,T]    instead, foreground = pixels within T of color R,G,B
 //     [--reversal-eps PX]  per-frame deltas under this are treated as 0 (default 0.10)
 //     [--max-residual PX]  SMOOTH verdict requires residual <= this (default 1.50)
+//     [--stationary]       assert the centroid does NOT move (pivot-pin check)
+//     [--max-deviation PX] PINNED verdict requires deviation <= this (default 1.50)
 //     [--verbose]          print the per-frame centroid + residual table
 //
 // Capture the sequence with an ISOLATED shape on a black field so the centroid
@@ -23,8 +25,20 @@
 // (pan jitter) or `--yaw-sweep` (rotation jitter). For a multi-shape scene pass
 // --color to lock onto one shape. Frames MUST be given in capture order.
 //
-// Exit: 0 = SMOOTH, 1 = JITTER detected, 2 = argument / IO error. (Mirrors
-// img_diff's 0/1/2 convention so it slots into the same verification scripts.)
+// --stationary answers a different question than the default line-fit: the
+// default asserts SMOOTH LINEAR motion (a sweep translates the shape without
+// oscillation), while --stationary asserts NO motion at all — the shape's
+// centroid holds its frame-0 position across the whole sequence. That is the
+// rotation-pivot contract (a probe centered on the pivot must not move during a
+// yaw sweep), and the line-fit cannot express it: a slow orbital arc fits a
+// line well enough to pass SMOOTH while being exactly the pivot-drift bug.
+// Verdict: PINNED iff max |centroid_i - centroid_0| <= --max-deviation on both
+// axes. Use a Z-yaw-invariant probe (vertical cylinder) so silhouette change
+// doesn't contaminate the centroid.
+//
+// Exit: 0 = SMOOTH/PINNED, 1 = JITTER/DRIFT detected, 2 = argument / IO error.
+// (Mirrors img_diff's 0/1/2 convention so it slots into the same verification
+// scripts.)
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
@@ -47,6 +61,8 @@ struct Args {
     int colorR_ = 0, colorG_ = 0, colorB_ = 0, colorTol_ = 0;
     double reversalEps_ = 0.10;
     double maxResidual_ = 1.50;
+    bool stationary_ = false;
+    double maxDeviation_ = 1.50;
     bool verbose_ = false;
 };
 
@@ -130,6 +146,29 @@ struct AxisStats {
     double deltaMaxAbs_ = 0.0;
 };
 
+// Max deviation of each valid sample from the FIRST valid sample — the
+// --stationary metric. The reference is frame 0 (not the mean) so a monotone
+// drift accumulates against it instead of averaging itself half away.
+double maxDeviationFromFirst(
+    const std::vector<double> &v, const std::vector<bool> &valid, std::vector<double> &deviation
+) {
+    double ref = 0.0;
+    bool haveRef = false;
+    double maxDev = 0.0;
+    deviation.assign(v.size(), 0.0);
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (!valid[i])
+            continue;
+        if (!haveRef) {
+            ref = v[i];
+            haveRef = true;
+        }
+        deviation[i] = v[i] - ref;
+        maxDev = std::max(maxDev, std::fabs(deviation[i]));
+    }
+    return maxDev;
+}
+
 AxisStats analyze(
     const std::vector<double> &v,
     const std::vector<bool> &valid,
@@ -184,6 +223,10 @@ int main(int argc, char **argv) {
     parser.string("--color", "Foreground = pixels within T of color R,G,B (format: R,G,B,T)", "");
     parser.number("--reversal-eps", "Per-frame deltas under this (px) are treated as 0", 0.10f);
     parser.number("--max-residual", "SMOOTH verdict requires residual <= this (px)", 1.50f);
+    parser.flag(
+        "--stationary", "Assert the centroid does NOT move (rotation-pivot pin check)"
+    );
+    parser.number("--max-deviation", "PINNED verdict requires deviation <= this (px)", 1.50f);
     parser.flag("--verbose", "Print the per-frame centroid + residual table");
     parser.variadic("frames", "Frame PNGs in capture order (>= 3)", 3);
     parser.parse(argc, argv);
@@ -192,6 +235,8 @@ int main(int argc, char **argv) {
     args.threshold_ = parser.getInt("--threshold");
     args.reversalEps_ = parser.getFloat("--reversal-eps");
     args.maxResidual_ = parser.getFloat("--max-residual");
+    args.stationary_ = parser.getFlag("--stationary");
+    args.maxDeviation_ = parser.getFloat("--max-deviation");
     args.verbose_ = parser.getFlag("--verbose");
     args.frames_ = parser.positionalArgs();
     if (parser.wasProvided("--color")) {
@@ -228,6 +273,38 @@ int main(int argc, char **argv) {
     if (validCount < 3) {
         std::fprintf(stderr, "jitter_probe: < 3 frames had a usable foreground\n");
         return 2;
+    }
+
+    if (args.stationary_) {
+        std::vector<double> dx, dy;
+        const double devX = maxDeviationFromFirst(cx, valid, dx);
+        const double devY = maxDeviationFromFirst(cy, valid, dy);
+        if (args.verbose_) {
+            std::printf("frame    centroid_x  dev_x      centroid_y  dev_y\n");
+            for (size_t i = 0; i < n; ++i) {
+                if (!valid[i]) {
+                    std::printf("%5zu    (empty)\n", i);
+                    continue;
+                }
+                std::printf(
+                    "%5zu    %9.2f  %+7.2f    %9.2f  %+7.2f\n", i, cx[i], dx[i], cy[i], dy[i]
+                );
+            }
+        }
+        const bool pinned = devX <= args.maxDeviation_ && devY <= args.maxDeviation_;
+        std::printf(
+            "jitter_probe: frames=%zu (valid=%d)  verdict=%s\n"
+            "  x: max_deviation=%.2fpx\n"
+            "  y: max_deviation=%.2fpx\n"
+            "  (threshold: max_deviation<=%.2fpx vs frame 0)\n",
+            n,
+            validCount,
+            pinned ? "PINNED" : "DRIFT",
+            devX,
+            devY,
+            args.maxDeviation_
+        );
+        return pinned ? 0 : 1;
     }
 
     std::vector<double> rx, ry;


### PR DESCRIPTION
## Summary

- Deterministic rotation-pivot invariance harness — the machine check the camera Z-yaw pivot contract (`docs/design/camera-yaw-pivot.md`) never had. A sweep can pass the existing SMOOTH gate and cardinal byte-identity while pinning the wrong point: a slow orbit fits the jitter line-fit, and a `(0.5,0.5,0.5)` anchor offset rides the iso depth axis (zero projection at yaw 0).
- `tools/jitter_probe`: new `--stationary` / `--max-deviation` mode — verdict `PINNED`/`DRIFT` on max centroid deviation vs frame 0.
- `IRShapeDebug --pivot-verify <block>` (+ `--pivot-verify-sdf`): one isolated vertical voxel/SDF cylinder probe per run (Z-yaw-invariant silhouette; whole-frame threshold mask — a color-locked mask tracks yaw-rotating lit faces and fabricates an orbit on pinned geometry), swept through cardinal + non-cardinal yaws at fixed pan. Blocks discriminate explicit-focus vs default pivot, and pinned-column vs at-depth-screen-center placement.
- `scripts/pivot-verify.py`: build → run → score wrapper (verify_common family); pass/fail table; **no committed reference images** — the assertion is pure temporal invariance.
- Docs: `engine/render/CLAUDE.md` gains the pivot-invariance third-property note; `docs/design/camera-yaw-pivot.md` gains §Known deviations; `tools/jitter_probe/README.md` documents the new mode.

## Baseline this harness measures on master (macos-debug, zoom 4, 1.5px threshold)

| pass | verdict | dev_x(px) | dev_y(px) |
|---|---|---|---|
| focus-ctr (voxel) | DRIFT | 29.13 | 16.00 |
| focus-ctr-sdf | DRIFT | 2.00 | 2.00 |
| focus-off (voxel) | DRIFT | 29.13 | 16.00 |
| center-column (voxel) | DRIFT | 29.13 | 16.00 |
| center-depth (voxel) | DRIFT | 336.00 | 336.00 |

Red is the point: the harness asserts the contract, and the three defects it isolates are filed as epic #2544 (P1 #2545 half-cell anchor → P2 #2546 per-axis registration → P3 #2547 depth-aware default focus → P4 #2548 cursor-pivot latch + indicator). Each child's fix flips its block(s) to PINNED; `pivot-verify.py` exits non-zero until then, so it is a diagnosis/gate tool, not a CI-green suite yet.

## Visual-change note (why no screenshot pair)

The demo diff is harness-only and flag-gated: with `--pivot-verify` absent the scene selection, shot tables, and defaults are untouched, so every existing capture is byte-identical (verified: default-suite references unaffected; the probe scene only spawns under the new flag). Nothing visual changed on any default path.

## Test plan

- [x] `fleet-build --target IRShapeDebug jitter_probe` green (macos-debug)
- [x] `python3 scripts/pivot-verify.py` runs all five passes, RESULT=CLEAN each, produces the baseline table above (expected exit 1 while #2544 is open)
- [x] `jitter_probe --stationary` PINNED/DRIFT verdicts verified against hand-checked centroid tables (cardinal-orbit and 336px cases)
- [x] `ruff check scripts/` green; `format-changed` applied
- [ ] Linux/GL twin run of the baseline (cross-host smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
