### PR TITLE
audio: MIDI client init failure degrades to no-MIDI instead of aborting (#2549)

### DIFF
--- a/.fleet/plans/issue-2549.md
+++ b/.fleet/plans/issue-2549.md
@@ -1,0 +1,66 @@
+## Plan: MIDI client init failure degrades to no-MIDI
+
+- **Issue:** #2549
+- **Model:** sonnet
+- **Date:** 2026-07-24
+
+### Verified current state (confirmed repro)
+
+`MidiIn::MidiIn()` (`engine/audio/src/midi_in.cpp:15-27`) and `MidiOut::MidiOut()`
+(`engine/audio/src/midi_out.cpp:5-17`) each hold a **by-value** RtMidi
+enumeration probe (`RtMidiIn m_rtMidiIn` at `midi_in.hpp:80`, `RtMidiOut
+m_rtMidiOut` at `midi_out.hpp:46`, both commented "enumeration probe only").
+`AudioManager` holds `MidiIn`/`MidiOut` by value (`audio_manager.hpp:57-60`),
+constructed with `World`. When the CoreMIDI client can't be created (repro: a
+sandboxed shell denying the `com.apple.midiserver` Mach lookup —
+`IRShapeDebug` aborts with `MidiInCore::initialize: error creating OS-X MIDI
+client object (-304)` → uncaught `RtMidiError` → SIGABRT, RESULT=CRASH), the
+throw escapes the member initializer list before any catch could run. The
+per-port handles are already `unique_ptr` (`MidiInPort::rtMidiIn_`,
+`MidiOutPort::rtMidiOut_`), constructed in `openPort` (`midi_in.cpp:75-80`,
+`midi_out.cpp` equivalent) — those construction/open calls can throw the
+same way on a degraded host. `AudioPlayback` already implements the module's
+"no device = silent, never a crash" doctrine (engine/audio/CLAUDE.md); MIDI
+is the gap.
+
+### Affected files
+
+- `engine/audio/include/irreden/audio/midi_in.hpp` — `m_rtMidiIn` becomes
+  `std::unique_ptr<RtMidiIn>`.
+- `engine/audio/src/midi_in.cpp` — ctor try/catch around probe construction
+  + enumeration (degraded ⇒ `m_numberPorts = 0`, one `IRE_LOG_WARN` naming
+  `RtMidiError::getMessage()`); `openPort(substring)` wraps the
+  `make_unique<RtMidiIn>()` + `openPort(i)` + `setCallback` triple in
+  try/catch (warn + return -1).
+- `engine/audio/include/irreden/audio/midi_out.hpp` /
+  `src/midi_out.cpp` — same treatment for `m_rtMidiOut` and
+  `MidiOut::openPort`; `sendAllNotesOff`/`sendMessage` already no-op on
+  empty `m_ports`.
+- Check `patches/` for local RtMidi patches before assuming stock throw
+  behavior (engine/audio/CLAUDE.md gotcha).
+
+### Approach
+
+Mirror the AudioPlayback failed-init pattern: construct the enumeration
+probes inside try/catch in the ctor body (member becomes a null
+`unique_ptr` on failure), keep `m_numberPorts`/`m_portNames` empty in the
+degraded state, and guard every `m_rtMidi*` dereference (`getPortCount`,
+`getPortName`) on the pointer. All query/tick paths already tolerate zero
+ports (`m_ports` empty ⇒ loops no-op), so no consumer changes. No behavior
+change on healthy hosts: same enumeration, same logs, same port handles.
+
+### Acceptance criteria
+
+As on the issue: (1) no throw escapes construction — degraded state is 0
+ports / warn-once / no-op sends; (2) an engine demo reaches RESULT=CLEAN in
+a MIDI-denied environment (repro above); (3) healthy-host behavior
+unchanged (ports enumerate + open, MIDI demos work); (4) one WARN log names
+the RtMidi error.
+
+### Verification
+
+`fleet-build --target IRShapeDebug`; run `IRShapeDebug --auto-screenshot 10`
+in a sandboxed (MIDI-denied) shell → RESULT=CLEAN; run once normally and
+confirm the MIDI enumeration log lines still appear; build + run one
+MIDI-using demo (e.g. the MIDI macro creation) on a healthy host for the
+no-regression check.

--- a/engine/audio/CLAUDE.md
+++ b/engine/audio/CLAUDE.md
@@ -107,6 +107,12 @@ Lua (`scripts/audio_demo.lua`).
   fallback patterns for common devices (UMC1820, Focusrite, MPKmini2,
   OP-1). Edit `midi_in.cpp` / `midi_out.cpp` to add a new hardware match.
   Opening an already-open port is a no-op that returns the existing handle.
+- **No device = silent, never a crash** (same doctrine as `AudioPlayback`).
+  If the RtMidi client can't be created (no MIDI server access), `MidiIn`/
+  `MidiOut` degrade to a no-MIDI state instead of throwing out of the
+  constructor: 0 ports, `openPort` warns and returns -1, `tick()`/queries/
+  `sendMidiMessage` no-op. One `IRE_LOG_WARN` names the RtMidi error at
+  degrade time.
 
 ## Outbound MIDI observer (#1869)
 

--- a/engine/audio/CMakeLists.txt
+++ b/engine/audio/CMakeLists.txt
@@ -68,6 +68,19 @@ FetchContent_Declare(
 # rtmidi's uninstall target no longer clashes with rtaudio's: upstream renamed
 # RTMIDI_TARGETNAME_UNINSTALL to "rt_uninstall", and ir_rtaudio.patch renames
 # rtaudio's to "RtAudioUninstall".
+# ir_rtmidi.patch: MidiInCore/MidiOutCore::getCoreMidiClientSingleton is
+# declared `throw()`, which C++17+ treats as `noexcept` — but it calls
+# error() with a non-WARNING type, which throws RtMidiError when no error
+# callback is registered. Under C++23 that violates the noexcept contract
+# and calls std::terminate() before the exception ever reaches a caller's
+# try/catch, no matter how the client code is written. Dropping the
+# obsolete `throw()` spec lets the CoreMIDI client-init failure propagate
+# normally so MidiIn/MidiOut can degrade to no-MIDI instead of crashing.
+IrredenEngine_applyPatchOnce(
+    rtmidi
+    "fix_coremidi_singleton_noexcept_violation"
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/ir_rtmidi.patch
+)
 FetchContent_MakeAvailable(rtmidi)
 target_link_libraries(
     IrredenEngineAudio PUBLIC

--- a/engine/audio/include/irreden/audio/midi_in.hpp
+++ b/engine/audio/include/irreden/audio/midi_in.hpp
@@ -77,7 +77,10 @@ class MidiIn {
     void insertCCMessage(int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage);
 
   private:
-    RtMidiIn m_rtMidiIn; // enumeration probe only — never opened for input
+    // Enumeration probe only — never opened for input. Null when the RtMidi
+    // client failed to init (no MIDI server available); degraded state is
+    // 0 ports, every query/tick path already tolerates that.
+    std::unique_ptr<RtMidiIn> m_rtMidiIn;
     unsigned int m_numberPorts;
     std::vector<std::string> m_portNames;
     std::vector<std::unique_ptr<MidiInPort>> m_ports;
@@ -86,9 +89,7 @@ class MidiIn {
     void clearPreviousMessages();
 };
 
-void onRtMidiMessage(
-    double deltaTime, std::vector<unsigned char> *message, void *userData
-);
+void onRtMidiMessage(double deltaTime, std::vector<unsigned char> *message, void *userData);
 
 } // namespace IRAudio
 

--- a/engine/audio/include/irreden/audio/midi_out.hpp
+++ b/engine/audio/include/irreden/audio/midi_out.hpp
@@ -43,7 +43,10 @@ class MidiOut {
     void sendAllNotesOff();
 
   private:
-    RtMidiOut m_rtMidiOut; // enumeration probe only — never opened for output
+    // Enumeration probe only — never opened for output. Null when the RtMidi
+    // client failed to init (no MIDI server available); degraded state is
+    // 0 ports, every query/tick path already tolerates that.
+    std::unique_ptr<RtMidiOut> m_rtMidiOut;
     unsigned int m_numberPorts;
     std::vector<std::string> m_portNames;
     std::vector<std::unique_ptr<MidiOutPort>> m_ports;

--- a/engine/audio/patches/ir_rtmidi.patch
+++ b/engine/audio/patches/ir_rtmidi.patch
@@ -1,0 +1,40 @@
+diff --git a/RtMidi.cpp b/RtMidi.cpp
+index 2303bb1..1bd317e 100644
+--- a/RtMidi.cpp
++++ b/RtMidi.cpp
+@@ -111,7 +111,7 @@ class MidiInCore: public MidiInApi
+   std::string getPortName( unsigned int portNumber );
+ 
+  protected:
+-  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName) throw();
++  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName);
+   void initialize( const std::string& clientName );
+ };
+ 
+@@ -131,7 +131,7 @@ class MidiOutCore: public MidiOutApi
+   void sendMessage( const unsigned char *message, size_t size );
+ 
+  protected:
+-  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName) throw();
++  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName);
+   void initialize( const std::string& clientName );
+ };
+ 
+@@ -1159,7 +1159,7 @@ MidiInCore :: ~MidiInCore( void )
+   delete data;
+ }
+ 
+-MIDIClientRef MidiInCore::getCoreMidiClientSingleton(const std::string& clientName) throw() {
++MIDIClientRef MidiInCore::getCoreMidiClientSingleton(const std::string& clientName) {
+ 
+   if (CoreMidiClientSingleton == 0){
+       // Set up our client.
+@@ -1496,7 +1496,7 @@ MidiOutCore :: ~MidiOutCore( void )
+   delete data;
+ }
+ 
+-MIDIClientRef MidiOutCore::getCoreMidiClientSingleton(const std::string& clientName) throw() {
++MIDIClientRef MidiOutCore::getCoreMidiClientSingleton(const std::string& clientName) {
+ 
+   if (CoreMidiClientSingleton == 0){
+       // Set up our client.

--- a/engine/audio/src/midi_in.cpp
+++ b/engine/audio/src/midi_in.cpp
@@ -14,16 +14,28 @@ namespace IRAudio {
 
 MidiIn::MidiIn()
     : m_rtMidiIn{}
-    , m_numberPorts(m_rtMidiIn.getPortCount())
+    , m_numberPorts(0)
     , m_portNames{}
     , m_ports{}
     , m_frameBuffer{} {
-    IRE_LOG_INFO("Descovered {} MIDI input sources", m_numberPorts);
-    for (int i = 0; i < m_numberPorts; i++) {
-        m_portNames.push_back(m_rtMidiIn.getPortName(i));
-        IRE_LOG_INFO("MIDI input source {}: {}", i, m_portNames[i].c_str());
+    try {
+        m_rtMidiIn = std::make_unique<RtMidiIn>();
+        m_numberPorts = m_rtMidiIn->getPortCount();
+        IRE_LOG_INFO("Descovered {} MIDI input sources", m_numberPorts);
+        for (int i = 0; i < m_numberPorts; i++) {
+            m_portNames.push_back(m_rtMidiIn->getPortName(i));
+            IRE_LOG_INFO("MIDI input source {}: {}", i, m_portNames[i].c_str());
+        }
+        IRE_LOG_INFO("Created MidiIn");
+    } catch (const RtMidiError &error) {
+        m_rtMidiIn.reset();
+        m_numberPorts = 0;
+        m_portNames.clear();
+        IRE_LOG_WARN(
+            "MidiIn: RtMidi client init failed ({}); MIDI input disabled",
+            error.getMessage()
+        );
     }
-    IRE_LOG_INFO("Created MidiIn");
 }
 
 MidiIn::~MidiIn() {}
@@ -72,15 +84,25 @@ int MidiIn::openPort(const std::string &portNameSubstring) {
                 return i;
             }
         }
-        auto port = std::make_unique<MidiInPort>();
-        port->portIndex_ = i;
-        port->name_ = m_portNames[i];
-        port->rtMidiIn_ = std::make_unique<RtMidiIn>();
-        port->rtMidiIn_->openPort(i);
-        port->rtMidiIn_->setCallback(onRtMidiMessage, &port->queue_);
-        m_ports.push_back(std::move(port));
-        IRE_LOG_INFO("Opened MIDI In port {}: {}", i, portName);
-        return i;
+        try {
+            auto port = std::make_unique<MidiInPort>();
+            port->portIndex_ = i;
+            port->name_ = m_portNames[i];
+            port->rtMidiIn_ = std::make_unique<RtMidiIn>();
+            port->rtMidiIn_->openPort(i);
+            port->rtMidiIn_->setCallback(onRtMidiMessage, &port->queue_);
+            m_ports.push_back(std::move(port));
+            IRE_LOG_INFO("Opened MIDI In port {}: {}", i, portName);
+            return i;
+        } catch (const RtMidiError &error) {
+            IRE_LOG_WARN(
+                "MidiIn::openPort: failed to open port {} ({}): {}",
+                i,
+                portName,
+                error.getMessage()
+            );
+            return -1;
+        }
     }
     IRE_LOG_WARN(
         "No MIDI input port matching '{}' — {} port(s) available",
@@ -148,9 +170,7 @@ void MidiIn::insertCCMessage(int portIndex, MidiChannel channel, const C_MidiMes
 
 //-----------Callback---------//
 
-void onRtMidiMessage(
-    double deltaTime, std::vector<unsigned char> *message, void *userdata
-) {
+void onRtMidiMessage(double deltaTime, std::vector<unsigned char> *message, void *userdata) {
     // Audio messages will be processed async
     // Game input messages will be added to synchronous queue
 

--- a/engine/audio/src/midi_out.cpp
+++ b/engine/audio/src/midi_out.cpp
@@ -4,16 +4,27 @@ namespace IRAudio {
 
 MidiOut::MidiOut()
     : m_rtMidiOut{}
-    , m_numberPorts(m_rtMidiOut.getPortCount())
+    , m_numberPorts(0)
     , m_portNames{}
     , m_ports{} {
-
-    IRE_LOG_INFO("Descovered {} MIDI output sources", m_numberPorts);
-    for (int i = 0; i < m_numberPorts; i++) {
-        m_portNames.push_back(m_rtMidiOut.getPortName(i));
-        IRE_LOG_INFO("MIDI Output source {}: {}", i, m_portNames[i].c_str());
+    try {
+        m_rtMidiOut = std::make_unique<RtMidiOut>();
+        m_numberPorts = m_rtMidiOut->getPortCount();
+        IRE_LOG_INFO("Descovered {} MIDI output sources", m_numberPorts);
+        for (int i = 0; i < m_numberPorts; i++) {
+            m_portNames.push_back(m_rtMidiOut->getPortName(i));
+            IRE_LOG_INFO("MIDI Output source {}: {}", i, m_portNames[i].c_str());
+        }
+        IRE_LOG_INFO("Created MidiOut");
+    } catch (const RtMidiError &error) {
+        m_rtMidiOut.reset();
+        m_numberPorts = 0;
+        m_portNames.clear();
+        IRE_LOG_WARN(
+            "MidiOut: RtMidi client init failed ({}); MIDI output disabled",
+            error.getMessage()
+        );
     }
-    IRE_LOG_INFO("Created MidiOut");
 }
 
 MidiOut::~MidiOut() {
@@ -50,14 +61,24 @@ int MidiOut::openPort(std::string portNameSubstring) {
                 return i;
             }
         }
-        auto port = std::make_unique<MidiOutPort>();
-        port->portIndex_ = i;
-        port->name_ = m_portNames[i];
-        port->rtMidiOut_ = std::make_unique<RtMidiOut>();
-        port->rtMidiOut_->openPort(i);
-        m_ports.push_back(std::move(port));
-        IRE_LOG_INFO("Opened MIDI Out port {}: {}", i, portName);
-        return i;
+        try {
+            auto port = std::make_unique<MidiOutPort>();
+            port->portIndex_ = i;
+            port->name_ = m_portNames[i];
+            port->rtMidiOut_ = std::make_unique<RtMidiOut>();
+            port->rtMidiOut_->openPort(i);
+            m_ports.push_back(std::move(port));
+            IRE_LOG_INFO("Opened MIDI Out port {}: {}", i, portName);
+            return i;
+        } catch (const RtMidiError &error) {
+            IRE_LOG_WARN(
+                "MidiOut::openPort: failed to open port {} ({}): {}",
+                i,
+                portName,
+                error.getMessage()
+            );
+            return -1;
+        }
     }
     IRE_LOG_WARN(
         "No MIDI output port matching '{}' — {} port(s) available",


### PR DESCRIPTION
## Summary
- `MidiIn`/`MidiOut` construction (and `openPort()`) now catches `RtMidiError`
  and degrades to a no-MIDI state (0 ports, warn-once, no-op sends) instead of
  letting the throw escape and abort the process — mirrors `AudioPlayback`'s
  existing "no device = silent, never a crash" doctrine.
- Patched the vendored RtMidi CoreMIDI backend (`ir_rtmidi.patch`, wired via
  the same `FetchContent` + `IrredenEngine_applyPatchOnce` mechanism as the
  existing `ir_rtaudio.patch`): `getCoreMidiClientSingleton()` was declared
  `throw()`, which C++17+ treats as `noexcept`, but it calls RtMidi's internal
  `error()` helper which throws on client-creation failure — violating the
  noexcept contract calls `std::terminate()` before any try/catch in the
  engine ever sees the exception. Dropping the stale spec was required for
  the engine-side guard above to actually work on macOS.
- Documented the degrade behavior in `engine/audio/CLAUDE.md`'s MIDI model
  section.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean.
- [x] Normal run (`IRShapeDebug --auto-screenshot 10`) — RESULT=CLEAN, MIDI
  enumeration log lines unchanged (healthy-host behavior unaffected).
- [x] Sandboxed repro (`sandbox-exec` denying the `com.apple.midiserver` Mach
  lookup) — before the fix: `SIGABRT` / `libc++abi: terminating due to
  unexpected exception of type rt::midi::RtMidiError`; after: exit 0, one
  `IRE_LOG_WARN` naming the RtMidi error for both `MidiIn` and `MidiOut`.
- [x] Verified the CMake patch mechanism end-to-end by reverting the vendored
  `RtMidi.cpp` to pristine and reconfiguring — `IrredenEngine_applyPatchOnce`
  applied `ir_rtmidi.patch` cleanly and the rebuilt `librtmidi.dylib` produced
  the same degrade-not-crash result.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| No throw escapes construction — degraded state is 0 ports / warn-once / no-op | sandboxed `IRShapeDebug --auto-screenshot 10` | `MidiIn: RtMidi client init failed (...); MIDI input disabled` / same for `MidiOut`, exit 0 |
| Demo reaches RESULT=CLEAN with no MIDI server access | `sandbox-exec -f deny-midiserver.sb ./IRShapeDebug --auto-screenshot 10` | exit=0, no `SIGABRT`/`libc++abi` termination |
| Normal MIDI hosts unaffected | `fleet-run IRShapeDebug --auto-screenshot 10` (unsandboxed) | `ir-run: RESULT=CLEAN exe=IRShapeDebug exit=0`, MIDI enumeration log lines present |
| One log line names the RtMidi error at degrade time | sandboxed run | single `IRE_LOG_WARN` per class citing `RtMidiError::getMessage()` |

## Notes for reviewer
The RtMidi `throw()`/noexcept issue is easy to miss if you only check the
engine-side try/catch shape — it looked correct in isolation but the crash
reproduced identically until the vendor patch went in. If you want to
re-verify: `sandbox-exec -f <(printf '(version 1)\n(allow default)\n(deny mach-lookup (global-name "com.apple.midiserver"))\n') ./build/creations/demos/shape_debug/IRShapeDebug --auto-screenshot 10`.

Closes #2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)
