### PR TITLE
fleet: model-class defaults become CLI tier aliases (opus -> Opus 5)

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -420,16 +420,17 @@ optional `**Effort:** low|medium|high|xhigh|max` line; when absent the
 class default applies (fable/opus → xhigh, sonnet → high).
 
 Class names are the stable queue vocabulary; the concrete model strings
-live in `scripts/fleet/fleet-up`'s class table, not here. The fable
-class resolves at boot from a probed ladder (Fable 5 [1m] → Fable 5 →
-Opus 4.8 [1m]), so when the plan stops covering Fable, `fleet:fable`
-tasks degrade to the Opus floor automatically; dispatched fable
-iterations also carry `--fallback-model` for mid-session resilience.
-The opus class is pinned to a full version (`claude-opus-4-8[1m]`) so a
-bare alias can't silently upgrade it, while the sonnet class is the bare
-`sonnet` alias on purpose — it always tracks the latest Sonnet (currently
-Sonnet 5) without a per-release edit. Pin classes with `FLEET_MODEL_FABLE`
-/ `FLEET_MODEL_OPUS` / `FLEET_MODEL_SONNET` in `~/.fleet/fleet-up.conf`.
+live in `scripts/fleet/fleet-common.sh`'s class defaults (consumed by
+`fleet-up`'s boot resolution), not here. All three classes default to
+CLI tier aliases (`fable[1m]` / `opus[1m]` / `sonnet`), which the claude
+CLI resolves to the newest model of each tier at launch — a new model
+release reaches the fleet with no edit anywhere. The fable class
+resolves at boot from a probed ladder (`fable[1m]` → `fable` →
+`opus[1m]`), so when the plan stops covering Fable, `fleet:fable` tasks
+degrade to the Opus floor automatically; dispatched fable iterations
+also carry `--fallback-model` for mid-session resilience. Freeze a
+class on a specific release by pinning `FLEET_MODEL_FABLE` /
+`FLEET_MODEL_OPUS` / `FLEET_MODEL_SONNET` in `~/.fleet/fleet-up.conf`.
 
 **fable — design-tier work.** Budget is the scarce resource;
 `FLEET_CONCURRENCY_MODEL_FABLE` (default 1) caps concurrent fable

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -78,10 +78,12 @@ LOOP_INTERVAL="${4:-}"
 # the architects babysit launches do the heavy design / render reasoning,
 # which is where xhigh earns its budget; sonnet defaults to high
 # (diminishing returns past that on its task mix).
+# Patterns match both spellings of each class: alias forms including the
+# suffixed "fable[1m]" (hence fable*, not bare fable) and full claude-* ids.
 case "$MODEL" in
-    fable|claude-fable*) _effort_default="xhigh" ;;
-    opus|claude-opus*) _effort_default="xhigh" ;;
-    sonnet|claude-sonnet*) _effort_default="high" ;;
+    fable*|claude-fable*) _effort_default="xhigh" ;;
+    opus*|claude-opus*) _effort_default="xhigh" ;;
+    sonnet*|claude-sonnet*) _effort_default="high" ;;
     *) _effort_default="high" ;;
 esac
 _role_effort_var="FLEET_EFFORT_$(printf '%s' "$ROLE" | tr 'a-z-' 'A-Z_')"
@@ -406,7 +408,7 @@ stream_claude() {
     # fleet-up's boot-time resolution.)
     local _fallback_args=()
     case "$MODEL" in
-        fable|claude-fable*)
+        fable*|claude-fable*)
             if [[ -n "${FLEET_FABLE_FALLBACK:-}" && "$FLEET_FABLE_FALLBACK" != "$MODEL" ]]; then
                 _fallback_args=(--fallback-model "$FLEET_FABLE_FALLBACK")
             fi

--- a/scripts/fleet/fleet-common.sh
+++ b/scripts/fleet/fleet-common.sh
@@ -71,6 +71,38 @@ canonicalize_path_spelling() {
     printf '%s' "$p"
 }
 
+# --- Model-class defaults (single source of truth) --------------------------
+# CLI tier ALIASES on purpose ("opus[1m]", never "claude-opus-4-8[1m]"): the
+# claude CLI resolves an alias to the NEWEST model of that tier at launch, so
+# a new Opus/Fable/Sonnet release reaches the fleet on its next iteration with
+# no edit anywhere — alias strings carry no version, so they never rot. Pin an
+# explicit ID via FLEET_MODEL_* (env or ~/.fleet/fleet-up.conf) to freeze a
+# class. "[1m]" selects the 1M-context variant and composes with aliases;
+# sonnet stays the 200K alias (the 1M beta is not covered for Sonnet on this
+# plan — see fleet-up's model notes). Consumers: fleet-up (boot resolution +
+# fable probe ladder), fleet-dispatcher (standalone defaults), solo-architect
+# (standalone fable default). Their inline `:-` backstops repeat these alias
+# strings for the common-missing case — version-free, so no sync burden.
+FLEET_FABLE_CANDIDATES_DEFAULT=("fable[1m]" "fable" "opus[1m]")
+FLEET_OPUS_CLASS_DEFAULT="opus[1m]"
+FLEET_SONNET_CLASS_DEFAULT="sonnet"
+
+# fleet_model_tag <model> — short human label for pane borders/logs, derived
+# programmatically so a new release never needs a label-map edit:
+#   claude-opus-4-8[1m] -> "opus 4.8 1m"    opus[1m] -> "opus 1m"
+#   claude-sonnet-5     -> "sonnet 5"       sonnet   -> "sonnet"
+# Unknown shapes pass through unchanged (label degrades to the raw id).
+fleet_model_tag() {
+    local t="${1#claude-}"
+    t="${t/\[1m\]/ 1m}"
+    if [[ "$t" =~ ^([a-z]+)-([0-9]+)-([0-9]+)(.*)$ ]]; then
+        t="${BASH_REMATCH[1]} ${BASH_REMATCH[2]}.${BASH_REMATCH[3]}${BASH_REMATCH[4]}"
+    elif [[ "$t" =~ ^([a-z]+)-([0-9]+)(.*)$ ]]; then
+        t="${BASH_REMATCH[1]} ${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
+    fi
+    printf '%s' "$t"
+}
+
 # --- install-symlink freshness (#2262) --------------------------------------
 # New fleet scripts / role slash-commands / ir-* tools merge to master, but a
 # host's ~/bin symlinks are only (re)created by install.sh — so a tool added

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -4,7 +4,7 @@
 #
 # Called by fleet-dispatcher via tmux send-keys. Arguments:
 #   $1  pane_key  e.g. "pane-3"
-#   $2  model     e.g. "sonnet" or "claude-fable-5[1m]"
+#   $2  model     e.g. "sonnet" or "fable[1m]" (alias or full id)
 #   $3  effort    e.g. "high" or "xhigh"
 #   $4  role      e.g. "worker"
 #   $5  fallback  optional --fallback-model chain (comma-separated) for
@@ -77,6 +77,7 @@ else
     # No-op release degrades a discarded planning assignment (#2197) to the
     # 1-hour TTL reaper — the same failure budget as the dispatcher's copy.
     fleet_planning_release_assignment() { :; }
+    fleet_model_tag() { printf '%s' "$1"; }  # raw-id label fallback
 fi
 unset _FLEET_COMMON_SH
 
@@ -112,11 +113,7 @@ unset _gh_app_token
 # "sonnet-reviewer"/"merger" labels. PANE_KEY is "pane-<N>" for tmux
 # pane id "%<N>" (see pane_id_to_key in fleet-dispatcher), so the exact
 # pane this dispatch landed in is reconstructible.
-_tag="$MODEL"
-_tag="${_tag/claude-fable-5/fable}"
-_tag="${_tag/claude-opus-4-8/opus 4.8}"
-_tag="${_tag/claude-sonnet-5/sonnet 5}"
-_tag="${_tag/\[1m\]/ 1m}"
+_tag="$(fleet_model_tag "$MODEL")"
 tmux set-option -t "%${PANE_KEY#pane-}" -p @role "$ROLE [$_tag]" 2>/dev/null || true
 unset _tag
 

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -512,16 +512,19 @@ fi
 # Model classes. Inherited from fleet-up's exported, boot-resolved
 # FLEET_MODEL_FABLE / FLEET_MODEL_OPUS / FLEET_MODEL_SONNET table (the
 # single source of truth — fleet-up probes the fable ladder there). The
-# conf knobs of the same names (captured above) and the literal defaults
+# conf knobs of the same names (captured above) and the shared defaults
 # here apply only when the dispatcher runs standalone (e.g. debugging)
-# without fleet-up in the environment; keep them in sync with fleet-up.
-# Standalone fable defaults to Fable unprobed — safe because every
-# fable-class dispatch carries --fallback-model, so a plan without Fable
-# degrades per-iteration. OPUS_MODEL / SONNET_MODEL are the pre-class
-# legacy env names, still honored as fallthroughs.
-FABLE_MODEL="${FLEET_MODEL_FABLE:-claude-fable-5[1m]}"
-OPUS_MODEL="${FLEET_MODEL_OPUS:-${OPUS_MODEL:-claude-opus-4-8[1m]}}"
-SONNET_MODEL="${FLEET_MODEL_SONNET:-${SONNET_MODEL:-sonnet}}"
+# without fleet-up in the environment. Defaults come from fleet-common.sh
+# (version-free tier aliases — the CLI resolves them to the newest model
+# of each tier, so they never need a per-release edit); the inline alias
+# backstops fire only if fleet-common.sh is missing. Standalone fable
+# defaults to Fable unprobed — safe because every fable-class dispatch
+# carries --fallback-model, so a plan without Fable degrades
+# per-iteration. OPUS_MODEL / SONNET_MODEL are the pre-class legacy env
+# names, still honored as fallthroughs.
+FABLE_MODEL="${FLEET_MODEL_FABLE:-${FLEET_FABLE_CANDIDATES_DEFAULT[0]:-fable[1m]}}"
+OPUS_MODEL="${FLEET_MODEL_OPUS:-${OPUS_MODEL:-${FLEET_OPUS_CLASS_DEFAULT:-opus[1m]}}}"
+SONNET_MODEL="${FLEET_MODEL_SONNET:-${SONNET_MODEL:-${FLEET_SONNET_CLASS_DEFAULT:-sonnet}}}"
 # Single-dash expansion is deliberate: fleet-up exports an EMPTY
 # FLEET_FABLE_FALLBACK to mean "fallback disabled" (fable resolved to the
 # opus floor), and `:-` would silently re-enable it. Don't "fix" to `:-`.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -58,10 +58,12 @@ if [[ -f "$_FLEET_COMMON_SH" ]]; then
     source "$_FLEET_COMMON_SH"
 else
     fleet_install_maybe_refresh() { :; }  # helper not installed yet — no-op
+    fleet_model_tag() { printf '%s' "$1"; }  # raw-id label fallback
 fi
 unset _FLEET_COMMON_SH
 
-# Model classes — change these when bumping the fleet to a new release.
+# Model classes. Defaults are CLI tier aliases from fleet-common.sh — a
+# new model release needs no edit here (pin via FLEET_MODEL_* to freeze).
 #
 # The queue routes work by model CLASS: fable | opus | sonnet. Tasks carry
 # a class (`fleet:fable` / `fleet:opus` / `fleet:sonnet` label, `Model:`
@@ -91,19 +93,24 @@ unset _FLEET_COMMON_SH
 # [1m] (real headroom for long architect/worker iterations); Sonnet uses
 # the standard 200K alias, which its bounded review/author iterations fit
 # fine. (If you ever want sonnet[1m], enable usage credits at
-# claude.ai/settings/usage and re-add the suffix.) fable/opus strings are
-# pinned to full versions (a bare "fable"/"opus" alias would silently
-# upgrade); sonnet stays the bare "sonnet" alias ON PURPOSE, so it always
-# tracks the latest Sonnet with no per-release edit here — currently
-# Sonnet 5 (claude-sonnet-5) on the 2.x CLI. Pin an explicit version via
-# FLEET_MODEL_SONNET only if you need to freeze it.
-FABLE_MODEL_CANDIDATES=(
-    "claude-fable-5[1m]"
-    "claude-fable-5"
-    "claude-opus-4-8[1m]"
-)
-OPUS_CLASS_DEFAULT="claude-opus-4-8[1m]"
-SONNET_CLASS_DEFAULT="sonnet"
+# claude.ai/settings/usage and re-add the suffix.)
+#
+# All three classes default to CLI tier ALIASES (fable/opus/sonnet), which
+# the claude CLI resolves to the newest model of that tier at launch — a
+# new release reaches the fleet with no edit here or anywhere. The
+# canonical defaults live in fleet-common.sh (shared with the
+# fleet-dispatcher / solo-architect standalone paths); the backstops below
+# only fire when fleet-common.sh is missing, and being version-free alias
+# strings they never need a per-release sync. Pin an explicit version via
+# FLEET_MODEL_FABLE / FLEET_MODEL_OPUS / FLEET_MODEL_SONNET (env or
+# ~/.fleet/fleet-up.conf) only when you need to freeze a class.
+if [[ -n "${FLEET_FABLE_CANDIDATES_DEFAULT+x}" ]]; then
+    FABLE_MODEL_CANDIDATES=("${FLEET_FABLE_CANDIDATES_DEFAULT[@]}")
+else
+    FABLE_MODEL_CANDIDATES=("fable[1m]" "fable" "opus[1m]")
+fi
+OPUS_CLASS_DEFAULT="${FLEET_OPUS_CLASS_DEFAULT:-opus[1m]}"
+SONNET_CLASS_DEFAULT="${FLEET_SONNET_CLASS_DEFAULT:-sonnet}"
 
 # Minimum seconds between opus-reviewer relaunches (cooldown floor).
 # fleet-babysit reads this via FLEET_MIN_BACKOFF; keep the two in sync.
@@ -410,15 +417,7 @@ export OPUS_MODEL SONNET_MODEL
 # and model, e.g. "worker [fable 1m]" (no numeric suffix — see
 # fleet-dispatch-wrap's pane re-tag). The bracket tag is what tells you
 # which model the role is actually running this session.
-model_tag() {
-    local tag="$1"
-    tag="${tag/claude-fable-5/fable}"
-    tag="${tag/claude-opus-4-8/opus 4.8}"
-    tag="${tag/claude-sonnet-5/sonnet 5}"
-    tag="${tag/\[1m\]/ 1m}"
-    printf '%s' "$tag"
-}
-FABLE_TAG="$(model_tag "$FLEET_MODEL_FABLE")"
+FABLE_TAG="$(fleet_model_tag "$FLEET_MODEL_FABLE")"
 # Pool panes launch label-less ("[idle]") — fleet-dispatch-wrap re-tags
 # each pane with the dispatched role + model per iteration, so only the
 # pinned architect panes need a boot-time model tag.

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -66,22 +66,23 @@
 # smoke, and the merger LLM pass run sonnet. See FLEET.md "Model split".
 #
 # The fable class resolves at boot from a probed ladder —
-# claude-fable-5[1m] -> claude-fable-5 -> claude-opus-4-8[1m] — one-token
-# claude call per rung (a few cents, ~5-15 s). When the plan loses Fable
-# access, re-running fleet-up lands the class on the Opus floor.
+# fable[1m] -> fable -> opus[1m] — one-token claude call per rung (a few
+# cents, ~5-15 s). When the plan loses Fable access, re-running fleet-up
+# lands the class on the Opus floor.
 #
-# The sonnet class stays the bare `sonnet` alias by default, so it always
-# tracks the latest Sonnet (currently Sonnet 5). Opus/fable are pinned to
-# full versions so a bare alias can't silently upgrade them.
+# All classes default to CLI tier ALIASES (fable/opus/sonnet — canonical
+# defaults in scripts/fleet/fleet-common.sh), which the claude CLI
+# resolves to the newest model of each tier at launch. New releases reach
+# the fleet automatically; pin a class only to freeze it.
 #
 # Pin a class verbatim (pinning fable skips the probe):
 # FLEET_MODEL_FABLE="claude-fable-5[1m]"
-# FLEET_MODEL_OPUS="claude-opus-4-8[1m]"
-# FLEET_MODEL_SONNET="claude-sonnet-5"   # freeze sonnet; omit to track latest
+# FLEET_MODEL_OPUS="claude-opus-5[1m]"
+# FLEET_MODEL_SONNET="claude-sonnet-5"
 #
 # Per-role dispatch models for the bounded fixed-model roles:
 # FLEET_MODEL_MERGER="sonnet"
-# FLEET_MODEL_OPUS_REVIEWER="claude-opus-4-8[1m]"
+# FLEET_MODEL_OPUS_REVIEWER="opus[1m]"
 #
 # FLEET_MODEL_FABLE_FALLBACK is handed to dispatched (print-mode) fable
 # iterations as `claude --fallback-model`, so a single iteration survives
@@ -89,7 +90,7 @@
 # Comma-separated chain accepted; set to "" to disable. Interactive
 # architect panes can't take the flag (print-only) — they rely on the
 # boot-time resolution above. opus/sonnet dispatches never get a fallback.
-# FLEET_MODEL_FABLE_FALLBACK="claude-opus-4-8[1m]"
+# FLEET_MODEL_FABLE_FALLBACK="opus[1m]"
 #
 # Fleet-wide cap on concurrent fable-class iterations (the budget
 # throttle; counted across all panes, 0 disables fable dispatch).

--- a/scripts/fleet/solo-architect
+++ b/scripts/fleet/solo-architect
@@ -35,19 +35,25 @@ set -euo pipefail
 
 ENGINE="${FLEET_ENGINE_ROOT:-$HOME/src/IrredenEngine}"
 GAME="$ENGINE/creations/game"
-# Architects run the fable class. Keep in sync with fleet-up's fable
-# ladder (FABLE_MODEL_CANDIDATES — the fleet's single source of truth)
-# and the fable xhigh default in fleet-babysit — a model/effort bump
-# there must be mirrored here. FLEET_MODEL_FABLE (env or
+# Architects run the fable class. The default comes from fleet-common.sh
+# (a version-free tier alias the CLI resolves to the newest Fable at
+# launch — no per-release edit needed here; the inline backstop fires
+# only if fleet-common.sh is missing). FLEET_MODEL_FABLE (env or
 # ~/.fleet/fleet-up.conf) pins the model, same knob fleet-up honors. No
 # availability probe here — this is an interactive launch, so an
 # unavailable model fails loudly on the first turn; pin
-# FLEET_MODEL_FABLE="claude-opus-4-8[1m]" once the plan loses Fable.
+# FLEET_MODEL_FABLE="opus[1m]" once the plan loses Fable.
+_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fleet-common.sh"
+if [[ -f "$_FLEET_COMMON_SH" ]]; then
+  # shellcheck source=/dev/null
+  source "$_FLEET_COMMON_SH"
+fi
+unset _FLEET_COMMON_SH
 if [[ -z "${FLEET_MODEL_FABLE:-}" && -f "$HOME/.fleet/fleet-up.conf" ]]; then
   # shellcheck disable=SC1091
   source "$HOME/.fleet/fleet-up.conf"
 fi
-MODEL="${FLEET_MODEL_FABLE:-claude-fable-5[1m]}"
+MODEL="${FLEET_MODEL_FABLE:-${FLEET_FABLE_CANDIDATES_DEFAULT[0]:-fable[1m]}}"
 # Global FLEET_EFFORT (env or conf) lowers solo sessions too; default
 # stays xhigh — heavy design work is where that budget earns its keep.
 EFFORT="${FLEET_EFFORT:-xhigh}"

--- a/scripts/fleet/tests/test_babysit_effort.sh
+++ b/scripts/fleet/tests/test_babysit_effort.sh
@@ -72,6 +72,15 @@ echo "T2: full model name hits heavy globs"
 assert_eq "$(effort_for 'claude-fable-5[1m]' opus-architect)"  "xhigh" "claude-fable-5[1m] -> xhigh"
 assert_eq "$(effort_for 'claude-opus-4-8[1m]' opus-architect)" "xhigh" "claude-opus-4-8[1m] -> xhigh"
 
+# --- Test 2b: suffixed alias forms hit the heavy globs ---------------------
+# The class defaults are tier aliases (fleet-common.sh), so the strings
+# babysit actually receives are "fable[1m]" / "opus[1m]" — a bare-word
+# `fable|` pattern would miss them and misroute effort to the sonnet tier.
+echo "T2b: alias-with-[1m] hits heavy globs"
+assert_eq "$(effort_for 'fable[1m]' opus-architect)" "xhigh" "fable[1m] -> xhigh"
+assert_eq "$(effort_for 'opus[1m]' opus-architect)"  "xhigh" "opus[1m] -> xhigh"
+assert_eq "$(effort_for 'sonnet[1m]' worker)"        "high"  "sonnet[1m] -> high"
+
 # --- Test 3: per-role override ---------------------------------------------
 echo "T3: per-role FLEET_EFFORT_<ROLE> overrides the default"
 assert_eq "$(effort_for opus opus-architect FLEET_EFFORT_OPUS_ARCHITECT=high)" \

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -14,6 +14,8 @@
 #   - planning pre-claim (#2197): plan=1 election, --plan-assign claim walk
 #     (grant / held-fallthrough / exit-3 --replan / all-held / game --repo
 #     namespacing / dry-run+review-only gating) against a stubbed fleet-claim
+#   - FLEET_MODEL_* unset -> standalone alias-default fallback resolves each
+#     class to its fleet-common.sh default (fable[1m]/opus[1m]/sonnet)
 #
 # The fable in-flight count comes from dispatch records under
 # $FLEET_STATE_DIR/dispatch, same records --count-active reads.
@@ -241,6 +243,31 @@ write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[],"semantic
 assert_eq "$(resolve worker)" \
     "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0 count=1 plan=0" \
     "conflicted PR alone elects opus with count=1"
+
+# --- T19: FLEET_MODEL_* unset -> fleet-common.sh alias-default fallback -------
+# T1-T18 pin FLEET_MODEL_FABLE/OPUS/SONNET (lines ~60-62), so the
+# ${FLEET_MODEL_*:-...} arms in fleet-dispatcher's standalone model resolution
+# always short-circuit and the alias-default fallback never runs. Unset the
+# whole table — plus the pre-class legacy OPUS_MODEL/SONNET_MODEL fallthroughs —
+# so each class resolves THROUGH the fallback to the fleet-common.sh alias
+# default (FLEET_FABLE_CANDIDATES_DEFAULT[0] / FLEET_{OPUS,SONNET}_CLASS_DEFAULT).
+# solo-architect's MODEL= line uses the byte-identical fable expansion;
+# test_solo_architect_model.sh covers that consumer end-to-end.
+echo "T19: FLEET_MODEL_* unset resolves to fleet-common.sh alias defaults"
+resolve_unpinned() { # $1 = task model class
+    write_slice worker "{\"tasks_open\":[{\"issue\":\"#10\",\"model\":\"$1\",\"effort\":null,\"owner\":\"free\",\"blocked\":false}],\"feedback_prs\":[],\"needs_plan\":[]}"
+    env -u FLEET_MODEL_FABLE -u FLEET_MODEL_OPUS -u FLEET_MODEL_SONNET \
+        -u OPUS_MODEL -u SONNET_MODEL "$DISPATCHER" --resolve-class worker
+}
+assert_eq "$(resolve_unpinned fable)" \
+    "class=fable model=fable[1m] effort=xhigh more=0 defer=0 count=1 plan=0" \
+    "unpinned fable resolves to FLEET_FABLE_CANDIDATES_DEFAULT[0]=fable[1m]"
+assert_eq "$(resolve_unpinned opus)" \
+    "class=opus model=opus[1m] effort=xhigh more=0 defer=0 count=1 plan=0" \
+    "unpinned opus resolves to FLEET_OPUS_CLASS_DEFAULT=opus[1m]"
+assert_eq "$(resolve_unpinned sonnet)" \
+    "class=sonnet model=sonnet effort=high more=0 defer=0 count=1 plan=0" \
+    "unpinned sonnet resolves to FLEET_SONNET_CLASS_DEFAULT=sonnet"
 
 echo
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_model_class_defaults.sh
+++ b/scripts/fleet/tests/test_model_class_defaults.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tests for fleet-common.sh's model-class defaults and fleet_model_tag.
+#
+# The class defaults are version-free CLI tier aliases so a new model
+# release needs no fleet edit; these tests pin the two properties that
+# make that safe: (1) the defaults stay alias-shaped (a full claude-* id
+# creeping back in reintroduces the per-release bump), and (2) the label
+# derivation handles both alias and full-id shapes without a per-version
+# map — including ids that don't exist yet.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/fleet-common.sh"
+
+echo "T1: class defaults are version-free aliases"
+assert_eq "$FLEET_OPUS_CLASS_DEFAULT"   "opus[1m]" "opus class default is the opus[1m] alias"
+assert_eq "$FLEET_SONNET_CLASS_DEFAULT" "sonnet"   "sonnet class default is the bare sonnet alias"
+assert_eq "${FLEET_FABLE_CANDIDATES_DEFAULT[0]}" "fable[1m]" "fable ladder rung 0 is fable[1m]"
+assert_eq "${FLEET_FABLE_CANDIDATES_DEFAULT[${#FLEET_FABLE_CANDIDATES_DEFAULT[@]}-1]}" \
+    "opus[1m]" "fable ladder floor is the opus alias"
+for _m in "$FLEET_OPUS_CLASS_DEFAULT" "$FLEET_SONNET_CLASS_DEFAULT" \
+    "${FLEET_FABLE_CANDIDATES_DEFAULT[@]}"; do
+    case "$_m" in
+        claude-*) bad "default '$_m' is a pinned full id, not an alias" ;;
+        *) ok "default '$_m' is alias-shaped" ;;
+    esac
+done
+
+echo "T2: fleet_model_tag derives labels for full ids"
+assert_eq "$(fleet_model_tag 'claude-opus-4-8[1m]')" "opus 4.8 1m" "claude-opus-4-8[1m]"
+assert_eq "$(fleet_model_tag 'claude-fable-5[1m]')"  "fable 5 1m"  "claude-fable-5[1m]"
+assert_eq "$(fleet_model_tag 'claude-sonnet-5')"     "sonnet 5"    "claude-sonnet-5"
+# A release that postdates this test must still label cleanly.
+assert_eq "$(fleet_model_tag 'claude-opus-5[1m]')"   "opus 5 1m"   "claude-opus-5[1m] (no map entry needed)"
+assert_eq "$(fleet_model_tag 'claude-opus-6-2[1m]')" "opus 6.2 1m" "claude-opus-6-2[1m] (future id)"
+
+echo "T3: fleet_model_tag passes aliases through readably"
+assert_eq "$(fleet_model_tag 'opus[1m]')"  "opus 1m"  "opus[1m] alias"
+assert_eq "$(fleet_model_tag 'fable[1m]')" "fable 1m" "fable[1m] alias"
+assert_eq "$(fleet_model_tag 'sonnet')"    "sonnet"   "bare sonnet alias"
+
+summarize "model-class defaults + fleet_model_tag"

--- a/scripts/fleet/tests/test_solo_architect_model.sh
+++ b/scripts/fleet/tests/test_solo_architect_model.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Tests for solo-architect's standalone model resolution — the
+# MODEL="${FLEET_MODEL_FABLE:-${FLEET_FABLE_CANDIDATES_DEFAULT[0]:-fable[1m]}}"
+# line, the fable-class sibling of fleet-dispatcher's standalone default
+# resolution (test_dispatcher_class_dispatch.sh T19 covers the dispatcher arm).
+#
+# solo-architect has no non-interactive print seam, so the resolution is
+# observed by intercepting its final `exec claude --model <MODEL> ...` with a
+# PATH-stubbed `claude` that echoes only the resolved --model value and exits.
+# Hermetic: HOME and FLEET_ENGINE_ROOT redirect into a tmp tree so the real
+# ~/.fleet/fleet-up.conf and session sidecar are never touched; --no-scout
+# skips the scout tick and --fresh skips reading a persisted session.
+#
+# Covers:
+#   - FLEET_MODEL_FABLE unset, no conf -> fleet-common.sh alias default (fable[1m])
+#   - FLEET_MODEL_FABLE pinned in env -> honors the pin
+#   - FLEET_MODEL_FABLE unset, ~/.fleet/fleet-up.conf pins it -> honors the pin
+#   - game-architect shares the same MODEL= line (alias default when unset)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+SOLO="$SCRIPT_DIR/solo-architect"
+
+if [[ ! -x "$SOLO" ]]; then
+    echo "test setup: solo-architect not found at $SOLO" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+TMPROOT=$(mktemp -d)
+mkdir -p "$TMPROOT/bin" "$TMPROOT/home/.fleet" \
+    "$TMPROOT/engine/.claude/worktrees/opus-architect" \
+    "$TMPROOT/engine/creations/game/.claude/worktrees/game-architect"
+
+# Stub claude: solo-architect exec's `claude --model <MODEL> ...`; print only
+# the resolved model value and exit before anything real launches.
+cat > "$TMPROOT/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--model" ]]; then echo "MODEL=$2"; exit 0; fi
+    shift
+done
+echo "MODEL=<none>"; exit 0
+EOF
+chmod +x "$TMPROOT/bin/claude"
+
+# Resolve the model solo-architect would launch with. $@ = extra env
+# assignments / `env -u VAR` tokens, then the solo-architect argv.
+resolve_model() {
+    env HOME="$TMPROOT/home" FLEET_ENGINE_ROOT="$TMPROOT/engine" \
+        PATH="$TMPROOT/bin:$PATH" "$@" 2>/dev/null
+}
+
+# --- T1: unset + no conf -> alias default ------------------------------------
+echo "T1: FLEET_MODEL_FABLE unset (no conf) resolves to the alias default"
+rm -f "$TMPROOT/home/.fleet/fleet-up.conf"
+assert_eq "$(resolve_model env -u FLEET_MODEL_FABLE "$SOLO" --no-scout --fresh)" \
+    "MODEL=fable[1m]" \
+    "unpinned engine architect -> FLEET_FABLE_CANDIDATES_DEFAULT[0]=fable[1m]"
+
+# --- T2: env pin wins --------------------------------------------------------
+echo "T2: FLEET_MODEL_FABLE env pin is honored"
+assert_eq "$(resolve_model FLEET_MODEL_FABLE='opus[1m]' "$SOLO" --no-scout --fresh)" \
+    "MODEL=opus[1m]" \
+    "FLEET_MODEL_FABLE=opus[1m] pins the model (fable ladder lost to opus floor)"
+
+# --- T3: conf pin used when env is unset -------------------------------------
+echo "T3: unset env falls back to ~/.fleet/fleet-up.conf pin"
+printf "FLEET_MODEL_FABLE='claude-fable-5[1m]'\n" > "$TMPROOT/home/.fleet/fleet-up.conf"
+assert_eq "$(resolve_model env -u FLEET_MODEL_FABLE "$SOLO" --no-scout --fresh)" \
+    "MODEL=claude-fable-5[1m]" \
+    "conf-file FLEET_MODEL_FABLE sourced when env is unset"
+rm -f "$TMPROOT/home/.fleet/fleet-up.conf"
+
+# --- T4: game-architect shares the same resolution ---------------------------
+echo "T4: game-architect uses the same MODEL= line"
+assert_eq "$(resolve_model env -u FLEET_MODEL_FABLE "$SOLO" game --no-scout --fresh)" \
+    "MODEL=fable[1m]" \
+    "unpinned game architect -> same fleet-common.sh alias default"
+
+summarize "solo-architect model-resolution tests"


### PR DESCRIPTION
## Summary
- Model-class defaults centralize in `fleet-common.sh` as version-free CLI tier aliases (`fable[1m]` / `opus[1m]` / `sonnet`) — the CLI resolves aliases to the newest model of each tier at launch, so the opus class lands on **Opus 5** today and future tier releases arrive with zero fleet edits; `FLEET_MODEL_*` pins still freeze a class
- The two verbatim-duplicated pane-label maps (`fleet-up`, `fleet-dispatch-wrap`) collapse into one generic `fleet_model_tag()` that derives labels from the id shape (future ids label cleanly, no per-release map edit)
- `fleet-babysit` effort-class globs fixed for alias-with-suffix spellings — `fable[1m]`/`opus[1m]` previously fell through to the sonnet-tier effort default
- `fleet-dispatcher` / `solo-architect` standalone defaults read the shared constants (alias backstops when `fleet-common.sh` is absent); docs + conf sample updated

## Test plan
- [x] `tests/test_model_class_defaults.sh` (new) — asserts defaults stay alias-shaped and `fleet_model_tag` handles current, alias, and future id shapes (17/17)
- [x] `tests/test_babysit_effort.sh` — new T2b alias-with-[1m] cases (13/13)
- [x] `tests/test_babysit_launch.sh`, `test_dispatch_wrap_session.sh`, `test_dispatcher_class_dispatch.sh`, `test_dispatcher_effort.sh` all pass
- [x] `bash -n` on all six edited scripts
- [x] Live probes: `claude --model 'opus[1m]'` resolves to `claude-opus-5[1m]`; `fable[1m]` → `claude-fable-5`; `sonnet` → `claude-sonnet-5`; `FLEET_DISPATCH_PRINT_LAUNCH=1 fleet-dispatch-wrap` launches `--model opus[1m]` and writes a correct sidecar

## Notes for reviewer
This deliberately reverses the old "pin fable/opus so a bare alias can't silently upgrade" policy — seamless tier upgrades are now the intent (human-directed). The alias backstop literals duplicated at standalone call sites are version-free, so they carry no per-release sync burden. Behavior is inert for a running fleet (the dispatcher inherits `FLEET_MODEL_*` from its boot env); the new defaults take effect at the next `fleet-up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)