### PR TITLE
fleet: exact-session resume survives net-blips, boot, power cycles

### DIFF
--- a/docs/agents/FLEET-RUNTIME.md
+++ b/docs/agents/FLEET-RUNTIME.md
@@ -174,10 +174,20 @@ this piece is a no-op at shutdown.
 Then exit cleanly. `fleet-dispatcher` launches a fresh `claude` for the
 role when the scout's projection sees new actionable state — no
 carry-over between iterations, except when `fleet-dispatch-wrap`'s
-session-id sidecar resumes a worker/sonnet-reviewer/opus-reviewer
-session after a hard kill (the resumed session keeps its full prior
-context; see `fleet-dispatch-wrap`'s "Session-id persistence" comment
-block).
+session-id sidecar resumes an interrupted session after a hard kill
+(the resumed session keeps its full prior context; see
+`fleet-dispatch-wrap`'s "Session-id persistence" comment block). Every
+dispatched role is resume-eligible — worker, both reviewers, merger,
+epic-steward, smoke-worker — and the durability contract spans the whole
+boot path: `fleet-up` preserves reserved / dirty / unpushed-`claude/*`
+worktrees, seeds a dispatcher trigger for any surviving sidecar so the
+resume actually fires after a power cycle, and the boot claim sweep
+keeps the GitHub claim label on any issue a local reservation says will
+resume (no cross-host duplicate-claim window). A resume that fails on
+quota or a short-window 429 keeps the sidecar (cooldowns pace the
+retry); any other failure gets one more attempt before the sidecar is
+cleared and the next dispatch goes fresh via the claim/reservation
+path.
 
 ---
 

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -2373,6 +2373,21 @@ print(0)
 
             [[ "$has_wip_pr" -eq 1 ]] && continue
 
+            # Reservation guard: a live local reservation binds this issue to
+            # a worktree whose interrupted session resumes it on the next
+            # dispatch (#521), so its claim label is NOT stale — sweeping it
+            # here advertises the task as free and another host can re-claim
+            # while this host finishes, yielding duplicate PRs. Reservations
+            # survive cmd_clear_all, so this guard holds through the boot
+            # sequence. (task_id is repo-unqualified; a cross-repo number
+            # collision at worst keeps a label that the 2h TTL still reaps.)
+            local resv_holder
+            resv_holder=$(reservation_holder_for_task "$issue_num" 2>/dev/null || true)
+            if [[ -n "$resv_holder" ]]; then
+                echo "reset-sweep-host-claims: keeping '$label_name' on $repo issue#$issue_num — reserved by worktree '$resv_holder' (resumes)"
+                continue
+            fi
+
             if gh issue edit "$issue_num" --repo "$repo" \
                     --remove-label "$label_name" >/dev/null 2>&1; then
                 echo "reset-sweep-host-claims: removed '$label_name' on $repo issue#$issue_num (no open PR)"

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -78,6 +78,7 @@ else
     # 1-hour TTL reaper — the same failure budget as the dispatcher's copy.
     fleet_planning_release_assignment() { :; }
     fleet_model_tag() { printf '%s' "$1"; }  # raw-id label fallback
+    fleet_main_clone_root() { :; }  # game-worktree in-flight check degrades off
 fi
 unset _FLEET_COMMON_SH
 
@@ -127,7 +128,7 @@ mkdir -p "$RATE_LIMIT_DIR"
 export FLEET_THROTTLE_FLAG="$RATE_LIMIT_DIR/$PANE_KEY.throttle-seen"
 rm -f "$FLEET_THROTTLE_FLAG"
 
-# --- Session-id persistence + interrupted-session resume (workers + reviewers) ---
+# --- Session-id persistence + interrupted-session resume (dispatched roles) ---
 #
 # Each iteration normally launches a FRESH `claude --session-id <uuid>` running
 # `/role-<role>`. On an interruption (fleet-down/up, crash, a killed pane) the
@@ -142,21 +143,27 @@ SESSIONS_DIR="${FLEET_SESSIONS_DIR:-$HOME/.fleet/sessions}"
 mkdir -p "$SESSIONS_DIR"
 worktree_name=$(basename "$PWD")
 SIDECAR="$SESSIONS_DIR/$worktree_name.session.json"
-# Roles worth resuming: workers (multi-step authoring; lost scratch is costly)
-# and reviewers (re-read a full diff). Short mechanical roles are not.
+# Roles worth resuming after an interruption: workers (multi-step authoring;
+# lost scratch is costly), reviewers (re-read a full diff), the merger
+# (mid-conflict-resolution context), the steward (mid-ledger pass), and the
+# smoke worker (mid build+run). For every non-worker role
+# worktree_in_flight stays false, so the sidecar clears on any clean exit
+# and only survives a HARD kill — resume there is pure crash recovery, never
+# a continuation of finished work.
 _resume_role=0
-case "$ROLE" in worker|sonnet-reviewer|opus-reviewer) _resume_role=1 ;; esac
+case "$ROLE" in
+    worker|sonnet-reviewer|opus-reviewer|merger|epic-steward|smoke-worker) _resume_role=1 ;;
+esac
 
 # Is there genuine unfinished work in this worktree that a resumed session should
 # continue? A reservation (feedback-amend) OR a claude/<N>-* branch carrying
 # uncommitted or unpushed-vs-master commits (a normal task mid-flow). Reviewers
 # hold no branch/reservation work, so they're never "in flight" — they clear on
 # a clean exit and only persist a sidecar across a hard kill.
-worktree_in_flight() {
-    [[ "$ROLE" == worker ]] || return 1
-    local _resv; _resv=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
-    [[ -n "$_resv" ]] && return 0
-    local _br; _br=$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+# True when <dir> carries work a resumed session would continue.
+_repo_in_flight() {
+    local _dir="$1"
+    local _br; _br=$(git -C "$_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     # Task branches only. Scratch branches (claude/<x>-scratch) are throwaway
     # by definition and must never pin a resume — worker-2 spent 07-09→07-14
     # resuming a dead session because its scratch branch matched claude/*.
@@ -164,17 +171,31 @@ worktree_in_flight() {
     # Tracked modifications only. Untracked leftovers (a screenshots dir from
     # a shipped task, stray body files) are junk, not work a resumed session
     # would continue.
-    [[ -n "$(git -C "$PWD" status --porcelain 2>/dev/null | grep -v '^??')" ]] && return 0
+    [[ -n "$(git -C "$_dir" status --porcelain 2>/dev/null | grep -v '^??')" ]] && return 0
     # Unpushed commits. Measure against the branch's OWN remote ref when one
     # exists — a fully-pushed branch loses nothing by going fresh, and a
     # squash-merged branch stays "ahead of origin/master" forever. Fall back
     # to origin/master only for a never-pushed branch.
     local _upstream="origin/master"
-    if git -C "$PWD" rev-parse --verify --quiet "refs/remotes/origin/$_br" >/dev/null 2>&1; then
+    if git -C "$_dir" rev-parse --verify --quiet "refs/remotes/origin/$_br" >/dev/null 2>&1; then
         _upstream="origin/$_br"
     fi
-    local _ahead; _ahead=$(git -C "$PWD" rev-list --count "$_upstream..HEAD" 2>/dev/null || echo 0)
+    local _ahead; _ahead=$(git -C "$_dir" rev-list --count "$_upstream..HEAD" 2>/dev/null || echo 0)
     [[ "$_ahead" =~ ^[0-9]+$ && "$_ahead" -gt 0 ]] && return 0
+    return 1
+}
+
+worktree_in_flight() {
+    [[ "$ROLE" == worker ]] || return 1
+    local _resv; _resv=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
+    [[ -n "$_resv" ]] && return 0
+    _repo_in_flight "$PWD" && return 0
+    # A worker mid-GAME-task has its branch/dirty state in the game worktree
+    # of the same basename, not in this engine pool cwd — an un-reserved
+    # interrupted game task must still pin the resume.
+    local _game_wt
+    _game_wt="$(fleet_main_clone_root 2>/dev/null || true)/creations/game/.claude/worktrees/$worktree_name"
+    [[ -d "$_game_wt" ]] && _repo_in_flight "$_game_wt" && return 0
     return 1
 }
 
@@ -284,6 +305,10 @@ elif [[ "$rc" != "0" && -f "$FLEET_THROTTLE_FLAG" ]]; then
     touch "$TRIGGERS_DIR/$ROLE"
     echo "fleet-dispatch-wrap: short-window 429 on $ROLE ($PANE_KEY); wrote throttle cooldown + re-armed $ROLE" >&2
 fi
+# The sidecar lifecycle below still needs to know a 429 was seen after the
+# flag file is cleaned up.
+THROTTLE_SEEN=0
+[[ -f "$FLEET_THROTTLE_FLAG" ]] && THROTTLE_SEEN=1
 rm -f "$FLEET_THROTTLE_FLAG"
 
 # Auto-retrigger: when a worker role exits cleanly (rc=0) with a dirty
@@ -306,13 +331,31 @@ fi
 
 # Session sidecar lifecycle. This runs only when claude EXITED (a hard kill skips
 # it, leaving the sidecar so the next dispatch resumes — the desired behavior):
-#   - a resume that itself failed (rc!=0) -> clear, so the next dispatch goes
-#     fresh and recovers via the claim/reservation path (breaks any resume loop);
+#   - a resume that failed on quota (rc=2) or a short-window 429 -> keep the
+#     sidecar untouched: the failure is the API's, not the session's, and the
+#     rate-limit / throttle cooldowns already pace the retry;
+#   - a resume that failed any other way (rc!=0) -> allow ONE more attempt,
+#     then clear: a single transient network error must not destroy the only
+#     pointer to the session (it is needed most exactly during flaky outage
+#     recovery), but a session that fails two straight resumes is poisoned —
+#     the next dispatch goes fresh and recovers via the claim/reservation path;
 #   - genuine in-flight work remaining -> keep, so the next dispatch resumes;
 #   - otherwise (task finished + worktree reset, or a no-op iteration) -> clear.
 if (( _resume_role )); then
     if (( RESUMED )) && [[ "$rc" != "0" ]]; then
-        rm -f "$SIDECAR"
+        if [[ "$rc" == "2" || "$THROTTLE_SEEN" == "1" ]]; then
+            :
+        else
+            _rfail=$(_read_sidecar resume_failures); _rfail=${_rfail:-0}
+            [[ "$_rfail" =~ ^[0-9]+$ ]] || _rfail=0
+            if (( _rfail >= 1 )); then
+                rm -f "$SIDECAR"
+                echo "fleet-dispatch-wrap: resume of $worktree_name failed twice (rc=$rc) — clearing sidecar; next dispatch goes fresh" >&2
+            else
+                python3 -c "import json;p='$SIDECAR';d=json.load(open(p));d['resume_failures']=int(d.get('resume_failures') or 0)+1;json.dump(d,open(p,'w'))" 2>/dev/null \
+                    || rm -f "$SIDECAR"
+            fi
+        fi
     elif worktree_in_flight; then
         if (( RESUMED )); then
             # Bounded resumes: a resumed session that exits CLEANLY while the
@@ -326,7 +369,8 @@ if (( _resume_role )); then
                 rm -f "$SIDECAR"
                 echo "fleet-dispatch-wrap: resumed session exited clean twice with the worktree still in-flight — clearing sidecar; next dispatch goes fresh" >&2
             else
-                python3 -c "import json;p='$SIDECAR';d=json.load(open(p));d['resumes']=int(d.get('resumes') or 0)+1;json.dump(d,open(p,'w'))" 2>/dev/null \
+                # A clean resumed exit also ends any transient-failure streak.
+                python3 -c "import json;p='$SIDECAR';d=json.load(open(p));d['resumes']=int(d.get('resumes') or 0)+1;d['resume_failures']=0;json.dump(d,open(p,'w'))" 2>/dev/null \
                     || rm -f "$SIDECAR"
             fi
         fi

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -805,6 +805,30 @@ reset_worktree() {
         return 0
     fi
 
+    # A clean tree can still carry unpushed work: a crash after commit but
+    # before push leaves a claude/<N>-* task branch ahead of its remote.
+    # Resetting it to scratch would strand the commits on a dangling ref AND
+    # break fleet-dispatch-wrap's in-flight check (which keys on the branch),
+    # so the interrupted session would never resume. Scratch branches are
+    # throwaway and never preserved. Compare against the branch's OWN remote
+    # ref when it exists — a fully-pushed (possibly squash-merged) branch is
+    # safe to reset; origin/master is the yardstick only for a never-pushed
+    # branch, and local-only commits stay "ahead" of it even when the fetch
+    # is stale.
+    local cur_branch upstream ahead
+    cur_branch="$(cd "$wt" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+    if [[ "$cur_branch" == claude/* && "$cur_branch" != *-scratch ]]; then
+        upstream="origin/master"
+        if (cd "$wt" && git rev-parse --verify --quiet "refs/remotes/origin/$cur_branch" >/dev/null 2>&1); then
+            upstream="origin/$cur_branch"
+        fi
+        ahead="$(cd "$wt" && git rev-list --count "$upstream..HEAD" 2>/dev/null || echo 0)"
+        if [[ "$ahead" =~ ^[0-9]+$ && "$ahead" -gt 0 ]]; then
+            echo "fleet-up: $wt on $cur_branch with $ahead unpushed commit(s) — preserving for resumption."
+            return 0
+        fi
+    fi
+
     echo "fleet-up: resetting $wt -> $branch"
     (cd "$wt" \
         && git fetch origin --quiet \
@@ -1391,6 +1415,36 @@ for role, predicate in [
         print(f"fleet-up: bootstrap-triggered {role} (projection has actionable content)")
 PY
 fi
+
+# Sidecar-resume bootstrap: a *.session.json left behind by a hard-killed
+# iteration (power cycle, pane kill) only resumes when its role is next
+# dispatched into that worktree — but after a reboot the projection often
+# shows nothing actionable for that role (its interrupted task reads as
+# in-progress), so the symmetric bootstrap above never fires and the session
+# strands until an organic trigger. Seed a trigger for every role with a
+# surviving sidecar so the dispatcher's first tick re-dispatches it and
+# fleet-dispatch-wrap's resume path reloads the exact session. A false
+# positive costs one short no-op iteration (the wrap clears a sidecar with
+# no in-flight work behind it). Role allowlist mirrors fleet-dispatch-wrap's
+# _resume_role set.
+seed_sidecar_resume_triggers() {
+    local sessions_dir="${FLEET_SESSIONS_DIR:-$HOME/.fleet/sessions}"
+    local trig_dir="${FLEET_STATE_DIR:-$HOME/.fleet/state}/triggers"
+    [[ -d "$sessions_dir" ]] || return 0
+    local sc sc_role
+    for sc in "$sessions_dir"/*.session.json; do
+        [[ -f "$sc" ]] || continue
+        sc_role=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("role",""))' "$sc" 2>/dev/null || true)
+        case "$sc_role" in
+            worker|sonnet-reviewer|opus-reviewer|merger|smoke-worker|epic-steward)
+                mkdir -p "$trig_dir"
+                touch "$trig_dir/$sc_role"
+                echo "fleet-up: bootstrap-triggered $sc_role (session sidecar $(basename "$sc") pending resume)"
+                ;;
+        esac
+    done
+}
+seed_sidecar_resume_triggers
 
 # ----------------------------------------------------------------------
 # Step 3f: launch fleet-dispatcher daemon

--- a/scripts/fleet/tests/test_dispatch_wrap_session.sh
+++ b/scripts/fleet/tests/test_dispatch_wrap_session.sh
@@ -8,11 +8,14 @@
 # resume) is checked by running to completion with stubbed claude/git/fleet-claim.
 #
 # Covers:
-#   - fresh dispatch: --session-id, /role-<role>, sidecar written (worker+reviewer)
-#   - non-resume role (merger): no --session-id sidecar, no resume
+#   - fresh dispatch: --session-id, /role-<role>, sidecar written (worker,
+#     reviewer, merger — every dispatched role resumes now)
+#   - non-dispatched role (queue-manager): no sidecar, no resume
 #   - resume: sidecar present -> --resume <id> with the STORED model/effort
 #     (not the dispatcher-passed class)
-#   - cleanup: failed resume clears the sidecar (no loop)
+#   - cleanup: failed resume keeps the sidecar ONCE (transient tolerance),
+#     clears on the second straight failure; quota (rc=2) and short-window
+#     429 failures never count against the streak
 #   - cleanup: in-flight work (claude/* branch + dirty) keeps the sidecar
 #   - cleanup: in-flight work (reservation present, branch otherwise clean) keeps the sidecar
 #   - cleanup: in-flight work (claude/* branch, clean but ahead of master) keeps the sidecar
@@ -46,6 +49,9 @@ exit "${STUB_CLAUDE_RC:-0}"
 EOF
 cat > "$BIN/fleet-claude-stream" <<'EOF'
 #!/usr/bin/env bash
+# STUB_TOUCH_THROTTLE simulates the real stream formatter spotting a
+# short-window 429 and touching the wrap-exported flag file.
+[[ -n "${STUB_TOUCH_THROTTLE:-}" && -n "${FLEET_THROTTLE_FLAG:-}" ]] && touch "$FLEET_THROTTLE_FLAG"
 cat >/dev/null 2>&1 || true
 EOF
 cat > "$BIN/fleet-claim" <<'EOF'
@@ -95,11 +101,18 @@ out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 "claude-opus-4-8[
 python3 -c "import json;d=json.load(open('$SIDECAR'));assert d['role']=='worker' and d['model']=='claude-opus-4-8[1m]' and d['effort']=='xhigh'" 2>/dev/null \
   && ok "fresh: sidecar records role/model/effort" || bad "fresh: sidecar fields wrong"
 
-echo "T2: non-resume role (merger) — no sidecar, no --session-id persistence"
+echo "T2: merger is resume-eligible — fresh dispatch writes a sidecar"
 rm -f "$FLEET_SESSIONS_DIR/worker-1.session.json"
 out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high merger "" live 2>/dev/null)
 [[ "$out" == resumed=0* ]] && ok "merger: resumed=0" || bad "merger resumed: $out"
-[[ ! -f "$SIDECAR" ]] && ok "merger: no sidecar written" || bad "merger wrote a sidecar"
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert d['role']=='merger'" 2>/dev/null \
+  && ok "merger: sidecar written (crash recovery)" || bad "merger: no/wrong sidecar"
+rm -f "$SIDECAR"
+
+echo "T2b: non-dispatched role (queue-manager) — no sidecar, no resume"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high queue-manager "" live 2>/dev/null)
+[[ "$out" == resumed=0* ]] && ok "queue-manager: resumed=0" || bad "queue-manager resumed: $out"
+[[ ! -f "$SIDECAR" ]] && ok "queue-manager: no sidecar written" || bad "queue-manager wrote a sidecar"
 
 echo "T3: resume — sidecar present -> --resume <id> with STORED model/effort"
 printf '{"session_id":"SID-123","role":"worker","model":"claude-opus-4-8[1m]","effort":"xhigh","created_epoch":1}\n' > "$SIDECAR"
@@ -127,10 +140,29 @@ out=$(cd "$WT2" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-7 "claude-opus-4-8
 [[ -f "$FLEET_SESSIONS_DIR/opus-reviewer.session.json" ]] && ok "reviewer: sidecar written" || bad "reviewer: no sidecar"
 
 # --- cleanup lifecycle (full run, stubbed claude) ------------------------
-echo "T5: cleanup — failed resume clears the sidecar (no loop)"
+echo "T5: cleanup — one failed resume is tolerated (transient), the second clears"
 printf '{"session_id":"SID-9","role":"worker","model":"sonnet","effort":"high","created_epoch":1}\n' > "$SIDECAR"
 STUB_CLAUDE_RC=1 run_wrap sonnet high worker
-[[ ! -f "$SIDECAR" ]] && ok "failed resume cleared the sidecar" || bad "failed resume left the sidecar"
+[[ -f "$SIDECAR" ]] && ok "1st failed resume kept the sidecar (one retry)" || bad "1st failed resume cleared the sidecar"
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert d.get('resume_failures')==1" 2>/dev/null \
+  && ok "failure streak recorded (resume_failures=1)" || bad "failure streak missing: $(cat "$SIDECAR" 2>/dev/null)"
+STUB_CLAUDE_RC=1 run_wrap sonnet high worker
+[[ ! -f "$SIDECAR" ]] && ok "2nd failed resume cleared the sidecar (poisoned session)" || bad "2nd failed resume left the sidecar"
+
+echo "T5b: quota exit (rc=2) on a resume keeps the sidecar untouched"
+printf '{"session_id":"SID-Q","role":"worker","model":"sonnet","effort":"high","created_epoch":1}\n' > "$SIDECAR"
+STUB_CLAUDE_RC=2 run_wrap sonnet high worker
+[[ -f "$SIDECAR" ]] && ok "quota failure kept the sidecar" || bad "quota failure cleared the sidecar"
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert not d.get('resume_failures')" 2>/dev/null \
+  && ok "quota failure did not count against the streak" || bad "quota failure bumped resume_failures"
+
+echo "T5c: short-window 429 (throttle flag) on a resume keeps the sidecar untouched"
+printf '{"session_id":"SID-T","role":"worker","model":"sonnet","effort":"high","created_epoch":1}\n' > "$SIDECAR"
+STUB_TOUCH_THROTTLE=1 STUB_CLAUDE_RC=1 run_wrap sonnet high worker
+[[ -f "$SIDECAR" ]] && ok "throttled failure kept the sidecar" || bad "throttled failure cleared the sidecar"
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert not d.get('resume_failures')" 2>/dev/null \
+  && ok "throttled failure did not count against the streak" || bad "throttled failure bumped resume_failures"
+rm -f "$SIDECAR"
 
 echo "T6: cleanup — in-flight (claude/* branch + dirty) keeps the sidecar"
 rm -f "$SIDECAR"
@@ -207,6 +239,13 @@ python3 -c "import json;d=json.load(open('$SIDECAR'));assert d.get('resumes')==1
 # 2nd resumed clean exit, still in-flight: breaker fires, sidecar cleared.
 STUB_BRANCH="claude/123-foo" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap sonnet high worker
 [[ ! -f "$SIDECAR" ]] && ok "2nd clean resume cleared the sidecar (loop broken)" || bad "2nd clean resume kept the sidecar (loop!)"
+
+echo "T15: a clean resumed exit resets the transient-failure streak"
+printf '{"session_id":"SID-OK","role":"worker","model":"sonnet","effort":"high","created_epoch":1,"resume_failures":1}\n' > "$SIDECAR"
+STUB_BRANCH="claude/123-foo" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap sonnet high worker
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert d.get('resume_failures')==0 and d.get('resumes')==1" 2>/dev/null \
+  && ok "clean resume zeroed resume_failures (and bumped resumes)" || bad "streak not reset: $(cat "$SIDECAR" 2>/dev/null)"
+rm -f "$SIDECAR"
 
 echo
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_claim_reset_sweep_reservation_guard.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reset_sweep_reservation_guard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Tests for the reservation guard in `fleet-claim reset-sweep-host-claims`.
+#
+# The boot sweep removes this host's fleet:claim-<host>-* labels from queued
+# issues with no open PR. But an interrupted-but-resumable task looks exactly
+# like that in GitHub terms — claimed, no PR yet — while its local reservation
+# (~/.fleet/reservations/<worktree>.json, which survives clear-all) pins the
+# worktree that will resume it. Sweeping that label advertises the task as
+# free to other hosts mid-resume: the duplicate-PR window. The guard keeps
+# the label whenever a reservation names the issue.
+#
+# Covers:
+#   - same-host claim, no PR, WITH a live reservation -> label kept
+#   - same-host claim, no PR, no reservation          -> label swept
+#   - reservation for a different issue does not shield the swept one
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+[[ -x "$FLEET_CLAIM" ]] || { echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2; exit 1; }
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_TEST_HOST="mac"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR"
+
+export ISSUES_JSON="$TMPROOT/issues.json"
+export PRS_JSON="$TMPROOT/prs.json"
+REMOVED_FILE="$TMPROOT/removed.log"; : > "$REMOVED_FILE"; export REMOVED_FILE
+
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    repo)
+        # game repo not reachable -> sweep covers the engine repo only
+        exit 1 ;;
+    issue)
+        case "$2" in
+            list) cat "$ISSUES_JSON"; exit 0 ;;
+            edit)
+                shift 2; issue="$1"; shift
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        --remove-label) printf '%s\t%s\n' "$issue" "$2" >> "$REMOVED_FILE"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        [[ "$2" == "list" ]] && { cat "$PRS_JSON"; exit 0; }
+        exit 0 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# Two queued issues claimed by this host, neither with an open PR. #42 is
+# reserved by pool-1 (interrupted mid-task, will resume); #43 is not.
+cat > "$ISSUES_JSON" <<'EOF'
+[
+  {"number": 42, "labels": [{"name": "fleet:queued"}, {"name": "fleet:claim-mac-pool-1"}]},
+  {"number": 43, "labels": [{"name": "fleet:queued"}, {"name": "fleet:claim-mac-pool-2"}]}
+]
+EOF
+echo "[]" > "$PRS_JSON"
+printf '{"task_id":"42","branch":"claude/42-topic","created_at":"t","created_epoch":1}\n' \
+    > "$FLEET_RESERVATIONS_DIR/pool-1.json"
+
+echo "T1: reserved issue keeps its claim label; unreserved is swept"
+out=$("$FLEET_CLAIM" reset-sweep-host-claims 2>&1 || true)
+assert_contains "$out" "keeping 'fleet:claim-mac-pool-1'" "reserved #42 reported as kept"
+if grep -qF "fleet:claim-mac-pool-1" "$REMOVED_FILE"; then
+    bad "reserved #42 label was swept (duplicate-PR window reopened)"
+else
+    ok "reserved #42 label untouched"
+fi
+if grep -qF "fleet:claim-mac-pool-2" "$REMOVED_FILE"; then
+    ok "unreserved #43 label swept (guard is issue-scoped, not global)"
+else
+    bad "unreserved #43 label was not swept"
+fi
+
+summarize "reset-sweep reservation guard"

--- a/scripts/fleet/tests/test_fleet_up_resume_boot.sh
+++ b/scripts/fleet/tests/test_fleet_up_resume_boot.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for fleet-up's boot-time resume preservation:
+#
+#   reset_worktree — must NOT strip a clean-but-unpushed claude/<N>-* task
+#   branch (crash after commit, before push): resetting it to scratch
+#   strands the commits on a dangling ref and breaks fleet-dispatch-wrap's
+#   branch-keyed in-flight check, so the interrupted session never resumes.
+#   Scratch branches and fully-pushed branches still reset.
+#
+#   seed_sidecar_resume_triggers — a surviving *.session.json must seed a
+#   dispatcher trigger for its role at boot, or a hard-killed session
+#   strands until an organic projection change; unknown roles seed nothing.
+#
+# Both are exercised by sed-extracting the function from fleet-up (they are
+# self-contained: git + $HOME/.fleet paths + FLEET_* env overrides only).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_UP="$SCRIPT_DIR/fleet-up"
+[[ -x "$FLEET_UP" ]] || { echo "test setup: fleet-up not found at $FLEET_UP" >&2; exit 1; }
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/reservations"
+
+extract_fn() {  # extract_fn <name> — print the function body from fleet-up
+    sed -n "/^$1() {/,/^}/p" "$FLEET_UP"
+}
+eval "$(extract_fn reset_worktree)"
+eval "$(extract_fn seed_sidecar_resume_triggers)"
+[[ "$(type -t reset_worktree)" == "function" ]] || { echo "test setup: reset_worktree not extracted" >&2; exit 1; }
+[[ "$(type -t seed_sidecar_resume_triggers)" == "function" ]] || { echo "test setup: seed_sidecar_resume_triggers not extracted" >&2; exit 1; }
+
+# --- git fixtures ---------------------------------------------------------
+ORIGIN="$TMPROOT/origin.git"
+git init --quiet --bare "$ORIGIN"
+SEED="$TMPROOT/seed"
+git clone --quiet "$ORIGIN" "$SEED" 2>/dev/null
+(cd "$SEED" \
+    && git -c user.email=t@t -c user.name=t commit --allow-empty -m init --quiet \
+    && git branch -M master \
+    && git push --quiet origin master)
+
+new_checkout() {  # new_checkout <name> -> clone with origin/master fetched
+    local dir="$TMPROOT/$1"
+    git clone --quiet "$ORIGIN" "$dir" 2>/dev/null
+    echo "$dir"
+}
+current_branch() { git -C "$1" rev-parse --abbrev-ref HEAD; }
+
+echo "T1: clean-but-unpushed claude/<N>-* branch is preserved"
+WT1=$(new_checkout wt1)
+(cd "$WT1" \
+    && git checkout -q -b claude/42-topic \
+    && git -c user.email=t@t -c user.name=t commit --allow-empty -m work --quiet)
+out=$(reset_worktree "$WT1" claude/pool-1-scratch)
+assert_contains "$out" "preserving for resumption" "reports preservation"
+assert_eq "$(current_branch "$WT1")" "claude/42-topic" "branch untouched"
+
+echo "T2: fully-pushed claude/<N>-* branch still resets (no squash-merge pin)"
+WT2=$(new_checkout wt2)
+(cd "$WT2" \
+    && git checkout -q -b claude/43-topic \
+    && git -c user.email=t@t -c user.name=t commit --allow-empty -m work --quiet \
+    && git push --quiet -u origin claude/43-topic 2>/dev/null)
+reset_worktree "$WT2" claude/pool-2-scratch >/dev/null
+assert_eq "$(current_branch "$WT2")" "claude/pool-2-scratch" "pushed branch reset to scratch"
+
+echo "T3: scratch branch resets even with local commits (throwaway by definition)"
+WT3=$(new_checkout wt3)
+(cd "$WT3" \
+    && git checkout -q -b claude/pool-3-scratch \
+    && git -c user.email=t@t -c user.name=t commit --allow-empty -m scratchwork --quiet)
+reset_worktree "$WT3" claude/pool-3-scratch >/dev/null
+assert_eq "$(git -C "$WT3" rev-parse HEAD)" "$(git -C "$WT3" rev-parse origin/master)" \
+    "scratch branch reset to origin/master"
+
+echo "T4: reservation preserves regardless of branch state"
+WT4=$(new_checkout wt4)
+printf '{"task_id":"7"}\n' > "$HOME/.fleet/reservations/wt4.json"
+out=$(reset_worktree "$WT4" claude/pool-4-scratch)
+assert_contains "$out" "has reservation" "reservation guard fired"
+assert_eq "$(current_branch "$WT4")" "master" "branch untouched under reservation"
+
+echo "T5: sidecar seeds a trigger for its role at boot; unknown roles do not"
+export FLEET_SESSIONS_DIR="$TMPROOT/sessions"
+export FLEET_STATE_DIR="$TMPROOT/state"
+mkdir -p "$FLEET_SESSIONS_DIR"
+printf '{"session_id":"S1","role":"worker"}\n'   > "$FLEET_SESSIONS_DIR/pool-1.session.json"
+printf '{"session_id":"S2","role":"mystery"}\n'  > "$FLEET_SESSIONS_DIR/pool-2.session.json"
+out=$(seed_sidecar_resume_triggers)
+assert_contains "$out" "bootstrap-triggered worker" "worker trigger reported"
+if [[ -f "$FLEET_STATE_DIR/triggers/worker" ]]; then
+    ok "worker trigger file created"
+else
+    bad "worker trigger file missing"
+fi
+if [[ -f "$FLEET_STATE_DIR/triggers/mystery" ]]; then
+    bad "unknown role seeded a trigger"
+else
+    ok "unknown role seeded nothing"
+fi
+
+summarize "fleet-up resume-boot preservation"


### PR DESCRIPTION
## Summary
Closes the gaps found in a full audit of the non-clean-shutdown path (net-blip / hard-kill / power-cycle), so interrupted workers reattach to the **exact same claude session, worktree, and claim state** instead of re-deriving from handoff files:

- **Transient-failure-tolerant resume** (`fleet-dispatch-wrap`): a resumed session that dies on quota (rc=2) or a short-window 429 keeps its sidecar untouched — the rate-limit/throttle cooldowns already pace the retry; any other failure gets one more attempt (`resume_failures` streak) before the sidecar clears and the next dispatch goes fresh. Previously a single transient network error during a resume permanently destroyed the only pointer to the session — exactly during flaky outage recovery. A clean resume resets the streak.
- **All dispatched roles resume now**: merger, epic-steward, and smoke-worker join worker + both reviewers. For the non-worker roles `worktree_in_flight` stays false, so their sidecar clears on any clean exit and only survives a hard kill — pure crash recovery, never a continuation of finished work.
- **Boot no longer strands or orphans resumable work** (`fleet-up`): `reset_worktree` preserves a clean-but-unpushed `claude/<N>-*` task branch (crash after commit, before push — previously stripped to scratch, orphaning the commits and breaking the branch-keyed in-flight check); a new `seed_sidecar_resume_triggers` pass fires each surviving sidecar's role on the dispatcher's first tick (post-reboot projections often show the interrupted task as in-progress, so the projection bootstrap never would).
- **Cross-host duplicate-PR window closed** (`fleet-claim reset-sweep-host-claims`): the boot sweep keeps the GitHub claim label on any issue a live local reservation pins to a resuming worktree; previously the label was swept and a second host could re-claim the task mid-resume.
- **Game-task resume pinning** (`fleet-dispatch-wrap`): a worker interrupted mid-game-task now pins its resume via the game worktree's branch/dirty state, not just the engine pool cwd.

## Test plan
- [x] `test_dispatch_wrap_session.sh` — 40/40: new two-strike semantics (T5), quota-keep (T5b), throttle-keep (T5c), merger sidecar (T2), non-dispatched negative (T2b), streak reset on clean resume (T15); all pre-existing lifecycle cases unchanged
- [x] `test_fleet_up_resume_boot.sh` (new, real-git fixtures) — 9/9: unpushed-branch preservation, pushed-branch reset, scratch reset, reservation guard, sidecar trigger seeding
- [x] `test_fleet_claim_reset_sweep_reservation_guard.sh` (new, stubbed gh) — 3/3: reserved issue kept, unreserved swept
- [x] Adjacent suites green: `test_fleet_claim_{orphan,amending,prlabel_orphan}_sweep.sh`, `test_fleet_up_conf_bootstrap.sh`
- [x] `bash -n` on all edited scripts

## Notes for reviewer
Architect panes already resume durably (`fleet-babysit` retries `--resume` every 30s, `.session-id` never auto-deleted) — audited, no change needed. Not addressed here (operational, needs a human decision): there is no autostart after a host reboot — recovery is a manual `fleet-up live`. An opt-in `fleet-autostart` (launchd) tool is the natural follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)