### PR TITLE
input: release entity-event handler Lua refs before World teardown

### DIFF
--- a/.fleet/plans/issue-2572.md
+++ b/.fleet/plans/issue-2572.md
@@ -15,9 +15,14 @@ empty vectors. No change to the runtime dispatch surface.
 2. Call it at the `IREngine::gameLoop()` tail, immediately **before** the
    `g_world.reset()` that #2539 added — the VM is still alive there, and the
    engine tail is unconditional, so a creation cannot forget the cleanup.
-3. This also fixes the latent multi-world hazard: without the clear, a
-   future second `World` in-process would dispatch stale handlers bound to
-   the dead VM.
+3. This also closes the stale-handler half of the latent multi-world
+   hazard: without the clear, a future second `World` in-process would
+   dispatch stale handlers bound to the dead VM; with it, the registry
+   starts empty. Multi-world is NOT fully clean after this fix —
+   `previousHoveredEntity` (a second process-lifetime static inside
+   `System<ENTITY_HOVER_DETECT>::create()`) survives into a hypothetical
+   second World, whose first hover change would fire `fireUnhovered` with
+   the previous World's stale id. Pre-existing and unreachable today.
 
 Implementation note: `IREngine::gameLoop()` is header-inline in
 `ir_engine.hpp`, and the handler registry lives behind a prefab header that

--- a/.fleet/plans/issue-2572.md
+++ b/.fleet/plans/issue-2572.md
@@ -1,0 +1,63 @@
+# Plan — #2572: EntityEventHandlers unrefs Lua handlers after World teardown (exit SIGSEGV)
+
+## Scope
+
+Make entity-event handler teardown deterministic: the Lua handler references
+in `IRSystem::EntityEventHandlers` must be released while the Lua VM is still
+alive, so the process-exit destruction of the static registry touches only
+empty vectors. No change to the runtime dispatch surface.
+
+## Approach
+
+1. Add `EntityEventHandlers::clear()` — drops all four `HandlerEntry`
+   vectors (destroying the `sol::protected_function`s) and leaves `nextId`
+   as-is (ids never recycle within a process; cheap and unambiguous).
+2. Call it at the `IREngine::gameLoop()` tail, immediately **before** the
+   `g_world.reset()` that #2539 added — the VM is still alive there, and the
+   engine tail is unconditional, so a creation cannot forget the cleanup.
+3. This also fixes the latent multi-world hazard: without the clear, a
+   future second `World` in-process would dispatch stale handlers bound to
+   the dead VM.
+
+Implementation note: `IREngine::gameLoop()` is header-inline in
+`ir_engine.hpp`, and the handler registry lives behind a prefab header that
+pulls in sol2 + `ir_render`. Including that header into `ir_engine.hpp` would
+transitively widen every creation's include of the engine entry point, so the
+call is routed through an out-of-line `IREngine::detail::clearEntityEventHandlers()`
+defined in `engine/engine.cpp` — the same pattern the pre-existing
+`detail::applyPreInitLuaConfig` uses for exactly this reason. (The plan's
+original "call in `ir_engine.cpp`" wording predated confirming the tail is
+header-inline.)
+
+Alternative considered: a generic `LuaScript::onTeardown(callback)` registry
+that prefab-layer statics hook at first registration. More general, but
+heavier than the one deterministic call site the engine tail already offers;
+revisit if a second Lua-ref-holding static appears.
+
+## Affected files
+
+- `engine/prefabs/irreden/input/systems/system_entity_hover_detect.hpp` —
+  add `EntityEventHandlers::clear()`.
+- `engine/include/irreden/ir_engine.hpp` — declare
+  `detail::clearEntityEventHandlers()`; call it in inline `gameLoop()` before
+  `g_world.reset()`.
+- `engine/engine.cpp` — include the prefab header; define
+  `detail::clearEntityEventHandlers()` calling
+  `IRSystem::getEntityEventHandlers().clear()`.
+
+## Acceptance criteria
+
+As on the issue: clean exit with a Lua `onRightClick` registered (macOS +
+Linux), unchanged dispatch during the run, registry empty post-`gameLoop`.
+A/B repro: register `IRInput.onRightClick` from any creation's `main.lua`;
+without the fix the run segfaults in `~EntityEventHandlers` at exit.
+
+## Gotchas
+
+- The clear must run **before** `g_world.reset()` — after it, the VM is
+  gone and `luaL_unref` is the crash itself.
+- Don't move the registry onto `System<ENTITY_HOVER_DETECT>`: Lua handlers
+  register at script-load time, before the system exists — that ordering is
+  why the static accessor exists.
+- `IR_RELEASE` builds strip asserts, not this path — the fix is a real call,
+  not an assert.

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -3,6 +3,7 @@
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_script.hpp>
 #include <irreden/render/voxel_pool_config.hpp>
+#include <irreden/input/systems/system_entity_hover_detect.hpp>
 
 namespace IREngine::detail {
 
@@ -27,6 +28,10 @@ void applyPreInitLuaConfig(const char *configFile) {
             );
         }
     }
+}
+
+void clearEntityEventHandlers() {
+    IRSystem::getEntityEventHandlers().clear();
 }
 
 } // namespace IREngine::detail

--- a/engine/include/irreden/ir_engine.hpp
+++ b/engine/include/irreden/ir_engine.hpp
@@ -54,6 +54,15 @@ namespace detail {
 // `engine/world/CLAUDE.md` "Init-affecting runtime params".
 void applyPreInitLuaConfig(const char *configFile);
 
+// Releases the prefab-layer Lua handler references held by the
+// process-lifetime IRSystem::EntityEventHandlers static, called at the
+// gameLoop() tail while the World's Lua VM is still alive. Out-of-line in
+// engine.cpp for the same reason as applyPreInitLuaConfig: the prefab header
+// pulls in sol2 + ir_render, and inlining the call would transitively widen
+// every includer of ir_engine.hpp. See #2572 for the __cxa_finalize crash
+// this deterministic clear prevents.
+void clearEntityEventHandlers();
+
 } // namespace detail
 
 // The process-global engine argument parser, pre-loaded with the engine-common
@@ -113,8 +122,14 @@ inline int entityCountOverride() {
 //
 // Engine access after gameLoop() returns is unsupported: getWorld() and every
 // IR<Module>::get*Manager() accessor assert on the cleared global in debug.
+//
+// The prefab-layer EntityEventHandlers static holds Lua handler references; it
+// is cleared here — before g_world.reset() destroys the Lua VM — so its own
+// process-exit destructor unrefs into nothing (#2572). Order matters: after
+// the reset the VM is gone and the unref is the crash itself.
 inline void gameLoop() {
     getWorld().gameLoop();
+    detail::clearEntityEventHandlers();
     g_world.reset();
 }
 

--- a/engine/prefabs/irreden/input/systems/system_entity_hover_detect.hpp
+++ b/engine/prefabs/irreden/input/systems/system_entity_hover_detect.hpp
@@ -69,6 +69,21 @@ struct EntityEventHandlers {
         eraseById(onRightClick);
     }
 
+    // Drops every registered handler, destroying the sol::protected_functions
+    // they hold. The engine tail calls this while the World's Lua VM is still
+    // alive (before g_world.reset()), so the process-lifetime static's own
+    // destructor later runs luaL_unref on nothing but empty vectors. Without
+    // it, that destructor fires at __cxa_finalize — after lua_close — and
+    // unrefs into freed memory, segfaulting any creation that registered a
+    // handler from Lua (#2572). nextId is intentionally left as-is: ids never
+    // recycle within a process, so there is no id-reuse hazard to guard.
+    void clear() {
+        onHovered.clear();
+        onUnhovered.clear();
+        onClicked.clear();
+        onRightClick.clear();
+    }
+
     void fireHovered(IREntity::EntityId entityId) {
         for (auto &entry : onHovered) {
             auto result = entry.fn(entityId);

--- a/engine/prefabs/irreden/input/systems/system_entity_hover_detect.hpp
+++ b/engine/prefabs/irreden/input/systems/system_entity_hover_detect.hpp
@@ -52,8 +52,18 @@ struct EntityEventHandlers {
         return id;
     }
 
+    // The single enumeration of the handler-category vectors — clear() and
+    // removeHandler() drive through it, so a new category is one edit here,
+    // not a silent miss in a hand-maintained copy.
+    template <typename F> void forEachHandlerVector(F &&f) {
+        f(onHovered);
+        f(onUnhovered);
+        f(onClicked);
+        f(onRightClick);
+    }
+
     void removeHandler(int handlerId) {
-        auto eraseById = [handlerId](std::vector<HandlerEntry> &vec) {
+        forEachHandlerVector([handlerId](std::vector<HandlerEntry> &vec) {
             vec.erase(
                 std::remove_if(
                     vec.begin(),
@@ -62,11 +72,7 @@ struct EntityEventHandlers {
                 ),
                 vec.end()
             );
-        };
-        eraseById(onHovered);
-        eraseById(onUnhovered);
-        eraseById(onClicked);
-        eraseById(onRightClick);
+        });
     }
 
     // Drops every registered handler, destroying the sol::protected_functions
@@ -78,10 +84,7 @@ struct EntityEventHandlers {
     // handler from Lua (#2572). nextId is intentionally left as-is: ids never
     // recycle within a process, so there is no id-reuse hazard to guard.
     void clear() {
-        onHovered.clear();
-        onUnhovered.clear();
-        onClicked.clear();
-        onRightClick.clear();
+        forEachHandlerVector([](std::vector<HandlerEntry> &vec) { vec.clear(); });
     }
 
     void fireHovered(IREntity::EntityId entityId) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(IrredenEngineTest
   common/ir_args_test.cpp
   common/ir_platform_test.cpp
   ecs/command_randomize_voxels_test.cpp
+  ecs/entity_event_handlers_test.cpp
   ecs/entity_manager_test.cpp
   ecs/execute_query_test.cpp
   ecs/grid_rotation_test.cpp

--- a/test/ecs/entity_event_handlers_test.cpp
+++ b/test/ecs/entity_event_handlers_test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <irreden/input/systems/system_entity_hover_detect.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <sol/sol.hpp>
+
+namespace {
+
+// Covers IRSystem::EntityEventHandlers::clear() — the mechanism the #2572 exit
+// SIGSEGV fix depends on. getEntityEventHandlers() returns a process-lifetime
+// static holding sol::protected_function refs into whatever LuaScript VM
+// registered them; clear() drops every handler (destroying those refs) so the
+// engine tail can empty the registry while the VM is still alive, before the
+// static's own destructor would otherwise run luaL_unref after lua_close.
+//
+// Member order is load-bearing: m_lua is the only member and outlives the
+// TearDown() clear(), so the sol::protected_functions are unref'd against a
+// still-open lua_State (same lifetime contract as lua_input_bindings_test.cpp).
+class EntityEventHandlersTest : public testing::Test {
+  protected:
+    void TearDown() override {
+        // Leave the process-static registry empty even if an assertion aborts
+        // the body before its own clear() — a surviving ref would luaL_unref
+        // into the closed VM at process exit and segfault the whole test
+        // binary, masking the real failure. This is the exact clear() contract
+        // #2572 added at the engine tail.
+        IRSystem::getEntityEventHandlers().clear();
+    }
+
+    IRScript::LuaScript m_lua;
+};
+
+// Register one handler through each of the four add* paths, then clear(): every
+// handler vector must go from non-empty back to empty. The pre-clear size
+// assertions are the positive control — they prove the registrations landed, so
+// the post-clear emptiness is a real drop rather than a vacuous already-empty
+// pass on the shared process static.
+TEST_F(EntityEventHandlersTest, ClearEmptiesAllFourHandlerVectors) {
+    auto &handlers = IRSystem::getEntityEventHandlers();
+    handlers.clear(); // known-empty baseline; the static may carry prior state
+
+    ASSERT_TRUE(
+        m_lua.lua().safe_script("noopHandler = function() end", sol::script_pass_on_error).valid()
+    );
+    sol::protected_function fn = m_lua.lua()["noopHandler"];
+
+    handlers.addOnHovered(fn);
+    handlers.addOnUnhovered(fn);
+    handlers.addOnClicked(fn);
+    handlers.addOnRightClick(fn);
+
+    EXPECT_EQ(handlers.onHovered.size(), 1u);
+    EXPECT_EQ(handlers.onUnhovered.size(), 1u);
+    EXPECT_EQ(handlers.onClicked.size(), 1u);
+    EXPECT_EQ(handlers.onRightClick.size(), 1u);
+
+    handlers.clear();
+
+    EXPECT_TRUE(handlers.onHovered.empty());
+    EXPECT_TRUE(handlers.onUnhovered.empty());
+    EXPECT_TRUE(handlers.onClicked.empty());
+    EXPECT_TRUE(handlers.onRightClick.empty());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Fixes an exit-time SIGSEGV (#2572). The process-lifetime `EntityEventHandlers`
  registry (hover / click / right-click callbacks) holds `sol::protected_function`
  refs into the World's Lua VM. Since #2539 moved World teardown to the
  `gameLoop()` tail, `lua_close` now runs before the static's destructor — which
  fires at `__cxa_finalize` and `luaL_unref`s into freed memory. Any creation
  that registered a handler from Lua segfaults at process exit.
- Adds `EntityEventHandlers::clear()` and calls it via an out-of-line
  `detail::clearEntityEventHandlers()` at the `gameLoop()` tail, immediately
  **before** `g_world.reset()`, while the VM is still alive — so the static's own
  destructor unrefs only empty vectors (acceptance criterion #3, empty registry
  post-`gameLoop`, holds by construction).
- The helper is out-of-line in `engine.cpp` (mirroring `applyPreInitLuaConfig`)
  so the prefab header's sol2 + `ir_render` includes don't transitively widen
  every includer of `ir_engine.hpp`. Runtime dispatch is unchanged; `nextId` is
  left as-is (ids never recycle within a process).

## Test plan
- [x] `IRShapeDebug` builds + runs clean on macOS/Metal — `RESULT=CLEAN exit=0`.
- [x] A/B with a handler registered against the World's Lua VM (the exact
  scenario a `IRInput.onRightClick` binding produces): **without** the clear →
  `SIGSEGV` (exit 139) after "Clean shutdown complete." — reproduces the issue's
  forensics; **with** the clear → `RESULT=CLEAN exit=0`. Dispatch still fires
  during the run.
- [ ] Linux/GL exit smoke — the fix is a host-agnostic teardown-ordering change
  (no render/backend code); reviewer to confirm on a GL host per acceptance.

Closes #2572

🤖 Generated with [Claude Code](https://claude.com/claude-code)