### PR TITLE
docs+editor(voxel_editor): -y-face pick no-op root-cause (#2575) + re-land #2584 picker-floor shadow model (#2578)

### DIFF
--- a/creations/editors/voxel_editor/session_builder.hpp
+++ b/creations/editors/voxel_editor/session_builder.hpp
@@ -32,7 +32,7 @@
 // aim that would be occluded is caught while the recipe is being built rather
 // than as a mystery FAIL (or, worse, a silent no-op) at run time.
 //
-// Two properties of the editor's isometric view drive the whole design:
+// Three properties of the editor's isometric view drive the whole design:
 //   - The picking ray marches along +(1,1,1), so exactly three faces of a voxel
 //     can ever be clicked: -x, -y, -z. Placing at cell T therefore means
 //     clicking face n of anchor cell T - n for one of those three normals.
@@ -41,6 +41,13 @@
 //     needs zoom >= 3 (see kSessionZoom), because a face-centre aim is offset
 //     half a column-spacing in screen space and rounds across the boundary
 //     below that.
+//   - The cursor->ray inverse FLOORS the aim onto the integer iso lattice, so a
+//     sub-half-pixel face offset is destroyed before the ray is cast. At the
+//     cardinal camera a voxel's -x and -y faces land on one pixel (root cause:
+//     docs/design/editor-authoring-friction.md §M-2), so the model must
+//     march the floored column and predict the face normal — a model that
+//     marched the exact aim ray would separate two aims the live picker cannot,
+//     and greenlight a click that silently no-ops.
 //
 // Recipes run at the cardinal baseline yaw (no camera rotation between
 // segments), which is what lets the model assume the (1,1,1) march axis.
@@ -55,20 +62,20 @@ inline constexpr IRMath::ivec3 kCameraFacingNormals[3] = {
     IRMath::ivec3(0, 0, -1),
 };
 
-// How far inside the anchor voxel a face click aims, measured from the voxel
-// centre toward the clicked face. Strictly < 0.5 so the point stays inside the
-// cube: the picker derives the hit face from the dominant axis of
-// (hit point - voxel centre), and a point exactly on the face plane can round
-// to either side of it. 0.4 leaves a 0.1-voxel margin to the clicked face while
-// the other two axes stay 0.5 away, so the dominant axis survives the cursor
-// pixel being rounded to an integer.
+// How far from the voxel centre, toward the clicked face, the model probes to
+// find out which iso pixel that face maps to. It is ONLY a pixel selector: the
+// picker floors the cursor onto the integer iso lattice and re-casts from the
+// pixel, so no sub-voxel structure of the probe point survives into the hit
+// (which is why the emitted aim is re-centred in the chosen pixel — see
+// faceAim). Strictly < 0.5 so the probe stays inside the cube; 0.4 puts the -z
+// probe a clear 0.8 iso row off the voxel's own pixel while leaving -x / -y on
+// it, which is the (unfixable) collapse §M-2 documents.
 inline constexpr float kFaceAimDepth = 0.4f;
 
-// Ray-march step for the occlusion model, in voxels per axis. The picker walks
-// iso depth in kPickingDepthStep increments and one iso-depth unit moves the
-// recovered world point by (1/3, 1/3, 1/3), so this matches its sampling
-// density — the model can't miss a cell the real ray would have hit.
-inline constexpr float kRayStep = IRPrefab::Picking::kPickingDepthStep / 3.0f;
+// Cardinal camera index the recipes author at. Sessions never rotate the
+// camera, so the model's aim->pixel projection is fixed at the identity
+// rotation — the same assumption that lets it hard-code the (1,1,1) march.
+inline constexpr IRMath::CardinalIndex kSessionCardinalIndex = IRMath::CardinalIndex::k0;
 
 // Frames a session shot leaves between the cursor MOVE and the button PRESS,
 // and again before the RELEASE. One frame each is what the existing scripted
@@ -155,33 +162,97 @@ class OccupancyModel {
         return m_origin + IRMath::vec3(local);
     }
 
-    // The cell IRPrefab::Picking::castVoxelRay would report for a cursor aimed
-    // at `worldAim` — the front-most occupied cell along the +(1,1,1) march.
+    // Iso depth (the picker's march coordinate) of `local`'s centre.
+    float cellIsoDepth(IRMath::ivec3 local) const {
+        return static_cast<float>(IRMath::pos3DtoDistance(worldCenter(local)));
+    }
+
+    // What IRPrefab::Picking::castVoxelRay would report for a cursor aimed at
+    // `worldAim`: the cell the ray lands on AND the face normal it derives.
+    // Both halves matter — the editor places at `voxelPos_ + faceNormal_`, so a
+    // prediction that only carries the cell can still greenlight a click that
+    // edits a different neighbour than the recipe asked for.
+    struct PickPrediction {
+        IRMath::ivec3 cell_ = IRMath::ivec3(0);
+        IRMath::ivec3 faceNormal_ = IRMath::ivec3(0);
+    };
+
     // Replays the picker's walk over the mirror rather than approximating it,
-    // so "is this aim occluded" is answered the same way the editor will answer
-    // it at run time.
-    std::optional<IRMath::ivec3> pick(IRMath::vec3 worldAim) const {
-        const float span = static_cast<float>(m_size.x + m_size.y + m_size.z);
-        for (float t = -span; t <= span; t += kRayStep) {
-            const IRMath::vec3 point = worldAim + IRMath::vec3(t);
+    // so "where does this aim land" is answered the same way the editor will
+    // answer it at run time — including the lossy parts. The aim is reduced to
+    // its floored iso pixel first (aimIsoPixel), because that pixel is the only
+    // thing the live picker ever sees; marching the exact aim ray instead would
+    // resolve sub-pixel detail the cursor cannot carry.
+    //
+    // The face normal this returns agrees with the live picker's only because
+    // both grids land on the same 0.5 lattice today (session scenes build
+    // without demo furniture and every occupied cell/ghost origin is a multiple
+    // of 0.5 — see docs/design/editor-authoring-friction.md §M-2's
+    // quantization caveat); a future visible entity with an off-lattice depth
+    // origin in a session scene would silently break that agreement on the
+    // collapsed -x/-y columns without failing a test.
+    std::optional<PickPrediction> pick(IRMath::vec3 worldAim) const {
+        const IRMath::ivec2 isoPixel =
+            IRPrefab::Picking::aimIsoPixel(worldAim, kSessionCardinalIndex);
+        // Front-to-back over the scene's iso-depth span at the picker's own
+        // step, so no cell the real ray would sample is skipped. The span is
+        // the near and far cells' own depths, widened by the picker's margin
+        // for the half-cell rounding at either end.
+        const float nearDepth = cellIsoDepth(IRMath::ivec3(0));
+        const float farDepth = cellIsoDepth(m_size - IRMath::ivec3(1));
+        for (float depth = nearDepth - IRPrefab::Picking::kPickingDepthMargin;
+             depth <= farDepth + IRPrefab::Picking::kPickingDepthMargin;
+             depth += IRPrefab::Picking::kPickingDepthStep) {
+            const IRMath::vec3 point = IRMath::isoPixelToPos3D(isoPixel.x, isoPixel.y, depth);
             const IRMath::ivec3 local = IRMath::roundVec3HalfUp(point - m_origin);
-            if (occupied(local))
-                return local;
+            if (!occupied(local))
+                continue;
+            return PickPrediction{
+                local,
+                IRPrefab::Picking::voxelHitFaceNormal(point - worldCenter(local))
+            };
         }
         return std::nullopt;
+    }
+
+    // Where to put the cursor to click `local`'s `normal` face.
+    //
+    // The face direction only chooses which iso pixel the click lands on; the
+    // picker floors the cursor onto the lattice and re-casts from that pixel, so
+    // nothing else about the aim survives. So probe for the pixel, then aim at
+    // the point that lands DEAD CENTRE of it rather than at the face plane.
+    //
+    // That margin is load-bearing. The live forward mapping rounds to a whole
+    // screen pixel before the inverse floors it back, and a face-plane aim sits
+    // only ~0.1 iso from a floor boundary — inside that rounding, so it flips
+    // onto the neighbouring column for some cells and not others (measured at
+    // kSessionZoom: every -x face-plane aim recovered a pixel one iso row off
+    // the model's). Re-centring buys the full half-pixel, which no rounding at
+    // any authoring zoom can cross, so model and live pick agree by
+    // construction. The depth argument only slides the point along the pixel's
+    // column; the anchor's own depth keeps it inside the anchor cube.
+    IRMath::vec3 faceAim(IRMath::ivec3 local, IRMath::ivec3 normal) const {
+        const IRMath::vec3 center = worldCenter(local);
+        const IRMath::ivec2 pixel = IRPrefab::Picking::aimIsoPixel(
+            center + IRMath::vec3(normal) * kFaceAimDepth,
+            kSessionCardinalIndex
+        );
+        return IRMath::isoPixelToPos3D(pixel.x, pixel.y, cellIsoDepth(local));
     }
 
     // Where to aim to click `target` itself (erase / drag over existing
     // geometry). Returns nullopt when every camera-facing face of `target` is
     // occluded — the caller reports that as a recipe error rather than emitting
-    // a click that would silently edit the wrong cell.
+    // a click that would silently edit the wrong cell. Deliberately
+    // normal-agnostic: the erase path acts on `hit.voxelPos_`, so which of the
+    // target's faces the picker attributes the hit to does not change the edit.
     std::optional<IRMath::vec3> aimAtVoxel(IRMath::ivec3 target) const {
         if (!occupied(target))
             return std::nullopt;
         for (const IRMath::ivec3 &normal : kCameraFacingNormals) {
-            const IRMath::vec3 aim = worldCenter(target) + IRMath::vec3(normal) * kFaceAimDepth;
-            const std::optional<IRMath::ivec3> hit = pick(aim);
-            if (hit && *hit == target)
+            const IRMath::vec3 aim = faceAim(target, normal);
+            const std::optional<PickPrediction> hit = pick(aim);
+            if (hit && hit->cell_ == target)
                 return aim;
         }
         return std::nullopt;
@@ -190,7 +261,11 @@ class OccupancyModel {
     // Where to aim so a place-mode click lands a voxel at `target`. The editor
     // places at (hit voxel + hit face normal), so the anchor is target - normal
     // for one of the camera-facing normals; the anchor must be occupied, the
-    // target empty, and the anchor's face unoccluded.
+    // target empty, and the anchor's face must be the one the picker actually
+    // resolves. Preferring the first normal that satisfies all three is what
+    // routes a target around the -x/-y pixel collapse: a cell with a +x-side or
+    // +z-side anchor is placed through that clean face instead, and only a cell
+    // whose sole anchor sits on the +y side comes back unreachable.
     std::optional<IRMath::vec3> aimToPlace(IRMath::ivec3 target) const {
         if (!inBounds(target) || occupied(target))
             return std::nullopt;
@@ -198,9 +273,13 @@ class OccupancyModel {
             const IRMath::ivec3 anchor = target - normal;
             if (!occupied(anchor))
                 continue;
-            const IRMath::vec3 aim = worldCenter(anchor) + IRMath::vec3(normal) * kFaceAimDepth;
-            const std::optional<IRMath::ivec3> hit = pick(aim);
-            if (hit && *hit == anchor)
+            const IRMath::vec3 aim = faceAim(anchor, normal);
+            const std::optional<PickPrediction> hit = pick(aim);
+            // The predicted face has to agree as well as the cell: an aim that
+            // picks the right anchor through the wrong face places the wrong
+            // neighbour, or — when that neighbour is already filled — nothing
+            // at all, which is the silent no-op this model exists to catch.
+            if (hit && hit->cell_ == anchor && hit->faceNormal_ == normal)
                 return aim;
         }
         return std::nullopt;
@@ -507,11 +586,20 @@ class Builder {
         m_frame += kFramesPerClickStep;
     }
 
+    // An op the model could not aim. In place mode that covers both "every
+    // camera-facing anchor is occluded" and "the only anchor's face is one the
+    // picker's iso-pixel floor collapses" — same remedy either way (re-order the
+    // recipe so a clean face is exposed, or take the cell from a mirror), so
+    // they share one error rather than splitting into two the author must
+    // distinguish. The docs pointer is what makes the second case diagnosable.
     void recordUnreachable(const char *op, IRMath::ivec3 target) {
         m_recipe.errors_.push_back(
             std::string(op) + " at local (" + std::to_string(target.x) + "," +
             std::to_string(target.y) + "," + std::to_string(target.z) +
-            "): no unoccluded camera-facing anchor in segment " + m_current.label_
+            "): no camera-facing anchor the picker resolves (occluded, or the face "
+            "collapses onto the voxel's own iso pixel — see "
+            "docs/design/editor-authoring-friction.md §M-2) in segment " +
+            m_current.label_
         );
     }
 

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -537,6 +537,12 @@ Findings:
 
 ### M-2 — `-y`-face single-click place no-ops at the cardinal (yaw-0) camera (#2575)
 
+*ID note — `M-` tags a **mechanism** limitation: one that lives in the shared
+picker rather than in a single authoring slice, so it is not numbered `F-2e-n`
+like the slice findings above. There is no `M-1`; the number is fixed at 2
+because #2575's acceptance criteria named this write-up `M-2` before it
+existed, and #2578 cites `§M-2` too.*
+
 Surfaced authoring the mushroom (2e). Growing a voxel outward by clicking the
 exposed face of a neighbour, at the editor's cardinal (yaw-0) camera and
 authoring zoom (`kSessionZoom = 4`):

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -421,9 +421,12 @@ time, but a `-y`-face click **no-ops**: measured directly — `(6,7,cz)` and
 `(5,7,cz)` (‑x arm) place; `(7,6,cz)` and `(7,5,cz)` (‑y arm) stay empty, at the
 same zoom, in the same segment. The iso-projected `-y`-face aim mis-picks (the
 click resolves to a face/cell that isn't the intended `-y` neighbour), so the
-place is dropped with no feedback. This is a **primary-placement** limitation in
-the editor's picking / drag-state path — *not* the mirror code, which is
-symmetric and is proven working on both axes by the stem checks (`(7,8,·)` Y
+place is dropped with no feedback. Root-caused in **§M-2** below (this paragraph
+is the slice-local summary of that section): the picker's iso-pixel *floor*
+collapses the `-x` and `-y` face aims onto the identical pixel at cardinal yaw,
+so the distinction is destroyed before the face derivation runs — a
+projection/quantization limitation of the picker, *not* the mirror code, which
+is symmetric and is proven working on both axes by the stem checks (`(7,8,·)` Y
 mirror and `(8,7,·)` X mirror both fill). A human hand-authoring would hit the
 same wall: some faces of a voxel can't be clicked to grow in that direction at
 this camera. Worked around here by growing the cap in `-x`/`-z` only and taking
@@ -531,3 +534,93 @@ Findings:
   from its own dimensional preconditions (the ant refuses anything under
   14 × 18 × 3). A recipe that scales its geometry off `sceneSize` should state
   the bound it actually needs rather than trusting the caller's `--scene-size`.
+
+### M-2 — `-y`-face single-click place no-ops at the cardinal (yaw-0) camera (#2575)
+
+Surfaced authoring the mushroom (2e). Growing a voxel outward by clicking the
+exposed face of a neighbour, at the editor's cardinal (yaw-0) camera and
+authoring zoom (`kSessionZoom = 4`):
+
+- A `-x`-face or `-z`-face single click places the intended neighbour every time.
+- A `-y`-face single click **no-ops** — the intended `-y` neighbour is never
+  placed, with no feedback.
+
+| primary click | anchored face | result |
+|---|---|---|
+| `(6,7,11)` | `-x` of `(7,7,11)` | placed ✓ |
+| `(7,6,11)` | `-y` of `(7,7,11)` | **empty ✗** |
+| `(7,5,11)` | `-y` of `(7,6,11)` | **empty ✗** |
+
+**Root cause — the picker's iso-pixel floor collapses `-x` and `-y` face aims
+onto the same pixel at cardinal yaw.** The place path is `hit.voxelPos_ +
+hit.faceNormal_` (`voxel_editor/main.cpp`), where `hit.faceNormal_` comes from
+`IRPrefab::Picking::detail::voxelHitFaceNormal(worldHitPos - voxelCenter)` — the
+dominant axis of the ray's entry offset, with tie-break priority **x > y > z**.
+The cursor→ray inverse (`IRRender::mouseWorldPos3DAtIsoDepth`) **floors** the iso
+pixel to the integer lattice: `isoPixelToPos3D(floor(canvasIso.x),
+floor(canvasIso.y), depth)`, and the forward aim (`worldPos3DToMouseScreenPx`)
+adds `+0.5` (aim-at-cell-centre). The iso projection is `iso.x = -x + y`,
+`iso.y = -x - y + 2z`.
+
+For a face aim `center + normal·kFaceAimDepth` (`kFaceAimDepth = 0.4`), the
+recovered floored iso pixel is `floor(pos3DtoPos2DIso(aim) + 0.5)`:
+
+| face of `(7,7,11)` | aim | `pos3DtoPos2DIso(aim)` | floored pixel |
+|---|---|---|---|
+| `-x` | `(6.6, 7, 11)` | `(0.4, 8.4)` | **`(0, 8)`** |
+| `-y` | `(7, 6.6, 11)` | `(-0.4, 8.4)` | **`(0, 8)`** |
+| `-z` | `(7, 7, 10.6)` | `(0, 7.2)` | `(0, 7)` |
+
+The `-x` and `-y` aims land on the **identical** pixel `(0, 8)` — which is also
+the voxel *centre's* pixel — because their iso offsets (`±0.4` in `iso.x`, from
+the coefficient-1 `x`/`y` terms) are smaller than the `+0.5` cell-centre bias, so
+the floor snaps both back to the centre column. `-z` escapes only because
+`iso.y`'s `2z` coefficient turns a `-0.4` z-offset into a `-0.8` iso shift, large
+enough to cross the floor boundary onto a distinct column. On the collapsed
+centre column the ray marches through the voxel centre and enters at the
+`(1,1,1)` corner, so `worldHitPos - voxelCenter` is **parallel to `(1,1,1)`** —
+`|Δx| = |Δy| = |Δz|` — a three-way tie that `voxelHitFaceNormal` resolves to
+`-x`. That is *correct* for a `-x` click (coincidentally) and *wrong* for a `-y`
+click (it should be `(0,-1,0)`), so the `-y` neighbour cell stays empty and the
+edit is dropped. (For `cx != cy`, e.g. `-y` of `(7,6,11)`, the aim collapses onto
+that voxel's own centre pixel `(-1, 9)` the same way — the offset is still
+parallel to `(1,1,1)`, so the tie still resolves to `-x`.)
+
+**A/B repro (no editor run required).** `A = -x` aim `(6.6,7,11)` and `B = -y`
+aim `(7,6.6,11)` both reduce to floored iso pixel `(0,8)` under
+`floor(pos3DtoPos2DIso(aim) + (0.5,0.5))`. The picker receives byte-identical
+input for A and B, so it *cannot* return different results for them — the `-y`
+distinction is destroyed at the floor, not merely mis-resolved downstream.
+
+**This is a genuine projection/quantization limitation, not a fixable
+face-derivation bug.** At the picker's integer-iso-pixel resolution a voxel's
+`-x` and `-y` faces map to the same picking pixel at cardinal yaw, so no
+tie-break rule or `Δ`-based heuristic can separate them (the inputs are equal).
+Disambiguating would require sub-iso-pixel picking precision — a change to the
+`mouseWorldPos3DAtIsoDepth` / `worldPos3DToMouseScreenPx` round-trip contract
+that every editor picking consumer (live click, hover, gizmo drag, the session
+shadow model) depends on — out of scope for this friction fix and a design-level
+change to the load-bearing picker.
+
+**Authoring path (per #2575 acceptance).**
+
+- **Hand-authoring:** rotate the camera one cardinal step with `Q`/`E` before
+  the click. Under a `±90°` yaw the target's `-y` face presents as an `-x`- or
+  `-z`-facing face, which the picker resolves cleanly; place, then rotate back.
+- **Symmetric solids:** take `-y` thickness from the **Y mirror** rather than a
+  raw `-y` click — the mushroom (2e) does exactly this (cap grown in `-x`/`-z`,
+  y-thickness mirrored). The F-1.2 mirror path fans a `-x`/`-z` primary click out
+  to both Y sides, so no `-y` primary click is needed.
+- **Session recipes:** `aimToPlace` already tries `-x` before `-y`, so any target
+  with a `+x`-side or `+z`-side anchor is placed through a clean face
+  automatically; only a target whose *sole* occupied anchor is on the `+y` side
+  hits this wall.
+
+**Recommended follow-up (#2578, agent-approved lane).** The session shadow model
+(`OccupancyModel::pick`, `session_builder.hpp`) marches the *exact* aim ray, so
+it does **not** reproduce the picker's iso-pixel floor and greenlights a `-y` aim
+whose live click misfires — the silent-no-op source. A hardening pass should make
+`pick` reproduce the floored-iso march + `voxelHitFaceNormal`, and have
+`aimToPlace` reject an aim whose predicted face normal disagrees with the
+intended one (so it either finds a disambiguable anchor or records an
+`unreachable` recipe error, instead of emitting a click that no-ops).

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -560,7 +560,7 @@ authoring zoom (`kSessionZoom = 4`):
 **Root cause — the picker's iso-pixel floor collapses `-x` and `-y` face aims
 onto the same pixel at cardinal yaw.** The place path is `hit.voxelPos_ +
 hit.faceNormal_` (`voxel_editor/main.cpp`), where `hit.faceNormal_` comes from
-`IRPrefab::Picking::detail::voxelHitFaceNormal(worldHitPos - voxelCenter)` — the
+`IRPrefab::Picking::voxelHitFaceNormal(worldHitPos - voxelCenter)` — the
 dominant axis of the ray's entry offset, with tie-break priority **x > y > z**.
 The cursor→ray inverse (`IRRender::mouseWorldPos3DAtIsoDepth`) **floors** the iso
 pixel to the integer lattice: `isoPixelToPos3D(floor(canvasIso.x),
@@ -622,11 +622,24 @@ change to the load-bearing picker.
   automatically; only a target whose *sole* occupied anchor is on the `+y` side
   hits this wall.
 
-**Recommended follow-up (#2578, agent-approved lane).** The session shadow model
-(`OccupancyModel::pick`, `session_builder.hpp`) marches the *exact* aim ray, so
-it does **not** reproduce the picker's iso-pixel floor and greenlights a `-y` aim
-whose live click misfires — the silent-no-op source. A hardening pass should make
-`pick` reproduce the floored-iso march + `voxelHitFaceNormal`, and have
-`aimToPlace` reject an aim whose predicted face normal disagrees with the
-intended one (so it either finds a disambiguable anchor or records an
-`unreachable` recipe error, instead of emitting a click that no-ops).
+**Follow-up (#2578, agent-approved lane) — LANDED.** The session shadow model
+(`OccupancyModel::pick`, `session_builder.hpp`) marched the *exact* aim ray, so
+it did **not** reproduce the picker's iso-pixel floor and greenlit a `-y` aim
+whose live click misfires — the silent-no-op source. `pick` now reproduces the
+floored-iso march + `voxelHitFaceNormal` and returns the predicted normal
+alongside the cell, and `aimToPlace` rejects an aim whose predicted normal
+disagrees with the intended one — so a `-y`-only target either finds a
+disambiguable anchor or records an `unreachable` recipe error, instead of
+emitting a click that no-ops.
+
+**The round trip above is idealized — the live one quantizes to a whole screen
+pixel first.** `worldPos3DToMouseScreenPx` rounds to an integer *screen* pixel
+before `mouseWorldPos3DAtIsoDepth` floors back to iso, and at `kSessionZoom = 4`
+an iso row is 4 screen px. A face-plane aim sits only ~0.1 iso from a floor
+boundary, i.e. inside that rounding, so its recovered pixel can be one row off
+the table above. The collapse tables stay valid as the *mechanism*; what changes
+is that a shadow model cannot place its aim on the face plane and expect the
+floor to agree. `pick` therefore treats the face offset as a pixel *probe* and
+re-centres the emitted aim inside the chosen pixel, which buys the full
+half-pixel of margin. See `aimIsoPixel` in
+`engine/prefabs/irreden/render/picking.hpp`.

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -538,10 +538,12 @@ Findings:
 ### M-2 — `-y`-face single-click place no-ops at the cardinal (yaw-0) camera (#2575)
 
 *ID note — `M-` tags a **mechanism** limitation: one that lives in the shared
-picker rather than in a single authoring slice, so it is not numbered `F-2e-n`
-like the slice findings above. There is no `M-1`; the number is fixed at 2
-because #2575's acceptance criteria named this write-up `M-2` before it
-existed, and #2578 cites `§M-2` too.*
+picker or edit path rather than in a single authoring slice, so it is not
+numbered `F-2e-n` like the slice findings above. `M-1` (mirror planes had no
+meaningful position) is recorded inline in §2e; this write-up keeps the number
+`M-2` because #2575's acceptance criteria named it `M-2` before it existed, and
+#2578 cites `§M-2` too. The `**M-2 —**` paragraph in §2e is the slice-local
+summary of this section.*
 
 Surfaced authoring the mushroom (2e). Growing a voxel outward by clicking the
 exposed face of a neighbour, at the editor's cardinal (yaw-0) camera and

--- a/engine/prefabs/irreden/render/picking.hpp
+++ b/engine/prefabs/irreden/render/picking.hpp
@@ -50,6 +50,67 @@
 
 namespace IRPrefab::Picking {
 
+// Picks the hit-face outward normal for a unit-cube voxel. Returns the
+// axis with the largest |delta| component, signed by that component —
+// "place adjacent" math just adds this normal to `voxelPos_` to land
+// on the cell on the entry side.
+//
+// The tie-break order is contractual, not incidental: equal magnitudes
+// resolve x → y → z, so a hit whose entry offset is parallel to the
+// (1,1,1) march axis (the ray passing exactly through the voxel centre)
+// always reports the x face. Predictors of `RayHit::faceNormal_` — the
+// voxel editor's session shadow model — depend on reproducing it
+// exactly. `test/render/picking_face_normal_test.cpp` pins it.
+inline IRMath::ivec3 voxelHitFaceNormal(IRMath::vec3 delta) {
+    const IRMath::vec3 absDelta = IRMath::abs(delta);
+    IRMath::ivec3 normal(0);
+    if (absDelta.x >= absDelta.y && absDelta.x >= absDelta.z) {
+        normal.x = delta.x >= 0.0f ? 1 : -1;
+    } else if (absDelta.y >= absDelta.z) {
+        normal.y = delta.y >= 0.0f ? 1 : -1;
+    } else {
+        normal.z = delta.z >= 0.0f ? 1 : -1;
+    }
+    return normal;
+}
+
+// The canvas-frame iso pixel a cursor aimed at `worldAim` casts its ray
+// from — the CPU mirror of the `IRRender::worldPos3DToMouseScreenPx` →
+// `IRRender::mouseWorldPos3DAtIsoDepth` round trip, with the camera pan
+// and letterbox terms cancelled (they appear identically in both halves).
+// What survives is the forward aim's `+0.5` cell-centre bias and the
+// inverse's floor back onto the integer iso lattice.
+//
+// The floor is lossy by design: an aim offset whose iso projection is
+// smaller than the half-pixel bias lands on the voxel centre's pixel, so
+// two faces of one voxel can share a pixel — at cardinal yaw the -x and
+// -y faces always do, the iso equations giving x and y coefficient 1
+// while z gets 2 (`docs/design/editor-authoring-friction.md` §M-2).
+// Anything predicting where a scripted click lands must go through this,
+// not through the exact aim ray.
+//
+// Exact only near a pixel's CENTRE. The live forward half rounds to a
+// whole screen pixel before the inverse divides back out, and near a
+// floor boundary that half-pixel is enough to land the real cursor one
+// iso pixel off this result (at zoom 4 an iso row is 4 screen px, so the
+// error reaches 0.125 iso while a face-plane aim sits 0.1 from the
+// boundary). A caller that chooses its own aim should therefore pick the
+// point that lands dead centre — `isoPixelToPos3D` re-projects onto a
+// pixel exactly. What the rounding cannot do is un-collapse two aims
+// this helper maps to one pixel.
+//
+// Cardinal-only in the same sense the rest of the picking chain is:
+// `cardinalIndex` covers the rasterYaw snap, not a residual yaw, whose
+// face deformation the picking math does not reverse either.
+inline IRMath::ivec2 aimIsoPixel(IRMath::vec3 worldAim, IRMath::CardinalIndex cardinalIndex) {
+    const IRMath::vec3 rotated = IRMath::rotateCardinalZ(worldAim, cardinalIndex);
+    const IRMath::vec2 iso = IRMath::pos3DtoPos2DIso(rotated) + IRMath::vec2(0.5f);
+    return IRMath::ivec2(
+        static_cast<int>(IRMath::floor(iso.x)),
+        static_cast<int>(IRMath::floor(iso.y))
+    );
+}
+
 struct RayHit {
     IREntity::EntityId entity_ = IREntity::kNullEntity;
     IRMath::vec3 worldHitPos_ = IRMath::vec3(0.0f);
@@ -191,23 +252,6 @@ gatherVisibleVoxelSets(IRMath::CardinalIndex cardinalIndex, IREntity::EntityId e
     return snapshot;
 }
 
-// Picks the hit-face outward normal for a unit-cube voxel. Returns the
-// axis with the largest |delta| component, signed by that component —
-// "place adjacent" math just adds this normal to `voxelPos_` to land
-// on the cell on the entry side.
-inline IRMath::ivec3 voxelHitFaceNormal(IRMath::vec3 delta) {
-    const IRMath::vec3 absDelta = IRMath::abs(delta);
-    IRMath::ivec3 normal(0);
-    if (absDelta.x >= absDelta.y && absDelta.x >= absDelta.z) {
-        normal.x = delta.x >= 0.0f ? 1 : -1;
-    } else if (absDelta.y >= absDelta.z) {
-        normal.y = delta.y >= 0.0f ? 1 : -1;
-    } else {
-        normal.z = delta.z >= 0.0f ? 1 : -1;
-    }
-    return normal;
-}
-
 } // namespace detail
 
 // Casts a ray from the cursor into the scene and returns the first
@@ -289,7 +333,7 @@ castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
                 vs.entity_,
                 worldPoint,
                 IRMath::roundVec3HalfUp(candidateCenter),
-                detail::voxelHitFaceNormal(delta)
+                voxelHitFaceNormal(delta)
             };
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,7 @@ add_executable(IrredenEngineTest
   render/frame_data_sun_layout_test.cpp
   render/gpu_compute_dispatch_test.cpp
   render/per_canvas_light_scope_test.cpp
+  render/picking_aim_iso_pixel_test.cpp
   render/picking_face_normal_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp

--- a/test/render/picking_aim_iso_pixel_test.cpp
+++ b/test/render/picking_aim_iso_pixel_test.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <irreden/render/picking.hpp>
+
+// `IRPrefab::Picking::aimIsoPixel` is the CPU mirror of the
+// `worldPos3DToMouseScreenPx` -> `mouseWorldPos3DAtIsoDepth` round trip: the
+// canvas-frame iso pixel a cursor aimed at a world point actually casts from.
+// It is what anything predicting a scripted click must go through, so its
+// lossiness is contractual and pinned here. Root cause + the measured table
+// these cases reproduce: `docs/design/editor-authoring-friction.md` §M-2
+// (#2575). The voxel editor's session shadow model is the consumer.
+
+namespace {
+
+using IRPrefab::Picking::aimIsoPixel;
+
+constexpr IRMath::CardinalIndex kCardinal = IRMath::CardinalIndex::k0;
+
+// The face-aim depth the session builder clicks at: far enough inside the cube
+// that the picker's dominant-axis face derivation is stable, but well under the
+// half-pixel bias the floor applies. Mirrors
+// IRVoxelEditor::Session::kFaceAimDepth (session_builder.hpp) — a test under
+// test/ can't include a creation header, so keep this value in sync by hand.
+constexpr float kFaceAimDepth = 0.4f;
+
+TEST(PickingAimIsoPixel, VoxelCentreLandsOnItsOwnPixel) {
+    const IRMath::vec3 centre(7.0f, 7.0f, 11.0f);
+    EXPECT_EQ(aimIsoPixel(centre, kCardinal), IRMath::ivec2(0, 8));
+}
+
+TEST(PickingAimIsoPixel, MinusXAndMinusYFaceAimsCollapseOntoOnePixel) {
+    // The defect this helper exists to make predictable: at cardinal yaw the
+    // iso equations give x and y coefficient 1, so a +-0.4 face offset moves
+    // iso.x by less than the +0.5 cell-centre bias and the floor snaps both
+    // aims back onto the voxel's own column. The picker receives byte-identical
+    // input for the two, so no downstream rule can separate them.
+    const IRMath::vec3 centre(7.0f, 7.0f, 11.0f);
+    const IRMath::vec3 minusXAim = centre - IRMath::vec3(kFaceAimDepth, 0.0f, 0.0f);
+    const IRMath::vec3 minusYAim = centre - IRMath::vec3(0.0f, kFaceAimDepth, 0.0f);
+
+    EXPECT_EQ(aimIsoPixel(minusXAim, kCardinal), IRMath::ivec2(0, 8));
+    EXPECT_EQ(aimIsoPixel(minusYAim, kCardinal), IRMath::ivec2(0, 8));
+    EXPECT_EQ(aimIsoPixel(minusXAim, kCardinal), aimIsoPixel(minusYAim, kCardinal));
+    EXPECT_EQ(aimIsoPixel(minusXAim, kCardinal), aimIsoPixel(centre, kCardinal));
+}
+
+TEST(PickingAimIsoPixel, MinusZFaceAimEscapesOntoItsOwnPixel) {
+    // iso.y carries z with coefficient 2, so the same 0.4 offset becomes a 0.8
+    // iso shift — large enough to cross the floor boundary. This is why -z
+    // anchors keep working while -y anchors do not.
+    const IRMath::vec3 centre(7.0f, 7.0f, 11.0f);
+    const IRMath::vec3 minusZAim = centre - IRMath::vec3(0.0f, 0.0f, kFaceAimDepth);
+
+    EXPECT_EQ(aimIsoPixel(minusZAim, kCardinal), IRMath::ivec2(0, 7));
+    EXPECT_NE(aimIsoPixel(minusZAim, kCardinal), aimIsoPixel(centre, kCardinal));
+}
+
+TEST(PickingAimIsoPixel, CollapseIsNotSpecificToTheDiagonalCell) {
+    // §M-2 notes the same collapse for a cell off the x == y diagonal (the
+    // aim lands on that voxel's own centre pixel either way), so the defect
+    // is a property of the projection, not of one measured coordinate.
+    const IRMath::vec3 centre(7.0f, 6.0f, 11.0f);
+    EXPECT_EQ(aimIsoPixel(centre, kCardinal), IRMath::ivec2(-1, 9));
+    EXPECT_EQ(
+        aimIsoPixel(centre - IRMath::vec3(kFaceAimDepth, 0.0f, 0.0f), kCardinal),
+        IRMath::ivec2(-1, 9)
+    );
+    EXPECT_EQ(
+        aimIsoPixel(centre - IRMath::vec3(0.0f, kFaceAimDepth, 0.0f), kCardinal),
+        IRMath::ivec2(-1, 9)
+    );
+}
+
+TEST(PickingAimIsoPixel, FloorsRatherThanTruncatesBelowTheOrigin) {
+    // `mouseWorldPos3DAtIsoDepth` floors; truncation would fold the whole
+    // (-1, 0) band onto pixel 0 and silently mis-aim every negative-iso cell.
+    EXPECT_EQ(aimIsoPixel(IRMath::vec3(0.6f, 0.0f, 0.0f), kCardinal), IRMath::ivec2(-1, -1));
+}
+
+TEST(PickingAimIsoPixel, AppliesTheCardinalRotation) {
+    // rotateCardinalZ((1,0,0), k90) == (0,-1,0), so aiming at (1,0,0) under a
+    // quarter turn must reduce to aiming at (0,-1,0) at the cardinal.
+    EXPECT_EQ(
+        aimIsoPixel(IRMath::vec3(1.0f, 0.0f, 0.0f), IRMath::CardinalIndex::k90),
+        aimIsoPixel(IRMath::vec3(0.0f, -1.0f, 0.0f), kCardinal)
+    );
+    EXPECT_NE(
+        aimIsoPixel(IRMath::vec3(1.0f, 0.0f, 0.0f), IRMath::CardinalIndex::k90),
+        aimIsoPixel(IRMath::vec3(1.0f, 0.0f, 0.0f), kCardinal)
+    );
+}
+
+} // namespace

--- a/test/render/picking_face_normal_test.cpp
+++ b/test/render/picking_face_normal_test.cpp
@@ -4,7 +4,7 @@
 
 namespace {
 
-using IRPrefab::Picking::detail::voxelHitFaceNormal;
+using IRPrefab::Picking::voxelHitFaceNormal;
 
 TEST(PickingFaceNormal, PositiveXFace) {
     EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.4f, 0.1f, -0.2f)), IRMath::ivec3(1, 0, 0));
@@ -33,17 +33,11 @@ TEST(PickingFaceNormal, OutOfBoundsDeltaPositiveXFace) {
     // Pure-function stress-test: delta (0.6, 0, 0) is outside the
     // [-0.5, 0.5) range the rounding step guarantees in normal flow.
     // Exercises robustness for callers that bypass the rounding path.
-    EXPECT_EQ(
-        voxelHitFaceNormal(IRMath::vec3(0.6f, 0.0f, 0.0f)),
-        IRMath::ivec3(1, 0, 0)
-    );
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.6f, 0.0f, 0.0f)), IRMath::ivec3(1, 0, 0));
 }
 
 TEST(PickingFaceNormal, OriginVoxelMinusZFace) {
-    EXPECT_EQ(
-        voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, -0.4f)),
-        IRMath::ivec3(0, 0, -1)
-    );
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, -0.4f)), IRMath::ivec3(0, 0, -1));
 }
 
 TEST(PickingFaceNormal, ExactCenterFavorsXAxisPositive) {
@@ -53,10 +47,24 @@ TEST(PickingFaceNormal, ExactCenterFavorsXAxisPositive) {
     // before the next depth step), so any of the three faces would be a
     // valid place-adjacent direction — this test pins the deterministic
     // choice for regression-detection rather than asserting a semantic.
-    EXPECT_EQ(
-        voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, 0.0f)),
-        IRMath::ivec3(1, 0, 0)
-    );
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, 0.0f)), IRMath::ivec3(1, 0, 0));
+}
+
+TEST(PickingFaceNormal, DiagonalEntryTieResolvesToNegativeX) {
+    // The (1,1,1) march enters a cell whose iso pixel is the cell's own
+    // centre pixel exactly at its near corner, so all three components are
+    // equal and negative. The tie-break lands on -x. This is not cosmetic:
+    // it is why a -y face click at cardinal yaw resolves to the -x face and
+    // places the wrong neighbour (#2575), which the voxel editor's session
+    // shadow model reproduces in order to reject such an aim.
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(-0.4f, -0.4f, -0.4f)), IRMath::ivec3(-1, 0, 0));
+    // The whole in-cell entry band the march can sample, not just one point:
+    // the sample step is 1/6 of a cell along the diagonal, so the first
+    // in-cell sample always lands in [-0.5, -1/3).
+    for (float offset = -0.5f; offset < -1.0f / 3.0f; offset += 0.02f) {
+        EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(offset, offset, offset)), IRMath::ivec3(-1, 0, 0))
+            << "offset=" << offset;
+    }
 }
 
 TEST(PickingFaceNormal, ReturnsSingleNonzeroAxis) {
@@ -64,9 +72,9 @@ TEST(PickingFaceNormal, ReturnsSingleNonzeroAxis) {
     // non-zero component — the place-adjacent compute `voxelPos + normal`
     // breaks badly if two axes fire simultaneously.
     const IRMath::vec3 deltas[] = {
-        IRMath::vec3(0.49f, 0.40f, 0.30f),   // X dominant
-        IRMath::vec3(0.30f, 0.49f, 0.40f),   // Y dominant
-        IRMath::vec3(0.30f, 0.40f, 0.49f),   // Z dominant
+        IRMath::vec3(0.49f, 0.40f, 0.30f),    // X dominant
+        IRMath::vec3(0.30f, 0.49f, 0.40f),    // Y dominant
+        IRMath::vec3(0.30f, 0.40f, 0.49f),    // Z dominant
         IRMath::vec3(-0.49f, -0.40f, -0.30f), // -X dominant
     };
     for (const IRMath::vec3 &delta : deltas) {


### PR DESCRIPTION
## Summary
- Root-causes the `-y`-face single-click place no-op at the cardinal (yaw-0) camera (#2575). The cursor→ray inverse (`mouseWorldPos3DAtIsoDepth`) **floors** the iso pixel, and a voxel's `-x` and `-y` face aims collapse to the **identical** floored pixel at yaw 0 — `iso.x = -x+y` gives them symmetric `±0.4` offsets that the `+0.5` cell-centre bias snaps back — so the picker receives byte-identical input for both and resolves the `(1,1,1)`-corner tie to `-x`. `-z` escapes only because `iso.y`'s `2z` coefficient shifts it onto a distinct column.
- Concludes this is a projection/quantization limitation (the `-x`/`-y` distinction is destroyed at the floor, not mis-resolved downstream), **not** a fixable face derivation. Per #2575 acceptance branch 2, documents the constraint + the camera-rotate (`Q`/`E`) / Y-mirror authoring path in `docs/design/editor-authoring-friction.md` §M-2.
- **Also lands the shadow-model hardening follow-up (#2578)**, absorbed into this branch via PR #2584 (reviewed + opus-rechecked there, then squash-merged into this branch rather than master). `OccupancyModel::pick` now reduces an aim to its floored iso pixel, marches that column, and predicts the face normal; `aimToPlace` requires the predicted normal to match the intended one, so an undeliverable `-y` aim becomes a loud recipe error instead of a silent no-op click. The emitted aim is re-centred in the chosen pixel via `isoPixelToPos3D` (the face offset is only a pixel *probe*), buying the half-pixel of margin that the live forward mapping's screen-pixel rounding otherwise eats. `voxelHitFaceNormal` is promoted out of `detail::` and the new `aimIsoPixel` owns the aim→pixel mirror.

## Test plan
- [x] `fleet-build --target IRVoxelEditor` — clean (macOS/Metal).
- [x] `fleet-build --target IrredenEngineTest` — clean.
- [x] Full suite **1451/1451 passed**, including the 6 `PickingAimIsoPixel` cases added here — `MinusXAndMinusYFaceAimsCollapseOntoOnePixel` asserts §M-2's load-bearing claim directly — plus the 9 `PickingFaceNormal` cases.
- [x] §M-2's cited symbols/paths/constants verified against the tree (`mouseWorldPos3DAtIsoDepth`, `worldPos3DToMouseScreenPx`, `isoPixelToPos3D`, `voxelHitFaceNormal`, `kFaceAimDepth = 0.4`, `kSessionZoom = 4`, `OccupancyModel::pick`, the `voxelPos_ + faceNormal_` place path).
- [x] A/B repro is a runnable computation: `-x` aim `(6.6,7,11)` and `-y` aim `(7,6.6,11)` both reduce to floored iso pixel `(0,8)` under `floor(pos3DtoPos2DIso(aim) + (0.5,0.5))`.

Closes #2575
Closes #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Re-land of #2584 (accidental stack-base merge)

#2584 (`Closes #2578`, approved + opus-recheck nits addressed) was
accidentally squash-merged into this PR's branch instead of master
(2026-07-29, f79be3ff), so this PR now carries **both** changesets: the
#2575 §M-2 docs root-cause AND #2584's session shadow-model hardening
(`aimIsoPixel` floored-pixel pick + `aimToPlace` predicted-normal
rejection). The semantic-conflict lane (pool-2) rebased the combined
branch onto current master twice as master moved (#2577/#2593 editor
churn); the architect verified the final weave — build green
(IRVoxelEditor + IrredenEngineTest), full suite + mushroom/ANT authoring
sessions run against the exact merged tree (evidence in PR comment).

Closes #2578
