### PR TITLE
editor(voxel_editor): session shadow model reproduces the picker floor (#2578)

### DIFF
--- a/creations/editors/voxel_editor/session_builder.hpp
+++ b/creations/editors/voxel_editor/session_builder.hpp
@@ -158,6 +158,14 @@ class OccupancyModel {
     // its floored iso pixel first (aimIsoPixel), because that pixel is the only
     // thing the live picker ever sees; marching the exact aim ray instead would
     // resolve sub-pixel detail the cursor cannot carry.
+    //
+    // The face normal this returns agrees with the live picker's only because
+    // both grids land on the same 0.5 lattice today (session scenes build
+    // without demo furniture and every occupied cell/ghost origin is a multiple
+    // of 0.5 — see docs/design/editor-authoring-friction.md §M-2's
+    // quantization caveat); a future visible entity with an off-lattice depth
+    // origin in a session scene would silently break that agreement on the
+    // collapsed -x/-y columns without failing a test.
     std::optional<PickPrediction> pick(IRMath::vec3 worldAim) const {
         const IRMath::ivec2 isoPixel =
             IRPrefab::Picking::aimIsoPixel(worldAim, kSessionCardinalIndex);

--- a/creations/editors/voxel_editor/session_builder.hpp
+++ b/creations/editors/voxel_editor/session_builder.hpp
@@ -30,7 +30,7 @@
 // aim that would be occluded is caught while the recipe is being built rather
 // than as a mystery FAIL (or, worse, a silent no-op) at run time.
 //
-// Two properties of the editor's isometric view drive the whole design:
+// Three properties of the editor's isometric view drive the whole design:
 //   - The picking ray marches along +(1,1,1), so exactly three faces of a voxel
 //     can ever be clicked: -x, -y, -z. Placing at cell T therefore means
 //     clicking face n of anchor cell T - n for one of those three normals.
@@ -39,6 +39,13 @@
 //     needs zoom >= 3 (see kSessionZoom), because a face-centre aim is offset
 //     half a column-spacing in screen space and rounds across the boundary
 //     below that.
+//   - The cursor->ray inverse FLOORS the aim onto the integer iso lattice, so a
+//     sub-half-pixel face offset is destroyed before the ray is cast. At the
+//     cardinal camera a voxel's -x and -y faces land on one pixel (root cause:
+//     docs/design/editor-authoring-friction.md §M-2), so the model must
+//     march the floored column and predict the face normal — a model that
+//     marched the exact aim ray would separate two aims the live picker cannot,
+//     and greenlight a click that silently no-ops.
 //
 // Recipes run at the cardinal baseline yaw (no camera rotation between
 // segments), which is what lets the model assume the (1,1,1) march axis.
@@ -53,20 +60,20 @@ inline constexpr IRMath::ivec3 kCameraFacingNormals[3] = {
     IRMath::ivec3(0, 0, -1),
 };
 
-// How far inside the anchor voxel a face click aims, measured from the voxel
-// centre toward the clicked face. Strictly < 0.5 so the point stays inside the
-// cube: the picker derives the hit face from the dominant axis of
-// (hit point - voxel centre), and a point exactly on the face plane can round
-// to either side of it. 0.4 leaves a 0.1-voxel margin to the clicked face while
-// the other two axes stay 0.5 away, so the dominant axis survives the cursor
-// pixel being rounded to an integer.
+// How far from the voxel centre, toward the clicked face, the model probes to
+// find out which iso pixel that face maps to. It is ONLY a pixel selector: the
+// picker floors the cursor onto the integer iso lattice and re-casts from the
+// pixel, so no sub-voxel structure of the probe point survives into the hit
+// (which is why the emitted aim is re-centred in the chosen pixel — see
+// faceAim). Strictly < 0.5 so the probe stays inside the cube; 0.4 puts the -z
+// probe a clear 0.8 iso row off the voxel's own pixel while leaving -x / -y on
+// it, which is the (unfixable) collapse §M-2 documents.
 inline constexpr float kFaceAimDepth = 0.4f;
 
-// Ray-march step for the occlusion model, in voxels per axis. The picker walks
-// iso depth in kPickingDepthStep increments and one iso-depth unit moves the
-// recovered world point by (1/3, 1/3, 1/3), so this matches its sampling
-// density — the model can't miss a cell the real ray would have hit.
-inline constexpr float kRayStep = IRPrefab::Picking::kPickingDepthStep / 3.0f;
+// Cardinal camera index the recipes author at. Sessions never rotate the
+// camera, so the model's aim->pixel projection is fixed at the identity
+// rotation — the same assumption that lets it hard-code the (1,1,1) march.
+inline constexpr IRMath::CardinalIndex kSessionCardinalIndex = IRMath::CardinalIndex::k0;
 
 // Frames a session shot leaves between the cursor MOVE and the button PRESS,
 // and again before the RELEASE. One frame each is what the existing scripted
@@ -130,33 +137,89 @@ class OccupancyModel {
         return m_origin + IRMath::vec3(local);
     }
 
-    // The cell IRPrefab::Picking::castVoxelRay would report for a cursor aimed
-    // at `worldAim` — the front-most occupied cell along the +(1,1,1) march.
+    // Iso depth (the picker's march coordinate) of `local`'s centre.
+    float cellIsoDepth(IRMath::ivec3 local) const {
+        return static_cast<float>(IRMath::pos3DtoDistance(worldCenter(local)));
+    }
+
+    // What IRPrefab::Picking::castVoxelRay would report for a cursor aimed at
+    // `worldAim`: the cell the ray lands on AND the face normal it derives.
+    // Both halves matter — the editor places at `voxelPos_ + faceNormal_`, so a
+    // prediction that only carries the cell can still greenlight a click that
+    // edits a different neighbour than the recipe asked for.
+    struct PickPrediction {
+        IRMath::ivec3 cell_ = IRMath::ivec3(0);
+        IRMath::ivec3 faceNormal_ = IRMath::ivec3(0);
+    };
+
     // Replays the picker's walk over the mirror rather than approximating it,
-    // so "is this aim occluded" is answered the same way the editor will answer
-    // it at run time.
-    std::optional<IRMath::ivec3> pick(IRMath::vec3 worldAim) const {
-        const float span = static_cast<float>(m_size.x + m_size.y + m_size.z);
-        for (float t = -span; t <= span; t += kRayStep) {
-            const IRMath::vec3 point = worldAim + IRMath::vec3(t);
+    // so "where does this aim land" is answered the same way the editor will
+    // answer it at run time — including the lossy parts. The aim is reduced to
+    // its floored iso pixel first (aimIsoPixel), because that pixel is the only
+    // thing the live picker ever sees; marching the exact aim ray instead would
+    // resolve sub-pixel detail the cursor cannot carry.
+    std::optional<PickPrediction> pick(IRMath::vec3 worldAim) const {
+        const IRMath::ivec2 isoPixel =
+            IRPrefab::Picking::aimIsoPixel(worldAim, kSessionCardinalIndex);
+        // Front-to-back over the scene's iso-depth span at the picker's own
+        // step, so no cell the real ray would sample is skipped. The span is
+        // the near and far cells' own depths, widened by the picker's margin
+        // for the half-cell rounding at either end.
+        const float nearDepth = cellIsoDepth(IRMath::ivec3(0));
+        const float farDepth = cellIsoDepth(m_size - IRMath::ivec3(1));
+        for (float depth = nearDepth - IRPrefab::Picking::kPickingDepthMargin;
+             depth <= farDepth + IRPrefab::Picking::kPickingDepthMargin;
+             depth += IRPrefab::Picking::kPickingDepthStep) {
+            const IRMath::vec3 point = IRMath::isoPixelToPos3D(isoPixel.x, isoPixel.y, depth);
             const IRMath::ivec3 local = IRMath::roundVec3HalfUp(point - m_origin);
-            if (occupied(local))
-                return local;
+            if (!occupied(local))
+                continue;
+            return PickPrediction{
+                local,
+                IRPrefab::Picking::voxelHitFaceNormal(point - worldCenter(local))
+            };
         }
         return std::nullopt;
+    }
+
+    // Where to put the cursor to click `local`'s `normal` face.
+    //
+    // The face direction only chooses which iso pixel the click lands on; the
+    // picker floors the cursor onto the lattice and re-casts from that pixel, so
+    // nothing else about the aim survives. So probe for the pixel, then aim at
+    // the point that lands DEAD CENTRE of it rather than at the face plane.
+    //
+    // That margin is load-bearing. The live forward mapping rounds to a whole
+    // screen pixel before the inverse floors it back, and a face-plane aim sits
+    // only ~0.1 iso from a floor boundary — inside that rounding, so it flips
+    // onto the neighbouring column for some cells and not others (measured at
+    // kSessionZoom: every -x face-plane aim recovered a pixel one iso row off
+    // the model's). Re-centring buys the full half-pixel, which no rounding at
+    // any authoring zoom can cross, so model and live pick agree by
+    // construction. The depth argument only slides the point along the pixel's
+    // column; the anchor's own depth keeps it inside the anchor cube.
+    IRMath::vec3 faceAim(IRMath::ivec3 local, IRMath::ivec3 normal) const {
+        const IRMath::vec3 center = worldCenter(local);
+        const IRMath::ivec2 pixel = IRPrefab::Picking::aimIsoPixel(
+            center + IRMath::vec3(normal) * kFaceAimDepth,
+            kSessionCardinalIndex
+        );
+        return IRMath::isoPixelToPos3D(pixel.x, pixel.y, cellIsoDepth(local));
     }
 
     // Where to aim to click `target` itself (erase / drag over existing
     // geometry). Returns nullopt when every camera-facing face of `target` is
     // occluded — the caller reports that as a recipe error rather than emitting
-    // a click that would silently edit the wrong cell.
+    // a click that would silently edit the wrong cell. Deliberately
+    // normal-agnostic: the erase path acts on `hit.voxelPos_`, so which of the
+    // target's faces the picker attributes the hit to does not change the edit.
     std::optional<IRMath::vec3> aimAtVoxel(IRMath::ivec3 target) const {
         if (!occupied(target))
             return std::nullopt;
         for (const IRMath::ivec3 &normal : kCameraFacingNormals) {
-            const IRMath::vec3 aim = worldCenter(target) + IRMath::vec3(normal) * kFaceAimDepth;
-            const std::optional<IRMath::ivec3> hit = pick(aim);
-            if (hit && *hit == target)
+            const IRMath::vec3 aim = faceAim(target, normal);
+            const std::optional<PickPrediction> hit = pick(aim);
+            if (hit && hit->cell_ == target)
                 return aim;
         }
         return std::nullopt;
@@ -165,7 +228,11 @@ class OccupancyModel {
     // Where to aim so a place-mode click lands a voxel at `target`. The editor
     // places at (hit voxel + hit face normal), so the anchor is target - normal
     // for one of the camera-facing normals; the anchor must be occupied, the
-    // target empty, and the anchor's face unoccluded.
+    // target empty, and the anchor's face must be the one the picker actually
+    // resolves. Preferring the first normal that satisfies all three is what
+    // routes a target around the -x/-y pixel collapse: a cell with a +x-side or
+    // +z-side anchor is placed through that clean face instead, and only a cell
+    // whose sole anchor sits on the +y side comes back unreachable.
     std::optional<IRMath::vec3> aimToPlace(IRMath::ivec3 target) const {
         if (!inBounds(target) || occupied(target))
             return std::nullopt;
@@ -173,9 +240,13 @@ class OccupancyModel {
             const IRMath::ivec3 anchor = target - normal;
             if (!occupied(anchor))
                 continue;
-            const IRMath::vec3 aim = worldCenter(anchor) + IRMath::vec3(normal) * kFaceAimDepth;
-            const std::optional<IRMath::ivec3> hit = pick(aim);
-            if (hit && *hit == anchor)
+            const IRMath::vec3 aim = faceAim(anchor, normal);
+            const std::optional<PickPrediction> hit = pick(aim);
+            // The predicted face has to agree as well as the cell: an aim that
+            // picks the right anchor through the wrong face places the wrong
+            // neighbour, or — when that neighbour is already filled — nothing
+            // at all, which is the silent no-op this model exists to catch.
+            if (hit && hit->cell_ == anchor && hit->faceNormal_ == normal)
                 return aim;
         }
         return std::nullopt;
@@ -417,11 +488,20 @@ class Builder {
         m_frame += kFramesPerClickStep;
     }
 
+    // An op the model could not aim. In place mode that covers both "every
+    // camera-facing anchor is occluded" and "the only anchor's face is one the
+    // picker's iso-pixel floor collapses" — same remedy either way (re-order the
+    // recipe so a clean face is exposed, or take the cell from a mirror), so
+    // they share one error rather than splitting into two the author must
+    // distinguish. The docs pointer is what makes the second case diagnosable.
     void recordUnreachable(const char *op, IRMath::ivec3 target) {
         m_recipe.errors_.push_back(
             std::string(op) + " at local (" + std::to_string(target.x) + "," +
             std::to_string(target.y) + "," + std::to_string(target.z) +
-            "): no unoccluded camera-facing anchor in segment " + m_current.label_
+            "): no camera-facing anchor the picker resolves (occluded, or the face "
+            "collapses onto the voxel's own iso pixel — see "
+            "docs/design/editor-authoring-friction.md §M-2) in segment " +
+            m_current.label_
         );
     }
 

--- a/docs/design/editor-authoring-friction.md
+++ b/docs/design/editor-authoring-friction.md
@@ -396,7 +396,7 @@ authoring zoom (`kSessionZoom = 4`):
 **Root cause — the picker's iso-pixel floor collapses `-x` and `-y` face aims
 onto the same pixel at cardinal yaw.** The place path is `hit.voxelPos_ +
 hit.faceNormal_` (`voxel_editor/main.cpp`), where `hit.faceNormal_` comes from
-`IRPrefab::Picking::detail::voxelHitFaceNormal(worldHitPos - voxelCenter)` — the
+`IRPrefab::Picking::voxelHitFaceNormal(worldHitPos - voxelCenter)` — the
 dominant axis of the ray's entry offset, with tie-break priority **x > y > z**.
 The cursor→ray inverse (`IRRender::mouseWorldPos3DAtIsoDepth`) **floors** the iso
 pixel to the integer lattice: `isoPixelToPos3D(floor(canvasIso.x),
@@ -458,11 +458,24 @@ change to the load-bearing picker.
   automatically; only a target whose *sole* occupied anchor is on the `+y` side
   hits this wall.
 
-**Recommended follow-up (#2578, agent-approved lane).** The session shadow model
-(`OccupancyModel::pick`, `session_builder.hpp`) marches the *exact* aim ray, so
-it does **not** reproduce the picker's iso-pixel floor and greenlights a `-y` aim
-whose live click misfires — the silent-no-op source. A hardening pass should make
-`pick` reproduce the floored-iso march + `voxelHitFaceNormal`, and have
-`aimToPlace` reject an aim whose predicted face normal disagrees with the
-intended one (so it either finds a disambiguable anchor or records an
-`unreachable` recipe error, instead of emitting a click that no-ops).
+**Follow-up (#2578, agent-approved lane) — LANDED.** The session shadow model
+(`OccupancyModel::pick`, `session_builder.hpp`) marched the *exact* aim ray, so
+it did **not** reproduce the picker's iso-pixel floor and greenlit a `-y` aim
+whose live click misfires — the silent-no-op source. `pick` now reproduces the
+floored-iso march + `voxelHitFaceNormal` and returns the predicted normal
+alongside the cell, and `aimToPlace` rejects an aim whose predicted normal
+disagrees with the intended one — so a `-y`-only target either finds a
+disambiguable anchor or records an `unreachable` recipe error, instead of
+emitting a click that no-ops.
+
+**The round trip above is idealized — the live one quantizes to a whole screen
+pixel first.** `worldPos3DToMouseScreenPx` rounds to an integer *screen* pixel
+before `mouseWorldPos3DAtIsoDepth` floors back to iso, and at `kSessionZoom = 4`
+an iso row is 4 screen px. A face-plane aim sits only ~0.1 iso from a floor
+boundary, i.e. inside that rounding, so its recovered pixel can be one row off
+the table above. The collapse tables stay valid as the *mechanism*; what changes
+is that a shadow model cannot place its aim on the face plane and expect the
+floor to agree. `pick` therefore treats the face offset as a pixel *probe* and
+re-centres the emitted aim inside the chosen pixel, which buys the full
+half-pixel of margin. See `aimIsoPixel` in
+`engine/prefabs/irreden/render/picking.hpp`.

--- a/engine/prefabs/irreden/render/picking.hpp
+++ b/engine/prefabs/irreden/render/picking.hpp
@@ -50,6 +50,67 @@
 
 namespace IRPrefab::Picking {
 
+// Picks the hit-face outward normal for a unit-cube voxel. Returns the
+// axis with the largest |delta| component, signed by that component —
+// "place adjacent" math just adds this normal to `voxelPos_` to land
+// on the cell on the entry side.
+//
+// The tie-break order is contractual, not incidental: equal magnitudes
+// resolve x → y → z, so a hit whose entry offset is parallel to the
+// (1,1,1) march axis (the ray passing exactly through the voxel centre)
+// always reports the x face. Predictors of `RayHit::faceNormal_` — the
+// voxel editor's session shadow model — depend on reproducing it
+// exactly. `test/render/picking_face_normal_test.cpp` pins it.
+inline IRMath::ivec3 voxelHitFaceNormal(IRMath::vec3 delta) {
+    const IRMath::vec3 absDelta = IRMath::abs(delta);
+    IRMath::ivec3 normal(0);
+    if (absDelta.x >= absDelta.y && absDelta.x >= absDelta.z) {
+        normal.x = delta.x >= 0.0f ? 1 : -1;
+    } else if (absDelta.y >= absDelta.z) {
+        normal.y = delta.y >= 0.0f ? 1 : -1;
+    } else {
+        normal.z = delta.z >= 0.0f ? 1 : -1;
+    }
+    return normal;
+}
+
+// The canvas-frame iso pixel a cursor aimed at `worldAim` casts its ray
+// from — the CPU mirror of the `IRRender::worldPos3DToMouseScreenPx` →
+// `IRRender::mouseWorldPos3DAtIsoDepth` round trip, with the camera pan
+// and letterbox terms cancelled (they appear identically in both halves).
+// What survives is the forward aim's `+0.5` cell-centre bias and the
+// inverse's floor back onto the integer iso lattice.
+//
+// The floor is lossy by design: an aim offset whose iso projection is
+// smaller than the half-pixel bias lands on the voxel centre's pixel, so
+// two faces of one voxel can share a pixel — at cardinal yaw the -x and
+// -y faces always do, the iso equations giving x and y coefficient 1
+// while z gets 2 (`docs/design/editor-authoring-friction.md` §M-2).
+// Anything predicting where a scripted click lands must go through this,
+// not through the exact aim ray.
+//
+// Exact only near a pixel's CENTRE. The live forward half rounds to a
+// whole screen pixel before the inverse divides back out, and near a
+// floor boundary that half-pixel is enough to land the real cursor one
+// iso pixel off this result (at zoom 4 an iso row is 4 screen px, so the
+// error reaches 0.125 iso while a face-plane aim sits 0.1 from the
+// boundary). A caller that chooses its own aim should therefore pick the
+// point that lands dead centre — `isoPixelToPos3D` re-projects onto a
+// pixel exactly. What the rounding cannot do is un-collapse two aims
+// this helper maps to one pixel.
+//
+// Cardinal-only in the same sense the rest of the picking chain is:
+// `cardinalIndex` covers the rasterYaw snap, not a residual yaw, whose
+// face deformation the picking math does not reverse either.
+inline IRMath::ivec2 aimIsoPixel(IRMath::vec3 worldAim, IRMath::CardinalIndex cardinalIndex) {
+    const IRMath::vec3 rotated = IRMath::rotateCardinalZ(worldAim, cardinalIndex);
+    const IRMath::vec2 iso = IRMath::pos3DtoPos2DIso(rotated) + IRMath::vec2(0.5f);
+    return IRMath::ivec2(
+        static_cast<int>(IRMath::floor(iso.x)),
+        static_cast<int>(IRMath::floor(iso.y))
+    );
+}
+
 struct RayHit {
     IREntity::EntityId entity_ = IREntity::kNullEntity;
     IRMath::vec3 worldHitPos_ = IRMath::vec3(0.0f);
@@ -191,23 +252,6 @@ gatherVisibleVoxelSets(IRMath::CardinalIndex cardinalIndex, IREntity::EntityId e
     return snapshot;
 }
 
-// Picks the hit-face outward normal for a unit-cube voxel. Returns the
-// axis with the largest |delta| component, signed by that component —
-// "place adjacent" math just adds this normal to `voxelPos_` to land
-// on the cell on the entry side.
-inline IRMath::ivec3 voxelHitFaceNormal(IRMath::vec3 delta) {
-    const IRMath::vec3 absDelta = IRMath::abs(delta);
-    IRMath::ivec3 normal(0);
-    if (absDelta.x >= absDelta.y && absDelta.x >= absDelta.z) {
-        normal.x = delta.x >= 0.0f ? 1 : -1;
-    } else if (absDelta.y >= absDelta.z) {
-        normal.y = delta.y >= 0.0f ? 1 : -1;
-    } else {
-        normal.z = delta.z >= 0.0f ? 1 : -1;
-    }
-    return normal;
-}
-
 } // namespace detail
 
 // Casts a ray from the cursor into the scene and returns the first
@@ -289,7 +333,7 @@ castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
                 vs.entity_,
                 worldPoint,
                 IRMath::roundVec3HalfUp(candidateCenter),
-                detail::voxelHitFaceNormal(delta)
+                voxelHitFaceNormal(delta)
             };
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(IrredenEngineTest
   render/frame_data_sun_layout_test.cpp
   render/gpu_compute_dispatch_test.cpp
   render/per_canvas_light_scope_test.cpp
+  render/picking_aim_iso_pixel_test.cpp
   render/picking_face_normal_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp

--- a/test/render/picking_aim_iso_pixel_test.cpp
+++ b/test/render/picking_aim_iso_pixel_test.cpp
@@ -18,7 +18,9 @@ constexpr IRMath::CardinalIndex kCardinal = IRMath::CardinalIndex::k0;
 
 // The face-aim depth the session builder clicks at: far enough inside the cube
 // that the picker's dominant-axis face derivation is stable, but well under the
-// half-pixel bias the floor applies.
+// half-pixel bias the floor applies. Mirrors
+// IRVoxelEditor::Session::kFaceAimDepth (session_builder.hpp) — a test under
+// test/ can't include a creation header, so keep this value in sync by hand.
 constexpr float kFaceAimDepth = 0.4f;
 
 TEST(PickingAimIsoPixel, VoxelCentreLandsOnItsOwnPixel) {

--- a/test/render/picking_aim_iso_pixel_test.cpp
+++ b/test/render/picking_aim_iso_pixel_test.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <irreden/render/picking.hpp>
+
+// `IRPrefab::Picking::aimIsoPixel` is the CPU mirror of the
+// `worldPos3DToMouseScreenPx` -> `mouseWorldPos3DAtIsoDepth` round trip: the
+// canvas-frame iso pixel a cursor aimed at a world point actually casts from.
+// It is what anything predicting a scripted click must go through, so its
+// lossiness is contractual and pinned here. Root cause + the measured table
+// these cases reproduce: `docs/design/editor-authoring-friction.md` §M-2
+// (#2575). The voxel editor's session shadow model is the consumer.
+
+namespace {
+
+using IRPrefab::Picking::aimIsoPixel;
+
+constexpr IRMath::CardinalIndex kCardinal = IRMath::CardinalIndex::k0;
+
+// The face-aim depth the session builder clicks at: far enough inside the cube
+// that the picker's dominant-axis face derivation is stable, but well under the
+// half-pixel bias the floor applies.
+constexpr float kFaceAimDepth = 0.4f;
+
+TEST(PickingAimIsoPixel, VoxelCentreLandsOnItsOwnPixel) {
+    const IRMath::vec3 centre(7.0f, 7.0f, 11.0f);
+    EXPECT_EQ(aimIsoPixel(centre, kCardinal), IRMath::ivec2(0, 8));
+}
+
+TEST(PickingAimIsoPixel, MinusXAndMinusYFaceAimsCollapseOntoOnePixel) {
+    // The defect this helper exists to make predictable: at cardinal yaw the
+    // iso equations give x and y coefficient 1, so a +-0.4 face offset moves
+    // iso.x by less than the +0.5 cell-centre bias and the floor snaps both
+    // aims back onto the voxel's own column. The picker receives byte-identical
+    // input for the two, so no downstream rule can separate them.
+    const IRMath::vec3 centre(7.0f, 7.0f, 11.0f);
+    const IRMath::vec3 minusXAim = centre - IRMath::vec3(kFaceAimDepth, 0.0f, 0.0f);
+    const IRMath::vec3 minusYAim = centre - IRMath::vec3(0.0f, kFaceAimDepth, 0.0f);
+
+    EXPECT_EQ(aimIsoPixel(minusXAim, kCardinal), IRMath::ivec2(0, 8));
+    EXPECT_EQ(aimIsoPixel(minusYAim, kCardinal), IRMath::ivec2(0, 8));
+    EXPECT_EQ(aimIsoPixel(minusXAim, kCardinal), aimIsoPixel(minusYAim, kCardinal));
+    EXPECT_EQ(aimIsoPixel(minusXAim, kCardinal), aimIsoPixel(centre, kCardinal));
+}
+
+TEST(PickingAimIsoPixel, MinusZFaceAimEscapesOntoItsOwnPixel) {
+    // iso.y carries z with coefficient 2, so the same 0.4 offset becomes a 0.8
+    // iso shift — large enough to cross the floor boundary. This is why -z
+    // anchors keep working while -y anchors do not.
+    const IRMath::vec3 centre(7.0f, 7.0f, 11.0f);
+    const IRMath::vec3 minusZAim = centre - IRMath::vec3(0.0f, 0.0f, kFaceAimDepth);
+
+    EXPECT_EQ(aimIsoPixel(minusZAim, kCardinal), IRMath::ivec2(0, 7));
+    EXPECT_NE(aimIsoPixel(minusZAim, kCardinal), aimIsoPixel(centre, kCardinal));
+}
+
+TEST(PickingAimIsoPixel, CollapseIsNotSpecificToTheDiagonalCell) {
+    // §M-2 notes the same collapse for a cell off the x == y diagonal (the
+    // aim lands on that voxel's own centre pixel either way), so the defect
+    // is a property of the projection, not of one measured coordinate.
+    const IRMath::vec3 centre(7.0f, 6.0f, 11.0f);
+    EXPECT_EQ(aimIsoPixel(centre, kCardinal), IRMath::ivec2(-1, 9));
+    EXPECT_EQ(
+        aimIsoPixel(centre - IRMath::vec3(kFaceAimDepth, 0.0f, 0.0f), kCardinal),
+        IRMath::ivec2(-1, 9)
+    );
+    EXPECT_EQ(
+        aimIsoPixel(centre - IRMath::vec3(0.0f, kFaceAimDepth, 0.0f), kCardinal),
+        IRMath::ivec2(-1, 9)
+    );
+}
+
+TEST(PickingAimIsoPixel, FloorsRatherThanTruncatesBelowTheOrigin) {
+    // `mouseWorldPos3DAtIsoDepth` floors; truncation would fold the whole
+    // (-1, 0) band onto pixel 0 and silently mis-aim every negative-iso cell.
+    EXPECT_EQ(aimIsoPixel(IRMath::vec3(0.6f, 0.0f, 0.0f), kCardinal), IRMath::ivec2(-1, -1));
+}
+
+TEST(PickingAimIsoPixel, AppliesTheCardinalRotation) {
+    // rotateCardinalZ((1,0,0), k90) == (0,-1,0), so aiming at (1,0,0) under a
+    // quarter turn must reduce to aiming at (0,-1,0) at the cardinal.
+    EXPECT_EQ(
+        aimIsoPixel(IRMath::vec3(1.0f, 0.0f, 0.0f), IRMath::CardinalIndex::k90),
+        aimIsoPixel(IRMath::vec3(0.0f, -1.0f, 0.0f), kCardinal)
+    );
+    EXPECT_NE(
+        aimIsoPixel(IRMath::vec3(1.0f, 0.0f, 0.0f), IRMath::CardinalIndex::k90),
+        aimIsoPixel(IRMath::vec3(1.0f, 0.0f, 0.0f), kCardinal)
+    );
+}
+
+} // namespace

--- a/test/render/picking_face_normal_test.cpp
+++ b/test/render/picking_face_normal_test.cpp
@@ -4,7 +4,7 @@
 
 namespace {
 
-using IRPrefab::Picking::detail::voxelHitFaceNormal;
+using IRPrefab::Picking::voxelHitFaceNormal;
 
 TEST(PickingFaceNormal, PositiveXFace) {
     EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.4f, 0.1f, -0.2f)), IRMath::ivec3(1, 0, 0));
@@ -33,17 +33,11 @@ TEST(PickingFaceNormal, OutOfBoundsDeltaPositiveXFace) {
     // Pure-function stress-test: delta (0.6, 0, 0) is outside the
     // [-0.5, 0.5) range the rounding step guarantees in normal flow.
     // Exercises robustness for callers that bypass the rounding path.
-    EXPECT_EQ(
-        voxelHitFaceNormal(IRMath::vec3(0.6f, 0.0f, 0.0f)),
-        IRMath::ivec3(1, 0, 0)
-    );
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.6f, 0.0f, 0.0f)), IRMath::ivec3(1, 0, 0));
 }
 
 TEST(PickingFaceNormal, OriginVoxelMinusZFace) {
-    EXPECT_EQ(
-        voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, -0.4f)),
-        IRMath::ivec3(0, 0, -1)
-    );
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, -0.4f)), IRMath::ivec3(0, 0, -1));
 }
 
 TEST(PickingFaceNormal, ExactCenterFavorsXAxisPositive) {
@@ -53,10 +47,24 @@ TEST(PickingFaceNormal, ExactCenterFavorsXAxisPositive) {
     // before the next depth step), so any of the three faces would be a
     // valid place-adjacent direction — this test pins the deterministic
     // choice for regression-detection rather than asserting a semantic.
-    EXPECT_EQ(
-        voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, 0.0f)),
-        IRMath::ivec3(1, 0, 0)
-    );
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, 0.0f)), IRMath::ivec3(1, 0, 0));
+}
+
+TEST(PickingFaceNormal, DiagonalEntryTieResolvesToNegativeX) {
+    // The (1,1,1) march enters a cell whose iso pixel is the cell's own
+    // centre pixel exactly at its near corner, so all three components are
+    // equal and negative. The tie-break lands on -x. This is not cosmetic:
+    // it is why a -y face click at cardinal yaw resolves to the -x face and
+    // places the wrong neighbour (#2575), which the voxel editor's session
+    // shadow model reproduces in order to reject such an aim.
+    EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(-0.4f, -0.4f, -0.4f)), IRMath::ivec3(-1, 0, 0));
+    // The whole in-cell entry band the march can sample, not just one point:
+    // the sample step is 1/6 of a cell along the diagonal, so the first
+    // in-cell sample always lands in [-0.5, -1/3).
+    for (float offset = -0.5f; offset < -1.0f / 3.0f; offset += 0.02f) {
+        EXPECT_EQ(voxelHitFaceNormal(IRMath::vec3(offset, offset, offset)), IRMath::ivec3(-1, 0, 0))
+            << "offset=" << offset;
+    }
 }
 
 TEST(PickingFaceNormal, ReturnsSingleNonzeroAxis) {
@@ -64,9 +72,9 @@ TEST(PickingFaceNormal, ReturnsSingleNonzeroAxis) {
     // non-zero component — the place-adjacent compute `voxelPos + normal`
     // breaks badly if two axes fire simultaneously.
     const IRMath::vec3 deltas[] = {
-        IRMath::vec3(0.49f, 0.40f, 0.30f),   // X dominant
-        IRMath::vec3(0.30f, 0.49f, 0.40f),   // Y dominant
-        IRMath::vec3(0.30f, 0.40f, 0.49f),   // Z dominant
+        IRMath::vec3(0.49f, 0.40f, 0.30f),    // X dominant
+        IRMath::vec3(0.30f, 0.49f, 0.40f),    // Y dominant
+        IRMath::vec3(0.30f, 0.40f, 0.49f),    // Z dominant
         IRMath::vec3(-0.49f, -0.40f, -0.30f), // -X dominant
     };
     for (const IRMath::vec3 &delta : deltas) {


### PR DESCRIPTION
## Summary
- `OccupancyModel::pick` no longer marches the exact aim ray. It reduces the aim to its **floored iso pixel** (the only thing the live picker ever sees), marches that pixel's column at the picker's own step, and returns the predicted **face normal** alongside the cell.
- `aimToPlace` now requires the predicted normal to match the intended placement normal. A target with a `+x`- or `+z`-side anchor is still placed through that clean face; a target whose *only* anchor is on the `+y` side becomes a loud `unreachable` recipe error instead of a click that silently edits a different cell. `aimAtVoxel` (erase) stays normal-agnostic — erase acts on `hit.voxelPos_`, not the face.
- **Second defect found while verifying** (not in the issue): the idealized round trip the issue specifies is not faithful on its own. The live forward mapping rounds to a whole **screen** pixel before the inverse floors it back, and a face-plane aim sits only ~0.1 iso from a floor boundary — inside that rounding. The face offset is now only a pixel *probe*; the emitted aim is re-centred in the chosen pixel via `isoPixelToPos3D`, buying the full half-pixel of margin. See "Notes for reviewer".
- `engine/prefabs/irreden/render/picking.hpp` grows two public pure helpers: `voxelHitFaceNormal` moves out of `detail::` (a creation predicting `RayHit::faceNormal_` should not reach into an internal namespace) and gains its tie-break contract in the doc; new `aimIsoPixel` owns the aim→pixel mirror so the iso equations aren't inlined at a second site.

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2579 (`claude/2575-neg-y-face-pick-cardinal`)

`#2579` is the write-up that creates `docs/design/editor-authoring-friction.md`
§M-2 — the section this PR's code and tests cite in six places, including a
runtime `recordUnreachable` string an editor author sees when a recipe fails.
Reviewer flagged the merge-order dependency (`fleet:needs-fix`, 2026-07-28);
basing this PR on `#2579`'s branch is the fleet-supported way to guarantee the
order (`_merger_action_signal` projects `base != master` as `stacked-pending`;
a `Blocked by:` line in a **PR** body is not parsed by anything, so it would
have been inert prose). The two branches touch disjoint files — the rebase was
clean and the code is byte-identical to the reviewed commit `a9bed1d7`.

Also lands one doc-sync commit on top of §M-2, which only became possible once
the section was in the tree: it drops the now-stale `detail::` qualifier on
`voxelHitFaceNormal` (this PR promotes it), marks the recommended follow-up
LANDED, and records the screen-pixel quantization measured below.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` + `fleet-run IrredenEngineTest` — **1368/1368 pass** (7 new: 6 `PickingAimIsoPixel`, 1 `PickingFaceNormal.DiagonalEntryTieResolvesToNegativeX`).
- [x] `fleet-build --target IRVoxelEditor` — clean.
- [x] `fleet-run IRVoxelEditor --gui-session rock --auto-screenshot 10` — 20 PASS / 0 FAIL, `RESULT=CLEAN`.
- [x] `fleet-run IRVoxelEditor --gui-session drag_probe --auto-screenshot 10` — 12 PASS / 0 FAIL, `RESULT=CLEAN`.
- [x] A/B against `origin/master` for both the regression check and the defect itself (below).

No screenshots: the `engine/prefabs/irreden/render/` change is an inline-function namespace move (identical body, identical call) plus an additive pure helper with no render-pipeline consumer — the "internal refactor with provably no runtime effect" exception in `engine/render/CLAUDE.md` § Verifying render changes. Nothing on a per-frame path changed, so `optimize` was skipped for the same reason.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `pick` reproduces the round-trip: floored iso pixel → `isoPixelToPos3D` march → `roundVec3HalfUp` cell → `voxelHitFaceNormal` face, returning cell **and** normal | `session_builder.hpp` `OccupancyModel::pick` → `PickPrediction{cell_, faceNormal_}`; the floor half is pinned by `fleet-run IrredenEngineTest --gtest_filter='PickingAimIsoPixel.*'` | 6/6 pass, incl. `MinusXAndMinusYFaceAimsCollapseOntoOnePixel` reproducing §M-2's measured table (`-x` and `-y` aims both → `(0,8)`; `-z` → `(0,7)`) |
| `aimToPlace` rejects an aim whose predicted normal disagrees; records `unreachable` instead of emitting a no-op click | A/B probe: a target whose only camera-facing anchor is its `+y` neighbour, run on both sides | **master**: no recipe error, run exits 0 `RESULT=CLEAN`, and the assertions show the silent misfire — target `(4,7,13)` `occupied=no want=yes` **FAIL** while the unintended `-x` neighbour `(3,8,13)` `occupied=yes want=no` **FAIL**. **branch**: `Session recipe error: click at local (8,7,13): no camera-facing anchor the picker resolves (occluded, or the face collapses onto the voxel's own iso pixel — see docs/design/editor-authoring-friction.md §M-2)`, exit 1 |
| `aimAtVoxel` (erase) stays normal-agnostic | `aimAtVoxel` checks `hit->cell_ == target` only; `rock`'s four erase drags + two carves exercise it | `carve_aim_hits_corner_a/b` PASS, `carve_removed_corner_a/b` PASS |
| No regression to `rock` / `drag_probe`; all `GUI-ASSERT` lines PASS | `fleet-run IRVoxelEditor --gui-session <name> --auto-screenshot 10` | `rock` 20 PASS / 0 FAIL; `drag_probe` 12 PASS / 0 FAIL; both `ir-run: RESULT=CLEAN exe=IRVoxelEditor exit=0` |

## Notes for reviewer

**The issue's literal spec regresses `rock`, and why.** Implementing exactly `floor(pos3DtoPos2DIso(worldAim) + 0.5)` → march made `-x` face aims *acceptable* to the model (they are correct in the idealized round trip). But `rock_clear_ground` then failed 3/8 — the ground-clearing drags truncated at high x. Master was 20/20, so this was a real regression, not pre-existing.

Root cause, measured by instrumenting the editor to recover the picker's actual floored pixel: **every** `-x` face-plane aim recovered a pixel one iso row off the model's. `worldPos3DToMouseScreenPx` rounds to a whole screen pixel; at the authoring zoom an iso row is 4 screen px, so half a pixel is 0.125 iso — while a face-plane aim's canvas iso has fractional part 0.9, i.e. 0.1 from the boundary. The rounding crosses it. (`-z` survives because `iso.y` carries z with coefficient 2, leaving 0.3 of margin — which is the accident that kept master's exact-ray model working: it rejected `-x`/`-y` for a flat plane and fell through to `-z`.)

So the aim is now re-centred in its pixel (margin 0.5, unreachable by any authoring-zoom rounding) rather than placed on the face plane. `kFaceAimDepth` keeps its value but changes meaning — it is a pixel selector, not a "stay inside the cube" constant — and its doc comment is rewritten accordingly. `aimIsoPixel`'s doc states the un-modelled screen quantization explicitly rather than claiming an exact inverse.

**`voxelHitFaceNormal` promotion.** Moved from `IRPrefab::Picking::detail::` to `IRPrefab::Picking::`; the only in-tree callers were `castVoxelRay` and its existing test, both updated. The tie-break order (x→y→z) is now documented as contractual, because the shadow model depends on reproducing it — the new `DiagonalEntryTieResolvesToNegativeX` test pins the whole in-cell entry band the march can sample, not just one point.

Closes #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

