### PR TITLE
persist: derive default SaveRegistry membership from the inventory (#2242)

### DIFF
--- a/.fleet/plans/issue-2242.md
+++ b/.fleet/plans/issue-2242.md
@@ -1,0 +1,124 @@
+## Plan: persist: grow the process-default SaveRegistry toward full engine-component coverage (P7 follow-up)
+
+- **Issue:** #2242
+- **Model:** opus — the mechanism is committed below; the remaining work is ~20 mostly-mechanical serializers plus test wiring, bounded but multi-module
+- **Date:** 2026-07-20
+
+### Scope
+
+Retire the hand-curated 4-component list in `makeDefaultSaveRegistry()` (`engine/world/src/world_default_registry.cpp`) and derive the process-default registry's membership from the inventory + a compile-time serializability filter, so every opted-in component is registered automatically and a future opt-in without a serializer is a **build error**, never a silent save omission. Ship the `SaveSerialize<C>` specializations that unlock this for the ~20 opted-in heap-owning components.
+
+### Verified current state (source-verified 2026-07-20 against master 5c53d2e5)
+
+- `world_default_registry.cpp` registers exactly 4 components (`C_VoxelSetNew`, `C_LocalTransform`, `C_PositionInt3D`, `C_SizeInt3D`).
+- Exactly **one** production `SaveSerialize` specialization exists: `C_VoxelSetNew` (`engine/prefabs/irreden/voxel/voxel_set_serialize.hpp`); the two others in the tree are test-local (`test/world/{world_snapshot,component_migration}_test.cpp`).
+- The inventory (`save_component_inventory.hpp`) has 165 components, ~110 opted IN. Struct-level audit of every opted-in component whose header contains heap types confirms the issue's premise — these opted-in components are **not** trivially copyable and would trip the primary template's `static_assert` if registered:
+  - **string-bearing:** `C_Name`, `C_TextSegment`, `C_JointName`, `C_Timer`, `C_Stopwatch`, `C_Cycle`, `C_SpriteAnimation`, `C_Example`
+  - **vector-bearing:** `C_Skeleton` (`vector<EntityId>` + `vector<SQT>`), `C_MidiSequence` (`vector<pair<int, C_MidiMessage>>`), `C_PeriodicIdle` (`vector<PeriodStage>`), `C_TrianglesOnlySet` (`vector<Color>` + `vector<Distance>`), `C_TriangleCanvasBackground` (private `m_colors` / `m_randomColorData` / `m_patternMask`)
+  - **map-bearing:** `C_BindPoints` (`unordered_map<string, BindPointRuntime>`)
+  - **widget family** (`component_widget.hpp`): `C_WidgetPanel/Label/Button/Slider/Checkbox/List/Dropdown/Radio/TextInput` hold `string` / `vector<string>`. `C_Widget`, `C_WidgetState`, `C_WidgetColorSwatch`, `C_WidgetScroll`, `C_Splitter` appear POD — phase 0 confirms which need nothing.
+- **No opted-in component holds `std::function` / `sol::` / raw-owning-pointer state** (grep across every opted-in header). The known non-serializable shapes (`C_LerpEntity`, `C_LambdaModifiers`) are already opted OUT — so no opt-in→opt-out flips are *expected*; the flip remains the documented bail (below) if phase 0 surfaces a hidden case.
+- `BinaryWriter/Reader` already provide `writeString`/`readString` (+ `writeVarUInt`, sized ints/floats); there is no vector helper yet.
+- C++ standard is **23** (root `CMakeLists.txt`), so concepts/constrained partial specializations are available.
+- No open PR touches the persist surface; no open sibling issue overlaps (checked open PR list + open issues, 2026-07-20).
+- Not compiler-verified on this host (macOS builds are broken, #2449) — hence phase 0 below runs the exact enumeration on the implementer's Linux host.
+
+### Approach
+
+**Committed mechanism — `SaveSerializable<C>` concept via a split primary, NOT a hand-maintained companion trait.** The issue sketches a `HasExplicitSaveSerialize<C>` trait; a companion trait has a dual-bookkeeping failure mode (serializer written, trait line forgotten → component silently drops out of the default registry — the exact silent-omission class this issue exists to kill). Instead make serializability self-detecting:
+
+```cpp
+// save_serialize.hpp
+template <typename C> struct SaveSerialize;          // primary: declared, undefined
+
+template <typename C>
+    requires std::is_trivially_copyable_v<C>
+struct SaveSerialize<C> { /* current raw-byte-image body, static_assert dropped */ };
+
+// A component is serializable iff SaveSerialize<C> is usable: the constrained
+// TC fast path, or an explicit specialization (C_VoxelSetNew et al).
+template <typename C>
+concept SaveSerializable = requires(IRAsset::BinaryWriter &w, const C &v, IRAsset::BinaryReader &r) {
+    SaveSerialize<C>::write(w, v);
+    { SaveSerialize<C>::read(r) } -> std::same_as<IRAsset::Result<C>>;
+};
+```
+
+Existing full specializations (`C_VoxelSetNew`, the two test-local ones) are untouched — full specializations of an undefined primary are fine, and TC types now match the constrained partial specialization with the identical body. The friendly diagnostic moves to registration: `static_assert(SaveSerializable<C>, "<current message>")` at the top of `SaveRegistry::registerComponent`'s `shouldSave<C>()` branch.
+
+**Phase 0 (probe, first commit on the Linux host).** Two cheap premise checks:
+1. A scratch TU proving the constrained-partial-specialization + concept detection compiles on gcc-13 (mechanism premise; expected: compiles, concept is `false` for an undefined-primary type, `true` for TC and explicitly-specialized types).
+2. Convert `makeDefaultSaveRegistry()` to the tuple walk (below) **before writing any serializer** and build once: the compile-error list is the exact, compiler-authoritative serializer work list. Expected reading ≈ the ~20 components enumerated above. **Bail path:** any surfaced component whose members can't honestly round-trip (hidden callback/handle state) is flipped `IR_SAVE_OPT_OUT` with a one-line class comment in the inventory — do not write a lossy serializer that silently defaults fields; if a flip feels wrong (the component is clearly authored gameplay state), stop and comment the finding on this issue for re-plan rather than improvising.
+
+**Phase 1 — mechanism.**
+- `save_serialize.hpp`: the split above + concept.
+- `save_registry.hpp`: the friendly `static_assert`; no other behavior change.
+- `world_default_registry.cpp`: replace the curated list with a tuple walk:
+  ```cpp
+  []<typename... Cs>(std::type_identity<std::tuple<Cs...>>) {
+      (registry.registerComponent<Cs>(), ...);
+  }(std::type_identity<AllEngineComponents>{});
+  ```
+  `registerComponent`'s existing `if constexpr (shouldSave<C>())` gate skips opt-outs; every opted-in element instantiates its serializer, so **this TU is the completeness gate** — a future `IR_SAVE_OPT_IN` without a serializer (or tuple entry, already asserted) breaks this build with the friendly message. Keep `voxel_set_serialize.hpp`'s include; add the new serializer headers (phase 2). Do **not** add serializer includes to `save_component_inventory.hpp` — it stays a pure decision table (and stays out of the prefab-serializer dependency business).
+- New `engine/world/include/irreden/world/save_serialize_common.hpp`: header-only helpers `writeTrivialVector<T>` / `readTrivialVector<T>` (varuint count + raw records, the `voxel_set_serialize.hpp` record pattern, with a per-use `static_assert(std::is_trivially_copyable_v<T>)`) so the vector serializers don't hand-roll the loop five times. String round-trip uses the existing `writeString`/`readString`.
+
+**Phase 2 — serializers, grouped per prefab module** (one header per module, mirroring the `voxel_set_serialize.hpp` placement precedent; ~20 specializations total, each `IR_SAVE_OPT_IN` version stays 1 since nothing has ever been written at these schemas):
+- `engine/prefabs/irreden/common/save_serializers_common.hpp` — `C_Name`, `C_Timer`, `C_Stopwatch`, `C_Cycle`, `C_Example` (+ any phase-0 stragglers from common).
+- `engine/prefabs/irreden/render/save_serializers_render.hpp` — `C_TextSegment`, the string/vector widget structs, `C_TrianglesOnlySet`, `C_TriangleCanvasBackground`, `C_SpriteAnimation`.
+- `engine/prefabs/irreden/voxel/save_serializers_voxel.hpp` — `C_Skeleton`, `C_JointName`, `C_BindPoints`.
+- `engine/prefabs/irreden/audio/save_serializers_audio.hpp` — `C_MidiSequence`.
+- `engine/prefabs/irreden/update/save_serializers_update.hpp` — `C_PeriodicIdle`.
+
+Key decisions inside phase 2:
+- `C_BindPoints`: write map entries **sorted by key** — unordered iteration order would break the double-save byte-identity contract (world-snapshot criterion 6).
+- `C_MidiSequence` / `C_PeriodicIdle` element types (`C_MidiMessage`, `PeriodStage`) and `C_Skeleton`'s `SQT`: `static_assert` trivially-copyable at the use site, then raw records via the vector helper.
+- `C_Skeleton.joints_` (`EntityId`s) round-trips as plain values — the snapshot's exact-id restore contract already blesses this (the inventory's own Class E comment).
+- `C_TriangleCanvasBackground`: serialize via its public accessor/ctor surface; where the private `m_*` vectors aren't reachable, add a `friend struct IRWorld::SaveSerialize<C_TriangleCanvasBackground>;` declaration rather than widening the public API.
+- Widget structs that phase 0 proves TC get **no** serializer (primary fast path).
+
+**Phase 3 — tests + docs.**
+- New `test/world/save_serializers_test.cpp`: value round-trip per serializer family incl. empty string, empty vector, and a `C_BindPoints` double-save byte-identity case (map-order determinism).
+- Extend `test/world/persist_round_trip_test.cpp`: a world carrying `C_Name` + `C_Skeleton` + one widget component round-trips with values asserted, and double-save stays byte-identical.
+- Extend `test/script/lua_world_snapshot_test.cpp`: `C_Name` round-trip **through the actual `IRPersist` Lua surface** — the mandatory wiring-level test per `world/CLAUDE.md` "Process-default registry" (#2244 rule); this is the issue's named acceptance component.
+- A registry-membership positive-fire check (in `save_serializers_test.cpp` or the snapshot test): `makeDefaultSaveRegistry().size()` equals the inventory's opted-in count computed from `AllEngineComponents` at compile time (a `detail::countOptIns<Tuple>()` sibling of `allExplicit`) — proves membership is *derived*, not curated, and fails if the two ever diverge.
+- Docs: update `engine/world/CLAUDE.md` "Process-default registry" (curated-subset story → derived-membership story + the new-opt-in-needs-serializer build gate), the header comments in `world_default_registry.cpp` / `save_registry.hpp` scope notes / `save_serialize.hpp`.
+
+One task, one PR — the pieces are coupled (the tuple walk cannot land without the serializers, and the serializers are unverifiable in the default registry without the walk); phase 0's error-list step keeps the serializer batch honest and bounded.
+
+### Affected files
+
+- `engine/world/include/irreden/world/save_serialize.hpp` — primary split + `SaveSerializable` concept
+- `engine/world/include/irreden/world/save_serialize_common.hpp` — **new**, vector round-trip helpers
+- `engine/world/include/irreden/world/save_registry.hpp` — friendly `static_assert` in `registerComponent`
+- `engine/world/include/irreden/world/save_trait.hpp` — `detail::countOptIns<Tuple>()` (sibling of `allExplicit`)
+- `engine/world/src/world_default_registry.cpp` — curated list → tuple walk + serializer includes (curated list retired)
+- `engine/prefabs/irreden/{common,render,voxel,audio,update}/save_serializers_<module>.hpp` — **new**, ~20 specializations
+- `engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp` — friend declaration (only if the accessor surface is insufficient)
+- `engine/world/include/irreden/world/save_component_inventory.hpp` — only if phase 0 forces an opt-out flip (none expected)
+- `test/world/save_serializers_test.cpp` — **new**
+- `test/world/persist_round_trip_test.cpp`, `test/script/lua_world_snapshot_test.cpp` — extended
+- `engine/world/CLAUDE.md` — registry section rewrite
+
+### Acceptance criteria
+
+1. `makeDefaultSaveRegistry()` membership is derived: the registry-size == compile-time opted-in count assertion passes (positive-fire — the count moves from 4 to ~110), and `world_default_registry.cpp` contains no per-component register lines.
+2. Lua `IRPersist` round-trip of a world using `C_Name` preserves the name value, asserted through the real binding path in `test/script/lua_world_snapshot_test.cpp`.
+3. New serializer round-trips pass, including empty-string/empty-vector edges and the `C_BindPoints` sorted-key double-save byte-identity case.
+4. `persist_round_trip_test` extended world double-save stays byte-identical.
+5. `linux-debug` build + full `test/world` + `test/script` suites green. macOS: gated on #2449 (fresh builds broken there); route through the normal cross-host smoke label rather than blocking the PR on a macOS build.
+6. A deliberately serializer-less `IR_SAVE_OPT_IN` (temporarily added in a scratch check, not committed) fails the `world_default_registry.cpp` build with the friendly message — the completeness gate demonstrably fires.
+
+### Gotchas
+
+- **Constraint placement matters:** constraining the *primary* template would make the `C_VoxelSetNew` full specialization ill-formed (explicit-specialization args must satisfy the primary's constraints). The committed shape — undefined primary + constrained *partial* specialization — avoids this; phase 0's scratch TU exists to prove it on the shipping compiler before anything else lands.
+- `unordered_map` iteration order is non-deterministic per process — any map-bearing serializer must sort before writing (byte-identity contract).
+- Old saves stay loadable by construction (CMPN is name-keyed; unknown names skip; all new schemas are v1) — no migration work in this task.
+- Registry construction cost grows from 4 to ~110 entries per save/load call — documented as fine (`save_registry.hpp`: never per-frame), don't cache it (session-local `ComponentId`s must stay live, per the existing header note).
+- Do not widen component public APIs for serialization — `friend struct SaveSerialize<...>` is the sanctioned reach into privates (single use expected: `C_TriangleCanvasBackground`).
+- `C_GeometricShape` keeps its one-representative (`SPHERE`) registration; other instantiations remain unsaved — pre-existing inventory decision, out of scope here.
+- The implementer must work on a Linux host (macOS engine builds are broken, #2449).
+
+### Cross-system audit (SaveSerialize shape change)
+
+All `SaveSerialize` consumers, by grep: `save_registry.hpp` (`registerComponent` — gains the assert, otherwise unchanged), `voxel_set_serialize.hpp` (full specialization — unaffected), `test/world/world_snapshot_test.cpp` + `test/world/component_migration_test.cpp` (test-local full specializations — unaffected; their TC test components move from primary to the constrained partial specialization with an identical body). `world_snapshot.cpp` and `chunk_persistence.*` reach serialization only through registry hooks — no direct dependence on the template shape.
+

--- a/engine/asset/include/irreden/asset/math_binary_io.hpp
+++ b/engine/asset/include/irreden/asset/math_binary_io.hpp
@@ -1,12 +1,49 @@
 #ifndef IR_ASSET_MATH_BINARY_IO_H
 #define IR_ASSET_MATH_BINARY_IO_H
 
-// Centralizes vec3/vec4/Color binary I/O — lives in engine/asset/ (not engine/math/) to avoid the reverse dep.
+// Centralizes vec3/vec4/Color binary I/O — lives in engine/asset/ (not engine/math/) to avoid the
+// reverse dep.
 
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/math/ir_math_types.hpp>
 
 namespace IRMath::BinaryIO {
+
+inline void writeVec2(IRAsset::BinaryWriter &w, const IRMath::vec2 &v) {
+    w.writeF32(v.x);
+    w.writeF32(v.y);
+}
+
+inline void writeIVec2(IRAsset::BinaryWriter &w, const IRMath::ivec2 &v) {
+    w.writeI32(v.x);
+    w.writeI32(v.y);
+}
+
+inline IRAsset::Result<IRMath::vec2> readVec2(IRAsset::BinaryReader &r) {
+    auto x = r.readF32();
+    if (!x.ok())
+        return IRAsset::Result<IRMath::vec2>::error(x.status_.code_, std::move(x.status_.message_));
+    auto y = r.readF32();
+    if (!y.ok())
+        return IRAsset::Result<IRMath::vec2>::error(y.status_.code_, std::move(y.status_.message_));
+    return IRAsset::Result<IRMath::vec2>::success(IRMath::vec2(x.value_, y.value_));
+}
+
+inline IRAsset::Result<IRMath::ivec2> readIVec2(IRAsset::BinaryReader &r) {
+    auto x = r.readI32();
+    if (!x.ok())
+        return IRAsset::Result<IRMath::ivec2>::error(
+            x.status_.code_,
+            std::move(x.status_.message_)
+        );
+    auto y = r.readI32();
+    if (!y.ok())
+        return IRAsset::Result<IRMath::ivec2>::error(
+            y.status_.code_,
+            std::move(y.status_.message_)
+        );
+    return IRAsset::Result<IRMath::ivec2>::success(IRMath::ivec2(x.value_, y.value_));
+}
 
 inline void writeVec3(IRAsset::BinaryWriter &w, const IRMath::vec3 &v) {
     w.writeF32(v.x);
@@ -47,7 +84,9 @@ inline IRAsset::Result<IRMath::vec4> readVec4(IRAsset::BinaryReader &r) {
     auto w = r.readF32();
     if (!w.ok())
         return IRAsset::Result<IRMath::vec4>::error(w.status_.code_, std::move(w.status_.message_));
-    return IRAsset::Result<IRMath::vec4>::success(IRMath::vec4(x.value_, y.value_, z.value_, w.value_));
+    return IRAsset::Result<IRMath::vec4>::success(
+        IRMath::vec4(x.value_, y.value_, z.value_, w.value_)
+    );
 }
 
 inline void writeColorPacked(IRAsset::BinaryWriter &w, IRMath::Color color) {

--- a/engine/prefabs/irreden/audio/save_serializers_audio.hpp
+++ b/engine/prefabs/irreden/audio/save_serializers_audio.hpp
@@ -1,0 +1,100 @@
+#ifndef IR_SAVE_SERIALIZERS_AUDIO_H
+#define IR_SAVE_SERIALIZERS_AUDIO_H
+
+/// `SaveSerialize<C>` specialization for `engine/prefabs/irreden/audio/`
+/// (#2242). Opt-in serializer header: include it wherever a registry
+/// registers `C_MidiSequence`; never pulled by the component header.
+
+#include <irreden/audio/components/component_midi_sequence.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <array>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace IRWorld {
+
+/// Only the **authored** sequence plus its playback cursor is persisted.
+/// `C_MidiSequence` derives a block of tempo scalars in its constructor
+/// (`m_bps`, `m_ticksPerMeasure`, `m_measuresPerSecond`, `m_ticksPerSecond`,
+/// and the public `lengthMidiTicks_`) purely from `bpm_`, `timeSignature_`
+/// and `lengthMeasures_`. Writing those out would persist the same facts
+/// twice and let a hand-edited file present a tempo whose derived scalars
+/// disagree with it; instead `read` funnels the authored fields back through
+/// the constructor so every derived value is recomputed by the one piece of
+/// code that owns the formula, then restores the two genuine pieces of live
+/// state the constructor zeroes (`tickCount_`, `nextMessageIndex_`).
+template <> struct SaveSerialize<IRComponents::C_MidiSequence> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_MidiSequence &value) {
+        w.writeF32(value.bpm_);
+        w.writeI32(value.timeSignature_.first);
+        w.writeI32(value.timeSignature_.second);
+        w.writeI32(value.lengthMeasures_);
+        w.writeU8(value.looping_ ? 1 : 0);
+        // Element-wise rather than detail::writeTrivialVector: the element is
+        // a std::pair, and std::pair is NOT trivially copyable (it declares a
+        // copy-assignment operator), even when both of its members are. The
+        // tick and the message are written as their own fields instead.
+        w.writeVarUInt(value.messageSequence_.size());
+        for (const std::pair<int, IRComponents::C_MidiMessage> &entry : value.messageSequence_) {
+            w.writeI32(entry.first);
+            w.writeBytes(&entry.second, sizeof(IRComponents::C_MidiMessage));
+        }
+        w.writeF64(value.tickCount_);
+        w.writeI32(value.nextMessageIndex_);
+    }
+
+    static IRAsset::Result<IRComponents::C_MidiSequence> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_MidiSequence>;
+
+        float bpm = 0.0f;
+        std::int32_t timeSignatureNumerator = 0;
+        std::int32_t timeSignatureDenominator = 0;
+        std::int32_t lengthMeasures = 0;
+        bool looping = false;
+        std::vector<std::pair<int, IRComponents::C_MidiMessage>> messageSequence;
+        double tickCount = 0.0;
+        std::int32_t nextMessageIndex = 0;
+
+        IR_SAVE_READ(bpm, r.readF32());
+        IR_SAVE_READ(timeSignatureNumerator, r.readI32());
+        IR_SAVE_READ(timeSignatureDenominator, r.readI32());
+        IR_SAVE_READ(lengthMeasures, r.readI32());
+        IR_SAVE_READ_BOOL(looping, r.readU8());
+
+        std::uint64_t messageCount = 0;
+        IR_SAVE_READ(messageCount, r.readVarUInt());
+        messageSequence.reserve(detail::boundedReserve(messageCount));
+        for (std::uint64_t i = 0; i < messageCount; ++i) {
+            std::int32_t tick = 0;
+            IR_SAVE_READ(tick, r.readI32());
+            std::array<std::byte, sizeof(IRComponents::C_MidiMessage)> raw{};
+            IR_SAVE_READ_STATUS(r.readBytes(raw.data(), raw.size()));
+            messageSequence.emplace_back(tick, std::bit_cast<IRComponents::C_MidiMessage>(raw));
+        }
+
+        IR_SAVE_READ(tickCount, r.readF64());
+        IR_SAVE_READ(nextMessageIndex, r.readI32());
+
+        IRComponents::C_MidiSequence value{
+            bpm,
+            std::pair<int, int>{timeSignatureNumerator, timeSignatureDenominator},
+            lengthMeasures,
+            looping,
+            std::move(messageSequence)
+        };
+        value.tickCount_ = tickCount;
+        value.nextMessageIndex_ = nextMessageIndex;
+        return Res::success(std::move(value));
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* IR_SAVE_SERIALIZERS_AUDIO_H */

--- a/engine/prefabs/irreden/common/save_serializers_common.hpp
+++ b/engine/prefabs/irreden/common/save_serializers_common.hpp
@@ -1,0 +1,158 @@
+#ifndef IR_SAVE_SERIALIZERS_COMMON_H
+#define IR_SAVE_SERIALIZERS_COMMON_H
+
+/// `SaveSerialize<C>` specializations for the string-bearing components in
+/// `engine/prefabs/irreden/common/` (#2242). Each of these opts IN to the
+/// world snapshot but owns a `std::string`, so the trivially-copyable arm of
+/// `SaveSerialize` does not apply — a raw byte image would persist a dangling
+/// pointer.
+///
+/// Same include contract as `voxel/voxel_set_serialize.hpp`: this is an
+/// opt-in serializer header pulled by whoever builds a registry over these
+/// components (`engine/world/src/world_default_registry.cpp`), never by the
+/// component headers themselves, so `common/`'s render-neutral layering
+/// holds.
+///
+/// Field coverage is the whole struct in every case here — these components
+/// carry no derived or process-local state, so "authored truth" and "all
+/// members" coincide. Where that stops being true for a component, the
+/// specialization says so (see the render / voxel / audio serializer headers).
+
+#include <irreden/common/components/component_cycle.hpp>
+#include <irreden/common/components/component_name.hpp>
+#include <irreden/common/components/component_stopwatch.hpp>
+#include <irreden/common/components/component_timer.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace IRWorld {
+
+template <> struct SaveSerialize<IRComponents::C_Name> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_Name &value) {
+        w.writeString(value.name_);
+    }
+
+    static IRAsset::Result<IRComponents::C_Name> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_Name>;
+        IRComponents::C_Name value{};
+        IR_SAVE_READ(value.name_, r.readString());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_Timer> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_Timer &value) {
+        w.writeString(value.name_);
+        w.writeU64(value.startTick_);
+        w.writeU64(value.targetTick_);
+        w.writeU64(value.intervalTicks_);
+        w.writeU8(value.active_ ? 1 : 0);
+        // `fired_` is a one-tick embedded event that TIMER_FIRE recomputes
+        // every tick, so it is self-clearing and never meaningful across a
+        // save. Persisted anyway: the alternative is a read that silently
+        // defaults a member, and a timer restored from a save taken on its
+        // firing tick should look exactly like the one that was saved.
+        w.writeU8(value.fired_ ? 1 : 0);
+    }
+
+    static IRAsset::Result<IRComponents::C_Timer> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_Timer>;
+        IRComponents::C_Timer value{};
+        IR_SAVE_READ(value.name_, r.readString());
+        IR_SAVE_READ(value.startTick_, r.readU64());
+        IR_SAVE_READ(value.targetTick_, r.readU64());
+        IR_SAVE_READ(value.intervalTicks_, r.readU64());
+        IR_SAVE_READ_BOOL(value.active_, r.readU8());
+        IR_SAVE_READ_BOOL(value.fired_, r.readU8());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_Stopwatch> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_Stopwatch &value) {
+        w.writeString(value.name_);
+        w.writeU64(value.startTick_);
+        w.writeU64(value.pausedElapsed_);
+        w.writeU8(value.running_ ? 1 : 0);
+    }
+
+    static IRAsset::Result<IRComponents::C_Stopwatch> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_Stopwatch>;
+        IRComponents::C_Stopwatch value{};
+        IR_SAVE_READ(value.name_, r.readString());
+        IR_SAVE_READ(value.startTick_, r.readU64());
+        IR_SAVE_READ(value.pausedElapsed_, r.readU64());
+        IR_SAVE_READ_BOOL(value.running_, r.readU8());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_Cycle> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_Cycle &value) {
+        w.writeString(value.name_);
+        w.writeU64(value.periodTicks_);
+        w.writeU64(value.phaseOffset_);
+        // `breakpoints_` is a fixed inline array but only the first
+        // `numBreakpoints_` entries are live — write the live prefix so the
+        // on-disk size tracks the content, not the (tunable) array capacity.
+        w.writeU8(value.numBreakpoints_);
+        for (std::uint8_t i = 0; i < value.numBreakpoints_; ++i) {
+            w.writeU64(value.breakpoints_[i]);
+        }
+        w.writeU64(value.lastCycleNum_);
+        w.writeU8(value.lastSegmentIndex_);
+        w.writeU8(value.boundaryCrossed_ ? 1 : 0);
+        w.writeU64(value.fromCycle_);
+        w.writeU64(value.toCycle_);
+        w.writeU8(value.segmentIndex_);
+        w.writeU8(value.fromSegment_);
+        w.writeU8(value.toSegment_);
+    }
+
+    static IRAsset::Result<IRComponents::C_Cycle> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_Cycle>;
+        IRComponents::C_Cycle value{};
+        IR_SAVE_READ(value.name_, r.readString());
+        IR_SAVE_READ(value.periodTicks_, r.readU64());
+        IR_SAVE_READ(value.phaseOffset_, r.readU64());
+
+        std::uint8_t numBreakpoints = 0;
+        IR_SAVE_READ(numBreakpoints, r.readU8());
+        // A count past the inline array's capacity means the bytes came from
+        // a build with a larger kMaxBreakpoints (or are corrupt); either way
+        // copying them would overrun the array. UnknownTag is the "record
+        // shape this build doesn't know, likely a newer writer" code.
+        if (numBreakpoints > IRComponents::C_Cycle::kMaxBreakpoints) {
+            return Res::error(
+                IRAsset::BinaryIOError::UnknownTag,
+                "C_Cycle: breakpoint count " + std::to_string(numBreakpoints) +
+                    " exceeds this build's kMaxBreakpoints (" +
+                    std::to_string(IRComponents::C_Cycle::kMaxBreakpoints) + ")"
+            );
+        }
+        value.numBreakpoints_ = numBreakpoints;
+        for (std::uint8_t i = 0; i < numBreakpoints; ++i) {
+            IR_SAVE_READ(value.breakpoints_[i], r.readU64());
+        }
+
+        IR_SAVE_READ(value.lastCycleNum_, r.readU64());
+        IR_SAVE_READ(value.lastSegmentIndex_, r.readU8());
+        IR_SAVE_READ_BOOL(value.boundaryCrossed_, r.readU8());
+        IR_SAVE_READ(value.fromCycle_, r.readU64());
+        IR_SAVE_READ(value.toCycle_, r.readU64());
+        IR_SAVE_READ(value.segmentIndex_, r.readU8());
+        IR_SAVE_READ(value.fromSegment_, r.readU8());
+        IR_SAVE_READ(value.toSegment_, r.readU8());
+        return Res::success(std::move(value));
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* IR_SAVE_SERIALIZERS_COMMON_H */

--- a/engine/prefabs/irreden/demo/save_serializers_demo.hpp
+++ b/engine/prefabs/irreden/demo/save_serializers_demo.hpp
@@ -1,0 +1,36 @@
+#ifndef IR_SAVE_SERIALIZERS_DEMO_H
+#define IR_SAVE_SERIALIZERS_DEMO_H
+
+/// `SaveSerialize<C>` specialization for `engine/prefabs/irreden/demo/`
+/// (#2242). One component, one string. It lives in its own header rather
+/// than folding into `common/save_serializers_common.hpp` because a prefab
+/// header must not reach across domains (`engine/prefabs/CLAUDE.md`
+/// anti-patterns) — the serializer headers mirror the domain split of the
+/// components they cover.
+
+#include <irreden/demo/components/component_example.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <utility>
+
+namespace IRWorld {
+
+template <> struct SaveSerialize<IRComponents::C_Example> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_Example &value) {
+        w.writeString(value.exampleSentence_);
+    }
+
+    static IRAsset::Result<IRComponents::C_Example> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_Example>;
+        IRComponents::C_Example value{};
+        IR_SAVE_READ(value.exampleSentence_, r.readString());
+        return Res::success(std::move(value));
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* IR_SAVE_SERIALIZERS_DEMO_H */

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp
@@ -11,6 +11,13 @@
 
 using namespace IRMath;
 
+namespace IRWorld {
+// Forward declaration only — the friend declaration below needs the template
+// to exist, not its definition, so this header stays free of
+// engine/world/save_serialize.hpp.
+template <typename C> struct SaveSerialize;
+} // namespace IRWorld
+
 namespace IRComponents {
 
 enum class BackgroundTypes { kSingleColor, kGradient, kGradientRandom, kPulsePattern };
@@ -353,6 +360,15 @@ struct C_TriangleCanvasBackground {
     }
 
   private:
+    // The world-snapshot serializer (#2242) persists the authored subset of
+    // the private state below — type, colors, size, and the pulse/pattern
+    // tuning parameters — and lets the per-frame caches (m_randomColorData,
+    // m_patternMask, and their initialization flags) rebuild on load.
+    // Declared a friend rather than widening the public API: none of these
+    // fields has a legitimate reader outside persistence, and the accessor
+    // pairs required to reach them would be a larger surface than the friend.
+    friend struct IRWorld::SaveSerialize<C_TriangleCanvasBackground>;
+
     ivec2 m_size;
     std::vector<Color> m_colors;
     std::vector<Color> m_randomColorData;

--- a/engine/prefabs/irreden/render/save_serializers_render.hpp
+++ b/engine/prefabs/irreden/render/save_serializers_render.hpp
@@ -25,6 +25,7 @@
 #include <irreden/asset/math_binary_io.hpp>
 
 #include <cstdint>
+#include <string>
 #include <utility>
 
 namespace IRWorld {
@@ -88,10 +89,17 @@ template <> struct SaveSerialize<IRComponents::C_SpriteAnimation> {
 
 /// The two parallel grids are the authored content; `size_` gives their
 /// expected extent. `read` restores the vectors verbatim rather than calling
-/// `resize()` off `size_`, so a file whose grids disagree with its extent
-/// round-trips to exactly what was written instead of being silently
-/// truncated or zero-padded — the mismatch stays visible to whatever reads
-/// it rather than being laundered here.
+/// `resize()` off `size_` — a mismatch is **rejected**, never truncated or
+/// zero-padded into looking valid, and never passed through: the
+/// `atTriangleColor` / `atTriangleDistance` accessors index
+/// `triangleColors_[index2DtoIndex1D(index, size_)]` unchecked and
+/// `setTriangle`'s lone bounds check is an `IR_ASSERT` that compiles out
+/// under `IR_RELEASE`, so an inconsistent grid is an out-of-bounds access on
+/// first use rather than visibly-wrong data. Rejecting keeps the reader's
+/// admissible set equal to the constructors', which establish
+/// `triangleColors_.size() == triangleDistances_.size() == size_.x*size_.y` —
+/// the same contract `SaveSerialize<C_Cycle>` enforces on its breakpoint
+/// count.
 template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
     static void write(IRAsset::BinaryWriter &w, const IRComponents::C_TrianglesOnlySet &value) {
         IRMath::BinaryIO::writeIVec2(w, value.size_);
@@ -107,6 +115,25 @@ template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
         IR_SAVE_READ(value.origin_, IRMath::BinaryIO::readIVec2(r));
         IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleColors_));
         IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleDistances_));
+
+        // Widened to 64-bit because both dimensions come off disk: a corrupt
+        // pair overflows the component's own `int` multiply. A negative
+        // product (mixed-sign dimensions) is unconstructible as well —
+        // `resize()` would convert it to a huge `size_t` — so the same test
+        // rejects it.
+        const std::int64_t expectedCells =
+            static_cast<std::int64_t>(value.size_.x) * static_cast<std::int64_t>(value.size_.y);
+        if (expectedCells < 0 ||
+            static_cast<std::int64_t>(value.triangleColors_.size()) != expectedCells ||
+            static_cast<std::int64_t>(value.triangleDistances_.size()) != expectedCells) {
+            return Res::error(
+                IRAsset::BinaryIOError::UnknownTag,
+                "C_TrianglesOnlySet: grid sizes (" + std::to_string(value.triangleColors_.size()) +
+                    " colors, " + std::to_string(value.triangleDistances_.size()) +
+                    " distances) disagree with the extent " + std::to_string(value.size_.x) + "x" +
+                    std::to_string(value.size_.y)
+            );
+        }
         return Res::success(std::move(value));
     }
 };

--- a/engine/prefabs/irreden/render/save_serializers_render.hpp
+++ b/engine/prefabs/irreden/render/save_serializers_render.hpp
@@ -1,0 +1,421 @@
+#ifndef IR_SAVE_SERIALIZERS_RENDER_H
+#define IR_SAVE_SERIALIZERS_RENDER_H
+
+/// `SaveSerialize<C>` specializations for the heap-owning components in
+/// `engine/prefabs/irreden/render/` (#2242) — text, sprite playback state,
+/// the triangle-canvas pair, and the widget family.
+///
+/// These are all **CPU-side** render components. The GPU-handle-owning ones
+/// (`C_TrixelCanvasFramebuffer`, `C_TriangleCanvasTextures`, the canvas
+/// texture bundle) are opted OUT of persistence entirely in
+/// `save_component_inventory.hpp` Class A and never reach a serializer.
+///
+/// Opt-in serializer header: include it wherever a registry registers these
+/// components; never pulled by the component headers themselves.
+
+#include <irreden/render/components/component_sprite_animation.hpp>
+#include <irreden/render/components/component_text_segment.hpp>
+#include <irreden/render/components/component_triangle_canvas_background.hpp>
+#include <irreden/render/components/component_triangles_only_set.hpp>
+#include <irreden/render/components/component_widget.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/math_binary_io.hpp>
+
+#include <cstdint>
+#include <utility>
+
+namespace IRWorld {
+
+template <> struct SaveSerialize<IRComponents::C_TextSegment> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_TextSegment &value) {
+        w.writeString(value.text_);
+    }
+
+    static IRAsset::Result<IRComponents::C_TextSegment> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_TextSegment>;
+        IRComponents::C_TextSegment value{};
+        IR_SAVE_READ(value.text_, r.readString());
+        return Res::success(std::move(value));
+    }
+};
+
+/// `sheetEntity_` is an `EntityId` and round-trips as a plain value under the
+/// snapshot's exact-id restore contract. `animationIndex_` is an index into
+/// the *sheet's* animation vector, resolved at `playAnimation` time; the
+/// component header already documents it as silently stale if the sheet
+/// changes underneath, and a reload is no different from that case.
+template <> struct SaveSerialize<IRComponents::C_SpriteAnimation> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_SpriteAnimation &value) {
+        w.writeU64(static_cast<std::uint64_t>(value.sheetEntity_));
+        w.writeI32(value.animationIndex_);
+        w.writeI32(value.frameIndex_);
+        w.writeF32(value.elapsedInFrame_);
+        w.writeI32(static_cast<std::int32_t>(value.loopMode_));
+        w.writeF32(value.speed_);
+        w.writeI32(value.pingPongDirection_);
+        w.writeU8(value.terminated_ ? 1 : 0);
+        w.writeU8(value.stopped_ ? 1 : 0);
+        w.writeString(value.currentAnimName_);
+    }
+
+    static IRAsset::Result<IRComponents::C_SpriteAnimation> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_SpriteAnimation>;
+        IRComponents::C_SpriteAnimation value{};
+
+        std::uint64_t sheetEntity = 0;
+        IR_SAVE_READ(sheetEntity, r.readU64());
+        value.sheetEntity_ = static_cast<IREntity::EntityId>(sheetEntity);
+
+        IR_SAVE_READ(value.animationIndex_, r.readI32());
+        IR_SAVE_READ(value.frameIndex_, r.readI32());
+        IR_SAVE_READ(value.elapsedInFrame_, r.readF32());
+
+        std::int32_t loopMode = 0;
+        IR_SAVE_READ(loopMode, r.readI32());
+        value.loopMode_ = static_cast<IRComponents::SpriteLoopMode>(loopMode);
+
+        IR_SAVE_READ(value.speed_, r.readF32());
+        IR_SAVE_READ(value.pingPongDirection_, r.readI32());
+        IR_SAVE_READ_BOOL(value.terminated_, r.readU8());
+        IR_SAVE_READ_BOOL(value.stopped_, r.readU8());
+        IR_SAVE_READ(value.currentAnimName_, r.readString());
+        return Res::success(std::move(value));
+    }
+};
+
+/// The two parallel grids are the authored content; `size_` gives their
+/// expected extent. `read` restores the vectors verbatim rather than calling
+/// `resize()` off `size_`, so a file whose grids disagree with its extent
+/// round-trips to exactly what was written instead of being silently
+/// truncated or zero-padded — the mismatch stays visible to whatever reads
+/// it rather than being laundered here.
+template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_TrianglesOnlySet &value) {
+        IRMath::BinaryIO::writeIVec2(w, value.size_);
+        IRMath::BinaryIO::writeIVec2(w, value.origin_);
+        detail::writeTrivialVector(w, value.triangleColors_);
+        detail::writeTrivialVector(w, value.triangleDistances_);
+    }
+
+    static IRAsset::Result<IRComponents::C_TrianglesOnlySet> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_TrianglesOnlySet>;
+        IRComponents::C_TrianglesOnlySet value{};
+        IR_SAVE_READ(value.size_, IRMath::BinaryIO::readIVec2(r));
+        IR_SAVE_READ(value.origin_, IRMath::BinaryIO::readIVec2(r));
+        IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleColors_));
+        IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleDistances_));
+        return Res::success(std::move(value));
+    }
+};
+
+/// Authored state only. `C_TriangleCanvasBackground` keeps two per-frame
+/// caches — `m_randomColorData` (re-randomized every frame in
+/// kGradientRandom, fully rewritten every pulse frame in kPulsePattern) and
+/// `m_patternMask` (recomputed whenever `m_patternMaskInitialized` is false)
+/// — plus the bookkeeping that drives them. None of that is authored truth,
+/// so `read` routes the authored fields through the constructor (which sizes
+/// both caches for `m_size`) and leaves `m_patternMaskInitialized` at its
+/// default `false` so the next frame rebuilds the mask for the restored zoom.
+///
+/// This specialization is a friend of the component; see the friend
+/// declaration in `component_triangle_canvas_background.hpp` for why the
+/// private fields are reached directly rather than through accessors.
+template <> struct SaveSerialize<IRComponents::C_TriangleCanvasBackground> {
+    static void
+    write(IRAsset::BinaryWriter &w, const IRComponents::C_TriangleCanvasBackground &value) {
+        w.writeI32(static_cast<std::int32_t>(value.m_type));
+        IRMath::BinaryIO::writeIVec2(w, value.m_size);
+        detail::writeTrivialVector(w, value.m_colors);
+        w.writeF32(value.m_pulseSpeed);
+        w.writeI32(value.m_patternScale);
+
+        // Live animation phase — genuinely stateful, not derived: it
+        // accumulates across frames and defines where in the pulse the
+        // canvas currently is.
+        w.writeF32(value.m_pulsePhase);
+        w.writeF32(value.m_patternZoomMultiplier);
+
+        IRMath::BinaryIO::writeVec2(w, value.m_pulseWaveDirection);
+        w.writeF32(value.m_pulseWavePhaseScale);
+        IRMath::BinaryIO::writeVec2(w, value.m_pulseWaveDirectionSecondary);
+        w.writeF32(value.m_pulseWavePhaseScaleSecondary);
+        w.writeF32(value.m_pulseWaveInterferenceMix);
+        w.writeF32(value.m_pulseWavePrimarySpeedMultiplier);
+        w.writeF32(value.m_pulseWavePrimaryStartOffset);
+        w.writeF32(value.m_pulseWaveSecondarySpeedMultiplier);
+        w.writeF32(value.m_pulseWaveSecondaryStartOffset);
+        w.writeF32(value.m_minPulseUpdateSeconds);
+
+        writeDirectionMotion(w, value.m_pulseWaveDirectionMotionPrimary);
+        writeDirectionMotion(w, value.m_pulseWaveDirectionMotionSecondary);
+    }
+
+    static IRAsset::Result<IRComponents::C_TriangleCanvasBackground>
+    read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_TriangleCanvasBackground>;
+
+        std::int32_t type = 0;
+        IRMath::ivec2 size{0, 0};
+        std::vector<IRMath::Color> colors;
+        float pulseSpeed = 1.0f;
+        std::int32_t patternScale = 10;
+
+        IR_SAVE_READ(type, r.readI32());
+        IR_SAVE_READ(size, IRMath::BinaryIO::readIVec2(r));
+        IR_SAVE_READ_STATUS(detail::readTrivialVector(r, colors));
+        IR_SAVE_READ(pulseSpeed, r.readF32());
+        IR_SAVE_READ(patternScale, r.readI32());
+
+        // Through the constructor so both per-frame caches come back sized
+        // for `size` by the code that owns that relationship.
+        IRComponents::C_TriangleCanvasBackground value{
+            static_cast<IRComponents::BackgroundTypes>(type),
+            colors,
+            size,
+            pulseSpeed,
+            patternScale
+        };
+
+        IR_SAVE_READ(value.m_pulsePhase, r.readF32());
+        IR_SAVE_READ(value.m_patternZoomMultiplier, r.readF32());
+
+        IR_SAVE_READ(value.m_pulseWaveDirection, IRMath::BinaryIO::readVec2(r));
+        IR_SAVE_READ(value.m_pulseWavePhaseScale, r.readF32());
+        IR_SAVE_READ(value.m_pulseWaveDirectionSecondary, IRMath::BinaryIO::readVec2(r));
+        IR_SAVE_READ(value.m_pulseWavePhaseScaleSecondary, r.readF32());
+        IR_SAVE_READ(value.m_pulseWaveInterferenceMix, r.readF32());
+        IR_SAVE_READ(value.m_pulseWavePrimarySpeedMultiplier, r.readF32());
+        IR_SAVE_READ(value.m_pulseWavePrimaryStartOffset, r.readF32());
+        IR_SAVE_READ(value.m_pulseWaveSecondarySpeedMultiplier, r.readF32());
+        IR_SAVE_READ(value.m_pulseWaveSecondaryStartOffset, r.readF32());
+        IR_SAVE_READ(value.m_minPulseUpdateSeconds, r.readF32());
+
+        IR_SAVE_READ_STATUS(readDirectionMotion(r, value.m_pulseWaveDirectionMotionPrimary));
+        IR_SAVE_READ_STATUS(readDirectionMotion(r, value.m_pulseWaveDirectionMotionSecondary));
+        return Res::success(std::move(value));
+    }
+
+  private:
+    using DirectionMotion = IRComponents::C_TriangleCanvasBackground::LinearDirectionMotion;
+
+    static void writeDirectionMotion(IRAsset::BinaryWriter &w, const DirectionMotion &motion) {
+        w.writeU8(motion.enabled_ ? 1 : 0);
+        w.writeF32(motion.timeSeconds_);
+        w.writeF32(motion.periodSeconds_);
+        IRMath::BinaryIO::writeVec2(w, motion.startDirection_);
+        IRMath::BinaryIO::writeVec2(w, motion.endDirection_);
+        w.writeI32(static_cast<std::int32_t>(motion.forwardEasing_));
+        w.writeI32(static_cast<std::int32_t>(motion.backwardEasing_));
+    }
+
+    // Reports a bare status rather than a Result so the caller can use the
+    // same IR_SAVE_READ_STATUS bail-out the container helpers use.
+    static IRAsset::BinaryStatus
+    readDirectionMotion(IRAsset::BinaryReader &r, DirectionMotion &motion) {
+        IRAsset::Result<std::uint8_t> enabled = r.readU8();
+        if (!enabled.ok()) {
+            return enabled.status_;
+        }
+        IRAsset::Result<float> timeSeconds = r.readF32();
+        if (!timeSeconds.ok()) {
+            return timeSeconds.status_;
+        }
+        IRAsset::Result<float> periodSeconds = r.readF32();
+        if (!periodSeconds.ok()) {
+            return periodSeconds.status_;
+        }
+        IRAsset::Result<IRMath::vec2> startDirection = IRMath::BinaryIO::readVec2(r);
+        if (!startDirection.ok()) {
+            return startDirection.status_;
+        }
+        IRAsset::Result<IRMath::vec2> endDirection = IRMath::BinaryIO::readVec2(r);
+        if (!endDirection.ok()) {
+            return endDirection.status_;
+        }
+        IRAsset::Result<std::int32_t> forwardEasing = r.readI32();
+        if (!forwardEasing.ok()) {
+            return forwardEasing.status_;
+        }
+        IRAsset::Result<std::int32_t> backwardEasing = r.readI32();
+        if (!backwardEasing.ok()) {
+            return backwardEasing.status_;
+        }
+
+        motion.enabled_ = enabled.value_ != 0;
+        motion.timeSeconds_ = timeSeconds.value_;
+        motion.periodSeconds_ = periodSeconds.value_;
+        motion.startDirection_ = startDirection.value_;
+        motion.endDirection_ = endDirection.value_;
+        motion.forwardEasing_ = static_cast<IREasingFunctions>(forwardEasing.value_);
+        motion.backwardEasing_ = static_cast<IREasingFunctions>(backwardEasing.value_);
+        return IRAsset::BinaryStatus::success();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Widget family. Every widget entity carries C_Widget + C_WidgetState (both
+// trivially copyable, so they take SaveSerialize's fast path) plus one
+// per-kind data component. Only the per-kind components that own a string or
+// a vector of strings need a specialization here; C_WidgetColorSwatch and
+// C_WidgetScroll are plain data and are covered by the fast path.
+// ---------------------------------------------------------------------------
+
+template <> struct SaveSerialize<IRComponents::C_WidgetPanel> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetPanel &value) {
+        w.writeString(value.title_);
+        w.writeU8(value.drawBorder_ ? 1 : 0);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetPanel> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetPanel>;
+        IRComponents::C_WidgetPanel value{};
+        IR_SAVE_READ(value.title_, r.readString());
+        IR_SAVE_READ_BOOL(value.drawBorder_, r.readU8());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetLabel> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetLabel &value) {
+        w.writeString(value.text_);
+        w.writeU32(value.colorOverride_.toPackedRGBA());
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetLabel> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetLabel>;
+        IRComponents::C_WidgetLabel value{};
+        IR_SAVE_READ(value.text_, r.readString());
+        std::uint32_t packed = 0;
+        IR_SAVE_READ(packed, r.readU32());
+        value.colorOverride_ = IRMath::Color::fromPackedRGBA(packed);
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetButton> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetButton &value) {
+        w.writeString(value.label_);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetButton> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetButton>;
+        IRComponents::C_WidgetButton value{};
+        IR_SAVE_READ(value.label_, r.readString());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetSlider> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetSlider &value) {
+        w.writeString(value.label_);
+        w.writeF32(value.minValue_);
+        w.writeF32(value.maxValue_);
+        w.writeF32(value.currentValue_);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetSlider> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetSlider>;
+        IRComponents::C_WidgetSlider value{};
+        IR_SAVE_READ(value.label_, r.readString());
+        IR_SAVE_READ(value.minValue_, r.readF32());
+        IR_SAVE_READ(value.maxValue_, r.readF32());
+        IR_SAVE_READ(value.currentValue_, r.readF32());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetCheckbox> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetCheckbox &value) {
+        w.writeString(value.label_);
+        w.writeU8(value.checked_ ? 1 : 0);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetCheckbox> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetCheckbox>;
+        IRComponents::C_WidgetCheckbox value{};
+        IR_SAVE_READ(value.label_, r.readString());
+        IR_SAVE_READ_BOOL(value.checked_, r.readU8());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetList> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetList &value) {
+        detail::writeStringVector(w, value.items_);
+        w.writeI32(value.selectedIndex_);
+        w.writeI32(value.scrollOffset_);
+        w.writeI32(value.itemHeight_);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetList> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetList>;
+        IRComponents::C_WidgetList value{};
+        IR_SAVE_READ_STATUS(detail::readStringVector(r, value.items_));
+        IR_SAVE_READ(value.selectedIndex_, r.readI32());
+        IR_SAVE_READ(value.scrollOffset_, r.readI32());
+        IR_SAVE_READ(value.itemHeight_, r.readI32());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetDropdown> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetDropdown &value) {
+        detail::writeStringVector(w, value.items_);
+        w.writeI32(value.selectedIndex_);
+        w.writeU8(value.isOpen_ ? 1 : 0);
+        w.writeI32(value.itemHeight_);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetDropdown> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetDropdown>;
+        IRComponents::C_WidgetDropdown value{};
+        IR_SAVE_READ_STATUS(detail::readStringVector(r, value.items_));
+        IR_SAVE_READ(value.selectedIndex_, r.readI32());
+        IR_SAVE_READ_BOOL(value.isOpen_, r.readU8());
+        IR_SAVE_READ(value.itemHeight_, r.readI32());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetRadio> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetRadio &value) {
+        w.writeString(value.label_);
+        w.writeU32(value.groupId_);
+        w.writeI32(value.value_);
+        w.writeU8(value.selected_ ? 1 : 0);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetRadio> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetRadio>;
+        IRComponents::C_WidgetRadio value{};
+        IR_SAVE_READ(value.label_, r.readString());
+        IR_SAVE_READ(value.groupId_, r.readU32());
+        IR_SAVE_READ(value.value_, r.readI32());
+        IR_SAVE_READ_BOOL(value.selected_, r.readU8());
+        return Res::success(std::move(value));
+    }
+};
+
+template <> struct SaveSerialize<IRComponents::C_WidgetTextInput> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_WidgetTextInput &value) {
+        w.writeString(value.text_);
+        w.writeI32(value.cursorPos_);
+        w.writeI32(value.maxLength_);
+    }
+
+    static IRAsset::Result<IRComponents::C_WidgetTextInput> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_WidgetTextInput>;
+        IRComponents::C_WidgetTextInput value{};
+        IR_SAVE_READ(value.text_, r.readString());
+        IR_SAVE_READ(value.cursorPos_, r.readI32());
+        IR_SAVE_READ(value.maxLength_, r.readI32());
+        return Res::success(std::move(value));
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* IR_SAVE_SERIALIZERS_RENDER_H */

--- a/engine/prefabs/irreden/render/save_serializers_render.hpp
+++ b/engine/prefabs/irreden/render/save_serializers_render.hpp
@@ -24,6 +24,8 @@
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/asset/math_binary_io.hpp>
 
+#include <irreden/ir_profile.hpp>
+
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -100,13 +102,33 @@ template <> struct SaveSerialize<IRComponents::C_SpriteAnimation> {
 /// `triangleColors_.size() == triangleDistances_.size() == size_.x*size_.y`,
 /// the same shape `SaveSerialize<C_Cycle>` enforces on its breakpoint count.
 /// The reader is deliberately **tighter** than the constructors in one respect:
-/// it also rejects a negative dimension. `resize()` admits one (a both-negative
-/// pair multiplies to a positive cell count, so the grids come out plausibly
-/// sized), but the resulting extent breaks the indexing math the accessors
-/// rely on — the component's own invariant is weaker here than the accessors
-/// need, so the reader does not widen to match it.
+/// it also rejects a negative dimension. Both the two-argument constructor and
+/// `resize()` admit one — each sizes the grids with an unguarded
+/// `resize(size_.x * size_.y)`, and a both-negative pair multiplies to a
+/// positive cell count, so the grids come out plausibly sized — but the
+/// resulting extent breaks the indexing math the accessors rely on. The
+/// component's own invariant is weaker here than the accessors need, so the
+/// reader does not widen to match it.
 template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
     static void write(IRAsset::BinaryWriter &w, const IRComponents::C_TrianglesOnlySet &value) {
+        // Debug-only mirror of `read`'s guard. Without it the fault surfaces
+        // one save/load cycle later as a corrupt-file error, by which point the
+        // entity that held the bad extent is gone; here the culprit is still
+        // live. `read` remains the enforcing check — this compiles out under
+        // `IR_RELEASE`.
+        IR_ASSERT(
+            value.size_.x >= 0 && value.size_.y >= 0 &&
+                static_cast<std::int64_t>(value.triangleColors_.size()) ==
+                    static_cast<std::int64_t>(value.size_.x) *
+                        static_cast<std::int64_t>(value.size_.y) &&
+                value.triangleDistances_.size() == value.triangleColors_.size(),
+            "C_TrianglesOnlySet: saving grids ({} colors, {} distances) that disagree with the "
+            "extent {}x{}; read will reject this file",
+            value.triangleColors_.size(),
+            value.triangleDistances_.size(),
+            value.size_.x,
+            value.size_.y
+        );
         IRMath::BinaryIO::writeIVec2(w, value.size_);
         IRMath::BinaryIO::writeIVec2(w, value.origin_);
         detail::writeTrivialVector(w, value.triangleColors_);
@@ -121,18 +143,32 @@ template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
         IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleColors_));
         IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleDistances_));
 
-        // Widened to 64-bit because both dimensions come off disk: a corrupt
-        // pair overflows the component's own `int` multiply. Each dimension is
-        // tested for sign independently rather than relying on the product:
-        // a mixed-sign pair gives a negative product, but a both-negative pair
-        // gives a POSITIVE one ((-2,-3) -> +6), so a product-only test admits
-        // it — and `index2DtoIndex1D` (`index.y * size_.x + index.x`) then goes
-        // negative for any row past the first, indexing out of bounds in the
-        // unchecked `atTriangleColor` / `atTriangleDistance` accessors.
+        // Two independent faults, so two checks with their own messages: a
+        // corrupt extent and a cardinality mismatch point at different repairs,
+        // and a shared message mis-names whichever one it wasn't written for
+        // (a both-negative extent reads as "6 and 6 disagree with -2x-3", which
+        // is self-contradicting — -2 * -3 predicts exactly 6).
+        //
+        // Sign first. A mixed-sign pair gives a negative product, but a
+        // both-negative pair gives a POSITIVE one ((-2,-3) -> +6), so a
+        // product-only test admits it — and `index2DtoIndex1D`
+        // (`index.y * size_.x + index.x`) then goes negative for any row past
+        // the first, indexing out of bounds in the unchecked `atTriangleColor`
+        // / `atTriangleDistance` accessors.
+        if (value.size_.x < 0 || value.size_.y < 0) {
+            return Res::error(
+                IRAsset::BinaryIOError::UnknownTag,
+                "C_TrianglesOnlySet: negative extent " + std::to_string(value.size_.x) + "x" +
+                    std::to_string(value.size_.y) + " is not indexable"
+            );
+        }
+
+        // Then cardinality. Widened to 64-bit because both dimensions come off
+        // disk: the check above bounds them at >= 0, but a corrupt pair still
+        // overflows the component's own `int` multiply.
         const std::int64_t expectedCells =
             static_cast<std::int64_t>(value.size_.x) * static_cast<std::int64_t>(value.size_.y);
-        if (value.size_.x < 0 || value.size_.y < 0 ||
-            static_cast<std::int64_t>(value.triangleColors_.size()) != expectedCells ||
+        if (static_cast<std::int64_t>(value.triangleColors_.size()) != expectedCells ||
             static_cast<std::int64_t>(value.triangleDistances_.size()) != expectedCells) {
             return Res::error(
                 IRAsset::BinaryIOError::UnknownTag,

--- a/engine/prefabs/irreden/render/save_serializers_render.hpp
+++ b/engine/prefabs/irreden/render/save_serializers_render.hpp
@@ -114,11 +114,22 @@ template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
         // Debug-only mirror of `read`'s guard. Without it the fault surfaces
         // one save/load cycle later as a corrupt-file error, by which point the
         // entity that held the bad extent is gone; here the culprit is still
-        // live. `read` remains the enforcing check — this compiles out under
+        // live. `read` remains the enforcing check — these compile out under
         // `IR_RELEASE`.
+        //
+        // Split into the same two checks as `read`, for the same reason: one
+        // message covering both faults mis-names whichever it wasn't written
+        // for. A failing assert throws, so the sign check short-circuits the
+        // cardinality check exactly as `read`'s early return does.
         IR_ASSERT(
-            value.size_.x >= 0 && value.size_.y >= 0 &&
-                static_cast<std::int64_t>(value.triangleColors_.size()) ==
+            value.size_.x >= 0 && value.size_.y >= 0,
+            "C_TrianglesOnlySet: saving a negative extent {}x{}; it is not indexable and read "
+            "will reject this file",
+            value.size_.x,
+            value.size_.y
+        );
+        IR_ASSERT(
+            static_cast<std::int64_t>(value.triangleColors_.size()) ==
                     static_cast<std::int64_t>(value.size_.x) *
                         static_cast<std::int64_t>(value.size_.y) &&
                 value.triangleDistances_.size() == value.triangleColors_.size(),

--- a/engine/prefabs/irreden/render/save_serializers_render.hpp
+++ b/engine/prefabs/irreden/render/save_serializers_render.hpp
@@ -95,11 +95,16 @@ template <> struct SaveSerialize<IRComponents::C_SpriteAnimation> {
 /// `triangleColors_[index2DtoIndex1D(index, size_)]` unchecked and
 /// `setTriangle`'s lone bounds check is an `IR_ASSERT` that compiles out
 /// under `IR_RELEASE`, so an inconsistent grid is an out-of-bounds access on
-/// first use rather than visibly-wrong data. Rejecting keeps the reader's
-/// admissible set equal to the constructors', which establish
-/// `triangleColors_.size() == triangleDistances_.size() == size_.x*size_.y` —
-/// the same contract `SaveSerialize<C_Cycle>` enforces on its breakpoint
-/// count.
+/// first use rather than visibly-wrong data. Rejecting holds the reader to the
+/// contract the constructors establish —
+/// `triangleColors_.size() == triangleDistances_.size() == size_.x*size_.y`,
+/// the same shape `SaveSerialize<C_Cycle>` enforces on its breakpoint count.
+/// The reader is deliberately **tighter** than the constructors in one respect:
+/// it also rejects a negative dimension. `resize()` admits one (a both-negative
+/// pair multiplies to a positive cell count, so the grids come out plausibly
+/// sized), but the resulting extent breaks the indexing math the accessors
+/// rely on — the component's own invariant is weaker here than the accessors
+/// need, so the reader does not widen to match it.
 template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
     static void write(IRAsset::BinaryWriter &w, const IRComponents::C_TrianglesOnlySet &value) {
         IRMath::BinaryIO::writeIVec2(w, value.size_);
@@ -117,13 +122,16 @@ template <> struct SaveSerialize<IRComponents::C_TrianglesOnlySet> {
         IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.triangleDistances_));
 
         // Widened to 64-bit because both dimensions come off disk: a corrupt
-        // pair overflows the component's own `int` multiply. A negative
-        // product (mixed-sign dimensions) is unconstructible as well —
-        // `resize()` would convert it to a huge `size_t` — so the same test
-        // rejects it.
+        // pair overflows the component's own `int` multiply. Each dimension is
+        // tested for sign independently rather than relying on the product:
+        // a mixed-sign pair gives a negative product, but a both-negative pair
+        // gives a POSITIVE one ((-2,-3) -> +6), so a product-only test admits
+        // it — and `index2DtoIndex1D` (`index.y * size_.x + index.x`) then goes
+        // negative for any row past the first, indexing out of bounds in the
+        // unchecked `atTriangleColor` / `atTriangleDistance` accessors.
         const std::int64_t expectedCells =
             static_cast<std::int64_t>(value.size_.x) * static_cast<std::int64_t>(value.size_.y);
-        if (expectedCells < 0 ||
+        if (value.size_.x < 0 || value.size_.y < 0 ||
             static_cast<std::int64_t>(value.triangleColors_.size()) != expectedCells ||
             static_cast<std::int64_t>(value.triangleDistances_.size()) != expectedCells) {
             return Res::error(

--- a/engine/prefabs/irreden/update/save_serializers_update.hpp
+++ b/engine/prefabs/irreden/update/save_serializers_update.hpp
@@ -1,0 +1,91 @@
+#ifndef IR_SAVE_SERIALIZERS_UPDATE_H
+#define IR_SAVE_SERIALIZERS_UPDATE_H
+
+/// `SaveSerialize<C>` specialization for `engine/prefabs/irreden/update/`
+/// (#2242). Opt-in serializer header: include it wherever a registry
+/// registers `C_PeriodicIdle`; never pulled by the component header.
+///
+/// The two other heap-owning components in this domain — `C_GotoEasing3D` and
+/// `C_RotationTarget` — are **not** here: both store a resolved
+/// `GLMEasingFunction` (a `std::function`) rather than the
+/// `IREasingFunctions` enum they were built from, so the authored curve is
+/// unrecoverable at save time. They are opted OUT in
+/// `save_component_inventory.hpp` alongside the other callback-bearing
+/// components; see the note there.
+
+#include <irreden/update/components/component_periodic_idle.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/math_binary_io.hpp>
+
+#include <cstdint>
+#include <utility>
+
+namespace IRWorld {
+
+/// `PeriodStage` stores its easing as the `IREasingFunctions` **enum**, not a
+/// resolved callback, so the stage list round-trips as plain records — the
+/// difference that makes this component serializable where its
+/// `C_GotoEasing3D` sibling is not.
+///
+/// The private cache (`m_angleIncrementPerTick`, `m_currentValue`,
+/// `m_previousValue`) is derived, so `read` reconstructs through the
+/// constructor — which computes the per-tick angle increment from
+/// `periodLengthSeconds_` — and then re-evaluates the current value rather
+/// than persisting either. `updateValue()` indexes `stages_`, so it only runs
+/// once the restored stage list is known to cover the restored index; a set
+/// with no stages keeps the constructor's zero value and self-heals on the
+/// first `tick()`.
+template <> struct SaveSerialize<IRComponents::C_PeriodicIdle> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_PeriodicIdle &value) {
+        w.writeI32(value.tickCount_);
+        w.writeF32(value.angle_);
+        IRMath::BinaryIO::writeVec3(w, value.amplitude_);
+        w.writeF32(value.periodLengthSeconds_);
+        detail::writeTrivialVector(w, value.stages_);
+        w.writeI32(value.currentStageIndex_);
+        w.writeU8(value.cycleCompleted_ ? 1 : 0);
+        w.writeU8(value.pauseRequested_ ? 1 : 0);
+        w.writeU8(value.paused_ ? 1 : 0);
+        w.writeF32(value.resumeCountdownSec_);
+    }
+
+    static IRAsset::Result<IRComponents::C_PeriodicIdle> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_PeriodicIdle>;
+
+        std::int32_t tickCount = 0;
+        float angle = 0.0f;
+        IRMath::vec3 amplitude{0.0f};
+        float periodLengthSeconds = 0.0f;
+
+        IR_SAVE_READ(tickCount, r.readI32());
+        IR_SAVE_READ(angle, r.readF32());
+        IR_SAVE_READ(amplitude, IRMath::BinaryIO::readVec3(r));
+        IR_SAVE_READ(periodLengthSeconds, r.readF32());
+
+        // Constructed with the authored amplitude/period/offset so the
+        // constructor derives m_angleIncrementPerTick from the same formula
+        // the live component used.
+        IRComponents::C_PeriodicIdle value{amplitude, periodLengthSeconds, angle};
+        value.tickCount_ = tickCount;
+
+        IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.stages_));
+        IR_SAVE_READ(value.currentStageIndex_, r.readI32());
+        IR_SAVE_READ_BOOL(value.cycleCompleted_, r.readU8());
+        IR_SAVE_READ_BOOL(value.pauseRequested_, r.readU8());
+        IR_SAVE_READ_BOOL(value.paused_, r.readU8());
+        IR_SAVE_READ(value.resumeCountdownSec_, r.readF32());
+
+        if (value.currentStageIndex_ >= 0 &&
+            value.currentStageIndex_ < static_cast<int>(value.stages_.size())) {
+            value.updateValue();
+        }
+        return Res::success(std::move(value));
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* IR_SAVE_SERIALIZERS_UPDATE_H */

--- a/engine/prefabs/irreden/voxel/save_serializers_voxel.hpp
+++ b/engine/prefabs/irreden/voxel/save_serializers_voxel.hpp
@@ -1,0 +1,83 @@
+#ifndef IR_SAVE_SERIALIZERS_VOXEL_H
+#define IR_SAVE_SERIALIZERS_VOXEL_H
+
+/// `SaveSerialize<C>` specializations for the heap-owning rig components in
+/// `engine/prefabs/irreden/voxel/` (#2242). `C_VoxelSetNew`'s serializer is
+/// the separate, older `voxel_set_serialize.hpp` (persist P6) — it stays on
+/// its own because its read path has a pool-interaction contract these do
+/// not.
+///
+/// Opt-in serializer header: include it wherever a registry registers these
+/// components; never pulled by the component headers themselves.
+
+#include <irreden/voxel/components/component_bind_points.hpp>
+#include <irreden/voxel/components/component_joint_name.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <utility>
+
+namespace IRWorld {
+
+template <> struct SaveSerialize<IRComponents::C_JointName> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_JointName &value) {
+        w.writeString(value.name_);
+    }
+
+    static IRAsset::Result<IRComponents::C_JointName> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_JointName>;
+        IRComponents::C_JointName value{};
+        IR_SAVE_READ(value.name_, r.readString());
+        return Res::success(std::move(value));
+    }
+};
+
+/// `joints_` holds joint `EntityId`s and round-trips as plain values: the
+/// snapshot restores entity ids **exact** (they never recycle — see
+/// `world_snapshot.hpp`), which is what makes a stored id meaningful across a
+/// save at all. The index of an entry is the bone_id baked into
+/// `C_Voxel.bone_id_`, so slot order is load-bearing and a severance hole
+/// (`kNullEntity`) must survive the round trip rather than being compacted
+/// away — writing the vector verbatim is what preserves that.
+///
+/// `bindPose_` is parallel to `joints_` but is NOT required to be the same
+/// length (a rig with no bind pose leaves it empty), so the two are written
+/// as independent counted vectors rather than one interleaved run.
+template <> struct SaveSerialize<IRComponents::C_Skeleton> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_Skeleton &value) {
+        detail::writeTrivialVector(w, value.joints_);
+        detail::writeTrivialVector(w, value.bindPose_);
+    }
+
+    static IRAsset::Result<IRComponents::C_Skeleton> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_Skeleton>;
+        IRComponents::C_Skeleton value{};
+        IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.joints_));
+        IR_SAVE_READ_STATUS(detail::readTrivialVector(r, value.bindPose_));
+        return Res::success(std::move(value));
+    }
+};
+
+/// `points_` is an `unordered_map`, whose iteration order is not a contract —
+/// writing it in hash order would make two saves of the same world differ
+/// byte-for-byte. `writeSortedStringMap` emits ascending key order so the
+/// double-save byte-identity requirement (world-snapshot criterion 6) holds.
+template <> struct SaveSerialize<IRComponents::C_BindPoints> {
+    static void write(IRAsset::BinaryWriter &w, const IRComponents::C_BindPoints &value) {
+        detail::writeSortedStringMap(w, value.points_);
+    }
+
+    static IRAsset::Result<IRComponents::C_BindPoints> read(IRAsset::BinaryReader &r) {
+        using Res = IRAsset::Result<IRComponents::C_BindPoints>;
+        IRComponents::C_BindPoints value{};
+        IR_SAVE_READ_STATUS(detail::readStringMap(r, value.points_));
+        return Res::success(std::move(value));
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* IR_SAVE_SERIALIZERS_VOXEL_H */

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -399,11 +399,17 @@ same change. Four consequences for authors:
   invariant its constructors establish (a count bounded by an inline array's
   capacity, parallel grids sized to a stored extent), re-check it after
   reading and return `BinaryIOError::UnknownTag` on violation, so the
-  reader's admissible set equals the constructors'. Truncation is already
+  reader admits no more than the constructors do. Truncation is already
   caught by the short read; this covers the well-formed-but-inconsistent
   file, whose damage otherwise surfaces as an out-of-bounds access in an
   unchecked accessor rather than as a load error. `SaveSerialize<C_Cycle>`
-  and `SaveSerialize<C_TrianglesOnlySet>` are the reference shape.
+  and `SaveSerialize<C_TrianglesOnlySet>` are the reference shape. Match
+  the **accessors'** requirements, not merely the constructors': where a
+  constructor is laxer than the indexing math its own accessors perform
+  (`C_TrianglesOnlySet::resize` accepts a both-negative extent, which
+  multiplies to a positive cell count), the reader is deliberately the
+  tighter of the two — a reader that only mirrored the constructor would
+  restore a component the accessors then index out of bounds.
 - **A component whose state cannot honestly round-trip opts OUT**, with a
   comment saying why. The current class is callback-bearing state:
   `C_LambdaModifiers`, `C_LerpEntity`, and — since #2242 — `C_GotoEasing3D`

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -200,10 +200,20 @@ write-only `.json` sidecar (Rule #6) rides alongside.
 Three collaborating headers:
 
 - `save_serialize.hpp` — `IRWorld::SaveSerialize<C>`, the per-component
-  bytes customization point. The primary template is a trivially-copyable
-  raw-image fast path (`static_assert`s trivial-copyability); a component
-  owning heap storage (`std::string`/`std::vector`/handles) must specialize
-  it. P1 decides *whether*; this decides *how*.
+  bytes customization point. The primary template is **declared but never
+  defined**; the two arms that exist are a constrained partial specialization
+  for trivially-copyable components (a raw byte image) and explicit
+  specializations for components owning heap storage
+  (`std::string`/`std::vector`/handles). Leaving the primary undefined is what
+  makes the companion `SaveSerializable<C>` concept in the same header a true
+  test of "does this component have a serializer" (#2242) — writing the
+  serializer IS the opt-in, with no second bookkeeping step to forget. P1
+  decides *whether*; this decides *how*.
+- `save_serialize_common.hpp` — the shared byte layouts most heap-owning
+  serializers need: counted vectors of trivially-copyable records, counted
+  string vectors, and `writeSortedStringMap` (ascending key order, so an
+  `unordered_map` member cannot make a double-save non-byte-identical). Also
+  home to the `IR_SAVE_READ*` bail-out macros the serializers read with.
 - `save_registry.hpp` — `IRWorld::SaveRegistry`, the type-erased bridge.
   `registerComponent<C>()` is `if constexpr`-gated on `shouldSave<C>()`
   (opted-out → no-op, and no `SaveSerialize<C>` instantiation), capturing
@@ -236,11 +246,9 @@ component names skip with counts.
 **P2 scope is the mechanism.** It ships one headless gtest
 (`test/world/world_snapshot_test.cpp`) proving the round-trip with
 trivially-copyable *test* components. The `(path)`-only convenience wrapper
-over a process-default registry (for the P7 Lua binding) has since landed —
-see "Process-default registry" below — but only over a **curated subset**;
-registering every engine component in `AllEngineComponents` (each needs a
-`SaveSerialize<C>` specialization for its non-POD fields) is still downstream
-work.
+over a process-default registry (for the P7 Lua binding) has since landed and
+now covers the **whole opted-in inventory** — see "Process-default registry"
+below.
 
 **Relation chunk `RELN` (persist P3, #2214).** `CHILD_OF` entity relations
 round-trip through one self-describing chunk: a `Relation`-enum name table at
@@ -362,24 +370,56 @@ pipeline (see `creations/demos/persist_roundtrip`).
 `makeDefaultSaveRegistry()` (`src/world_default_registry.cpp`) builds the
 process-default `SaveRegistry` the no-registry-argument overloads
 `saveWorld(path)` / `loadWorld(path)` forward to — the surface the `IRPersist`
-Lua binding (`engine/script`) needs, since Lua passes no registry. It is
-**deliberately a curated subset** of `AllEngineComponents`: only components
-with a working `SaveSerialize<C>` today — `C_VoxelSetNew` (P6's explicit
-serializer, so `voxel_set_serialize.hpp` must be included there) plus
-trivially-copyable plain-data components (`C_LocalTransform`,
-`C_PositionInt3D`, `C_SizeInt3D`). Registering the **full** inventory does not
-compile: the heap-owning opted-in components (`C_Name`, `C_Skeleton`,
-`C_MidiSequence`, `C_TextSegment`, ...) still lack a serializer and hit the
-primary-template `static_assert`. Add each component to the curated list as its
-serializer lands; the full-inventory path (a per-component serializer pass + a
-`HasExplicitSaveSerialize<C>` filter over `AllEngineComponents`) is tracked
-downstream. **Adding a component here must also extend
+Lua binding (`engine/script`) needs, since Lua passes no registry.
+
+**Membership is derived, never curated (#2242).** The function walks
+`AllEngineComponents` and hands every entry to `registerComponent<C>()`; the
+opt-outs no-op through that call's `if constexpr (shouldSave<C>())` gate, so
+the registry's membership *is* the inventory's opted-in set, by construction.
+There are deliberately **no per-component register lines** — adding one is the
+regression this design exists to prevent, and
+`test/world/save_serializers_test.cpp` asserts
+`makeDefaultSaveRegistry().size() == detail::countOptIns<AllEngineComponents>()`
+so the two cannot drift.
+
+**That walk is also the completeness gate.** Every opted-in entry instantiates
+`SaveSerialize<C>`, so a future `IR_SAVE_OPT_IN` with no serializer **breaks
+this build** with `registerComponent`'s `SaveSerializable<C>` `static_assert`
+instead of silently dropping the component from every Lua-driven save. Adding
+an engine component that opts in therefore means writing its serializer in the
+same change. Three consequences for authors:
+
+- **A heap-owning component needs a `SaveSerialize<C>` specialization** in its
+  domain's `engine/prefabs/irreden/<domain>/save_serializers_<domain>.hpp`
+  (`C_VoxelSetNew` keeps its own `voxel_set_serialize.hpp` — its read path has
+  a pool-interaction contract the others don't). Those headers are included by
+  `world_default_registry.cpp` only, never by the component headers, so the
+  prefab domains stay out of `engine/world`'s include graph.
+- **A component whose state cannot honestly round-trip opts OUT**, with a
+  comment saying why. The current class is callback-bearing state:
+  `C_LambdaModifiers`, `C_LerpEntity`, and — since #2242 — `C_GotoEasing3D`
+  and `C_RotationTarget`, which keep a resolved `GLMEasingFunction`
+  (`std::function`) rather than the `IREasingFunctions` enum they were built
+  from, so the authored curve is unrecoverable at save time. Do **not** write a
+  serializer that substitutes a default on load; that is a silent behavior
+  change wearing a round-trip's clothes.
+- **Any TU that builds a registry must include `save_component_inventory.hpp`.**
+  `registerComponent<C>` is `if constexpr`-gated on `shouldSave<C>()`, and
+  without the `IR_SAVE_OPT_IN` specializations in scope `SaveTrait<C>` resolves
+  to the "no decision yet" primary (`kSave = false`) — so every call silently
+  no-ops and you get an empty registry that saves an empty world without
+  erroring.
+
+**Adding a component here must also extend
 `test/script/lua_world_snapshot_test.cpp` with a round-trip case through the
 actual `IRPersist` Lua surface** — a standalone `SaveSerialize<C>` unit test
-(e.g. `voxel_set_serialize_test.cpp`) covers the serializer but leaves the
-wiring itself (registry entry → Lua binding → reload) unverified (#2244). The registry is built **fresh per call** — cheap (a few
-allocations, never a per-frame path) and, unlike a process-static, its
-session-local `ComponentId`s always match the live `EntityManager`.
+(e.g. `save_serializers_test.cpp`, `voxel_set_serialize_test.cpp`) covers the
+serializer but leaves the wiring itself (registry entry → Lua binding →
+reload) unverified (#2244).
+
+The registry is built **fresh per call** — cheap (a few allocations, never a
+per-frame path) and, unlike a process-static, its session-local `ComponentId`s
+always match the live `EntityManager`.
 
 The `.json.txt` **debug dump** (W-11) is a second, richer writer over the same
 save walk (archetype members + `CHILD_OF` edges), gated by the

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -387,14 +387,23 @@ so the two cannot drift.
 this build** with `registerComponent`'s `SaveSerializable<C>` `static_assert`
 instead of silently dropping the component from every Lua-driven save. Adding
 an engine component that opts in therefore means writing its serializer in the
-same change. Three consequences for authors:
+same change. Four consequences for authors:
 
 - **A heap-owning component needs a `SaveSerialize<C>` specialization** in its
   domain's `engine/prefabs/irreden/<domain>/save_serializers_<domain>.hpp`
   (`C_VoxelSetNew` keeps its own `voxel_set_serialize.hpp` — its read path has
   a pool-interaction contract the others don't). Those headers are included by
   `world_default_registry.cpp` only, never by the component headers, so the
-  prefab domains stay out of `engine/world`'s include graph.
+  prefab domains stay out of `engine/world`'s include graph. **`read` must
+  reject bytes it cannot honestly restore** — if the component has a class
+  invariant its constructors establish (a count bounded by an inline array's
+  capacity, parallel grids sized to a stored extent), re-check it after
+  reading and return `BinaryIOError::UnknownTag` on violation, so the
+  reader's admissible set equals the constructors'. Truncation is already
+  caught by the short read; this covers the well-formed-but-inconsistent
+  file, whose damage otherwise surfaces as an out-of-bounds access in an
+  unchecked accessor rather than as a load error. `SaveSerialize<C_Cycle>`
+  and `SaveSerialize<C_TrianglesOnlySet>` are the reference shape.
 - **A component whose state cannot honestly round-trip opts OUT**, with a
   comment saying why. The current class is callback-bearing state:
   `C_LambdaModifiers`, `C_LerpEntity`, and — since #2242 — `C_GotoEasing3D`
@@ -409,6 +418,18 @@ same change. Three consequences for authors:
   to the "no decision yet" primary (`kSave = false`) — so every call silently
   no-ops and you get an empty registry that saves an empty world without
   erroring.
+- **Never write an explicit `SaveSerialize<C>` for a component that IS
+  trivially copyable.** A missing serializer header is loud today only because
+  every explicit specialization is on a non-trivially-copyable component: with
+  the primary declared-but-undefined, a TU that misses the header sees an
+  incomplete type, `SaveSerializable<C>` is false, and the `static_assert`
+  fires. A trivially-copyable component has the constrained partial
+  specialization to fall back on, so the same missing header binds **silently**
+  to the raw-image arm — different bytes under the same save-name and version,
+  no diagnostic, and formally an ODR violation across the two TUs. If you need
+  a hand-written layout (to skip a derived field, narrow an enum, drop
+  padding), make the component non-trivially-copyable or route the exception
+  through the inventory instead.
 
 **Adding a component here must also extend
 `test/script/lua_world_snapshot_test.cpp` with a round-trip case through the

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -406,10 +406,14 @@ same change. Four consequences for authors:
   and `SaveSerialize<C_TrianglesOnlySet>` are the reference shape. Match
   the **accessors'** requirements, not merely the constructors': where a
   constructor is laxer than the indexing math its own accessors perform
-  (`C_TrianglesOnlySet::resize` accepts a both-negative extent, which
-  multiplies to a positive cell count), the reader is deliberately the
-  tighter of the two — a reader that only mirrored the constructor would
-  restore a component the accessors then index out of bounds.
+  (`C_TrianglesOnlySet`'s two-argument constructor and `resize()` both accept
+  a both-negative extent, which multiplies to a positive cell count), the
+  reader is deliberately the tighter of the two — a reader that only mirrored
+  the constructor would restore a component the accessors then index out of
+  bounds. When one guard covers two distinct faults, give each its own check
+  and message: a shared message necessarily mis-describes whichever fault it
+  wasn't written for, and a load-time diagnostic is the only thing the person
+  debugging a corrupt save has.
 - **A component whose state cannot honestly round-trip opts OUT**, with a
   comment saying why. The current class is callback-bearing state:
   `C_LambdaModifiers`, `C_LerpEntity`, and — since #2242 — `C_GotoEasing3D`

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -413,7 +413,16 @@ same change. Four consequences for authors:
   bounds. When one guard covers two distinct faults, give each its own check
   and message: a shared message necessarily mis-describes whichever fault it
   wasn't written for, and a load-time diagnostic is the only thing the person
-  debugging a corrupt save has.
+  debugging a corrupt save has. **A reader guard that is tighter than the type
+  gets a debug-only `IR_ASSERT` mirror in `write`** (split the same way): the
+  state it rejects is state the component's own API can produce, so the mirror
+  catches the producer while the offending entity is still live, instead of one
+  save/load cycle later as a corrupt-file error with the culprit long gone.
+  `read` stays the enforcing check — the mirror compiles out under
+  `IR_RELEASE`. A guard that only re-checks what the type already enforces
+  needs **no** mirror (`SaveSerialize<C_Cycle>`'s breakpoint-count clamp: only
+  `addBreakpoint` writes the count and it bounds itself at `kMaxBreakpoints`,
+  so the clamp can fire on a corrupt file but never on a live component).
 - **A component whose state cannot honestly round-trip opts OUT**, with a
   comment saying why. The current class is callback-bearing state:
   `C_LambdaModifiers`, `C_LerpEntity`, and — since #2242 — `C_GotoEasing3D`

--- a/engine/world/include/irreden/world/save_component_inventory.hpp
+++ b/engine/world/include/irreden/world/save_component_inventory.hpp
@@ -203,6 +203,18 @@ IR_SAVE_OPT_OUT(IRComponents::C_Modifiers)
 // as C_LambdaModifiers above, so it opts out too.
 IR_SAVE_OPT_OUT(IRComponents::C_LerpEntity)
 
+// C_GotoEasing3D and C_RotationTarget store `GLMEasingFunction
+// easingFunction_` — a std::function, the same non-serializable shape as
+// C_LerpEntity and C_LambdaModifiers. Both are *constructed* from an
+// IREasingFunctions enum (`kEasingFunctions.at(e)`) but keep only the
+// resolved callable, so the authored curve cannot be recovered at save time:
+// a serializer would have to substitute some default easing on load, silently
+// changing the animation. Their live *output* still persists — both systems
+// write C_LocalTransform, which is opted in. Re-opting in means storing the
+// enum on the component; see #2597.
+IR_SAVE_OPT_OUT(IRComponents::C_GotoEasing3D)
+IR_SAVE_OPT_OUT(IRComponents::C_RotationTarget)
+
 // Class E — C_VoxelSetNew: OPT-IN, flagged provisional (custom serializer is P2/W-3+; flip to
 // OPT-OUT is one line if the slice can't absorb it)
 IR_SAVE_OPT_IN(IRComponents::C_VoxelSetNew, 1)
@@ -227,7 +239,6 @@ IR_SAVE_OPT_IN(IRComponents::C_SizeTriangles, 1)
 IR_SAVE_OPT_IN(IRComponents::C_Direction3D, 1)
 IR_SAVE_OPT_IN(IRComponents::C_Magnitude, 1)
 IR_SAVE_OPT_IN(IRComponents::C_RotationMode, 1)
-IR_SAVE_OPT_IN(IRComponents::C_RotationTarget, 1)
 IR_SAVE_OPT_IN(IRComponents::C_AutoSpin, 1)
 IR_SAVE_OPT_IN(IRComponents::C_ChunkMembership, 1)
 IR_SAVE_OPT_IN(IRComponents::C_Velocity3D, 1)
@@ -236,7 +247,6 @@ IR_SAVE_OPT_IN(IRComponents::C_VelocityDrag, 1)
 IR_SAVE_OPT_IN(IRComponents::C_Acceleration3D, 1)
 IR_SAVE_OPT_IN(IRComponents::C_Gravity3D, 1)
 IR_SAVE_OPT_IN(IRComponents::C_HasGravity, 1)
-IR_SAVE_OPT_IN(IRComponents::C_GotoEasing3D, 1)
 IR_SAVE_OPT_IN(IRComponents::C_ReactiveReturn3D, 1)
 IR_SAVE_OPT_IN(IRComponents::C_SpringPlatform, 1)
 IR_SAVE_OPT_IN(IRComponents::C_WallBounce, 1)

--- a/engine/world/include/irreden/world/save_registry.hpp
+++ b/engine/world/include/irreden/world/save_registry.hpp
@@ -24,11 +24,12 @@
 /// opted-out type never instantiates `SaveSerialize<C>`, so a component
 /// with no serializer only breaks the build if it actually opts in.
 ///
-/// Scope note (P2): this layer is the *mechanism*. P2 proves it with
-/// trivially-copyable test components (see `test/world/world_snapshot_test.cpp`);
-/// wiring every engine component in `AllEngineComponents` — each of which
-/// needs a `SaveSerialize<C>` specialization for its non-POD fields — is
-/// downstream work, not this slice.
+/// The `SaveSerializable<C>` `static_assert` in that same branch is the
+/// engine-wide completeness gate (#2242): the process-default registry walks
+/// all of `AllEngineComponents`, so an opted-in component with no serializer
+/// fails to compile there rather than silently vanishing from every save.
+/// Note the pairing — opting out is what makes a serializer unnecessary, and
+/// the `if constexpr` is what keeps that true.
 
 #include <irreden/world/save_migration.hpp>
 #include <irreden/world/save_serialize.hpp>
@@ -155,6 +156,15 @@ class SaveRegistry {
     /// a caller can register defensively.
     template <typename C> void registerComponent() {
         if constexpr (shouldSave<C>()) {
+            static_assert(
+                SaveSerializable<C>,
+                "SaveRegistry::registerComponent<C>: C opts in to persistence but has no "
+                "usable SaveSerialize<C> — it is not trivially copyable and no explicit "
+                "specialization is in scope. Either write one (e.g. for a component owning "
+                "std::string / std::vector / resource handles), include the header that "
+                "defines it, or flip the component to IR_SAVE_OPT_OUT in "
+                "save_component_inventory.hpp."
+            );
             const char *name = saveName<C>();
             if (name == nullptr || m_byName.contains(name)) {
                 return;

--- a/engine/world/include/irreden/world/save_serialize.hpp
+++ b/engine/world/include/irreden/world/save_serialize.hpp
@@ -74,8 +74,11 @@ struct SaveSerialize<C> {
 /// True iff `SaveSerialize<C>` is usable — the trivially-copyable arm or an
 /// explicit specialization. Self-detecting by construction: writing the
 /// serializer IS the opt-in, so there is no second bookkeeping step to
-/// forget. `makeDefaultSaveRegistry` filters `AllEngineComponents` on this,
-/// and `SaveRegistry::registerComponent` asserts it.
+/// forget. Used as a **gate, not a filter**: `makeDefaultSaveRegistry` hands
+/// every `AllEngineComponents` entry to `SaveRegistry::registerComponent`,
+/// which `static_assert`s this — so "opted in but no serializer" is a build
+/// error, never a silent drop. Reintroducing a filter here would restore
+/// exactly that silent drop.
 template <typename C>
 concept SaveSerializable =
     requires(IRAsset::BinaryWriter &w, const C &value, IRAsset::BinaryReader &r) {

--- a/engine/world/include/irreden/world/save_serialize.hpp
+++ b/engine/world/include/irreden/world/save_serialize.hpp
@@ -6,15 +6,25 @@
 /// *whether* a component is saved and at what schema version; this header
 /// decides *how* one instance turns into bytes.
 ///
-/// The primary template is a trivially-copyable fast path: any component
-/// that is `std::is_trivially_copyable` round-trips as a raw byte image,
-/// which covers the bulk of plain gameplay data (positions, velocities,
-/// timers, flags, small PODs). A component that owns heap storage
-/// (`std::string`, `std::vector`, resource handles) is NOT trivially
-/// copyable — a raw memcpy would persist dangling pointers — so it must
-/// provide an explicit `SaveSerialize<C>` specialization. The
-/// `static_assert` in the primary template turns "opted in but no
-/// serializer" into a compile error rather than a silent corrupt save.
+/// The primary template is **declared but never defined**; the two ways to
+/// be serializable are both specializations of it:
+///
+///   - the constrained partial specialization below — a trivially-copyable
+///     fast path: any component that is `std::is_trivially_copyable`
+///     round-trips as a raw byte image, which covers the bulk of plain
+///     gameplay data (positions, velocities, timers, flags, small PODs);
+///   - an explicit full specialization, for a component that owns heap
+///     storage (`std::string`, `std::vector`, resource handles) and is NOT
+///     trivially copyable — a raw memcpy would persist dangling pointers.
+///
+/// Leaving the primary undefined is what makes serializability *detectable*:
+/// `SaveSerializable<C>` below is satisfied exactly when one of those two
+/// arms exists, so `makeDefaultSaveRegistry` can filter `AllEngineComponents`
+/// on a fact the compiler already knows instead of a hand-maintained
+/// companion trait (which would drift the moment a serializer landed without
+/// its trait line — the silent-omission failure this concept exists to kill).
+/// "Opted in but no serializer" stays a compile error: `registerComponent<C>`
+/// static_asserts `SaveSerializable<C>` with the friendly diagnostic.
 ///
 /// Determinism note: the byte image of a trivially-copyable struct
 /// includes padding. Padding bytes are stable for a fixed in-memory value
@@ -24,24 +34,24 @@
 
 #include <irreden/asset/binary_io.hpp>
 
+#include <concepts>
 #include <cstddef>
 #include <type_traits>
 
 namespace IRWorld {
 
-/// Customization point: `write` serializes one `const C&`; `read` pulls
-/// one `C` back. Specialize for any component that is not trivially
-/// copyable. The default requires trivial-copyability and stores the raw
-/// byte image little-endian-agnostically (host layout — the snapshot is a
-/// same-machine round-trip contract; cross-endian is out of scope).
-template <typename C> struct SaveSerialize {
-    static_assert(
-        std::is_trivially_copyable_v<C>,
-        "SaveSerialize<C>: C is not trivially copyable — provide an explicit "
-        "SaveSerialize<C> specialization (e.g. for components owning std::string / "
-        "std::vector / resource handles). The primary template only handles PODs."
-    );
+/// Customization point: `write` serializes one `const C&`; `read` pulls one
+/// `C` back. Declared-not-defined on purpose — see the header note; a
+/// component is serializable only via the trivially-copyable arm below or an
+/// explicit full specialization.
+template <typename C> struct SaveSerialize;
 
+/// Trivially-copyable fast path: store the raw byte image little-endian-
+/// agnostically (host layout — the snapshot is a same-machine round-trip
+/// contract; cross-endian is out of scope).
+template <typename C>
+    requires std::is_trivially_copyable_v<C>
+struct SaveSerialize<C> {
     static void write(IRAsset::BinaryWriter &w, const C &value) {
         w.writeBytes(&value, sizeof(C));
     }
@@ -55,6 +65,18 @@ template <typename C> struct SaveSerialize {
         return IRAsset::Result<C>::success(value);
     }
 };
+
+/// True iff `SaveSerialize<C>` is usable — the trivially-copyable arm or an
+/// explicit specialization. Self-detecting by construction: writing the
+/// serializer IS the opt-in, so there is no second bookkeeping step to
+/// forget. `makeDefaultSaveRegistry` filters `AllEngineComponents` on this,
+/// and `SaveRegistry::registerComponent` asserts it.
+template <typename C>
+concept SaveSerializable =
+    requires(IRAsset::BinaryWriter &w, const C &value, IRAsset::BinaryReader &r) {
+        SaveSerialize<C>::write(w, value);
+        { SaveSerialize<C>::read(r) } -> std::same_as<IRAsset::Result<C>>;
+    };
 
 } // namespace IRWorld
 

--- a/engine/world/include/irreden/world/save_serialize.hpp
+++ b/engine/world/include/irreden/world/save_serialize.hpp
@@ -19,12 +19,17 @@
 ///
 /// Leaving the primary undefined is what makes serializability *detectable*:
 /// `SaveSerializable<C>` below is satisfied exactly when one of those two
-/// arms exists, so `makeDefaultSaveRegistry` can filter `AllEngineComponents`
-/// on a fact the compiler already knows instead of a hand-maintained
-/// companion trait (which would drift the moment a serializer landed without
-/// its trait line — the silent-omission failure this concept exists to kill).
-/// "Opted in but no serializer" stays a compile error: `registerComponent<C>`
-/// static_asserts `SaveSerializable<C>` with the friendly diagnostic.
+/// arms exists — a fact the compiler already knows, rather than a
+/// hand-maintained companion trait (which would drift the moment a serializer
+/// landed without its trait line — the silent-omission failure this concept
+/// exists to kill).
+///
+/// The concept is a **gate, not a filter**: `makeDefaultSaveRegistry` hands
+/// every `AllEngineComponents` entry to `registerComponent<C>`, which
+/// `static_assert`s `SaveSerializable<C>` with a friendly diagnostic, so
+/// "opted in but no serializer" is a build error. Do not "restore" a filter
+/// here — silently dropping such a component from every save is the precise
+/// failure this design exists to kill.
 ///
 /// Determinism note: the byte image of a trivially-copyable struct
 /// includes padding. Padding bytes are stable for a fixed in-memory value

--- a/engine/world/include/irreden/world/save_serialize_common.hpp
+++ b/engine/world/include/irreden/world/save_serialize_common.hpp
@@ -1,0 +1,242 @@
+#ifndef SAVE_SERIALIZE_COMMON_H
+#define SAVE_SERIALIZE_COMMON_H
+
+/// Shared building blocks for `SaveSerialize<C>` specializations (#2242).
+/// `save_serialize.hpp` handles the two ends of the spectrum — a whole
+/// component that is trivially copyable, or one that hand-rolls everything.
+/// Most heap-owning components sit in between: a few scalars plus a
+/// `std::vector` of trivially-copyable records, a `std::vector<std::string>`,
+/// or a string-keyed map. These helpers own the byte layout for those shapes
+/// so ~20 serializers don't each re-derive the count-then-records loop.
+///
+/// Layout for every container helper: a `writeVarUInt` element count followed
+/// by the elements. Scalars and strings use the `BinaryWriter` primitives
+/// directly (`writeString` is already length-prefixed).
+///
+/// Determinism: `writeSortedStringMap` emits entries in ascending key order,
+/// because an `unordered_map`'s iteration order is not a contract — writing it
+/// raw would break the same-session double-save byte-identity requirement
+/// (world-snapshot criterion 6). Vectors keep their authored order.
+///
+/// Read-side guard: element counts come off disk, so a corrupt or truncated
+/// stream can claim an absurd count. The readers never pre-size to the
+/// claimed count — they reserve a bounded amount and append per record, so a
+/// bad count fails on the first short read instead of attempting a huge
+/// allocation first.
+///
+/// Versioning note: a component's schema version is **not** the
+/// `// IRAsset: serialized` + `kSaveVersion` member pair that `engine/asset/`
+/// records use. World-snapshot components carry it on the trait instead —
+/// `SaveTrait<C>::kSaveVersion`, set by `IR_SAVE_OPT_IN(Type, Version)` — and
+/// changing a serializer's field layout means bumping that and registering a
+/// `SaveMigration<C>` reader for the retired version, or an old save decodes
+/// at the new layout and silently corrupts.
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <array>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace IRWorld::detail {
+
+/// Upper bound on how much a reader speculatively reserves before it has
+/// actually read any records. Purely an allocation-churn guard; a larger
+/// container still round-trips, it just grows geometrically past this point.
+inline constexpr std::size_t kReadReserveCap = 4096;
+
+/// How much to `reserve` for a container whose on-disk element count is
+/// @p count. Clamped to `kReadReserveCap` so a corrupt count cannot turn into
+/// a huge allocation before a single element has been read.
+inline std::size_t boundedReserve(std::uint64_t count) {
+    return static_cast<std::size_t>(count < kReadReserveCap ? count : kReadReserveCap);
+}
+
+/// varuint count + one raw byte image per element. `T` must be trivially
+/// copyable — the same raw-image contract `SaveSerialize`'s trivially-copyable
+/// arm uses for whole components.
+template <typename T> void writeTrivialVector(IRAsset::BinaryWriter &w, const std::vector<T> &v) {
+    static_assert(
+        std::is_trivially_copyable_v<T>,
+        "writeTrivialVector<T>: T is not trivially copyable — a raw byte image would persist "
+        "dangling pointers. Write an element-wise loop for this type instead."
+    );
+    w.writeVarUInt(v.size());
+    for (const T &element : v) {
+        w.writeBytes(&element, sizeof(T));
+    }
+}
+
+/// Inverse of `writeTrivialVector`. Leaves @p out untouched on failure.
+template <typename T>
+IRAsset::BinaryStatus readTrivialVector(IRAsset::BinaryReader &r, std::vector<T> &out) {
+    static_assert(
+        std::is_trivially_copyable_v<T>,
+        "readTrivialVector<T>: T is not trivially copyable — see writeTrivialVector."
+    );
+    IRAsset::Result<std::uint64_t> count = r.readVarUInt();
+    if (!count.ok()) {
+        return count.status_;
+    }
+    std::vector<T> values;
+    values.reserve(boundedReserve(count.value_));
+    for (std::uint64_t i = 0; i < count.value_; ++i) {
+        // Read into raw bytes and bit_cast rather than default-constructing a
+        // T: a trivially-copyable record is not necessarily *default
+        // constructible* (IRComponents::PeriodStage, for one, only has a
+        // 5-argument constructor), and the byte image is the contract here
+        // anyway.
+        std::array<std::byte, sizeof(T)> raw{};
+        IRAsset::BinaryStatus status = r.readBytes(raw.data(), sizeof(T));
+        if (!status.ok()) {
+            return status;
+        }
+        values.push_back(std::bit_cast<T>(raw));
+    }
+    out = std::move(values);
+    return IRAsset::BinaryStatus::success();
+}
+
+/// varuint count + one length-prefixed string per element.
+inline void writeStringVector(IRAsset::BinaryWriter &w, const std::vector<std::string> &v) {
+    w.writeVarUInt(v.size());
+    for (const std::string &element : v) {
+        w.writeString(element);
+    }
+}
+
+/// Inverse of `writeStringVector`. Leaves @p out untouched on failure.
+inline IRAsset::BinaryStatus
+readStringVector(IRAsset::BinaryReader &r, std::vector<std::string> &out) {
+    IRAsset::Result<std::uint64_t> count = r.readVarUInt();
+    if (!count.ok()) {
+        return count.status_;
+    }
+    std::vector<std::string> values;
+    values.reserve(boundedReserve(count.value_));
+    for (std::uint64_t i = 0; i < count.value_; ++i) {
+        IRAsset::Result<std::string> element = r.readString();
+        if (!element.ok()) {
+            return element.status_;
+        }
+        values.push_back(std::move(element.value_));
+    }
+    out = std::move(values);
+    return IRAsset::BinaryStatus::success();
+}
+
+/// varuint count + `(string key, raw value image)` pairs in ascending key
+/// order. Takes any string-keyed map; the sort is what makes an
+/// `unordered_map` round-trip byte-identically across saves.
+template <typename Map> void writeSortedStringMap(IRAsset::BinaryWriter &w, const Map &map) {
+    using Value = typename Map::mapped_type;
+    static_assert(
+        std::is_trivially_copyable_v<Value>,
+        "writeSortedStringMap: the mapped type is not trivially copyable — see "
+        "writeTrivialVector."
+    );
+    std::vector<const typename Map::value_type *> ordered;
+    ordered.reserve(map.size());
+    for (const auto &entry : map) {
+        ordered.push_back(&entry);
+    }
+    // Insertion sort over pointers: these maps are small (bind points on one
+    // rig), and it keeps <algorithm> out of a header every serializer includes.
+    for (std::size_t i = 1; i < ordered.size(); ++i) {
+        const typename Map::value_type *key = ordered[i];
+        std::size_t j = i;
+        while (j > 0 && ordered[j - 1]->first > key->first) {
+            ordered[j] = ordered[j - 1];
+            --j;
+        }
+        ordered[j] = key;
+    }
+    w.writeVarUInt(ordered.size());
+    for (const typename Map::value_type *entry : ordered) {
+        w.writeString(entry->first);
+        w.writeBytes(&entry->second, sizeof(Value));
+    }
+}
+
+/// Inverse of `writeSortedStringMap`. Leaves @p out untouched on failure.
+template <typename Map> IRAsset::BinaryStatus readStringMap(IRAsset::BinaryReader &r, Map &out) {
+    using Value = typename Map::mapped_type;
+    static_assert(
+        std::is_trivially_copyable_v<Value>,
+        "readStringMap: the mapped type is not trivially copyable — see writeSortedStringMap."
+    );
+    IRAsset::Result<std::uint64_t> count = r.readVarUInt();
+    if (!count.ok()) {
+        return count.status_;
+    }
+    Map values;
+    for (std::uint64_t i = 0; i < count.value_; ++i) {
+        IRAsset::Result<std::string> key = r.readString();
+        if (!key.ok()) {
+            return key.status_;
+        }
+        // Raw bytes + bit_cast, for the same reason as readTrivialVector.
+        std::array<std::byte, sizeof(Value)> raw{};
+        IRAsset::BinaryStatus status = r.readBytes(raw.data(), sizeof(Value));
+        if (!status.ok()) {
+            return status;
+        }
+        values.emplace(std::move(key.value_), std::bit_cast<Value>(raw));
+    }
+    out = std::move(values);
+    return IRAsset::BinaryStatus::success();
+}
+
+} // namespace IRWorld::detail
+
+/// Read-one-field-or-bail, for use inside a `SaveSerialize<C>::read` body.
+///
+/// Every read in a serializer is the same five lines: call a `BinaryReader`
+/// accessor, return its status as a `Result<C>` error if it failed, else move
+/// the value into a field. Written out longhand across ~25 serializers that
+/// is ~750 lines in which the only variation is *which* `Result` gets
+/// checked — precisely the shape where a copy-paste slip (checking the
+/// previous field's result, or forgetting the check) is both easy to make and
+/// invisible in review. These macros make the bail-out uniform.
+///
+/// Contract: the enclosing `read()` must (a) return `IRAsset::Result<C>` and
+/// (b) have `using Res = IRAsset::Result<C>;` in scope — the convention every
+/// serializer in the tree already follows. Statement macros, so they take a
+/// trailing semicolon like any other statement.
+#define IR_SAVE_READ(target, readExpr)                                                             \
+    do {                                                                                           \
+        auto irSaveField = (readExpr);                                                             \
+        if (!irSaveField.ok()) {                                                                   \
+            return Res::error(irSaveField.status_.code_, std::move(irSaveField.status_.message_)); \
+        }                                                                                          \
+        (target) = std::move(irSaveField.value_);                                                  \
+    } while (false)
+
+/// `IR_SAVE_READ` for a `bool` field: the wire form is a `u8`, so the value
+/// needs the `!= 0` narrowing that a direct assignment would warn on.
+#define IR_SAVE_READ_BOOL(target, readExpr)                                                        \
+    do {                                                                                           \
+        auto irSaveField = (readExpr);                                                             \
+        if (!irSaveField.ok()) {                                                                   \
+            return Res::error(irSaveField.status_.code_, std::move(irSaveField.status_.message_)); \
+        }                                                                                          \
+        (target) = irSaveField.value_ != 0;                                                        \
+    } while (false)
+
+/// `IR_SAVE_READ` for the `detail::read*` container helpers, which report a
+/// bare `BinaryStatus` and write their result through an out-parameter rather
+/// than returning a `Result`.
+#define IR_SAVE_READ_STATUS(statusExpr)                                                            \
+    do {                                                                                           \
+        IRAsset::BinaryStatus irSaveStatus = (statusExpr);                                         \
+        if (!irSaveStatus.ok()) {                                                                  \
+            return Res::error(irSaveStatus.code_, std::move(irSaveStatus.message_));               \
+        }                                                                                          \
+    } while (false)
+
+#endif /* SAVE_SERIALIZE_COMMON_H */

--- a/engine/world/include/irreden/world/save_serialize_common.hpp
+++ b/engine/world/include/irreden/world/save_serialize_common.hpp
@@ -19,10 +19,14 @@
 /// (world-snapshot criterion 6). Vectors keep their authored order.
 ///
 /// Read-side guard: element counts come off disk, so a corrupt or truncated
-/// stream can claim an absurd count. The readers never pre-size to the
-/// claimed count — they reserve a bounded amount and append per record, so a
-/// bad count fails on the first short read instead of attempting a huge
-/// allocation first.
+/// stream can claim an absurd count. No reader ever pre-sizes to the claimed
+/// count — each appends per record, so a bad count fails on the first short
+/// read instead of attempting a huge allocation first. The **vector** readers
+/// additionally `detail::boundedReserve` up to `kReadReserveCap` before the
+/// loop; the map reader does not, because the helper is generic over `Map`
+/// and `std::map` has no `reserve`. That asymmetry is a non-issue: it is an
+/// allocation-churn guard, and node-based map inserts don't benefit from a
+/// reserve anyway.
 ///
 /// Versioning note: a component's schema version is **not** the
 /// `// IRAsset: serialized` + `kSaveVersion` member pair that `engine/asset/`

--- a/engine/world/include/irreden/world/save_trait.hpp
+++ b/engine/world/include/irreden/world/save_trait.hpp
@@ -56,6 +56,23 @@ template <typename Tuple> constexpr bool allExplicit() {
     return allExplicitImpl<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>{});
 }
 
+template <typename Tuple, std::size_t... I>
+constexpr std::size_t countOptInsImpl(std::index_sequence<I...>) {
+    return (
+        std::size_t{0} + ... +
+        (SaveTrait<std::tuple_element_t<I, Tuple>>::kSave ? std::size_t{1} : std::size_t{0})
+    );
+}
+
+// How many types in Tuple opt IN. This is the expected size of a registry
+// built by walking the whole tuple, so a test can assert that the
+// process-default registry's membership is *derived* from the inventory
+// rather than hand-curated — the two diverge the moment someone adds a
+// register line by hand or an opt-in silently stops being registered.
+template <typename Tuple> constexpr std::size_t countOptIns() {
+    return countOptInsImpl<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+}
+
 } // namespace detail
 
 } // namespace IRWorld

--- a/engine/world/include/irreden/world/world_snapshot.hpp
+++ b/engine/world/include/irreden/world/world_snapshot.hpp
@@ -139,22 +139,20 @@ IRAsset::BinaryStatus saveWorld(const SaveRegistry &registry, const std::string 
 /// then apply. Call after `IREntity::resetGameplay()` at a frame boundary.
 LoadResult loadWorld(const SaveRegistry &registry, const std::string &path);
 
-/// Build the process-default `SaveRegistry` — the curated subset of engine
-/// components that currently have a working `SaveSerialize<C>`: `C_VoxelSetNew`
-/// (explicit serializer, persist P6) plus trivially-copyable plain-data
-/// components (`C_LocalTransform`, `C_PositionInt3D`, `C_SizeInt3D`). This is
-/// the registry the no-registry-argument `saveWorld/loadWorld` overloads (and
-/// the P7 `IRPersist` Lua binding) forward to.
+/// Build the process-default `SaveRegistry` — the registry the
+/// no-registry-argument `saveWorld/loadWorld` overloads (and the P7
+/// `IRPersist` Lua binding) forward to.
 ///
-/// It is deliberately a **subset** of `AllEngineComponents`
-/// (`save_component_inventory.hpp`): registering the full inventory does not
-/// compile today because most opted-in heap-owning components
-/// (`C_Name`, `C_Skeleton`, `C_MidiSequence`, ...) still lack a
-/// `SaveSerialize<C>` specialization and would hit the primary template's
-/// `static_assert`. Growing this to the full inventory (a per-component
-/// serializer pass + a `HasExplicitSaveSerialize<C>` filter over
-/// `AllEngineComponents`) is tracked as downstream work; add each component
-/// here as its serializer lands.
+/// Its membership is **derived** from `AllEngineComponents`
+/// (`save_component_inventory.hpp`), not curated (#2242): the implementation
+/// walks the whole tuple and lets `registerComponent<C>`'s
+/// `if constexpr (shouldSave<C>())` gate drop the opt-outs, so every opted-in
+/// component is registered automatically and a newly-serialized one needs no
+/// edit here. That walk doubles as the completeness gate — each opted-in entry
+/// instantiates `SaveSerialize<C>`, so an `IR_SAVE_OPT_IN` with no serializer
+/// is a build error, never a silently-omitted component. See
+/// `engine/world/CLAUDE.md` §"Process-default registry" for the author-facing
+/// rules that follow from it.
 ///
 /// Built fresh per call (a handful of allocations — never a per-frame path, and
 /// save/load are one-shot load-time ops), so the entries' session-local

--- a/engine/world/src/world_default_registry.cpp
+++ b/engine/world/src/world_default_registry.cpp
@@ -6,29 +6,53 @@
 // registry to more components only recompiles this file.
 #include <irreden/world/save_component_inventory.hpp>
 
-// The SaveSerialize<C_VoxelSetNew> specialization (persist P6) — NOT pulled by
-// the component header, so it must be in scope wherever a registry registers
-// C_VoxelSetNew, else registerComponent instantiates the primary template and
-// the static_assert (not trivially copyable) fires.
+// The SaveSerialize<C> specializations for every opted-in component that owns
+// heap storage. These are NOT pulled by the component headers (that would drag
+// engine/world into every prefab domain's include graph), so they must be in
+// scope wherever a registry registers those components — otherwise
+// registerComponent<C> finds no usable SaveSerialize<C> and the friendly
+// static_assert in save_registry.hpp fires. C_VoxelSetNew keeps its own
+// header (persist P6) because its read path has a pool-interaction contract
+// the rest do not.
+#include <irreden/audio/save_serializers_audio.hpp>
+#include <irreden/common/save_serializers_common.hpp>
+#include <irreden/demo/save_serializers_demo.hpp>
+#include <irreden/render/save_serializers_render.hpp>
+#include <irreden/update/save_serializers_update.hpp>
+#include <irreden/voxel/save_serializers_voxel.hpp>
 #include <irreden/voxel/voxel_set_serialize.hpp>
+
+#include <tuple>
+#include <type_traits>
 
 namespace IRWorld {
 
-// The curated process-default registry (persist P7, #2218). Only components
-// with a working SaveSerialize<C> today: C_VoxelSetNew (explicit serializer,
-// P6) plus trivially-copyable plain-data components. Registering the full
-// AllEngineComponents tuple does NOT compile — the heap-owning opted-in
-// components (C_Name, C_Skeleton, C_MidiSequence, C_TextSegment, ...) have no
-// SaveSerialize<C> yet and would hit the primary template's static_assert.
-// Extend this list as each component grows a serializer; the full-inventory
-// filter (a HasExplicitSaveSerialize<C> trait over AllEngineComponents) is
-// deferred downstream work. See world_snapshot.hpp for the rationale.
+namespace {
+
+// Walk the audited inventory and hand every entry to registerComponent<C>.
+// The opt-outs no-op (registerComponent's `if constexpr (shouldSave<C>())`
+// gate) without instantiating their serializer, so membership is exactly the
+// opted-in set — derived from save_component_inventory.hpp, never curated
+// here. Every opted-in entry DOES instantiate SaveSerialize<C>, which makes
+// this TU the completeness gate: a future IR_SAVE_OPT_IN with no serializer
+// breaks this build with registerComponent's friendly static_assert instead
+// of silently dropping the component from every Lua-driven save.
+template <typename... Cs>
+void registerAll(SaveRegistry &registry, std::type_identity<std::tuple<Cs...>>) {
+    (registry.registerComponent<Cs>(), ...);
+}
+
+} // namespace
+
+// The process-default SaveRegistry (persist P7 #2218; membership derived from
+// the inventory in #2242) that the no-registry-argument saveWorld(path) /
+// loadWorld(path) overloads — and through them the IRPersist Lua binding —
+// forward to. There is deliberately no per-component register line here; the
+// generic walk is what keeps membership derived and doubles as the
+// serializer-completeness gate.
 SaveRegistry makeDefaultSaveRegistry() {
     SaveRegistry registry;
-    registry.registerComponent<IRComponents::C_VoxelSetNew>();
-    registry.registerComponent<IRComponents::C_LocalTransform>();
-    registry.registerComponent<IRComponents::C_PositionInt3D>();
-    registry.registerComponent<IRComponents::C_SizeInt3D>();
+    registerAll(registry, std::type_identity<AllEngineComponents>{});
     return registry;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,6 +106,7 @@ add_executable(IrredenEngineTest
   world/persist_round_trip_test.cpp
   world/component_migration_test.cpp
   world/voxel_set_serialize_test.cpp
+  world/save_serializers_test.cpp
 )
 
 FetchContent_Declare(

--- a/test/script/lua_world_snapshot_test.cpp
+++ b/test/script/lua_world_snapshot_test.cpp
@@ -6,8 +6,12 @@
 #include <irreden/script/lua_script.hpp>
 
 #include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/common/components/component_name.hpp>
 #include <irreden/common/components/component_position_int_3d.hpp>
 #include <irreden/common/components/component_size_int_3d.hpp>
+#include <irreden/render/components/component_widget.hpp>
+#include <irreden/voxel/components/component_bind_points.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
 
 #include <sol/sol.hpp>
@@ -28,11 +32,15 @@
 
 namespace {
 
+using IRComponents::C_BindPoints;
 using IRComponents::C_LocalTransform;
+using IRComponents::C_Name;
 using IRComponents::C_PositionInt3D;
 using IRComponents::C_SizeInt3D;
+using IRComponents::C_Skeleton;
 using IRComponents::C_Voxel;
 using IRComponents::C_VoxelSetNew;
+using IRComponents::C_WidgetLabel;
 using IREntity::EntityId;
 
 std::vector<std::uint8_t> readFileBytes(const std::string &path) {
@@ -225,6 +233,107 @@ TEST_F(LuaWorldSnapshotTest, RoundTripsVoxelSetNew) {
         EXPECT_EQ(0, std::memcmp(&reloaded.pendingVoxels_[i], &voxels[i], sizeof(C_Voxel)))
             << "voxel record " << i << " differs after round-trip";
     }
+}
+
+// #2242 acceptance: the process-default registry now derives its membership
+// from the whole opted-in inventory, so heap-owning components round-trip
+// through the Lua binding too — not just the four hand-curated PODs P7
+// shipped with. C_Name is the issue's named criterion; C_WidgetLabel and
+// C_Skeleton cover the other two container shapes the serializers introduce
+// (string + packed color, and two independent vectors).
+//
+// This is the wiring-level test `engine/world/CLAUDE.md` requires for any
+// component reachable through the default registry (#2244): the per-serializer
+// unit coverage in test/world/save_serializers_test.cpp proves the bytes, but
+// only a run through the real IRPersist surface proves registry entry ->
+// binding -> reload.
+TEST_F(LuaWorldSnapshotTest, RoundTripsHeapOwningComponents) {
+    const EntityId named = m_entity_manager.createEntity(C_Name{"the player"});
+    const EntityId emptyName = m_entity_manager.createEntity(C_Name{""});
+
+    C_WidgetLabel label{};
+    label.text_ = "Frames/sec";
+    label.colorOverride_ = IRMath::Color{9, 8, 7, 240};
+    const EntityId widget = m_entity_manager.createEntity(label);
+
+    C_Skeleton skeleton{};
+    skeleton.joints_ = {101, IREntity::kNullEntity, 103};
+    skeleton.bindPose_.resize(3);
+    skeleton.bindPose_[1].translation_ = IRMath::vec3(1.5f, -2.5f, 3.5f);
+    const EntityId rig = m_entity_manager.createEntity(skeleton);
+
+    const std::string path = tempPath("heap_owning");
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + path + "'))"));
+
+    m_entity_manager.destroyAllEntities();
+    ASSERT_EQ(m_entity_manager.getLiveEntityCount(), 0u);
+    ASSERT_TRUE(runOk("assert(IRPersist.loadWorld('" + path + "'))"));
+
+    ASSERT_TRUE(m_entity_manager.entityExists(named));
+    EXPECT_EQ(m_entity_manager.getComponent<C_Name>(named).name_, "the player")
+        << "C_Name did not survive the Lua round trip";
+    ASSERT_TRUE(m_entity_manager.entityExists(emptyName));
+    EXPECT_EQ(m_entity_manager.getComponent<C_Name>(emptyName).name_, "");
+
+    ASSERT_TRUE(m_entity_manager.entityExists(widget));
+    const C_WidgetLabel &reloadedLabel = m_entity_manager.getComponent<C_WidgetLabel>(widget);
+    EXPECT_EQ(reloadedLabel.text_, "Frames/sec");
+    EXPECT_EQ(reloadedLabel.colorOverride_.red_, 9);
+    EXPECT_EQ(reloadedLabel.colorOverride_.alpha_, 240);
+
+    ASSERT_TRUE(m_entity_manager.entityExists(rig));
+    const C_Skeleton &reloadedRig = m_entity_manager.getComponent<C_Skeleton>(rig);
+    ASSERT_EQ(reloadedRig.joints_.size(), 3u);
+    EXPECT_EQ(reloadedRig.joints_[0], 101u);
+    EXPECT_EQ(reloadedRig.joints_[1], IREntity::kNullEntity)
+        << "a severance hole must not be compacted away — slot order is the bone-id space";
+    EXPECT_EQ(reloadedRig.joints_[2], 103u);
+    ASSERT_EQ(reloadedRig.bindPose_.size(), 3u);
+    EXPECT_FLOAT_EQ(reloadedRig.bindPose_[1].translation_.y, -2.5f);
+}
+
+// W-8 determinism over the widened registry: a world carrying heap-owning
+// components must still double-save byte-identically. The map-ordering hazard
+// this guards against (C_BindPoints) is unit-tested directly; this is the
+// end-to-end backstop through the real save path.
+TEST_F(LuaWorldSnapshotTest, DoubleSaveIsByteIdenticalWithHeapOwningComponents) {
+    m_entity_manager.createEntity(C_Name{"alpha"});
+    m_entity_manager.createEntity(C_Name{"beta"}, C_PositionInt3D{1, 2, 3});
+
+    C_BindPoints points{};
+    points.setPoint(
+        "hand.R",
+        IRComponents::BindPointRuntime{
+            2,
+            IRMath::vec3(1.0f, 0.0f, 0.0f),
+            IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+        }
+    );
+    points.setPoint(
+        "hand.L",
+        IRComponents::BindPointRuntime{
+            1,
+            IRMath::vec3(-1.0f, 0.0f, 0.0f),
+            IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+        }
+    );
+    points.setPoint(
+        "head",
+        IRComponents::BindPointRuntime{
+            0,
+            IRMath::vec3(0.0f, 0.0f, 2.0f),
+            IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+        }
+    );
+    m_entity_manager.createEntity(points);
+
+    const std::string first = tempPath("determinism_a");
+    const std::string second = tempPath("determinism_b");
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + first + "'))"));
+    ASSERT_TRUE(runOk("assert(IRPersist.saveWorld('" + second + "'))"));
+
+    EXPECT_EQ(readFileBytes(first), readFileBytes(second))
+        << "same-world double save is not byte-identical";
 }
 
 // Missing/corrupt path -> false with no Lua error (I/O failure is a bool, not

--- a/test/world/persist_round_trip_test.cpp
+++ b/test/world/persist_round_trip_test.cpp
@@ -7,6 +7,24 @@
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/ir_entity.hpp>
 
+// The heap-owning half of this file (#2242) registers real engine components,
+// so it needs their SaveSerialize<C> specializations in scope — the same
+// include contract world_default_registry.cpp follows. The inventory include
+// is load-bearing, not incidental: registerComponent<C> is `if constexpr`-gated
+// on shouldSave<C>(), and without the IR_SAVE_OPT_IN specializations in scope
+// SaveTrait<C> falls back to the "no decision yet" primary (kSave = false), so
+// every registerComponent call would silently no-op and the test would save an
+// empty world and still pass its ok() assertions.
+#include <irreden/world/save_component_inventory.hpp>
+
+#include <irreden/common/components/component_name.hpp>
+#include <irreden/common/save_serializers_common.hpp>
+#include <irreden/render/components/component_widget.hpp>
+#include <irreden/render/save_serializers_render.hpp>
+#include <irreden/voxel/components/component_bind_points.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/save_serializers_voxel.hpp>
+
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -327,6 +345,137 @@ TEST_F(PersistDeterminism, SaveLoadSaveDigestStable) {
     ASSERT_FALSE(bytesB.empty());
     EXPECT_EQ(fnv1a64(bytesB), fnv1a64(bytesC));
     EXPECT_EQ(bytesB, bytesC);
+}
+
+// #2242: W-7 and W-8 over *heap-owning* engine components. Every test above
+// uses in-TU trivially-copyable stand-ins, so they exercise the walker but
+// never a real SaveSerialize<C> specialization. This one drives the direct
+// C++ saveWorld(registry, path) surface (the Lua binding's coverage lives in
+// test/script/lua_world_snapshot_test.cpp) with a world whose components own
+// a string, two independent vectors, and a hash map — the three shapes where
+// a serializer can silently drop content or emit non-deterministic bytes.
+class PersistHeapOwningFixture : public PersistRoundTripFixture {
+  protected:
+    IRWorld::SaveRegistry heapOwningRegistry() {
+        IRWorld::SaveRegistry reg;
+        reg.registerComponent<IRComponents::C_Name>();
+        reg.registerComponent<IRComponents::C_Skeleton>();
+        reg.registerComponent<IRComponents::C_WidgetLabel>();
+        reg.registerComponent<IRComponents::C_BindPoints>();
+        // Vacuity guard: registerComponent no-ops for a type whose
+        // IR_SAVE_OPT_IN is not in scope, which would make every assertion
+        // below pass against an empty save.
+        EXPECT_EQ(reg.size(), 4u) << "registry is not holding all four components";
+        return reg;
+    }
+
+    // Deliberately inserts the bind points in non-sorted order: the map's
+    // iteration order is not the write order, so a serializer that skipped
+    // the sort would produce different bytes here than for the same content
+    // inserted the other way round.
+    void buildHeapOwningWorld() {
+        m_named =
+            m_em.createEntity(IRComponents::C_Name{"the player"}) & IREntity::IR_ENTITY_ID_BITS;
+        m_emptyNamed = m_em.createEntity(IRComponents::C_Name{""}) & IREntity::IR_ENTITY_ID_BITS;
+
+        IRComponents::C_WidgetLabel label{};
+        label.text_ = "Frames/sec";
+        label.colorOverride_ = IRMath::Color{9, 8, 7, 240};
+        m_widget = m_em.createEntity(label) & IREntity::IR_ENTITY_ID_BITS;
+
+        IRComponents::C_Skeleton skeleton{};
+        skeleton.joints_ = {101, IREntity::kNullEntity, 103};
+        skeleton.bindPose_.resize(3);
+        skeleton.bindPose_[1].translation_ = IRMath::vec3(1.5f, -2.5f, 3.5f);
+
+        IRComponents::C_BindPoints points{};
+        points.setPoint(
+            "hand.R",
+            IRComponents::BindPointRuntime{
+                2,
+                IRMath::vec3(1.0f, 0.0f, 0.0f),
+                IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+            }
+        );
+        points.setPoint(
+            "hand.L",
+            IRComponents::BindPointRuntime{
+                1,
+                IRMath::vec3(-1.0f, 0.0f, 0.0f),
+                IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+            }
+        );
+        points.setPoint(
+            "head",
+            IRComponents::BindPointRuntime{
+                0,
+                IRMath::vec3(0.0f, 0.0f, 2.0f),
+                IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+            }
+        );
+        m_rig = m_em.createEntity(skeleton, points) & IREntity::IR_ENTITY_ID_BITS;
+    }
+
+    IREntity::EntityId m_named = IREntity::kNullEntity;
+    IREntity::EntityId m_emptyNamed = IREntity::kNullEntity;
+    IREntity::EntityId m_widget = IREntity::kNullEntity;
+    IREntity::EntityId m_rig = IREntity::kNullEntity;
+};
+
+using PersistHeapOwning = PersistHeapOwningFixture;
+
+TEST_F(PersistHeapOwning, ValuesSurviveRoundTrip) {
+    buildHeapOwningWorld();
+    IRWorld::SaveRegistry reg = heapOwningRegistry();
+    const std::string path = tempPath("heap_owning");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    m_em.destroyAllEntities();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.entitiesRestored_, 4u);
+    EXPECT_EQ(result.columnsSkipped_, 0u);
+
+    ASSERT_TRUE(m_em.entityExists(m_named));
+    EXPECT_EQ(m_em.getComponent<IRComponents::C_Name>(m_named).name_, "the player");
+    ASSERT_TRUE(m_em.entityExists(m_emptyNamed));
+    EXPECT_EQ(m_em.getComponent<IRComponents::C_Name>(m_emptyNamed).name_, "");
+
+    ASSERT_TRUE(m_em.entityExists(m_widget));
+    const IRComponents::C_WidgetLabel &label =
+        m_em.getComponent<IRComponents::C_WidgetLabel>(m_widget);
+    EXPECT_EQ(label.text_, "Frames/sec");
+    EXPECT_EQ(label.colorOverride_.red_, 9);
+    EXPECT_EQ(label.colorOverride_.alpha_, 240);
+
+    ASSERT_TRUE(m_em.entityExists(m_rig));
+    const IRComponents::C_Skeleton &skeleton = m_em.getComponent<IRComponents::C_Skeleton>(m_rig);
+    ASSERT_EQ(skeleton.joints_.size(), 3u);
+    EXPECT_EQ(skeleton.joints_[1], IREntity::kNullEntity)
+        << "a severance hole must not be compacted away — slot order is the bone-id space";
+    EXPECT_EQ(skeleton.joints_[2], 103u);
+    ASSERT_EQ(skeleton.bindPose_.size(), 3u);
+    EXPECT_FLOAT_EQ(skeleton.bindPose_[1].translation_.y, -2.5f);
+
+    const IRComponents::C_BindPoints &points = m_em.getComponent<IRComponents::C_BindPoints>(m_rig);
+    ASSERT_EQ(points.points_.size(), 3u);
+    EXPECT_EQ(points.points_.at("hand.L").boneId_, 1u);
+    EXPECT_FLOAT_EQ(points.points_.at("head").offset_.z, 2.0f);
+}
+
+TEST_F(PersistHeapOwning, DoubleSaveIsByteIdentical) {
+    buildHeapOwningWorld();
+    IRWorld::SaveRegistry reg = heapOwningRegistry();
+    const std::string pathA = tempPath("heap_det_a");
+    const std::string pathB = tempPath("heap_det_b");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, pathA).ok());
+    ASSERT_TRUE(IRWorld::saveWorld(reg, pathB).ok());
+
+    const std::vector<std::uint8_t> bytesA = readFileBytes(pathA);
+    const std::vector<std::uint8_t> bytesB = readFileBytes(pathB);
+    ASSERT_FALSE(bytesA.empty());
+    EXPECT_EQ(bytesA, bytesB);
+    EXPECT_EQ(fnv1a64(bytesA), fnv1a64(bytesB));
 }
 
 } // namespace

--- a/test/world/save_serializers_test.cpp
+++ b/test/world/save_serializers_test.cpp
@@ -447,6 +447,33 @@ TEST(SaveSerializers, TrianglesOnlySetRejectsExtentGridMismatch) {
     EXPECT_EQ(restored.status_.code_, IRAsset::BinaryIOError::UnknownTag);
 }
 
+// A both-negative extent multiplies to a POSITIVE cell count ((-2,-3) -> +6),
+// so it agrees with the six colors and six distances actually on disk — a
+// product-only consistency test admits it. It must still be rejected: the
+// accessors index `index.y * size_.x + index.x`, which goes negative for any
+// row past the first. TrianglesOnlySetRoundTrips is the positive control —
+// the same bytes, unpatched, restore cleanly.
+TEST(SaveSerializers, TrianglesOnlySetRejectsNegativeExtent) {
+    const C_TrianglesOnlySet set{IRMath::ivec2(2, 3), IRMath::ivec2(-1, 4)};
+    std::vector<std::uint8_t> bytes = serialize(set);
+    // Layout: size_ = i32 x then i32 y (little-endian), so x is [0..3], y is [4..7].
+    ASSERT_GE(bytes.size(), 8u);
+    ASSERT_EQ(bytes[0], 2u) << "expected size_.x at this offset";
+    ASSERT_EQ(bytes[4], 3u) << "expected size_.y at this offset";
+    bytes[0] = 0xFEu; // size_.x = -2
+    bytes[1] = 0xFFu;
+    bytes[2] = 0xFFu;
+    bytes[3] = 0xFFu;
+    bytes[4] = 0xFDu; // size_.y = -3, so size_.x * size_.y == +6 == the grid sizes
+    bytes[5] = 0xFFu;
+    bytes[6] = 0xFFu;
+    bytes[7] = 0xFFu;
+
+    IRAsset::Result<C_TrianglesOnlySet> restored = deserialize<C_TrianglesOnlySet>(bytes);
+    EXPECT_FALSE(restored.ok());
+    EXPECT_EQ(restored.status_.code_, IRAsset::BinaryIOError::UnknownTag);
+}
+
 // Every field of C_TriangleCanvasBackground is private, so the round trip is
 // asserted through byte identity rather than field comparison — see the
 // helper's comment.

--- a/test/world/save_serializers_test.cpp
+++ b/test/world/save_serializers_test.cpp
@@ -445,6 +445,10 @@ TEST(SaveSerializers, TrianglesOnlySetRejectsExtentGridMismatch) {
     IRAsset::Result<C_TrianglesOnlySet> restored = deserialize<C_TrianglesOnlySet>(bytes);
     EXPECT_FALSE(restored.ok());
     EXPECT_EQ(restored.status_.code_, IRAsset::BinaryIOError::UnknownTag);
+    // The two rejection paths share a status code, so the message is the only
+    // thing that tells them apart — pin which one fired.
+    EXPECT_NE(restored.status_.message_.find("disagree with the extent"), std::string::npos)
+        << "expected the cardinality message, got: " << restored.status_.message_;
 }
 
 // A both-negative extent multiplies to a POSITIVE cell count ((-2,-3) -> +6),
@@ -472,6 +476,11 @@ TEST(SaveSerializers, TrianglesOnlySetRejectsNegativeExtent) {
     IRAsset::Result<C_TrianglesOnlySet> restored = deserialize<C_TrianglesOnlySet>(bytes);
     EXPECT_FALSE(restored.ok());
     EXPECT_EQ(restored.status_.code_, IRAsset::BinaryIOError::UnknownTag);
+    // The sign fault must name itself. The grids DO hold the 6 cells -2 * -3
+    // predicts, so the cardinality message would be actively misleading here —
+    // that mis-diagnosis is exactly why the two checks are separate.
+    EXPECT_NE(restored.status_.message_.find("negative extent"), std::string::npos)
+        << "expected the negative-extent message, got: " << restored.status_.message_;
 }
 
 // Every field of C_TriangleCanvasBackground is private, so the round trip is

--- a/test/world/save_serializers_test.cpp
+++ b/test/world/save_serializers_test.cpp
@@ -426,6 +426,27 @@ TEST(SaveSerializers, TrianglesOnlySetRoundTripsEmpty) {
     expectConsumesAllBytes(set);
 }
 
+// Truncation is already caught by readTrivialVector's short read; this is the
+// well-formed-but-inconsistent file — every byte present, but the extent
+// disagrees with the two grids it is supposed to describe. Restoring it would
+// hand back a component no constructor can build, and the unchecked
+// atTriangle* accessors turn that into an out-of-bounds access on first use
+// (setTriangle's bounds check is an IR_ASSERT and compiles out under
+// IR_RELEASE). TrianglesOnlySetRoundTrips is the positive control for this
+// case: the same bytes, unpatched, restore cleanly.
+TEST(SaveSerializers, TrianglesOnlySetRejectsExtentGridMismatch) {
+    const C_TrianglesOnlySet set{IRMath::ivec2(2, 3), IRMath::ivec2(-1, 4)};
+    std::vector<std::uint8_t> bytes = serialize(set);
+    // Layout: size_ = i32 x then i32 y, so x occupies bytes [0..3].
+    ASSERT_GE(bytes.size(), 4u);
+    ASSERT_EQ(bytes[0], 2u) << "expected size_.x at this offset";
+    bytes[0] = 3u; // claims a 3x3 = 9-cell extent over the 6 cells on disk
+
+    IRAsset::Result<C_TrianglesOnlySet> restored = deserialize<C_TrianglesOnlySet>(bytes);
+    EXPECT_FALSE(restored.ok());
+    EXPECT_EQ(restored.status_.code_, IRAsset::BinaryIOError::UnknownTag);
+}
+
 // Every field of C_TriangleCanvasBackground is private, so the round trip is
 // asserted through byte identity rather than field comparison — see the
 // helper's comment.

--- a/test/world/save_serializers_test.cpp
+++ b/test/world/save_serializers_test.cpp
@@ -1,0 +1,664 @@
+#include <gtest/gtest.h>
+
+#include <irreden/world/save_component_inventory.hpp>
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_serialize_common.hpp>
+#include <irreden/world/save_trait.hpp>
+#include <irreden/world/world_snapshot.hpp>
+
+#include <irreden/audio/save_serializers_audio.hpp>
+#include <irreden/common/save_serializers_common.hpp>
+#include <irreden/demo/save_serializers_demo.hpp>
+#include <irreden/render/save_serializers_render.hpp>
+#include <irreden/update/save_serializers_update.hpp>
+#include <irreden/voxel/save_serializers_voxel.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Per-component SaveSerialize<C> coverage for the heap-owning components the
+// process-default registry gained in #2242, plus the membership assertion
+// that proves that registry is *derived* from the inventory rather than
+// hand-curated.
+//
+// Two shapes of assertion per serializer:
+//
+//   - `roundTrip(value)` returns the value after a write -> read cycle, so a
+//     test can assert on the specific fields that matter.
+//   - `reserializesIdentically(value)` writes, reads, and writes again,
+//     asserting the two byte images match. That catches a field written but
+//     never read back (or read in the wrong order) *without* the test needing
+//     access to the component's fields — which is the only practical check
+//     for C_TriangleCanvasBackground, whose state is entirely private.
+//
+// Edge cases the plan calls out — empty string, empty vector, and
+// C_BindPoints' map-order determinism — get their own tests below.
+
+namespace {
+
+using namespace IRComponents;
+
+template <typename C> std::vector<std::uint8_t> serialize(const C &value) {
+    IRAsset::MemoryBinaryWriter writer;
+    IRWorld::SaveSerialize<C>::write(writer, value);
+    return writer.buffer();
+}
+
+// Write -> read. Fails the calling test (via ADD_FAILURE) and returns a
+// default-ish value if the read reports an error.
+template <typename C> IRAsset::Result<C> deserialize(const std::vector<std::uint8_t> &bytes) {
+    IRAsset::MemoryBinaryReader reader(bytes.data(), bytes.size());
+    return IRWorld::SaveSerialize<C>::read(reader);
+}
+
+// A serializer must consume exactly what it produced: a read that stops short
+// would silently corrupt the *next* column in a real ARCH chunk, where
+// component rows are written back to back with no per-row framing.
+template <typename C> void expectConsumesAllBytes(const C &value) {
+    const std::vector<std::uint8_t> bytes = serialize(value);
+    IRAsset::MemoryBinaryReader reader(bytes.data(), bytes.size());
+    IRAsset::Result<C> restored = IRWorld::SaveSerialize<C>::read(reader);
+    ASSERT_TRUE(restored.ok()) << restored.status_.message_;
+    EXPECT_EQ(reader.remaining(), 0u)
+        << "serializer left " << reader.remaining() << " unread byte(s)";
+}
+
+template <typename C> void expectReserializesIdentically(const C &value) {
+    const std::vector<std::uint8_t> first = serialize(value);
+    IRAsset::Result<C> restored = deserialize<C>(first);
+    ASSERT_TRUE(restored.ok()) << restored.status_.message_;
+    const std::vector<std::uint8_t> second = serialize(restored.value_);
+    EXPECT_EQ(first, second) << "re-serializing the restored value produced different bytes — a "
+                                "field is written but not read back, or read out of order";
+}
+
+// Convenience for the common "round-trip and inspect" case.
+template <typename C> C roundTrip(const C &value) {
+    IRAsset::Result<C> restored = deserialize<C>(serialize(value));
+    EXPECT_TRUE(restored.ok()) << restored.status_.message_;
+    return restored.value_;
+}
+
+// --- common/ ---------------------------------------------------------------
+
+TEST(SaveSerializers, NameRoundTrips) {
+    EXPECT_EQ(roundTrip(C_Name{"player one"}).name_, "player one");
+    expectReserializesIdentically(C_Name{"player one"});
+    expectConsumesAllBytes(C_Name{"player one"});
+}
+
+TEST(SaveSerializers, NameRoundTripsEmptyString) {
+    EXPECT_EQ(roundTrip(C_Name{""}).name_, "");
+    expectConsumesAllBytes(C_Name{""});
+}
+
+TEST(SaveSerializers, TimerRoundTrips) {
+    C_Timer timer{"spawn", 1200, 300};
+    timer.startTick_ = 900;
+    timer.active_ = false;
+    timer.fired_ = true;
+
+    const C_Timer restored = roundTrip(timer);
+    EXPECT_EQ(restored.name_, "spawn");
+    EXPECT_EQ(restored.startTick_, 900u);
+    EXPECT_EQ(restored.targetTick_, 1200u);
+    EXPECT_EQ(restored.intervalTicks_, 300u);
+    EXPECT_FALSE(restored.active_);
+    EXPECT_TRUE(restored.fired_);
+    expectConsumesAllBytes(timer);
+}
+
+TEST(SaveSerializers, StopwatchRoundTrips) {
+    C_Stopwatch stopwatch{"lap", 4242};
+    stopwatch.pausedElapsed_ = 77;
+    stopwatch.running_ = false;
+
+    const C_Stopwatch restored = roundTrip(stopwatch);
+    EXPECT_EQ(restored.name_, "lap");
+    EXPECT_EQ(restored.startTick_, 4242u);
+    EXPECT_EQ(restored.pausedElapsed_, 77u);
+    EXPECT_FALSE(restored.running_);
+    expectConsumesAllBytes(stopwatch);
+}
+
+TEST(SaveSerializers, CycleRoundTripsWithBreakpoints) {
+    C_Cycle cycle{"day", 1000, 25};
+    cycle.addBreakpoint(0.25f);
+    cycle.addBreakpoint(0.5f);
+    cycle.addBreakpoint(0.75f);
+    ASSERT_EQ(cycle.numBreakpoints_, 3);
+    cycle.lastCycleNum_ = 9;
+    cycle.lastSegmentIndex_ = 2;
+    cycle.boundaryCrossed_ = true;
+    cycle.fromCycle_ = 8;
+    cycle.toCycle_ = 9;
+    cycle.segmentIndex_ = 2;
+    cycle.fromSegment_ = 1;
+    cycle.toSegment_ = 2;
+
+    const C_Cycle restored = roundTrip(cycle);
+    EXPECT_EQ(restored.name_, "day");
+    EXPECT_EQ(restored.periodTicks_, 1000u);
+    EXPECT_EQ(restored.phaseOffset_, 25u);
+    ASSERT_EQ(restored.numBreakpoints_, 3);
+    EXPECT_EQ(restored.breakpoints_[0], 250u);
+    EXPECT_EQ(restored.breakpoints_[1], 500u);
+    EXPECT_EQ(restored.breakpoints_[2], 750u);
+    EXPECT_EQ(restored.lastCycleNum_, 9u);
+    EXPECT_TRUE(restored.boundaryCrossed_);
+    EXPECT_EQ(restored.toSegment_, 2);
+    expectConsumesAllBytes(cycle);
+}
+
+TEST(SaveSerializers, CycleRoundTripsWithNoBreakpoints) {
+    const C_Cycle cycle{"bare", 60};
+    const C_Cycle restored = roundTrip(cycle);
+    EXPECT_EQ(restored.numBreakpoints_, 0);
+    EXPECT_EQ(restored.lastCycleNum_, C_Cycle::kUnprimed);
+    expectConsumesAllBytes(cycle);
+}
+
+// A breakpoint count above this build's inline-array capacity must be
+// rejected rather than copied past the end of the array.
+TEST(SaveSerializers, CycleRejectsOverlongBreakpointCount) {
+    std::vector<std::uint8_t> bytes = serialize(C_Cycle{"bad", 100});
+    // Layout: string("bad") = varuint len + 3 bytes, then two u64, then the
+    // breakpoint count byte.
+    const std::size_t countIndex = 1 + 3 + 8 + 8;
+    ASSERT_LT(countIndex, bytes.size());
+    ASSERT_EQ(bytes[countIndex], 0u) << "expected the breakpoint count at this offset";
+    bytes[countIndex] = C_Cycle::kMaxBreakpoints + 1;
+
+    IRAsset::Result<C_Cycle> restored = deserialize<C_Cycle>(bytes);
+    EXPECT_FALSE(restored.ok());
+    EXPECT_EQ(restored.status_.code_, IRAsset::BinaryIOError::UnknownTag);
+}
+
+// --- demo/ -----------------------------------------------------------------
+
+TEST(SaveSerializers, ExampleRoundTrips) {
+    EXPECT_EQ(roundTrip(C_Example{"hello"}).exampleSentence_, "hello");
+    expectConsumesAllBytes(C_Example{"hello"});
+}
+
+// --- voxel/ ----------------------------------------------------------------
+
+TEST(SaveSerializers, JointNameRoundTrips) {
+    C_JointName joint{};
+    joint.name_ = "spine.02";
+    EXPECT_EQ(roundTrip(joint).name_, "spine.02");
+    expectConsumesAllBytes(joint);
+}
+
+TEST(SaveSerializers, SkeletonRoundTrips) {
+    C_Skeleton skeleton{};
+    // A severance hole (kNullEntity) in the middle: slot order is the bone-id
+    // space, so the hole must survive rather than being compacted away.
+    skeleton.joints_ = {11, IREntity::kNullEntity, 13};
+    skeleton.bindPose_.resize(3);
+    skeleton.bindPose_[0].translation_ = IRMath::vec3(1.0f, 2.0f, 3.0f);
+    skeleton.bindPose_[2].translation_ = IRMath::vec3(-4.0f, 5.0f, -6.0f);
+
+    const C_Skeleton restored = roundTrip(skeleton);
+    ASSERT_EQ(restored.joints_.size(), 3u);
+    EXPECT_EQ(restored.joints_[0], 11u);
+    EXPECT_EQ(restored.joints_[1], IREntity::kNullEntity);
+    EXPECT_EQ(restored.joints_[2], 13u);
+    ASSERT_EQ(restored.bindPose_.size(), 3u);
+    EXPECT_FLOAT_EQ(restored.bindPose_[0].translation_.x, 1.0f);
+    EXPECT_FLOAT_EQ(restored.bindPose_[2].translation_.z, -6.0f);
+    expectConsumesAllBytes(skeleton);
+}
+
+TEST(SaveSerializers, SkeletonRoundTripsEmpty) {
+    const C_Skeleton skeleton{};
+    const C_Skeleton restored = roundTrip(skeleton);
+    EXPECT_TRUE(restored.joints_.empty());
+    EXPECT_TRUE(restored.bindPose_.empty());
+    expectConsumesAllBytes(skeleton);
+}
+
+// A rig with joints but no bind pose: the two vectors are independent, so a
+// serializer that assumed them parallel would corrupt the read.
+TEST(SaveSerializers, SkeletonRoundTripsJointsWithoutBindPose) {
+    C_Skeleton skeleton{};
+    skeleton.joints_ = {1, 2, 3, 4};
+    const C_Skeleton restored = roundTrip(skeleton);
+    EXPECT_EQ(restored.joints_.size(), 4u);
+    EXPECT_TRUE(restored.bindPose_.empty());
+    expectConsumesAllBytes(skeleton);
+}
+
+TEST(SaveSerializers, BindPointsRoundTrips) {
+    C_BindPoints points{};
+    points.setPoint(
+        "hand.L",
+        BindPointRuntime{3, IRMath::vec3(1.0f, 0.0f, 0.0f), IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)}
+    );
+    points.setPoint(
+        "hand.R",
+        BindPointRuntime{4, IRMath::vec3(-1.0f, 0.0f, 0.0f), IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)}
+    );
+
+    const C_BindPoints restored = roundTrip(points);
+    ASSERT_TRUE(restored.hasPoint("hand.L"));
+    ASSERT_TRUE(restored.hasPoint("hand.R"));
+    EXPECT_EQ(restored.points_.at("hand.L").boneId_, 3u);
+    EXPECT_FLOAT_EQ(restored.points_.at("hand.R").offset_.x, -1.0f);
+    expectConsumesAllBytes(points);
+}
+
+// The map is an unordered_map, so hash order is not a contract. Two maps with
+// the same entries inserted in opposite orders must serialize to identical
+// bytes — otherwise a same-world double-save is not byte-identical
+// (world-snapshot criterion 6).
+TEST(SaveSerializers, BindPointsAreOrderIndependent) {
+    const BindPointRuntime a{
+        1,
+        IRMath::vec3(1.0f, 2.0f, 3.0f),
+        IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+    };
+    const BindPointRuntime b{
+        2,
+        IRMath::vec3(4.0f, 5.0f, 6.0f),
+        IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+    };
+    const BindPointRuntime c{
+        3,
+        IRMath::vec3(7.0f, 8.0f, 9.0f),
+        IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+    };
+
+    C_BindPoints forward{};
+    forward.setPoint("alpha", a);
+    forward.setPoint("beta", b);
+    forward.setPoint("gamma", c);
+
+    C_BindPoints reverse{};
+    reverse.setPoint("gamma", c);
+    reverse.setPoint("beta", b);
+    reverse.setPoint("alpha", a);
+
+    EXPECT_EQ(serialize(forward), serialize(reverse))
+        << "bind-point bytes depend on unordered_map iteration order";
+}
+
+TEST(SaveSerializers, BindPointsRoundTripsEmpty) {
+    const C_BindPoints points{};
+    EXPECT_TRUE(roundTrip(points).points_.empty());
+    expectConsumesAllBytes(points);
+}
+
+// --- audio/ ----------------------------------------------------------------
+
+TEST(SaveSerializers, MidiSequenceRoundTrips) {
+    C_MidiSequence sequence{140.0f, 3, 4, 2, false};
+    sequence.insertNote(0.0, 0.25, 60, 100);
+    sequence.insertNote(1.0, 0.5, 64, 90);
+    ASSERT_EQ(sequence.messageSequence_.size(), 4u);
+    sequence.tickCount_ = 512.0;
+    sequence.nextMessageIndex_ = 2;
+
+    const C_MidiSequence restored = roundTrip(sequence);
+    EXPECT_FLOAT_EQ(restored.bpm_, 140.0f);
+    EXPECT_EQ(restored.timeSignature_.first, 3);
+    EXPECT_EQ(restored.timeSignature_.second, 4);
+    EXPECT_EQ(restored.lengthMeasures_, 2);
+    EXPECT_FALSE(restored.looping_);
+    ASSERT_EQ(restored.messageSequence_.size(), 4u);
+    EXPECT_EQ(restored.messageSequence_[0].first, sequence.messageSequence_[0].first);
+    EXPECT_EQ(restored.messageSequence_[0].second.data1_, 60);
+    EXPECT_EQ(restored.messageSequence_[2].second.data1_, 64);
+    EXPECT_DOUBLE_EQ(restored.tickCount_, 512.0);
+    EXPECT_EQ(restored.nextMessageIndex_, 2);
+    // The constructor-derived scalars must come back consistent with the
+    // authored tempo rather than being persisted independently.
+    EXPECT_DOUBLE_EQ(restored.lengthMidiTicks_, sequence.lengthMidiTicks_);
+    EXPECT_DOUBLE_EQ(restored.calcMidiTicksPerFrameTick(), sequence.calcMidiTicksPerFrameTick());
+    expectConsumesAllBytes(sequence);
+}
+
+TEST(SaveSerializers, MidiSequenceRoundTripsEmptySequence) {
+    const C_MidiSequence sequence{};
+    const C_MidiSequence restored = roundTrip(sequence);
+    EXPECT_TRUE(restored.messageSequence_.empty());
+    expectConsumesAllBytes(sequence);
+}
+
+// --- update/ ---------------------------------------------------------------
+
+TEST(SaveSerializers, PeriodicIdleRoundTrips) {
+    C_PeriodicIdle idle{IRMath::vec3{0.0f, 0.0f, 4.0f}, 2.0f, 0.5f};
+    idle.addStagePeriodRange(0.0f, 3.0f, 0.0f, 1.0f, IREasingFunctions::kCubicEaseOut);
+    idle.appendStageFillEnd(1.0f, 0.0f, IREasingFunctions::kCubicEaseIn);
+    ASSERT_EQ(idle.stages_.size(), 2u);
+    idle.tickCount_ = 31;
+    idle.currentStageIndex_ = 1;
+    idle.pauseRequested_ = true;
+    idle.resumeCountdownSec_ = 0.75f;
+
+    const C_PeriodicIdle restored = roundTrip(idle);
+    EXPECT_EQ(restored.tickCount_, 31);
+    EXPECT_FLOAT_EQ(restored.angle_, idle.angle_);
+    EXPECT_FLOAT_EQ(restored.amplitude_.z, 4.0f);
+    EXPECT_FLOAT_EQ(restored.periodLengthSeconds_, 2.0f);
+    ASSERT_EQ(restored.stages_.size(), 2u);
+    EXPECT_EQ(restored.stages_[0].easingFunction_, IREasingFunctions::kCubicEaseOut);
+    EXPECT_FLOAT_EQ(restored.stages_[1].endAngle_, idle.stages_[1].endAngle_);
+    EXPECT_EQ(restored.currentStageIndex_, 1);
+    EXPECT_TRUE(restored.isPauseRequested());
+    EXPECT_FLOAT_EQ(restored.resumeCountdownSec_, 0.75f);
+    // The private per-tick cache is derived, so the check that it came back
+    // consistent is that the restored component evaluates to the same offset
+    // the live one does at the same angle.
+    EXPECT_FLOAT_EQ(restored.valueAtAngle(idle.angle_).z, idle.valueAtAngle(idle.angle_).z);
+    expectConsumesAllBytes(idle);
+}
+
+TEST(SaveSerializers, PeriodicIdleRoundTripsWithNoStages) {
+    const C_PeriodicIdle idle{IRMath::vec3{1.0f, 0.0f, 0.0f}, 1.0f};
+    const C_PeriodicIdle restored = roundTrip(idle);
+    EXPECT_TRUE(restored.stages_.empty());
+    expectConsumesAllBytes(idle);
+}
+
+// --- render/ ---------------------------------------------------------------
+
+TEST(SaveSerializers, TextSegmentRoundTrips) {
+    EXPECT_EQ(roundTrip(C_TextSegment{"score: 42"}).text_, "score: 42");
+    expectConsumesAllBytes(C_TextSegment{""});
+}
+
+TEST(SaveSerializers, SpriteAnimationRoundTrips) {
+    C_SpriteAnimation animation{};
+    animation.sheetEntity_ = 4242;
+    animation.animationIndex_ = 3;
+    animation.frameIndex_ = 5;
+    animation.elapsedInFrame_ = 0.125f;
+    animation.loopMode_ = SpriteLoopMode::PING_PONG;
+    animation.speed_ = 2.5f;
+    animation.pingPongDirection_ = -1;
+    animation.terminated_ = true;
+    animation.stopped_ = true;
+    animation.currentAnimName_ = "walk_south";
+
+    const C_SpriteAnimation restored = roundTrip(animation);
+    EXPECT_EQ(restored.sheetEntity_, 4242u);
+    EXPECT_EQ(restored.animationIndex_, 3);
+    EXPECT_EQ(restored.frameIndex_, 5);
+    EXPECT_FLOAT_EQ(restored.elapsedInFrame_, 0.125f);
+    EXPECT_EQ(restored.loopMode_, SpriteLoopMode::PING_PONG);
+    EXPECT_FLOAT_EQ(restored.speed_, 2.5f);
+    EXPECT_EQ(restored.pingPongDirection_, -1);
+    EXPECT_TRUE(restored.terminated_);
+    EXPECT_TRUE(restored.stopped_);
+    EXPECT_EQ(restored.currentAnimName_, "walk_south");
+    expectConsumesAllBytes(animation);
+}
+
+TEST(SaveSerializers, TrianglesOnlySetRoundTrips) {
+    C_TrianglesOnlySet set{IRMath::ivec2(2, 3), IRMath::ivec2(-1, 4)};
+    set.setTriangle(IRMath::ivec2(0, 0), IRMath::Color{1, 2, 3, 255});
+    set.setTriangle(IRMath::ivec2(1, 2), IRMath::Color{9, 8, 7, 255});
+
+    const C_TrianglesOnlySet restored = roundTrip(set);
+    EXPECT_EQ(restored.size_.x, 2);
+    EXPECT_EQ(restored.size_.y, 3);
+    EXPECT_EQ(restored.origin_.x, -1);
+    EXPECT_EQ(restored.origin_.y, 4);
+    ASSERT_EQ(restored.triangleColors_.size(), set.triangleColors_.size());
+    ASSERT_EQ(restored.triangleDistances_.size(), set.triangleDistances_.size());
+    EXPECT_EQ(restored.atTriangleColor(IRMath::uvec2(0, 0)).red_, 1);
+    EXPECT_EQ(restored.atTriangleColor(IRMath::uvec2(1, 2)).blue_, 7);
+    expectConsumesAllBytes(set);
+}
+
+TEST(SaveSerializers, TrianglesOnlySetRoundTripsEmpty) {
+    const C_TrianglesOnlySet set{};
+    const C_TrianglesOnlySet restored = roundTrip(set);
+    EXPECT_TRUE(restored.triangleColors_.empty());
+    EXPECT_TRUE(restored.triangleDistances_.empty());
+    expectConsumesAllBytes(set);
+}
+
+// Every field of C_TriangleCanvasBackground is private, so the round trip is
+// asserted through byte identity rather than field comparison — see the
+// helper's comment.
+TEST(SaveSerializers, TriangleCanvasBackgroundRoundTrips) {
+    C_TriangleCanvasBackground background{
+        BackgroundTypes::kPulsePattern,
+        std::vector<IRMath::Color>{IRMath::Color{10, 20, 30, 255}, IRMath::Color{40, 50, 60, 255}},
+        IRMath::ivec2(4, 4),
+        2.5f,
+        7
+    };
+    background.setPulseWaveDirection(0.0f, 1.0f, 3.0f);
+    background.setPulseWaveInterference(1.0f, 0.0f, 5.0f, 0.25f);
+    background.setPulseWavePrimaryTiming(1.5f, 0.75f);
+    background.setPulseWaveDirectionLinearMotion(
+        1.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        4.0f,
+        IREasingFunctions::kCubicEaseIn,
+        IREasingFunctions::kCubicEaseOut
+    );
+    background.setPatternZoomMultiplier(4.0f);
+
+    expectReserializesIdentically(background);
+    expectConsumesAllBytes(background);
+}
+
+TEST(SaveSerializers, TriangleCanvasBackgroundRoundTripsDefault) {
+    const C_TriangleCanvasBackground background{};
+    expectReserializesIdentically(background);
+    expectConsumesAllBytes(background);
+}
+
+TEST(SaveSerializers, WidgetPanelRoundTrips) {
+    C_WidgetPanel panel{};
+    panel.title_ = "Inspector";
+    panel.drawBorder_ = false;
+    const C_WidgetPanel restored = roundTrip(panel);
+    EXPECT_EQ(restored.title_, "Inspector");
+    EXPECT_FALSE(restored.drawBorder_);
+    expectConsumesAllBytes(panel);
+}
+
+TEST(SaveSerializers, WidgetLabelRoundTrips) {
+    C_WidgetLabel label{};
+    label.text_ = "Frames";
+    label.colorOverride_ = IRMath::Color{12, 34, 56, 200};
+    const C_WidgetLabel restored = roundTrip(label);
+    EXPECT_EQ(restored.text_, "Frames");
+    EXPECT_EQ(restored.colorOverride_.red_, 12);
+    EXPECT_EQ(restored.colorOverride_.green_, 34);
+    EXPECT_EQ(restored.colorOverride_.blue_, 56);
+    EXPECT_EQ(restored.colorOverride_.alpha_, 200);
+    expectConsumesAllBytes(label);
+}
+
+TEST(SaveSerializers, WidgetButtonRoundTrips) {
+    C_WidgetButton button{};
+    button.label_ = "Save";
+    EXPECT_EQ(roundTrip(button).label_, "Save");
+    expectConsumesAllBytes(button);
+}
+
+TEST(SaveSerializers, WidgetSliderRoundTrips) {
+    C_WidgetSlider slider{};
+    slider.label_ = "Zoom";
+    slider.minValue_ = -2.0f;
+    slider.maxValue_ = 8.0f;
+    slider.currentValue_ = 3.25f;
+    const C_WidgetSlider restored = roundTrip(slider);
+    EXPECT_EQ(restored.label_, "Zoom");
+    EXPECT_FLOAT_EQ(restored.minValue_, -2.0f);
+    EXPECT_FLOAT_EQ(restored.maxValue_, 8.0f);
+    EXPECT_FLOAT_EQ(restored.currentValue_, 3.25f);
+    expectConsumesAllBytes(slider);
+}
+
+TEST(SaveSerializers, WidgetCheckboxRoundTrips) {
+    C_WidgetCheckbox checkbox{};
+    checkbox.label_ = "Wireframe";
+    checkbox.checked_ = true;
+    const C_WidgetCheckbox restored = roundTrip(checkbox);
+    EXPECT_EQ(restored.label_, "Wireframe");
+    EXPECT_TRUE(restored.checked_);
+    expectConsumesAllBytes(checkbox);
+}
+
+TEST(SaveSerializers, WidgetListRoundTrips) {
+    C_WidgetList list{};
+    list.items_ = {"alpha", "", "gamma"}; // includes an empty-string element
+    list.selectedIndex_ = 2;
+    list.scrollOffset_ = 1;
+    list.itemHeight_ = 24;
+    const C_WidgetList restored = roundTrip(list);
+    ASSERT_EQ(restored.items_.size(), 3u);
+    EXPECT_EQ(restored.items_[0], "alpha");
+    EXPECT_EQ(restored.items_[1], "");
+    EXPECT_EQ(restored.items_[2], "gamma");
+    EXPECT_EQ(restored.selectedIndex_, 2);
+    EXPECT_EQ(restored.scrollOffset_, 1);
+    EXPECT_EQ(restored.itemHeight_, 24);
+    expectConsumesAllBytes(list);
+}
+
+TEST(SaveSerializers, WidgetListRoundTripsEmptyItems) {
+    const C_WidgetList list{};
+    EXPECT_TRUE(roundTrip(list).items_.empty());
+    expectConsumesAllBytes(list);
+}
+
+TEST(SaveSerializers, WidgetDropdownRoundTrips) {
+    C_WidgetDropdown dropdown{};
+    dropdown.items_ = {"one", "two"};
+    dropdown.selectedIndex_ = 1;
+    dropdown.isOpen_ = true;
+    dropdown.itemHeight_ = 20;
+    const C_WidgetDropdown restored = roundTrip(dropdown);
+    ASSERT_EQ(restored.items_.size(), 2u);
+    EXPECT_EQ(restored.items_[1], "two");
+    EXPECT_EQ(restored.selectedIndex_, 1);
+    EXPECT_TRUE(restored.isOpen_);
+    EXPECT_EQ(restored.itemHeight_, 20);
+    expectConsumesAllBytes(dropdown);
+}
+
+TEST(SaveSerializers, WidgetRadioRoundTrips) {
+    C_WidgetRadio radio{};
+    radio.label_ = "Metal";
+    radio.groupId_ = 77;
+    radio.value_ = -3;
+    radio.selected_ = true;
+    const C_WidgetRadio restored = roundTrip(radio);
+    EXPECT_EQ(restored.label_, "Metal");
+    EXPECT_EQ(restored.groupId_, 77u);
+    EXPECT_EQ(restored.value_, -3);
+    EXPECT_TRUE(restored.selected_);
+    expectConsumesAllBytes(radio);
+}
+
+TEST(SaveSerializers, WidgetTextInputRoundTrips) {
+    C_WidgetTextInput input{};
+    input.text_ = "entity name";
+    input.cursorPos_ = 6;
+    input.maxLength_ = 64;
+    const C_WidgetTextInput restored = roundTrip(input);
+    EXPECT_EQ(restored.text_, "entity name");
+    EXPECT_EQ(restored.cursorPos_, 6);
+    EXPECT_EQ(restored.maxLength_, 64);
+    expectConsumesAllBytes(input);
+}
+
+// --- truncation ------------------------------------------------------------
+
+// Rule #5: a truncated payload is a recoverable error, not a crash or a
+// silently half-filled component. Checked on a representative serializer from
+// each container shape (string, string vector, trivial vector, map).
+template <typename C> void expectTruncationIsRecoverable(const C &value) {
+    const std::vector<std::uint8_t> full = serialize(value);
+    ASSERT_GT(full.size(), 1u);
+    for (std::size_t cut = 0; cut < full.size(); ++cut) {
+        const std::vector<std::uint8_t> partial(full.begin(), full.begin() + cut);
+        IRAsset::MemoryBinaryReader reader(partial.data(), partial.size());
+        IRAsset::Result<C> restored = IRWorld::SaveSerialize<C>::read(reader);
+        EXPECT_FALSE(restored.ok()) << "truncating to " << cut << " byte(s) still read as OK";
+    }
+}
+
+TEST(SaveSerializers, TruncatedPayloadsFailCleanly) {
+    expectTruncationIsRecoverable(C_Name{"abc"});
+
+    C_WidgetList list{};
+    list.items_ = {"aa", "bb"};
+    expectTruncationIsRecoverable(list);
+
+    C_Skeleton skeleton{};
+    skeleton.joints_ = {1, 2};
+    expectTruncationIsRecoverable(skeleton);
+
+    C_BindPoints points{};
+    points.setPoint("k", BindPointRuntime{1, IRMath::vec3(0.0f), IRMath::vec4(0.0f)});
+    expectTruncationIsRecoverable(points);
+}
+
+// --- derived registry membership ------------------------------------------
+
+// makeDefaultSaveRegistry resolves a session-local ComponentId per entry, so
+// these tests need a live EntityManager where the pure-serializer tests above
+// do not.
+class DefaultRegistryTest : public testing::Test {
+  protected:
+    IREntity::EntityManager m_entity_manager;
+};
+
+// The headline acceptance criterion for #2242: the process-default registry's
+// membership is *derived* from save_component_inventory.hpp, not a curated
+// list. If someone re-adds a hand-written registerComponent line, or an
+// opt-in silently stops being registered, these two counts diverge.
+TEST_F(DefaultRegistryTest, MembershipIsDerivedFromInventory) {
+    const IRWorld::SaveRegistry registry = IRWorld::makeDefaultSaveRegistry();
+    constexpr std::size_t expected = IRWorld::detail::countOptIns<IRWorld::AllEngineComponents>();
+
+    EXPECT_EQ(registry.size(), expected);
+    // Positive-fire guard: the pre-#2242 curated registry held 4 entries, so
+    // an assertion that passed at 4 would prove nothing about "derived".
+    EXPECT_GT(registry.size(), 4u);
+}
+
+// Spot-check that components which previously had no serializer are now
+// actually reachable through the process-default registry by their on-disk
+// name — the registry is what the Lua IRPersist surface uses.
+TEST_F(DefaultRegistryTest, ResolvesHeapOwningComponents) {
+    const IRWorld::SaveRegistry registry = IRWorld::makeDefaultSaveRegistry();
+    for (const char *name :
+         {"IRComponents::C_Name",
+          "IRComponents::C_Skeleton",
+          "IRComponents::C_MidiSequence",
+          "IRComponents::C_TextSegment",
+          "IRComponents::C_WidgetLabel",
+          "IRComponents::C_BindPoints"}) {
+        EXPECT_NE(registry.findByName(name), nullptr) << name << " is not registered";
+    }
+}
+
+// The two components #2242 flipped OPT_IN -> OPT_OUT: both store a resolved
+// std::function easing curve, so no honest serializer exists for them. Pinned
+// here so a future re-opt-in has to confront the callback problem rather than
+// silently shipping a lossy default.
+TEST(SaveSerializers, CallbackBearingComponentsStayOptedOut) {
+    EXPECT_FALSE(IRWorld::shouldSave<C_GotoEasing3D>());
+    EXPECT_FALSE(IRWorld::shouldSave<C_RotationTarget>());
+    EXPECT_FALSE(IRWorld::shouldSave<C_LerpEntity>());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

`makeDefaultSaveRegistry()` — the registry the `IRPersist` Lua binding and the
`saveWorld(path)` / `loadWorld(path)` overloads forward to — was a hand-curated
list of four components. Anything else on an entity was **silently omitted**
from every Lua-driven save. This makes membership derived from the audited
inventory instead, and makes the omission impossible to reintroduce quietly.

- **Membership is derived.** The registry walks `AllEngineComponents` and lets
  `registerComponent<C>`'s existing `if constexpr (shouldSave<C>())` gate drop
  the opt-outs. There are no per-component register lines left; a test pins
  `registry.size() == detail::countOptIns<AllEngineComponents>()`.
- **The walk is also a completeness gate.** `SaveSerialize`'s primary template
  is now *declared but never defined*, with a constrained partial
  specialization for trivially-copyable components. That makes the new
  `SaveSerializable<C>` concept a genuine test of "does a serializer exist",
  so an `IR_SAVE_OPT_IN` with no serializer is a **build error** with a
  friendly diagnostic, not a component that quietly stops being saved. The
  companion-trait approach the issue sketched was rejected for the plan's
  reason: it has a dual-bookkeeping failure mode (serializer written, trait
  line forgotten) — the exact silent omission this issue exists to kill.
- **23 new `SaveSerialize<C>` specializations**, grouped one header per prefab
  domain (`save_serializers_<domain>.hpp`), included only by
  `world_default_registry.cpp` so `engine/world` stays out of the prefab
  domains' include graphs. Shared count-prefixed container helpers live in
  `save_serialize_common.hpp`; `vec2`/`ivec2` binary IO went to
  `engine/asset/math_binary_io.hpp` per the IRMath rule rather than being
  hand-rolled at the call sites.
- **Determinism:** `C_BindPoints` holds an `unordered_map`, so its serializer
  writes entries in sorted key order — otherwise hash order would make a
  same-world double save non-byte-identical (world-snapshot criterion 6).

### Deviation from the plan: two components flip to `IR_SAVE_OPT_OUT`

Phase 0's compile-error enumeration returned **25** components, not the ~20 the
plan predicted. Two of the extras are not serializer work: `C_GotoEasing3D` and
`C_RotationTarget` store `GLMEasingFunction easingFunction_`, which is
`std::function<float(const float &)>`. The plan's premise that no opted-in
component held `std::function` state was wrong — its grep looked for that
spelling, which the `GLMEasingFunction` alias hides.

Both are *constructed* from an `IREasingFunctions` enum but keep only the
resolved callable, so the authored curve is unrecoverable at save time. Per the
plan's documented bail path I flipped both to `IR_SAVE_OPT_OUT` rather than
writing a serializer that silently substitutes a default easing on load. This
follows the already-audited precedent one line above them in the same file
(`C_LerpEntity` — "holds a std::function member … so it opts out too"), and
their live *output* still persists via `C_LocalTransform`. The honest fix
(store the enum) changes two public components, so it is filed for human
triage as **#2597** rather than through the agent-approved lane. A test pins
the opt-out so a future re-opt-in must confront the callback problem
deliberately.

## Test plan

- [x] `test/world/save_serializers_test.cpp` (new, 39 cases): per-serializer
      round trips; empty-string and empty-vector edges; `C_BindPoints`
      insertion-order independence; every serializer consumes exactly the bytes
      it wrote (a short read would corrupt the *next* column in a real ARCH
      chunk); truncation at every byte offset fails recoverably rather than
      crashing or half-filling.
- [x] `test/script/lua_world_snapshot_test.cpp`: `C_Name` (the issue's named
      criterion), `C_WidgetLabel` and `C_Skeleton` round-trip through the real
      `IRPersist` Lua surface; a world with heap-owning components double-saves
      byte-identically.
- [x] `test/world/persist_round_trip_test.cpp`: same coverage against the
      direct C++ `saveWorld(registry, path)` surface, incl. a severance-hole
      (`kNullEntity`) slot surviving in `C_Skeleton.joints_`.
- [x] Completeness gate demonstrated: temporarily re-opting `C_GotoEasing3D` in
      (scratch, not committed) fails the `IrredenEngineWorld` build with
      `registerComponent`'s `SaveSerializable<C>` static_assert naming the
      component. Reverted before commit.
- [x] Full suite green on `macos-debug`: **1404 tests, 0 failures**.
- [ ] `linux-debug` build + suite — not runnable on this macOS host; routed via
      the cross-host smoke label.

## Reviewer notes

- `C_TriangleCanvasBackground` is entirely private, so its serializer is a
  `friend` (the plan's choice) rather than a new accessor pair. It persists
  authored state only and lets the two per-frame caches rebuild on load; the
  test asserts round-trip fidelity by byte identity since fields aren't
  reachable.
- `std::pair` is **not** trivially copyable (it declares a copy-assignment
  operator), so `C_MidiSequence`'s message vector is written element-wise. The
  `writeTrivialVector` static_assert is what caught that.
- Schema versions still live on `SaveTrait<C>::kSaveVersion`, not the
  `// IRAsset: serialized` + `kSaveVersion` member pair `engine/asset/` records
  use — noted in `save_serialize_common.hpp` so the version-bump check isn't
  misapplied here.
- One behavior note worth flagging: the default registry now builds ~110
  entries per call instead of 4. It is built fresh per `saveWorld`/`loadWorld`
  (a one-shot load-time op, never a frame path), so this is a small constant
  cost on save/load only. `optimize` was not run — the diff touches no system
  tick, render stage, shader, or math hot path.

Closes #2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
