### PR TITLE
render: guard the light-volume global-buffer single-canvas assumption (#2341)

### DIFF
--- a/.fleet/plans/issue-2341.md
+++ b/.fleet/plans/issue-2341.md
@@ -1,0 +1,199 @@
+<!--
+Plan file for #2341 (per #1932 — committed as the first commit of the
+implementer's PR). This is the `## Plan` comment posted on issue #2341 on
+2026-07-20. Reproduced verbatim below; the issue thread is the canonical
+source.
+-->
+
+## Plan: light-volume global buffers go stale across canvases with 2+ populated C_CanvasLightVolume
+
+- **Issue:** #2341
+- **Model:** sonnet — the design judgment (option a vs b, guard location, the exact predicate, the positive-fire test shape) is resolved in this plan; implementation is a bounded, CPU-side diagnostic change (begin/endTick counters + one `IR_ASSERT` + a pure predicate + comments + a unit test). No shader, GPU-buffer, dispatch, or pipeline-state changes — render output stays byte-identical — so it does not carry opus-tier render judgment despite touching render system headers.
+- **Date:** 2026-07-20
+
+### Scope
+
+Pick **option (a)** from the acceptance criteria: make the load-bearing
+"single light-volume canvas" assumption of the spot-cone path **explicit and
+guarded**, rather than building the full per-canvas light-list/params storage
+(option b). The full fix is deferred — it should be filed as a follow-up only
+when a real multi-canvas-SPOT consumer exists to validate it against (today
+there are zero; see "Why (a), not (b)" below).
+
+The deliverable: a debug `IR_ASSERT` that fires the moment a scene threads
+per-canvas-**varying** spot data through the shared global buffers for 2+
+rendered light-volume canvases, plus a documenting comment at the consumer's
+global binds, plus a pure-CPU unit test that positively fires the guard.
+
+### Verified current state (mechanism confirmed against code, not asserted)
+
+Read both systems in full at current master (`5c53d2e5`). The staleness is real
+and exactly as the Opus recheck on PR #2337 described:
+
+- **Producer** `System<COMPUTE_LIGHT_VOLUME>::tick` (`system_compute_light_volume.hpp:375`)
+  runs **per canvas** and re-uploads the single global named buffers every
+  iteration: `lightSourceBuf_->subData(...)` (line 441) and
+  `paramsBuf_->subData(...)` (line 443). Both `LightSourceBuffer` (SSBO) and
+  `LightVolumeParamsBuffer` (UBO) are created once in `create()`
+  (lines 551–566) as **global** resources. `params_.worldOriginVoxel_.w` is the
+  per-canvas **has-SPOT** flag (line 422–423); `params_.lightCount_` and the
+  light list are per-canvas. After the system finishes all canvases, the globals
+  hold only the **last-processed** canvas's data.
+- The two systems are **not** interleaved — each pipeline system iterates all
+  its matched canvases before the next runs, so `COMPUTE_LIGHT_VOLUME` finishes
+  every canvas before `LIGHTING_TO_TRIXEL` starts.
+- **Consumer** `System<LIGHTING_TO_TRIXEL>::tick` (`system_lighting_to_trixel.hpp:145`)
+  binds each canvas's **own** volume texture (slot 5, line 208) and **own**
+  winning-light ID texture (image unit 7, line 213), but binds the **global**
+  `lightVolumeParamsBuf_` (line 226) and **global** `lightSourceBuf_` (line 231).
+  On the has-SPOT path it reads `worldOriginVoxel.w` and indexes `lights[winId-1]`
+  from those globals — i.e. from the last canvas's data, not the canvas being lit.
+- `.xyz` (`cameraAnchorVoxel()`) is canvas-invariant within a frame, so it was
+  always safe; `.w`/light-list are the **first** per-canvas-varying data threaded
+  through the globals (#2318), which is why the "last canvas wins" property only
+  became load-bearing then.
+- **No shipping scene hits it**: every creation attaches exactly one
+  `C_CanvasLightVolume` (on `mainCanvas`); the per-axis path shares the main
+  canvas's volume/params inside the main tick (`dispatchPerAxisLighting`, not a
+  separate `C_CanvasLightVolume` entity); and `main_per_canvas_scope.cpp` (#363)
+  is emissive-only with a **non-rendered** sentinel B canvas
+  (`useCameraPositionIso_ == false`, so `COMPUTE_LIGHT_VOLUME::tick` early-returns
+  at line 380 and never counts it). Worst case is a visual miss (spot → omni),
+  **never a crash** (`LightSourceBuffer` is always sized to 256).
+
+### Why (a), not (b)
+
+The Opus recheck (PR #2337, 2026-07-09) recommended **(a) a comment + `IR_ASSERT`**
+as the primary path and framed (b) per-canvas buffers as a heavier "tracked
+follow-up." Option (b) would add a ~20 KiB per-canvas `LightSourceBuffer` + a
+per-canvas params UBO on `C_CanvasLightVolume` and re-bind the canvas's own
+buffers in the consumer — real storage + code for a capability
+(multi-light-volume-canvas scenes with SPOT lights) that has **zero** current
+consumers, and whose only positive-fire acceptance test would be a synthetic
+new demo scene. Per engine convention (assert the load-bearing invariant; defer
+generalization until a real consumer exists), (a) is the proportionate fix: it
+converts a silent wrong-cone into a loud debug abort, and the abort message is
+the trigger to do (b) — validated against the actual scene that needs it — when
+one appears.
+
+### Approach
+
+Guard **in the producer** (`COMPUTE_LIGHT_VOLUME`), with a cross-referencing
+comment in the consumer. Deviation-with-rationale from the recheck's "assert in
+`LIGHTING_TO_TRIXEL`" phrasing: the per-canvas has-SPOT flag and the
+processed-canvas count are available **CPU-side only in the producer** (the
+consumer would have to read the flag back off the GPU UBO). Putting the assert
+in the producer lets the guard be **precise** (`!(2+ canvases && any spot)`)
+instead of the conservative "≤1 light-volume canvas" a consumer-side count would
+force — and the producer is the system that actually clobbers the shared buffers.
+
+1. **`system_compute_light_volume.hpp` — add a pure predicate** in the existing
+   `IRSystem::detail` namespace (alongside `gatherLightSources`, so the existing
+   isolated gtest can call it the same way):
+   ```cpp
+   // The consumer (LIGHTING_TO_TRIXEL) reads the has-SPOT gate + light list from
+   // the GLOBAL LightVolumeParamsBuffer / LightSourceBuffer, which this system
+   // overwrites per canvas — after the tick they hold only the LAST processed
+   // canvas's data. That is simultaneously correct for every processed canvas
+   // only while at most one light-volume canvas is processed, OR no processed
+   // canvas seeds a SPOT (the only per-canvas-VARYING field the consumer reads;
+   // .xyz is the camera anchor, identical for all canvases). Returns false when
+   // the globals cannot be correct for all processed canvases at once — 2+
+   // processed canvases AND at least one SPOT. Multi-canvas SPOT scenes need
+   // per-canvas storage (issue #2341 deferred option b).
+   inline bool lightVolumeGlobalBufferSafe(int processedLightVolumeCanvases,
+                                           bool anyCanvasSeededSpot) {
+       return !(processedLightVolumeCanvases >= 2 && anyCanvasSeededSpot);
+   }
+   ```
+2. **`system_compute_light_volume.hpp` — wire per-frame counters** on
+   `System<COMPUTE_LIGHT_VOLUME>` (registerSystem auto-wires begin/endTick when
+   defined; the system currently has neither):
+   - Add members `int processedLightVolumeCanvases_ = 0;` and
+     `bool anyCanvasSeededSpot_ = false;`.
+   - Add `void beginTick() { processedLightVolumeCanvases_ = 0; anyCanvasSeededSpot_ = false; }`.
+   - In `tick`, **after** the `if (!behavior.useCameraPositionIso_) return;`
+     early-return (line 380–381) so non-rendered canvases like #363's sentinel B
+     are not counted: `++processedLightVolumeCanvases_;` and, inside/after the
+     upload block where the local `hasSpot` is computed (line 409–418),
+     `anyCanvasSeededSpot_ |= hasSpot;`.
+   - Add `void endTick()` with the guard:
+     ```cpp
+     IR_ASSERT(
+         detail::lightVolumeGlobalBufferSafe(processedLightVolumeCanvases_, anyCanvasSeededSpot_),
+         "COMPUTE_LIGHT_VOLUME: global LightSourceBuffer/LightVolumeParams hold only the "
+         "last processed canvas's spot data; a scene with 2+ rendered C_CanvasLightVolume "
+         "canvases where any seeds a SPOT renders wrong/omni cones (issue #2341). Make the "
+         "light list / has-SPOT per-canvas (option b) to lift this assumption."
+     );
+     ```
+3. **`system_lighting_to_trixel.hpp` — documenting comment only** (no code
+   change) at the two global binds (lines 226 and 231): note the params/light-list
+   buffers are per-frame-correct only for the last-processed light-volume canvas,
+   so the spot-cone read here relies on the single-light-volume-canvas assumption
+   guarded in `COMPUTE_LIGHT_VOLUME::endTick`; multi-canvas + SPOT needs per-canvas
+   storage (#2341 option b).
+4. **`test/render/per_canvas_light_scope_test.cpp` — positive-fire unit test**
+   (existing gtest, runs without a RenderManager): assert the predicate.
+
+### Affected files
+
+- `engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp` — new
+  `detail::lightVolumeGlobalBufferSafe` predicate; `beginTick`/`endTick` +
+  two counter members on `System<COMPUTE_LIGHT_VOLUME>`; count/`|= hasSpot` in `tick`.
+- `engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp` —
+  documenting comment at the global `lightVolumeParamsBuf_`/`lightSourceBuf_`
+  binds (no logic change).
+- `test/render/per_canvas_light_scope_test.cpp` — new gtest cases for the predicate.
+
+### Cross-system audit (consumers of the shared global buffers)
+
+The change documents/guards the shared global `LightSourceBuffer` +
+`LightVolumeParamsBuffer`; it does not alter their layout or bindings, so no
+consumer needs migration. For completeness, the CPU-side readers/binders:
+- `COMPUTE_LIGHT_VOLUME` — owner; binds both for its own clear/seed/propagate
+  dispatch (one canvas at a time — internally consistent).
+- `LIGHTING_TO_TRIXEL` — the affected consumer; binds both globally (lines 226,
+  231) and reads them on the has-SPOT path. This is the sole read-site that is
+  per-canvas-incorrect, and the target of the documenting comment.
+No shader `binding=`/slot changes — `kBufferIndex_LightSourceBuffer` and
+`kBufferIndex_LightVolumeParams` are untouched.
+
+### Acceptance criteria
+
+Positive-fire (the guard observably trips with the unsafe condition), with
+positive controls — mirrors the isolated-gather test style already in the file,
+no GPU/RenderManager, no death test:
+- `EXPECT_FALSE(IRSystem::detail::lightVolumeGlobalBufferSafe(2, /*anySpot=*/true))`
+  — **the positive fire**: 2 canvases + a spot ⇒ guard trips.
+- `EXPECT_FALSE(... lightVolumeGlobalBufferSafe(3, true))`.
+- Positive controls (guard must NOT trip on currently-correct configs):
+  `EXPECT_TRUE(... lightVolumeGlobalBufferSafe(1, true))` (single canvas, spot ok),
+  `EXPECT_TRUE(... lightVolumeGlobalBufferSafe(2, false))` (multi canvas, no spot — correct today),
+  `EXPECT_TRUE(... lightVolumeGlobalBufferSafe(0, false))`.
+- Build is clean and the existing `per_canvas_light_scope_test` suite stays green
+  (`IRShapeDebug` builds; no render-verify needed — output is byte-identical, the
+  change is a debug assert + comments).
+
+### Gotchas
+
+- **Count after the early-return.** The `++processedLightVolumeCanvases_` must
+  land *after* `if (!behavior.useCameraPositionIso_) return;` — otherwise #363's
+  non-rendered sentinel B canvas counts and the assert false-fires on an existing
+  demo.
+- **Predicate is intentionally conservative on one exotic case.** Two canvases
+  that both carry the *same* world-scope spot upload identical lists and are
+  technically correct, yet the predicate returns false. That is acceptable: the
+  config is exotic, the abort is debug-only (`IR_ASSERT` is stripped under
+  `IR_RELEASE`), and the message tells the author to verify or move to option (b).
+- **`IR_ASSERT` is debug-only** (`engine/profile/include/irreden/ir_profile.hpp`;
+  stripped in `IR_RELEASE`). That is fine — this is a developer-misuse guard, not
+  a runtime fallback; release builds keep the existing benign omni-fallback.
+- **Do NOT build option (b) here.** If a real multi-canvas-SPOT scene is needed
+  later, file a follow-up per TASK-FILING.md to make the light list/has-SPOT
+  per-canvas (per-canvas SSBO/UBO on `C_CanvasLightVolume`, re-bound by the
+  consumer) — validated against that scene. This task is the guard only.
+- **No `simplify` "dead assert" flag:** the `endTick` assert references
+  `detail::lightVolumeGlobalBufferSafe`, keeping the predicate live even though
+  the guard is never expected to fire in shipping scenes.
+

--- a/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
@@ -335,6 +335,21 @@ inline std::uint32_t gatherLightSources(
     return static_cast<std::uint32_t>(out.size());
 }
 
+// The consumer (LIGHTING_TO_TRIXEL) reads the has-SPOT gate + light list from
+// the GLOBAL LightVolumeParamsBuffer / LightSourceBuffer, which this system
+// overwrites per canvas — after the tick they hold only the LAST processed
+// canvas's data. That is simultaneously correct for every processed canvas
+// only while at most one light-volume canvas is processed, OR no processed
+// canvas seeds a SPOT (the only per-canvas-VARYING field the consumer reads;
+// .xyz is the camera anchor, identical for all canvases). Returns false when
+// the globals cannot be correct for all processed canvases at once — 2+
+// processed canvases AND at least one SPOT. Multi-canvas SPOT scenes need
+// per-canvas storage (issue #2341 deferred option b).
+inline bool
+lightVolumeGlobalBufferSafe(int processedLightVolumeCanvases, bool anyCanvasSeededSpot) {
+    return !(processedLightVolumeCanvases >= 2 && anyCanvasSeededSpot);
+}
+
 } // namespace detail
 
 // `LightVolumeParams` defaults must mirror the volume's CPU constants —
@@ -371,6 +386,34 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
     // budget defaults to today's behavior if a frame ever dispatches
     // the loop without first running the upload phase.
     int propagateIterations_ = kLightVolumePropagateIterations;
+    // Per-frame tally backing the endTick global-buffer guard (#2341). Counts
+    // only canvases this system actually PROCESSES, since a canvas that takes
+    // the `useCameraPositionIso_` early-return never clobbers the shared
+    // buffers.
+    int processedLightVolumeCanvases_ = 0;
+    bool anyCanvasSeededSpot_ = false;
+
+    void beginTick() {
+        processedLightVolumeCanvases_ = 0;
+        anyCanvasSeededSpot_ = false;
+    }
+
+    // The shared LightSourceBuffer / LightVolumeParamsBuffer this tick
+    // overwrote per canvas are read back by LIGHTING_TO_TRIXEL as if they
+    // described the canvas it is lighting. Assert the assumption that makes
+    // that sound — see `detail::lightVolumeGlobalBufferSafe`.
+    void endTick() {
+        IR_ASSERT(
+            detail::lightVolumeGlobalBufferSafe(
+                processedLightVolumeCanvases_,
+                anyCanvasSeededSpot_
+            ),
+            "COMPUTE_LIGHT_VOLUME: global LightSourceBuffer/LightVolumeParams hold only the "
+            "last processed canvas's spot data; a scene with 2+ rendered C_CanvasLightVolume "
+            "canvases where any seeds a SPOT renders wrong/omni cones (issue #2341). Make the "
+            "light list / has-SPOT per-canvas (option b) to lift this assumption."
+        );
+    }
 
     void tick(
         IREntity::EntityId canvasEntity,
@@ -379,6 +422,13 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
     ) {
         if (!behavior.useCameraPositionIso_)
             return;
+        // Counted only past the early-return — a skipped canvas never reaches
+        // the uploads that clobber the shared buffers. The count DOES include
+        // #363's sentinel canvas B: `C_TrixelCanvasRenderBehavior`'s default
+        // ctor sets `useCameraPositionIso_ = true`, so that scene legitimately
+        // reaches 2 processed canvases and stays under the guard by seeding no
+        // SPOT, not by skipping the sentinel.
+        ++processedLightVolumeCanvases_;
         IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
         auto &phaseTiming = IRRender::computeLightVolumeTiming();
 
@@ -416,6 +466,7 @@ template <> struct System<COMPUTE_LIGHT_VOLUME> {
                 hasSpot,
                 &lightGatherRecords_
             );
+            anyCanvasSeededSpot_ |= hasSpot;
             // worldOriginVoxel_.w carries the has-SPOT flag (#2318): the
             // consumer skips the winning-light-ID read entirely when 0, so
             // no-spot scenes stay byte-identical.

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -235,6 +235,15 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                 kBufferIndex_FrameDataVoxelToCanvas
             );
             sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
+            // The two light-volume buffers are GLOBAL, not per-canvas:
+            // COMPUTE_LIGHT_VOLUME re-uploads them once per canvas, so by the time
+            // this system runs they hold only the LAST processed canvas's has-SPOT
+            // gate (`worldOriginVoxel.w`) and light list. The spot-cone read here
+            // therefore assumes at most one rendered C_CanvasLightVolume canvas
+            // seeds a SPOT — guarded in COMPUTE_LIGHT_VOLUME::endTick via
+            // `detail::lightVolumeGlobalBufferSafe` (#2341). `.xyz` is the camera
+            // anchor, identical for every canvas in a frame, so it was always safe.
+            // Multi-canvas + SPOT needs per-canvas storage (#2341 option b).
             lightVolumeParamsBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_LightVolumeParams);
             // Light list (SSBO slot 4) for the spot-cone factor (#2318). SSBO and
             // image bindings are independent namespaces on both backends, so slot 4

--- a/test/render/per_canvas_light_scope_test.cpp
+++ b/test/render/per_canvas_light_scope_test.cpp
@@ -320,3 +320,32 @@ TEST_F(PerCanvasLightScopeTest, GatherSpotFlagsHasSpotAndCarriesTrueOrigin) {
     // Type lane still encodes SPOT for the consumer's branch.
     EXPECT_EQ(static_cast<int>(out[0].originAndType_.w), static_cast<int>(LightType::SPOT));
 }
+
+// #2341: COMPUTE_LIGHT_VOLUME re-uploads the GLOBAL LightSourceBuffer /
+// LightVolumeParamsBuffer per canvas, so after its tick they describe only the
+// last processed canvas — while LIGHTING_TO_TRIXEL reads them per canvas. The
+// endTick guard trips exactly when that cannot be simultaneously correct.
+// Pure predicate: no RenderManager, no GPU, no death test.
+TEST(LightVolumeGlobalBufferGuardTest, TripsForMultiCanvasWithSpot) {
+    // The positive fire — 2+ processed canvases and some canvas seeded a SPOT
+    // means the per-canvas-varying has-SPOT gate / light list is already lost.
+    EXPECT_FALSE(IRSystem::detail::lightVolumeGlobalBufferSafe(2, /*anySpot=*/true));
+    EXPECT_FALSE(IRSystem::detail::lightVolumeGlobalBufferSafe(3, /*anySpot=*/true));
+}
+
+TEST(LightVolumeGlobalBufferGuardTest, PermitsConfigurationsCorrectToday) {
+    // Positive controls — the guard must stay silent on every config that
+    // renders correctly today, or it would abort shipping scenes.
+    // Single canvas: the globals ARE that canvas's data, spot or not.
+    EXPECT_TRUE(IRSystem::detail::lightVolumeGlobalBufferSafe(1, /*anySpot=*/true));
+    // Multi-canvas without a spot: the consumer's has-SPOT gate reads 0 for
+    // every canvas, so the stale light list is never indexed. This is the
+    // case that keeps #363's two-canvas `lighting_per_canvas_scope` demo
+    // silent — its sentinel canvas B IS processed and counted (the default
+    // C_TrixelCanvasRenderBehavior sets useCameraPositionIso_ = true), but
+    // the scene is emissive-only.
+    EXPECT_TRUE(IRSystem::detail::lightVolumeGlobalBufferSafe(2, /*anySpot=*/false));
+    // No processed light-volume canvas at all (every candidate canvas took
+    // the useCameraPositionIso_ early-return).
+    EXPECT_TRUE(IRSystem::detail::lightVolumeGlobalBufferSafe(0, /*anySpot=*/false));
+}


### PR DESCRIPTION
## Summary
- `COMPUTE_LIGHT_VOLUME` re-uploads the shared `LightSourceBuffer` / `LightVolumeParamsBuffer` **per canvas**, so after its tick they describe only the last-processed canvas. `LIGHTING_TO_TRIXEL` reads the has-SPOT gate and `lights[winId-1]` from those globals **per canvas** — so 2+ rendered `C_CanvasLightVolume` canvases where any seeds a SPOT light the non-last canvases from the wrong data (wrong cone axis/aperture, or spot → omni).
- Implements **option (a)** from the issue (the plan's choice): make the load-bearing assumption explicit and loud, rather than build per-canvas storage for a capability with zero current consumers.
- Adds `detail::lightVolumeGlobalBufferSafe(processedCanvases, anySpot)` (pure predicate), per-frame counters wired via `beginTick`/`endTick`, and an `IR_ASSERT` whose message names the fix. Guard lives in the **producer** because the has-SPOT flag and processed-canvas count exist CPU-side only there.
- Documenting comment at `LIGHTING_TO_TRIXEL`'s global light-volume binds, cross-referencing the guard.

**Render output is byte-identical** — no shader, GPU-buffer, dispatch, or pipeline-state change; `IR_ASSERT` is stripped under `IR_RELEASE`. Hence no screenshots / `render-verify` (a before/after capture would be identical by construction), and `optimize` was skipped: the per-frame cost is one `int` increment plus one bool OR on an O(canvases ≤ 3) loop already dominated by its GPU dispatch chain.

## Correction to the plan's premise (worth a reviewer's eye)
The plan's "Verified current state" asserts #363's `main_per_canvas_scope.cpp` sentinel canvas B is *not counted* because `useCameraPositionIso_ == false`. **That is wrong** — `C_TrixelCanvasRenderBehavior`'s default ctor sets `useCameraPositionIso_ = true`, so that scene genuinely reaches **2 processed canvases**. It stays under the guard because it is emissive-only (`anySpot = false`), not because the sentinel is skipped. Behavior is unchanged either way, but the comments now state the real mechanism, and the demo is one SPOT light away from legitimately tripping the guard — which is the intended semantics.

## Test plan
- [x] `IrredenEngineTest` — full suite green (**1363/1363**), including 2 new `LightVolumeGlobalBufferGuardTest` cases: the positive fire (`(2,true)`, `(3,true)` → false) plus positive controls (`(1,true)`, `(2,false)`, `(0,false)` → true) so the guard can't abort a config that renders correctly today.
- [x] `IRShapeDebug` builds clean.
- [x] `IRLightingPerCanvasScope` (the 2-canvas #363 scene) `--auto-screenshot` → `exit=0`, clean shutdown, **no assert**.
- [x] `IRLightingSpot` (single canvas + SPOT) `--auto-screenshot` → `exit=0`, **no assert**.
- [x] **Positive control that the guard is actually live** (a passing pure-predicate test alone proves nothing about wiring): temporarily relaxed the predicate to fire on canvas count alone, rebuilt, and `IRLightingPerCanvasScope` aborted with the #2341 message (`exit=134`) — proving `endTick` is wired by `registerSystem` and the counter really reaches 2. Reverted; the demo returns to `exit=0` with zero asserts.

## Acceptance evidence
Criteria from `.fleet/plans/issue-2341.md` § "Acceptance criteria" (committed as this PR's first commit). Every check below was re-run on the **final tree** at `b1e448f0`, macOS/Metal host — not transcribed from an earlier iteration.

| Criterion | Check run | Observed |
|---|---|---|
| `EXPECT_FALSE(lightVolumeGlobalBufferSafe(2, /*anySpot=*/true))` — **the positive fire** | `./build/IrredenEngineTest --gtest_filter='LightVolumeGlobalBufferGuardTest*'` (assertion at `test/render/per_canvas_light_scope_test.cpp:332`) | `[ OK ] LightVolumeGlobalBufferGuardTest.TripsForMultiCanvasWithSpot (0 ms)` — predicate returned `false`, i.e. the guard trips |
| `EXPECT_FALSE(lightVolumeGlobalBufferSafe(3, true))` | same case, assertion at `per_canvas_light_scope_test.cpp:333` | same `[ OK ]` line — both `EXPECT_FALSE`s in the case held |
| `EXPECT_TRUE(lightVolumeGlobalBufferSafe(1, true))` — single canvas + spot stays silent | same command (assertion at `per_canvas_light_scope_test.cpp:340`) | `[ OK ] LightVolumeGlobalBufferGuardTest.PermitsConfigurationsCorrectToday (0 ms)` |
| `EXPECT_TRUE(lightVolumeGlobalBufferSafe(2, false))` — #363's emissive-only 2-canvas scene stays silent | same case, assertion at `per_canvas_light_scope_test.cpp:347` | same `[ OK ]` line |
| `EXPECT_TRUE(lightVolumeGlobalBufferSafe(0, false))` | same case, assertion at `per_canvas_light_scope_test.cpp:350` | same `[ OK ]` line |
| Build clean; `per_canvas_light_scope_test` suite stays green; `IRShapeDebug` builds; no render-verify needed | `fleet-build --target IrredenEngineTest`; `./build/IrredenEngineTest`; `./build/IrredenEngineTest --gtest_filter='*PerCanvasLight*:*LightVolume*'`; `fleet-build --target IRShapeDebug` | `[100%] Built target IrredenEngineTest` / `[100%] Built target IRShapeDebug`, no diff-attributable warnings; `1363 tests from 244 test suites ran. [ PASSED ] 1363 tests.`; the test file's two suites → `10 tests from 2 test suites ran. [ PASSED ] 10 tests.` No render-verify: the diff is a debug-only `IR_ASSERT` + counters + comments, so a before/after capture is identical by construction |

All six criteria met. The one criterion the predicate tests cannot cover on their own — that `endTick` is actually wired and the counter reaches 2 — is discharged by the live-abort probe in the Test plan above (relax predicate → `exit=134` with the #2341 message → revert → `exit=0`).

## Note for the reviewer
Not applied, to stay inside the plan's 3-file scope: `engine/prefabs/irreden/render/CLAUDE.md` has no §Gotchas entry for "at most one rendered `C_CanvasLightVolume` canvas may seed a SPOT". The assert message is self-documenting, so I reported rather than expanded scope — happy to add a one-liner if you'd prefer it documented there.

Closes #2341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
