### PR TITLE
engine/system: give SystemId its own unreachable miss sentinel (#2540)

### DIFF
--- a/.fleet/plans/issue-2540.md
+++ b/.fleet/plans/issue-2540.md
@@ -1,0 +1,86 @@
+## Plan: engine/system: SystemId 0 collides with the kNullEntity 'no such system' sentinel
+
+- **Issue:** #2540
+- **Model:** opus — bounded and fully enumerated below, but it edits ECS system-core types, changes the public `ir_system.hpp` miss-value contract, and likely stacks on an open PR; not sonnet-mechanical.
+- **Date:** 2026-07-25
+
+### Verified current state
+
+All claims below re-verified this session by reading the code (file:line cited against the tree named in each item).
+
+- `SystemId` is `EntityId` (`std::uint64_t`) — `engine/system/include/irreden/system/ir_system_types.hpp:10`; `kNullEntity = 0` — `engine/entity/include/irreden/entity/ir_entity_types.hpp:34`; `m_nextSystemId = 0` handed out with `m_nextSystemId++` — `system_manager.hpp:325`, `system_manager.cpp:58`. So the first system registered in a process gets id `0 == kNullEntity`, exactly as the issue states.
+- **The entire fix surface lives on PR #2529** (`claude/2526-systemname-registry`, approved, unmerged at plan time). `findSystem` / `findEngineSystem` / `recordEngineSystemId` and both prefab-handle resolvers do **not** exist on master (`git grep findSystem origin/master` is empty). `findEngineSystem`'s own doc comment on that branch already cites #2540 as the fix for this caveat.
+- **`SystemId` is a dense index** into parallel vectors: `m_systemNames[id]`, `m_ticks[system]`, `m_timingAccum[id]`, plus the access/cadence/params vectors kept in lockstep by `createSystem`/`createSystemDynamic` (`system_manager.hpp:296,179,302`; the ctor range-for resets `m_timingAccum` wholesale). `getSystemCount()` returns `m_nextSystemId` and there is a range assert `system < m_nextSystemId` (`system_manager.cpp:221`). This is why option 1 (reserve id 0) is rejected — see Approach.
+- **Exhaustive sentinel-compare audit** (branch `claude/2526-systemname-registry`, whole tree greps on `findSystem`, `SystemId.*kNullEntity`, and `SystemId x = 0` forms). Sites where a `SystemId` participates in a `kNullEntity`/zero sentinel convention:
+  1. `engine/system/include/irreden/system/system_manager.hpp:342` — `findEngineSystem` miss return.
+  2. `engine/system/include/irreden/ir_system.hpp:468` — `findSystem` null-manager return.
+  3. `engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp:311` — `IRPrefab::VoxelTransform::allocator()` compare.
+  4. `engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp:420` — `IRPrefab::JointTransform::system()` compare.
+  5. `engine/prefabs/irreden/render/systems/system_debug_culling_minimap.hpp:229,230,242,243` (member + params-struct defaults) and `:352,385` (compares) — "unwired" sentinel on `SystemId` members.
+  6. `creations/demos/lua_widgets/main_lua.cpp:57` — `g_dispatchId = kNullEntity` default (assigned at :204, passed at :230, never compared).
+  7. `creations/demos/scene_reset/main.cpp:93-97` — five `SystemId … = 0;` defaults (all unconditionally assigned at :147-152 before use, never compared).
+  8. `creations/demos/lighting/common/lighting_demo_scene.hpp:163,168` — `{}`-value-initialized `SystemId` globals (assigned during scene setup at :583,:588 before the reads at :492/:623-624).
+  9. `test/system/register_system_test.cpp:174,187` — `EXPECT_EQ(findSystem(...), IREntity::kNullEntity)` miss expectations.
+  All other `kNullEntity` comparisons under `engine/` and `creations/` are `EntityId`-typed (modifier resolve, hover detect, canvas/camera/fog/gizmo entities — checked) and are out of scope.
+- **Lua boundary**: `SystemId`s cross into Lua as `lua_Integer` (`IRSystem.registerSystem` return, `IRSystem.systemId(name)`), but the Lua-side miss contract is **raise a Lua error**, not return-a-sentinel (`engine/script/CLAUDE.md:810-813`). No Lua code compares against a numeric sentinel, so the new sentinel never needs to cross the boundary.
+
+No phase-0 probe is needed: every premise above is a static structural fact verified by reading the source, not a runtime mechanism claim.
+
+### Scope
+
+Give `SystemId` its own "no such system" sentinel that no real id can ever equal, migrate every enumerated sentinel site to it, and remove the first-system-is-indistinguishable caveat from `findSystem`. One task, one PR; no split.
+
+### Approach
+
+**Committed approach: option 2 — a dedicated `kNullSystemId`, value `std::numeric_limits<SystemId>::max()`.**
+
+Why not the alternatives:
+- *Option 1 (start `m_nextSystemId` at 1)*: fights the id-as-dense-index invariant. Either every parallel vector needs a phantom slot 0 (corrupting `getSystemCount()` and every whole-vector range-for), or every index site needs a `-1` shift. Larger blast radius and a permanent invariant tax for zero extra benefit.
+- *Option 3 (`std::optional<SystemId>` return)*: changes the call-site shape of a query API, breaks the established sentinel idiom (`kNullEntity`, `kVoxelTransformStatic`), and cannot express the "unwired" default on stored `SystemId` members (audit items 5–8) without wider churn.
+
+`max()` as the value has a robustness bonus: an accidental deref of the sentinel (e.g. `m_ticks[kNullSystemId]`) now trips the existing `system < m_nextSystemId` range assert loudly in debug instead of silently reading slot 0.
+
+Steps, in order:
+
+1. **Base resolution.** If PR #2529 has merged, branch from `origin/master` normally. If it is still open, claim with `--stackable-on 2529` and branch from `origin/claude/2526-systemname-registry`'s head — every file below refers to the post-#2529 tree. If #2529 merges mid-implementation, `git rebase --onto origin/master <fork-point>` per the inherited-prefix drop.
+2. **Define the sentinel** in `engine/system/include/irreden/system/ir_system_types.hpp`, directly after `using SystemId = EntityId;`:
+   `constexpr SystemId kNullSystemId = std::numeric_limits<SystemId>::max();`
+   (add `#include <limits>`). Doc comment: why it is not `kNullEntity` (id 0 is a valid `SystemId` — the first system registered), and that it must never cross the Lua boundary (see Gotchas).
+3. **Migrate the miss returns**: `findEngineSystem` (`system_manager.hpp:342`) and `findSystem`'s null-manager arm (`ir_system.hpp:468`). Delete `findEngineSystem`'s caveat paragraph (it cites #2540 as this fix) and update both doc comments.
+4. **Migrate the compares and defaults**: audit items 3–8 above — the two prefab-handle resolvers, the four minimap defaults + two compares, `g_dispatchId`, the five `scene_reset` zero-defaults, and the two `lighting_demo_scene` `{}`-inits. Items 6–8 are never compared today (proven above), but migrating the defaults makes "not yet assigned" loud (range assert) instead of silently aliasing slot 0, and leaves the tree with a single convention.
+5. **Update tests** (`test/system/register_system_test.cpp`): swap the `:174`/`:187` miss expectations to `kNullSystemId`, and add the positive-fire regression test (Acceptance criteria).
+6. **Update docs**: `engine/system/CLAUDE.md` §`findSystem` (`:103` miss value, `:119` caveat bullet — replace with a pointer to `kNullSystemId`). Check `engine/prefabs/irreden/render/CLAUDE.md:625-626` migration-table rows at impl time — they name the resolution path but not the sentinel value, so likely no edit. Do **not** edit `.fleet/plans/issue-2526.md` (historical record).
+7. **Sweep gate**: `git grep -nE "kNullEntity" -- engine/system engine/prefabs creations test | grep -i system` must come back empty of `SystemId`-typed hits before the PR opens.
+
+### Affected files
+
+- `engine/system/include/irreden/system/ir_system_types.hpp` — add `kNullSystemId` + `<limits>` include + doc comment
+- `engine/system/include/irreden/system/system_manager.hpp` — `findEngineSystem` miss return; drop the caveat paragraph
+- `engine/system/include/irreden/ir_system.hpp` — `findSystem` null-manager return; doc comment
+- `engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp` — `allocator()` compare + doc
+- `engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp` — `system()` compare + doc
+- `engine/prefabs/irreden/render/systems/system_debug_culling_minimap.hpp` — 4 defaults + 2 compares
+- `creations/demos/lua_widgets/main_lua.cpp` — `g_dispatchId` default
+- `creations/demos/scene_reset/main.cpp` — 5 zero-defaults
+- `creations/demos/lighting/common/lighting_demo_scene.hpp` — 2 `{}`-init globals
+- `test/system/register_system_test.cpp` — 2 expectation swaps + 1 new test
+- `engine/system/CLAUDE.md` — miss value + caveat bullet
+
+### Acceptance criteria
+
+- **Positive-fire regression test** (new, in `register_system_test.cpp`): in a fresh fixture, create `TEST_REGISTER_SYSTEM_A` as the **first** system and never create `TEST_REGISTER_SYSTEM_B`. Assert:
+  - `ASSERT_EQ(sysA, 0u)` — documents that the collision premise (first id is 0) still holds; if `SystemManager` ever pre-registers systems this flags the premise change;
+  - `EXPECT_EQ(IRSystem::findSystem(TEST_REGISTER_SYSTEM_A), sysA)`;
+  - `EXPECT_NE(IRSystem::findSystem(TEST_REGISTER_SYSTEM_A), IRSystem::findSystem(TEST_REGISTER_SYSTEM_B))` — **fails before this fix** (both sides are 0) and passes after: the observable "registered-first vs never-registered are distinguishable" check.
+- Updated miss expectations: `FindSystemReportsANameThatWasNeverCreated` and `FindSystemNoManagerTest` expect `kNullSystemId`; the latter (plus the headless `voxel_bone_slot_seed_test` path) proves the handles' "unwired → nullptr" behavior is preserved.
+- `IrredenEngineTest` green; `fleet-build --target IRShapeDebug` green (compiles the touched prefab headers + shape_debug); the touched demos (`scene_reset`, `lua_widgets`, lighting demos) still build.
+- The step-7 sweep gate returns no `SystemId`-typed `kNullEntity` hits.
+
+### Gotchas
+
+- **Never pass `kNullSystemId` across the Lua boundary.** LuaJIT numbers are doubles; `2^64-1` is not exactly representable. The Lua miss contract is already "raise a Lua error" (`IRSystem.systemId`) — keep it that way; the sentinel stays C++-side.
+- **`IR_RELEASE` strips `IR_ASSERT`**, so an unguarded `getSystemParams(kNullSystemId)` in release is an out-of-bounds vector read. Same failure class as today's silent slot-0 read, not worse — but always sentinel-check before indexing (every migrated site already does).
+- **`recordEngineSystemId` double-report is legitimate** (nested `createSystem<N>` → `System<N>::create()` → `registerSystem<N,...>` both record the same id) — do not "fix" the try_emplace/assert dance while in there.
+- The two current handle consumers degrade gracefully on a false miss, so nothing visual changes in any demo — this is a correctness fix with test-level evidence only; no screenshots or render-verify needed.
+- If stacked on #2529 and it merges during review, strip any stale `Stacked on:` line from the PR body after the `--onto` drop.
+

--- a/creations/demos/lighting/common/lighting_demo_scene.hpp
+++ b/creations/demos/lighting/common/lighting_demo_scene.hpp
@@ -160,12 +160,12 @@ inline bool g_cliDisableAO = false;
 // (`IRSystem::lightGatherRecords`) — the system stores that state on
 // itself (`engine/system/CLAUDE.md` "System-owned state"), not in a
 // globally-queryable component.
-inline IRSystem::SystemId g_computeLightVolumeSystemId{};
+inline IRSystem::SystemId g_computeLightVolumeSystemId = IRSystem::kNullSystemId;
 // BAKE_SUN_SHADOW_MAP SystemId (#2316, V2) — the culling minimap's caster
 // domain reads world-placed casters back via
 // `IRSystem::worldPlacedCasters(g_bakeSunShadowMapSystemId)`, mirroring
 // `g_computeLightVolumeSystemId` above.
-inline IRSystem::SystemId g_bakeSunShadowMapSystemId{};
+inline IRSystem::SystemId g_bakeSunShadowMapSystemId = IRSystem::kNullSystemId;
 // The shot table actually wired into AutoScreenshotConfig this run (kShots or
 // one of the runtime-built series: --light-boundary-sweep,
 // --light-domain-matrix, --hover-sweep) — the DOMAIN-STATE hook only receives

--- a/creations/demos/lua_widgets/main_lua.cpp
+++ b/creations/demos/lua_widgets/main_lua.cpp
@@ -54,7 +54,7 @@ namespace IRLuaWidgets {
 // The single WIDGET_LUA_DISPATCH instance, registered as a prefab system in
 // the Lua-binding callback (so the binding resolves the SAME instance the
 // INPUT pipeline ticks) and inserted into the pipeline in initSystems().
-IRSystem::SystemId g_dispatchId = IREntity::kNullEntity;
+IRSystem::SystemId g_dispatchId = IRSystem::kNullSystemId;
 
 // Widget ids, published from main.lua via IRTest.setButtons once built.
 IREntity::EntityId g_onClickButton = IREntity::kNullEntity;

--- a/creations/demos/scene_reset/main.cpp
+++ b/creations/demos/scene_reset/main.cpp
@@ -90,11 +90,11 @@ int g_baselineWaterline = 0;
 // they persist across resetGameplay and never count toward getLiveEntityCount;
 // re-calling createSystem each cycle would slowly grow those arrays for nothing.
 struct SceneSystems {
-    IRSystem::SystemId lodUpdate_ = 0;
-    IRSystem::SystemId propagateTransform_ = 0;
-    IRSystem::SystemId updateVoxelSetChildren_ = 0;
-    IRSystem::SystemId rebuildGridVoxels_ = 0;
-    IRSystem::SystemId squashStretch_ = 0;
+    IRSystem::SystemId lodUpdate_ = IRSystem::kNullSystemId;
+    IRSystem::SystemId propagateTransform_ = IRSystem::kNullSystemId;
+    IRSystem::SystemId updateVoxelSetChildren_ = IRSystem::kNullSystemId;
+    IRSystem::SystemId rebuildGridVoxels_ = IRSystem::kNullSystemId;
+    IRSystem::SystemId squashStretch_ = IRSystem::kNullSystemId;
 };
 SceneSystems g_systems;
 

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -623,8 +623,8 @@ void initSystems() {
     // BAKE_SUN_SHADOW_MAP::create() depends on a named resource
     // RESOLVE_PER_AXIS_SCREEN_DEPTH::create() creates earlier in this same
     // list; calling create() early breaks that ordering.
-    IRSystem::SystemId bakeSunShadowMapId{};
-    IRSystem::SystemId computeLightVolumeId{};
+    IRSystem::SystemId bakeSunShadowMapId = IRSystem::kNullSystemId;
+    IRSystem::SystemId computeLightVolumeId = IRSystem::kNullSystemId;
     renderPipeline.insert(
         renderPipeline.end(),
         {

--- a/engine/prefabs/irreden/render/systems/system_debug_culling_minimap.hpp
+++ b/engine/prefabs/irreden/render/systems/system_debug_culling_minimap.hpp
@@ -223,11 +223,11 @@ template <> struct System<DEBUG_CULLING_MINIMAP> {
     float padding_ = 10.0f;
 
     // Light + caster domain sources (#2316, V2) — settable via create(Params).
-    // Optional: kNullEntity means "not wired", so a demo with no lighting
+    // Optional: kNullSystemId means "not wired", so a demo with no lighting
     // pipeline (e.g. the default demo) just gets the shape domain, no
     // spurious empty-window rectangle.
-    IRSystem::SystemId lightVolumeSystemId_ = IREntity::kNullEntity;
-    IRSystem::SystemId bakeSunShadowSystemId_ = IREntity::kNullEntity;
+    IRSystem::SystemId lightVolumeSystemId_ = IRSystem::kNullSystemId;
+    IRSystem::SystemId bakeSunShadowSystemId_ = IRSystem::kNullSystemId;
 
     // Per-frame scratch buffers (reused across ticks).
     std::vector<detail::EntityRecord> entityRecords_;
@@ -239,8 +239,8 @@ template <> struct System<DEBUG_CULLING_MINIMAP> {
         float screenWidthFraction_ = 0.15f;
         float aspectRatio_ = 12.0f / 7.0f;
         float padding_ = 10.0f;
-        IRSystem::SystemId lightVolumeSystemId_ = IREntity::kNullEntity;
-        IRSystem::SystemId bakeSunShadowSystemId_ = IREntity::kNullEntity;
+        IRSystem::SystemId lightVolumeSystemId_ = IRSystem::kNullSystemId;
+        IRSystem::SystemId bakeSunShadowSystemId_ = IRSystem::kNullSystemId;
     };
 
     void tick(
@@ -349,7 +349,7 @@ template <> struct System<DEBUG_CULLING_MINIMAP> {
         // Light domain (#2316, V2): gather-state-colored dots + the pinned
         // light-volume window rectangle. Skipped when this instance wasn't
         // wired to a COMPUTE_LIGHT_VOLUME system.
-        if (lightVolumeSystemId_ != IREntity::kNullEntity) {
+        if (lightVolumeSystemId_ != IRSystem::kNullSystemId) {
             const auto &lightRecords = IRSystem::lightGatherRecords(lightVolumeSystemId_);
             detail::drawLightDots(
                 lightRecords,
@@ -382,7 +382,7 @@ template <> struct System<DEBUG_CULLING_MINIMAP> {
         // Caster domain (#2316, V2): world-placed casters as squares +
         // the shadow-feeder AABB rectangle they're tested against. Skipped
         // when this instance wasn't wired to a BAKE_SUN_SHADOW_MAP system.
-        if (bakeSunShadowSystemId_ != IREntity::kNullEntity) {
+        if (bakeSunShadowSystemId_ != IRSystem::kNullSystemId) {
             const auto shadowFeederParams = IRPrefab::SunShadow::frameShadowFeederParams();
             const IsoBounds2D feederViewport =
                 IRPrefab::SunShadow::shadowFeederCullViewport(0, shadowFeederParams);

--- a/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
@@ -417,7 +417,7 @@ namespace IRPrefab::JointTransform {
 // rigs voxel sets needs no follow-up call.
 inline IRSystem::System<IRSystem::UPDATE_JOINT_MATRICES> *system() {
     const IRSystem::SystemId systemId = IRSystem::findSystem(IRSystem::UPDATE_JOINT_MATRICES);
-    if (systemId == IREntity::kNullEntity) {
+    if (systemId == IRSystem::kNullSystemId) {
         return nullptr;
     }
     return IRSystem::getSystemParams<IRSystem::System<IRSystem::UPDATE_JOINT_MATRICES>>(systemId);

--- a/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
@@ -304,11 +304,11 @@ namespace IRPrefab::VoxelTransform {
 // consumer reaches the system's free-list through this rather than threading the
 // SystemId through every call, so the slot API stays id-free. The id is resolved
 // from SystemManager's `SystemName` registry (#2526): creating the system is all
-// the wiring there is, and `IREntity::kNullEntity` means "never created" —
+// the wiring there is, and `IRSystem::kNullSystemId` means "never created" —
 // callers treat that as "stay CPU-direct".
 inline IRSystem::System<IRSystem::UPDATE_VOXEL_POSITIONS_GPU> *allocator() {
     const IRSystem::SystemId systemId = IRSystem::findSystem(IRSystem::UPDATE_VOXEL_POSITIONS_GPU);
-    if (systemId == IREntity::kNullEntity) {
+    if (systemId == IRSystem::kNullSystemId) {
         return nullptr;
     }
     return IRSystem::getSystemParams<IRSystem::System<IRSystem::UPDATE_VOXEL_POSITIONS_GPU>>(

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -100,7 +100,7 @@ delegate to callers".
 
 Contract:
 
-- Returns `IREntity::kNullEntity` when the name was never registered, and
+- Returns `IRSystem::kNullSystemId` when the name was never registered, and
   when no `SystemManager` exists at all (headless unit tests that tick a
   `System<N>` against a bare `EntityManager`) — so a prefab handle built
   on it degrades to its "unwired" branch instead of dereferencing null.
@@ -116,8 +116,13 @@ Contract:
 - Costs one hash lookup. Fine per-operation; a per-entity tick should
   resolve once in `beginTick` and cache the pointer (the ECS footgun
   rule), not call it per row.
-- Caveat: ids count up from 0 and `kNullEntity` is 0, so the first system
-  created in a process is indistinguishable from "unregistered" — #2540.
+- The miss sentinel is `IRSystem::kNullSystemId`
+  (`std::numeric_limits<SystemId>::max()`, `ir_system_types.hpp`), **not**
+  `IREntity::kNullEntity` — ids count up from 0, so `0` is the real id of the
+  first system registered in the process (#2540). Use `kNullSystemId` for any
+  stored "not wired yet" `SystemId` too; it can never be handed out, and an
+  accidental index-by-sentinel trips `SystemManager`'s range assert instead of
+  silently reading slot 0.
 
 ## Three valid TICK function signatures
 

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -121,8 +121,12 @@ Contract:
   `IREntity::kNullEntity` — ids count up from 0, so `0` is the real id of the
   first system registered in the process (#2540). Use `kNullSystemId` for any
   stored "not wired yet" `SystemId` too; it can never be handed out, and an
-  accidental index-by-sentinel trips `SystemManager`'s range assert instead of
-  silently reading slot 0.
+  accidental index-by-sentinel trips `SystemManager`'s `system < m_nextSystemId`
+  range assert — on the params accessors (`getSystemParams` /
+  `setSystemParams`) as well as `replaceSystemBody` — instead of silently
+  reading slot 0. The assert is debug-only (`IR_ASSERT` is stripped under
+  `IR_RELEASE`); in release the same misuse is an out-of-bounds access that
+  crashes rather than silently reading a real system's state.
 
 ## Three valid TICK function signatures
 

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -447,7 +447,7 @@ registerSystem(std::string name, RelationParams<RelationComponents...> relationP
 }
 
 // #2526: resolve a `SystemName` to the id it was registered under, or
-// `IREntity::kNullEntity` if no enum-templated registration recorded it.
+// `kNullSystemId` if no enum-templated registration recorded it.
 // This is the manager-owned replacement for the wire-once
 // `setSystem(id)` / `setAllocatorSystem(id)` handles prefab headers used to
 // carry: registration self-wires, so a creation no longer has to remember a
@@ -465,8 +465,7 @@ registerSystem(std::string name, RelationParams<RelationComponents...> relationP
 // dereferencing null; the sentinel check the wire-once globals did before
 // touching the manager is what this preserves.
 inline SystemId findSystem(SystemName name) {
-    return g_systemManager == nullptr ? IREntity::kNullEntity
-                                      : g_systemManager->findEngineSystem(name);
+    return g_systemManager == nullptr ? kNullSystemId : g_systemManager->findEngineSystem(name);
 }
 
 // Free-function wrapper around `SystemManager::createSystemDynamic`. Used by

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -17,8 +17,13 @@ using SystemId = EntityId;
 /// system registered in the process — a real id that `kNullEntity` cannot
 /// be told apart from. `max()` is unreachable (the counter would have to
 /// exhaust the whole id space to reach it) and fails loudly rather than
-/// silently: a sentinel mistakenly used as an index trips the
-/// `system < m_nextSystemId` range assert instead of aliasing slot 0.
+/// silently: a sentinel mistakenly used as an index trips `SystemManager`'s
+/// `system < m_nextSystemId` range assert — on the params accessors
+/// (`getSystemParams` / `setSystemParams`) as well as `replaceSystemBody` —
+/// instead of aliasing slot 0. That assert is debug-only (`IR_ASSERT` is
+/// stripped under `IR_RELEASE`); in a release build the same misuse is an
+/// out-of-bounds access that crashes rather than silently reading the state
+/// of a real system.
 ///
 /// C++-side only. `SystemId`s cross into Lua as plain integers, but the Lua
 /// miss contract is to raise an error rather than return a sentinel (see

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -3,11 +3,27 @@
 
 #include <irreden/entity/ir_entity_types.hpp>
 
+#include <limits>
+
 using namespace IREntity;
 
 namespace IRSystem {
 
 using SystemId = EntityId;
+
+/// The "no such system" sentinel (#2540). Deliberately NOT
+/// `IREntity::kNullEntity`: ids are handed out from `SystemManager`'s
+/// `m_nextSystemId` counting up from 0, so `0` is the id of the *first*
+/// system registered in the process — a real id that `kNullEntity` cannot
+/// be told apart from. `max()` is unreachable (the counter would have to
+/// exhaust the whole id space to reach it) and fails loudly rather than
+/// silently: a sentinel mistakenly used as an index trips the
+/// `system < m_nextSystemId` range assert instead of aliasing slot 0.
+///
+/// C++-side only. `SystemId`s cross into Lua as plain integers, but the Lua
+/// miss contract is to raise an error rather than return a sentinel (see
+/// `engine/script/CLAUDE.md`), so this value is never bound.
+constexpr SystemId kNullSystemId = std::numeric_limits<SystemId>::max();
 
 enum SystemTickModifiers { SYSTEM_MODIFIER_NONE = 0, SYSTEM_MODIFIER_WITH_ENTITY = 1 };
 

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -330,16 +330,12 @@ class SystemManager {
     }
 
     /// #2526: resolve a `SystemName` to the `SystemId` it was registered
-    /// under, or `IREntity::kNullEntity` when it was never registered.
-    ///
-    /// Caveat: `kNullEntity` is 0 and system ids also count up from 0, so
-    /// the *first* system created in a process is indistinguishable from
-    /// "not registered" through this return value. Harmless for the current
-    /// consumers, which are never the first system a creation registers —
-    /// see #2540 for the sentinel fix.
+    /// under, or `kNullSystemId` when it was never registered. The sentinel
+    /// is unreachable as a real id (#2540), so a system registered first in
+    /// the process — id 0 — reads back as registered rather than as a miss.
     SystemId findEngineSystem(SystemName name) const {
         const auto it = m_engineSystemIds.find(name);
-        return it == m_engineSystemIds.end() ? IREntity::kNullEntity : it->second;
+        return it == m_engineSystemIds.end() ? kNullSystemId : it->second;
     }
     const TimingAccum &getTimingAccum(SystemId id) const {
         return m_timingAccum[id];

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -183,12 +183,29 @@ class SystemManager {
         m_ticks[system].excludeArchetype_.insert(IREntity::getComponentType<Tag>());
     }
 
+    /// Asserts on out-of-range SystemId (debug), same as `replaceSystemBody`
+    /// — this is the guard that turns an accidental index by
+    /// `kNullSystemId` into a diagnosed failure instead of an unchecked
+    /// `std::vector::operator[]` past the end (#2540).
     template <typename Params>
     void setSystemParams(SystemId system, std::unique_ptr<Params> params) {
+        IR_ASSERT(
+            system < m_nextSystemId,
+            "setSystemParams: SystemId {} out of range (have {} systems)",
+            system,
+            m_nextSystemId
+        );
         m_systemParams[system] = std::make_unique<ISystemParamsImpl<Params>>(std::move(params));
     }
 
+    /// Asserts on out-of-range SystemId (debug); see `setSystemParams`.
     template <typename Params> Params *getSystemParams(SystemId system) {
+        IR_ASSERT(
+            system < m_nextSystemId,
+            "getSystemParams: SystemId {} out of range (have {} systems)",
+            system,
+            m_nextSystemId
+        );
         auto *paramsImpl = static_cast<ISystemParamsImpl<Params> *>(m_systemParams[system].get());
         return paramsImpl == nullptr ? nullptr : paramsImpl->params_.get();
     }

--- a/test/system/register_system_test.cpp
+++ b/test/system/register_system_test.cpp
@@ -166,12 +166,30 @@ TEST_F(RegisterSystemTest, FindSystemResolvesEachRegisteredName) {
 }
 
 TEST_F(RegisterSystemTest, FindSystemReportsANameThatWasNeverCreated) {
-    // Only A is created, so B has no entry — the miss value is the same
-    // `kNullEntity` the wire-once globals used as their "unwired" sentinel, so
-    // `system()` / `allocator()` null-return semantics are unchanged.
+    // Only A is created, so B has no entry — the miss value is `kNullSystemId`,
+    // which the prefab handles compare against for their "unwired -> nullptr"
+    // branch, so `system()` / `allocator()` null-return semantics are unchanged.
     IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
 
-    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_B), IREntity::kNullEntity);
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_B), IRSystem::kNullSystemId);
+}
+
+// The miss sentinel has to be unreachable as a real id, and id 0 — handed to
+// whichever system registers first — is the one value a `kNullEntity`-based
+// sentinel could not express (#2540).
+TEST_F(RegisterSystemTest, FirstRegisteredSystemIsDistinguishableFromAMiss) {
+    // A is the first system this fixture creates, so it holds id 0; B is never
+    // created. The ASSERT pins that premise: if SystemManager ever
+    // pre-registers a system or stops counting from 0, it fails here rather
+    // than letting the EXPECT_NE below pass vacuously.
+    const auto sysA = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    ASSERT_EQ(sysA, 0u) << "premise: the first system registered holds id 0";
+
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_A), sysA);
+    EXPECT_NE(
+        IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_A),
+        IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_B)
+    ) << "registered-first must not read back as never-registered";
 }
 
 // Deliberately NOT a RegisterSystemTest fixture case: the guard under test is
@@ -184,7 +202,7 @@ TEST(FindSystemNoManagerTest, ReportsNullWhenNoSystemManagerExists) {
     ASSERT_EQ(IRSystem::g_systemManager, nullptr)
         << "precondition: no SystemManager is alive between fixtures";
 
-    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_A), IREntity::kNullEntity);
+    EXPECT_EQ(IRSystem::findSystem(IRSystem::TEST_REGISTER_SYSTEM_A), IRSystem::kNullSystemId);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

`SystemManager` hands `SystemId`s out from `m_nextSystemId` starting at 0, and
`IREntity::kNullEntity` is 0 — so the **first system registered in a process
has an id indistinguishable from "no such system"**. #2526 promoted that from a
private two-call-site convention to public API (`IRSystem::findSystem`), so the
next consumer resolving an early-registered system would get a silent wrong
answer.

Committed approach is the plan's **option 2**: a dedicated
`IRSystem::kNullSystemId = std::numeric_limits<SystemId>::max()` in
`ir_system_types.hpp`, with every `SystemId` sentinel site migrated onto it.

- `max()` is unreachable as a real id, and it **fails loudly** — indexing by the
  sentinel trips `SystemManager`'s `system < m_nextSystemId` range assert
  instead of silently aliasing slot 0. That assert now covers the params
  accessors (`getSystemParams` / `setSystemParams`) as well as
  `replaceSystemBody`, added in the nit pass below; it is debug-only
  (`IR_ASSERT` is stripped under `IR_RELEASE`), so in release the same misuse
  is an out-of-bounds access that crashes rather than reading a real system.
- Option 1 (reserve id 0) was rejected because `SystemId` is a **dense index**
  into `m_systemNames` / `m_ticks` / `m_timingAccum` and the lockstep
  access/cadence/params vectors; it would need a phantom slot 0 in each (and
  would corrupt `getSystemCount()`) or a `-1` shift at every index site.

Migrated sites: both miss returns (`findEngineSystem`, `findSystem`'s
null-manager arm), both prefab handles' `unwired -> nullptr` branch
(`VoxelTransform::allocator()`, `JointTransform::system()`), the culling
minimap's 4 optional domain-source defaults + 2 compares, and the stored
"not wired yet" defaults in `shape_debug`, `scene_reset`, `lua_widgets`, and
`lighting_demo_scene`.

**Latent, not live.** Neither current consumer is ever a creation's first
system, so no shipped scene changes behavior — see the Test plan.

Two notes against the plan as filed:

- The plan's affected-file list predates #2529 merging and missed
  `shape_debug/main.cpp`'s two `SystemId x{}` locals. They're the same
  category as the `lighting_demo_scene` globals (audit item 8) and are
  migrated here so the `kNullEntity`-shaped sentinel sites carry one
  convention. Scope note: that is **not** the same as "the tree has a single
  convention" — the Opus recheck found one surviving zero-as-`SystemId`
  sentinel at `lua_perf_grid/main_lua.cpp:358` that neither the plan's grep
  nor the review sweeps matched (it writes a bare `0` literal). It is
  deliberately not migrated here — swapping in `kNullSystemId` would turn a
  wrong-system tick into an out-of-bounds pipeline splice, so it needs an
  early-return / hard-fail at the call site instead. Filed as #2599.
- Plan step 6 said to check `engine/prefabs/irreden/render/CLAUDE.md:625-626`
  at impl time — checked; those rows name the resolution path, not the
  sentinel value, so no edit was needed.

## Test plan

- [x] **Negative control on the new regression test.** Temporarily set
  `kNullSystemId = 0` (the pre-fix value), rebuilt, and confirmed
  `FirstRegisteredSystemIsDistinguishableFromAMiss` **fails** with
  `actual: 0 vs 0`. The test is not vacuous.
- [x] `IrredenEngineTest` — **1362/1362 pass** (includes the new test, the two
  migrated miss expectations, and `voxel_bone_slot_seed_test`, which is the
  headless proof the handles' unwired→nullptr behavior is preserved).
- [x] `render-verify --target IRShapeDebug` — **24/24 checks PASS**, every shot
  at `match% 100.0` / `max_delta 0` against the committed `macos-debug`
  references. Byte-identical output.
- [x] Builds green: `IRShapeDebug`, `IRSceneReset`, `IRLuaWidgetsDemo`,
  `IRLightingHDR`, `IRLightingSunOrbit`, `IRVoxelEditor`.
- [x] Plan's sweep gate:
  `git grep -nE "kNullEntity" -- engine/system engine/prefabs creations test | grep -iE "systemid|findSystem"`
  returns empty.

`attach-screenshots` skipped deliberately: render-verify proves the output is
byte-identical, so a before/after pair would be two identical images.

## Opus-recheck nits addressed

- **Nit 1 (doc-vs-code drift) — fixed in code, the option the reviewer
  preferred.** The sentinel's doc comment claimed a range assert protected an
  accidental index-by-sentinel, but that assert lived only on
  `replaceSystemBody`, not on the `getSystemParams` path the two prefab
  handles and `lightGatherRecords` actually use. Added the same
  `system < m_nextSystemId` assert to `getSystemParams` and `setSystemParams`
  (`m_systemParams` is `emplace_back`-ed once per created system, so
  `size() == m_nextSystemId` and the bound matches `replaceSystemBody`'s), and
  tightened both doc sites (`ir_system_types.hpp`, `engine/system/CLAUDE.md`)
  to name the accessors and to state the debug-only caveat — the claim is now
  true in debug and honest about release.
- **Nit 2 (surviving `SystemId{0}` sentinel) — filed as #2599**, not migrated
  here, for the reason the reviewer gave. The PR body's "single convention"
  line is corrected above.

Checked before adding the asserts that no live path can trip them: both
prefab handles guard on `== kNullSystemId` and return `nullptr` first, every
other call site passes an id freshly returned by `registerSystem`, and the two
stored lighting handles are assigned in `initSystems()` before their only
unguarded read. `IRLightingCombined --auto-screenshot` exercises that read 6×
(one `DOMAIN-STATE` line per shot) and is clean.

## Note for the reviewer (out of scope here)

`.claude/rules/cpp-globals.md:71-72` and `.claude/skills/simplify/SKILL.md:361-362`
still list `g_jointMatrixSystem` / `g_allocatorSystem` under **live
deviations**, but #2529 deleted both symbols — the only remaining references in
the tree are those two docs plus the historical `issue-2526.md` plan. Not
bundled here: both are gated self-config, and it's unrelated cleanup.

Closes #2540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
