### PR TITLE
render: accept per-axis scatter sub-pixel yaw-sweep residual as the probe floor (#2469)

### DIFF
--- a/.fleet/plans/issue-2469.md
+++ b/.fleet/plans/issue-2469.md
@@ -1,0 +1,75 @@
+## Plan: render: per-axis scatter sub-pixel centroid residual under yaw-sweep — accept as measured probe floor; re-parameterize the zoom-4/8 gate
+
+- **Issue:** #2469
+- **Model:** opus
+- **Date:** 2026-07-20
+
+### Scope
+
+Resolve the issue's chase-vs-accept question: **accept** the zoom-4/8 sub-pixel residual as the probe's own floor (voxel-content anisotropy + raster-sampling noise, not a pipeline positioning defect), document it as intentional drift next to the #1883 precedent, and re-parameterize the canonical voxel-cylinder rotation-jitter gate so it encodes the accepted floor while still firing on every real defect signature the gate exists to catch. No shader or C++ behavior changes ship — the diff is docs + gate parameters, gated by a phase-0 measurement that converts the accept premise from inspection to proof.
+
+### Verified current state (planner, 2026-07-20 — source inspection + cited measurements)
+
+Baseline metrics (issue table, measured during #2427 on macOS/Metal on the #2465 base, post-fix):
+
+| zoom | x rev | x resid | verdict | resid ÷ zoom (world units) |
+|---|---|---|---|---|
+| 2 | 0 | 0.64px | SMOOTH | 0.32 |
+| 4 | 2 | 1.01px | JITTER (sub-px reversals) | 0.25 |
+| 8 | 0 | 1.57px | JITTER (0.07px over bar) | 0.20 |
+
+Three source-level findings that reframe the issue's "likely surface" (the 4-bit face-frac encoding + `emitDeformedFace` rounding):
+
+1. **The 4-bit frac lane is inert on this exact probe.** The canonical probe's cylinder is `createVoxelPoolShape(vec3(0), CYLINDER, …, halfExtent (4,4,4))` (`creations/demos/shape_debug/main.cpp:898`, spawn at `:1319`): an odd-size (9³) origin-centred grid, so every active voxel sits on the exact integer lattice, and `--yaw-sweep` steps only the camera yaw (`main.cpp:271` — position + zoom fixed, shape static). The per-axis store computes `fracInCell = worldAligned − worldPos` after `snapNearIntegerVoxelPosition` (1e-4 snap, `ir_iso_common.glsl:450`), so `fracInCell ≡ 0` and `fracToFrac4` encodes exactly 8/8/8 (`ir_iso_common.glsl:279`) — the documented "integer content encodes zero offsets, byte-identical" case. A quantization lane pinned at its zero point cannot produce a yaw-varying wobble.
+2. **`emitDeformedFace` is not on this path.** The T3 per-axis store writes ONE cell per face centre (`c_voxel_to_trixel_stage_1_body.glsl` per-axis branch, ~line 690–790); `emitDeformedFace` (~line 329) serves the single-canvas/world and detached routes only.
+3. **What actually varies under the sweep** — the cardinal store is yaw-independent within one quadrant and the scatter reprojection (`pos3DtoPos2DIsoYawed`) is continuous and linear in yaw, so the remaining yaw-varying terms are: (a) pixel-coverage sampling (quad edges crossing fragment centres discretely as the projection moves), (b) boundary-pixel arbitration (conservative dilation margin, margin-yield, tie-bands), and (c) the content itself — a voxelized cylinder is only 4-fold symmetric; only the *continuous* cylinder is Z-yaw-invariant, so the true silhouette of the rotating staircase legitimately wobbles.
+
+The measured scaling fits (c)+(a): resid/zoom ≈ 0.32 → 0.25 → 0.20 world units — approximately constant in **world** space (content anisotropy of order ~¼ voxel plus a fixed sub-pixel sampling floor). A pixel-domain positioning defect would sit ~constant in px across zooms; a compounding store defect would scale super-linearly. Neither matches. The defect class this gate exists for looks nothing like the residual: the pre-#2427 overflow flicker measured resid 2.93px / Δmax 5.37 at zoom 4.
+
+Independent control already on record (#2427 plan phase-0 table): the SDF cylinder twin (continuous geometry, no voxel store) sweeps at resid 1.43px x / 0.95px y @ zoom 4 — the defect-free control also sits just under the 1.5px default bar, i.e. the default bar has ~zero headroom over the probe floor.
+
+Sibling/in-flight reconciliation: #2469 is #2427's only carve-off; PR #2471 (the #2427 fix) is approved and unmerged (see Gotchas — base ordering). No open PR touches the scatter positioning surface (#2460 is fog-vision, #2393 is sun-shadow softness). Needs-plan sibling #2360 (Metal sampler binds) is unrelated.
+
+### Approach
+
+**Phase 0 — premise confirm (cheap; base MUST include #2427's fix — see Gotchas):**
+
+- (a) **Frac-lane inertness A/B (runtime proof of finding 1).** Stage a diagnostic copy of the scatter shader with the three decoded sub-cell offsets forced to zero — delete the `eu·(uFrac4/16−0.5) + ev·(vFrac4/16−0.5) + faceOutOfPlaneUnitAxis·(wFrac4/16−0.5)` origin adjustment (`v_peraxis_scatter.glsl` ~line 230; on macOS edit the `metal/peraxis_scatter.metal` twin — Metal loads `.metal` at runtime, so a staged-dir swap needs no rebuild). Run the canonical sweep at zoom 4 and zoom 8; `img_diff` every frame against the unmodified run. **Expected reading: img_diff = 0 for every frame** — the encoding demonstrably contributes nothing on this probe. Diagnostic staging only; nothing commits.
+- (b) **Control completion + delta tables.** Run the SDF twin (drop `--spin-shape-voxel`) at zoom 8; expected: the continuous-geometry control's residual also grows with zoom (order ~1px+). Capture the voxel sweeps at zoom 4/8 with `--verbose` — the per-frame delta tables feed the eps pick in phase 2.
+- **Bail path:** if (a) shows ANY non-zero frame diff, the frac lane is live on this probe and the accept premise is refuted — stop, comment both probe outputs on the issue, and swap back to `fleet:needs-plan` for a chase-directed re-plan (the live lane then has a measured signature to chase). Same bail if (b)'s SDF control at zoom 8 stays ≤ 0.5px while the voxel path reads 1.57px (a real voxel-path excess, not a shared floor). Never build phases 1–2 on a refuted premise.
+
+**Phase 1 — document the accepted drift.** `engine/render/CLAUDE.md`, adjacent to the #1883 accepted-drift block (~line 741): a titled block "Accepted sub-pixel yaw-sweep centroid drift (voxel content) — #2469" recording the mechanism (voxel content is only approximately Z-yaw-invariant, plus the sampling floor), the measured table with the world-space-constant scaling fit, the phase-0 inertness proof (frac lane contributes zero; `emitDeformedFace` off-path), why there is no local fix (the residual is content + sampling, not a positioning defect; the principled root fix is the same conservative-rasterization/MSAA direction already deferred to epic #1933), and the phase-2 gate parameters.
+
+**Phase 2 — encode the floor in the canonical gate (the issue's "relax to residual-only").** Update the §"Verifying temporal stability" recipe (`engine/render/CLAUDE.md` ~lines 400–435) and `tools/jitter_probe/README.md` (an "accepted floors" note pointing at the CLAUDE.md block). The canonical voxel-cylinder rotation gate becomes:
+
+- zoom 2: unchanged (defaults; measured SMOOTH with 2.3× residual headroom),
+- zoom 4: `--reversal-eps 0.5` (max-residual stays 1.5; sub-half-pixel direction flips are the accepted floor — multi-px face-pop reversals still fire),
+- zoom 8: `--reversal-eps 0.5 --max-residual 2.0` (measured 1.57 + 27% margin, still 32% below the 2.93px defect signature).
+
+No `jitter_probe` code changes — both flags exist; the budget lives in the documented recipe. The starting eps/budget values above are constrained by acceptance criteria 2 and 3: adjust from the phase-0(b) verbose tables until both hold, and ship the final numbers in the docs.
+
+**Phase 3 — close out.** The PR body records the accept decision (`Closes #2469`) and notes that #2427's own acceptance criterion 3 is superseded at zoom 4/8 by the phase-2 budget — reference only; no edits to #2427 or epic #1881 (the steward's ledger pass picks it up).
+
+### Affected files
+
+- `.fleet/plans/issue-2469.md` — this plan (first commit of the implementation PR)
+- `engine/render/CLAUDE.md` — accepted-drift block + updated canonical gate recipe
+- `tools/jitter_probe/README.md` — accepted-floors note referencing the block
+
+### Acceptance criteria (positive-fire)
+
+1. **Premise measured, not asserted:** phase 0(a) byte-identity holds — img_diff = 0 for every frame across both zoom sweeps.
+2. **Floor passes:** under the shipped recipe, the canonical voxel-cylinder sweep reports SMOOTH at zoom 2, 4, AND 8 (probe outputs pasted into the PR).
+3. **Gate still fires on a real lever:** the `IR_PERAXIS_OVERFLOW_DISABLE=1` kill-switch sweep at zoom 4 (re-exposes the θ-unstable membership class; recorded rev=12 / Δmax 0.84) reports JITTER under the exact shipped flags. Hard analytic floor regardless: the pre-#2427 defect record (rev=9, resid 2.93px, Δmax 5.37) fails every shipped setting on the residual axis alone. If no eps satisfies 2 and 3 simultaneously (floor reversals and control reversals overlap in delta magnitude), ship the residual-axis gate, record the runtime control's measured overlap in the CLAUDE.md block as a known limitation, and keep the analytic floor as the hard check.
+4. **Untouched twin stays green:** pan-sweep (`--spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 --zoom 4`) stays SMOOTH under default flags.
+5. Cardinal byte-identity untouched by construction — the shipped diff is docs-only.
+
+### Gotchas
+
+- **Base ordering:** every baseline number is measured on top of #2427's fix. PR #2471 (the #2427 implementation) is approved but unmerged at planning time — if still unmerged at pickup, claim with `--stackable-on 2471` and branch from its head. Running phase 0 on a pre-#2471 base re-exposes the multi-pixel overflow flicker and invalidates every expected reading.
+- The phase-0(a) shader edit is DIAGNOSTIC ONLY — never commit it; it deliberately breaks fractional-content rendering (any scene with sub-cell voxel positions). Byte-identity holds only for this probe's integer-lattice content.
+- `IR_PERAXIS_OVERFLOW_DISABLE` is a `getenv != nullptr` kill switch — `VAR=` (empty value) counts as SET; fully unset it between runs.
+- Keep the sweep inside one cardinal quadrant (the default `--yaw-sweep` range): crossing a quadrant boundary changes the visible-face triplet and legitimately steps the centroid — that is not part of the accepted floor.
+- The zoom-4/8 budget is for the CANONICAL cylinder probe only — do not generalize the numbers to other shapes or probes; the floor is content-dependent (the figure fixture or a coarser shape has a different anisotropy amplitude).
+- Plans are engine-public: keep all measurements and terminology engine-side.
+

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -456,8 +456,10 @@ Three checks, in order:
    # rotation jitter (voxel cylinder, Z-yaw-invariant probe):
    IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep \
        --zoom 4 --auto-screenshot 6
-   # then score the captured sequence (in order):
-   build/tools/jitter_probe/jitter_probe <save_files>/screenshots/screenshot_0*.png
+   # then score the captured sequence (in order). --reversal-eps 0.8 retires the
+   # reversal criterion on these probes (see "the reversal criterion" below):
+   build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 \
+       <save_files>/screenshots/screenshot_0*.png
    ```
 
 3. **Read the verdict.** `jitter_probe` tracks the shape's centroid across the
@@ -467,6 +469,34 @@ Three checks, in order:
    zooms (the per-axis class worsens with zoom/subdivision). For a multi-shape
    scene with no isolation, pass `jitter_probe --color R,G,B,T` to lock onto one
    shape. See `tools/jitter_probe/README.md`.
+
+   **The reversal criterion, and what this gate does NOT catch (#2469).** On both
+   canonical probes one axis is near-**pinned** while the other translates, so
+   `reversals == 0` counts sign flips of sub-pixel coverage noise and is
+   unsatisfiable on healthy master — measured 2026-07-28 at zoom 2/4/8 on the
+   yaw sweep AND on the pan-sweep twin. `--reversal-eps 0.8` zeroes those deltas
+   and makes the gate effectively **residual-axis only**; the `--max-residual`
+   default (1.50px) is unchanged and is the live assertion. Do not read the eps
+   as a calibrated floor — it sits at the top of the observed per-frame delta
+   range precisely because the criterion is being retired for these probes.
+
+   Two consequences to know before you lean on this gate:
+
+   - **It does not fire on the `IR_PERAXIS_OVERFLOW_DISABLE=1` runtime control.**
+     That lever now presents as a *smooth* 11.13px x-centroid migration scoring
+     `reversals=0, max_residual=0.73px` — clean on both shipped axes. No eps
+     separates the populations (the control clears at 0.6, healthy master at
+     0.8), which is why the eps was not calibrated against it.
+   - **The hard check is the residual axis against the analytic floor.** The
+     pre-#2427 defect record (residual 2.93px, Δmax 5.37 at zoom 4) fails the
+     1.50px bar by ~2×, so the original multi-pixel face-pop class is still
+     caught. A *systematic migration* class is not.
+
+   The principled fix — a per-axis excursion assertion, so a probe can require
+   "x stays pinned while y may translate" — is **#2606**. Until it lands, check
+   per-axis excursion by hand (`--verbose`, max-min per column) when validating
+   a change to the per-axis store, the scatter, or the camera-offset
+   decomposition; healthy master reads 1.26–2.83px on the pinned axis.
 
 **Jitter is NOT the same as cardinal byte-identity.** Confirm yaw-0 / static
 frames stay byte-identical (`img_diff`) *and* that motion is jitter-free
@@ -811,6 +841,50 @@ rasterization / MSAA** on the scatter pass, which removes the sub-pixel
 rasterization dropout at the source so no manual dilation/margin is needed
 (killing spikes and silhouette dashing together) — is deferred to epic
 **#1933** (fits #935/#937).
+
+**Accepted sub-pixel yaw-sweep centroid residual (voxel content) — #2469.**
+On the canonical Z-yaw-invariant probe (voxel cylinder, `--yaw-sweep`) the
+per-axis path leaves a sub-pixel centroid residual that scales with zoom. It is
+**content + sampling, not a positioning defect**, and is accepted as intentional
+drift. Measured on macOS/Metal, 2026-07-28 (24-frame sweeps, one quadrant):
+
+| probe | x excursion | x rev | x residual | y excursion | y rev | y residual |
+|---|---|---|---|---|---|---|
+| voxel cylinder, zoom 2 | 1.68px | 3 | 0.85px | 2.69px | 2 | 0.21px |
+| voxel cylinder, zoom 4 | 1.26px | 5 | 0.57px | 5.29px | 0 | 0.19px |
+| voxel cylinder, zoom 8 | 2.83px | 5 | 1.25px | 10.79px | 0 | 0.18px |
+| **SDF cylinder** (continuous-geometry control), zoom 4 / 8 | 2.00px | 0 | 1.43px | 4.00 / 10.00px | 0 | 0.95px |
+
+Three findings ground the accept, each measured rather than asserted:
+
+1. **The 4-bit face-frac lane is inert on this probe.** The probe's cylinder is
+   an odd-size (9³) origin-centred grid, so every active voxel sits on the exact
+   integer lattice: `fracInCell ≡ 0` after `snapNearIntegerVoxelPosition`, and
+   `fracToFrac4` encodes exactly 8/8/8, for which the scatter's decoded origin
+   adjustment (`peraxis_scatter.metal:281-284`, `v_peraxis_scatter.glsl:243-246`)
+   evaluates to exactly `0.0`. Staging a diagnostic scatter shader with that
+   adjustment deleted produced **`img_diff` = 0 on all 24 frames at both zoom 4
+   and zoom 8**, with bit-identical probe metrics. A lane pinned at its zero
+   point cannot produce a yaw-varying wobble. (`emitDeformedFace` is likewise
+   off-path: the per-axis store writes one cell per face centre.)
+2. **The voxel path's residual is LOWER than the defect-free control's.** The
+   SDF twin — continuous geometry, no voxel store — reads 1.43px at zoom 4 and 8,
+   above the voxel path at every zoom. The residual is a floor the probe itself
+   carries, not a per-axis excess.
+3. **The scaling fits content anisotropy, not a pixel-domain defect.** A voxelized
+   cylinder is only 4-fold symmetric — only the *continuous* cylinder is
+   Z-yaw-invariant, so the rotating staircase's true silhouette legitimately
+   wobbles. A pixel-domain positioning defect would sit ~constant in px across
+   zooms; the pre-#2427 overflow defect measured 2.93px residual / 5.37 Δmax at
+   zoom 4, ~2-5x this floor.
+
+There is no local fix: the residual is content plus the sampling floor, so the
+principled root fix is the same conservative-rasterization / MSAA direction
+already deferred to epic **#1933** (as for the #1883 corner drift above).
+
+**The `reversals == 0` criterion misfires on these probes — see the gate recipe
+in §"Verifying temporal stability" for the shipped flags and the limitation
+they carry.**
 
 Per-axis voxels **cast** sun shadows under continuous yaw via
 `RESOLVE_PER_AXIS_SCREEN_DEPTH` (#1435), which collapses the three face-local

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -84,3 +84,34 @@ jitter_probe: frames=24 (valid=24)  verdict=SMOOTH
 SMOOTH requires `reversals == 0` on both axes and `max_residual <= --max-residual`.
 A clean fix flips a JITTER verdict (high reversals, multi-px residual) to SMOOTH
 (0 reversals, sub-px residual).
+
+## Accepted floors, and the model's blind spot (#2469)
+
+The default verdict models **linear** motion. On a probe where one axis is
+supposed to stay **pinned** (the Z-yaw-invariant cylinder under `--yaw-sweep`),
+that model is mis-specified on exactly that axis, in both directions:
+
+- **False positives.** A pinned centroid still moves ±0.1–0.8px from coverage
+  noise, and every sign flip counts as a reversal. Healthy engine master fails
+  `reversals == 0` at zoom 2, 4 and 8 on the yaw sweep, and on the `--pan-sweep`
+  twin. The canonical recipe therefore passes `--reversal-eps 0.8`, which
+  retires the criterion for these probes and leaves `--max-residual` as the live
+  assertion. That eps is not a calibrated floor — it sits at the top of the
+  observed per-frame delta range.
+- **False negatives.** A large but *smooth* centroid migration is what the line
+  fit calls correct. A known render defect (re-exposed via the engine's
+  `IR_PERAXIS_OVERFLOW_DISABLE=1` kill switch) migrates the x centroid by an
+  order of magnitude more than healthy master and still scores `reversals=0`
+  with a sub-pixel residual. Neither shipped axis fires on it.
+
+`--stationary` does not close the gap: it requires BOTH axes pinned, but on a
+yaw sweep the *other* axis legitimately translates — by more than the defect
+migrates — so `--stationary` reports DRIFT on every healthy run, including on
+the defect-free continuous-geometry control.
+
+Until **#2606** adds a per-axis excursion assertion, read per-axis excursion by
+hand from `--verbose` (max-min per centroid column) when a change touches the
+per-axis store, the scatter, or the camera-offset decomposition. Measured
+accepted floors and the full table live in
+[`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Accepted sub-pixel
+yaw-sweep centroid residual (voxel content) — #2469".


### PR DESCRIPTION
## Summary
- **Accepts** the per-axis scatter sub-pixel yaw-sweep centroid residual as the probe's own floor (content anisotropy + sampling), documented as intentional drift in `engine/render/CLAUDE.md` next to the #1883 precedent.
- **Re-parameterizes** the canonical rotation gate to `--reversal-eps 0.8` (residual-axis gate), and records the two limitations that carries.
- Files **#2606** for the principled fix: a per-axis excursion assertion in `jitter_probe`.
- Docs-only — no shader or C++ behavior changes.

## What the measurements changed about the plan

The plan's numbers were taken 2026-07-20; master has moved since. Two of its premises did not survive re-measurement, so the shipped gate differs from the one it sketched:

1. **Every zoom now fails, and all fail on reversals only.** The plan expected zoom 2 SMOOTH with zoom 4/8 marginal. Current master reads residual 0.85 / 0.57 / 1.25px at zoom 2/4/8 — all comfortably under the 1.50px bar — while `reversals == 0` fails at all three. The `--pan-sweep` twin fails it too, so the plan's criterion 4 ("stays SMOOTH under default flags") is unsatisfiable on master and is met under the shipped flags instead.
2. **No `--reversal-eps` separates floor from defect.** The plan proposed eps 0.5 at zoom 4/8. Measured: the overflow-disabled defect control clears at eps 0.6, *before* healthy master clears at 0.8 — the populations overlap in the wrong direction. This is exactly the case criterion 3 pre-authorized ("ship the residual-axis gate, record the overlap, keep the analytic floor as the hard check"), so that is what ships.

**New finding the plan did not anticipate (→ #2606):** the smooth-motion model scores a *systematic centroid migration* as clean. With the overflow lane disabled the x centroid migrates `1264.67 → 1275.80` (+11.13px) monotonically, and that axis reports `reversals=0, max_residual=0.73px`. The run only fails because the y axis incidentally picks up reversals — the gate catches this defect by accident, not by construction. `--stationary` can't close the gap either (it requires both axes pinned, but y legitimately translates 10.79px at zoom 8; the defect-free SDF control translates 10.00px). Both limitations are now documented at the gate.

## Acceptance evidence

Measured on macOS/Metal, this branch, 24-frame sweeps in one cardinal quadrant. Base includes #2427's fix (PR #2471 merged 2026-07-21), as the plan's base-ordering gotcha requires.

| Criterion | Check run | Observed |
|---|---|---|
| 1. Premise measured, not asserted — frac lane inert (`img_diff = 0` every frame, both zooms) | staged `metal/peraxis_scatter.metal` with the decoded sub-cell origin adjustment (`:281-284`) deleted; `img_diff` each frame vs the unmodified run at zoom 4 and 8 | **0 / 24 frames differ at zoom 4; 0 / 24 at zoom 8**, and `jitter_probe` metrics bit-identical. Premise confirmed. |
| — control for the above (A==A) | same binary + shaders, two independent runs, zoom 4 | **0 / 24 frames differ** — the sweep is run-to-run deterministic, so the byte-identity test is not vacuous |
| — control that the staged copy is actually read | deliberately corrupted the staged `.metal`, re-ran | `Metal shader compile failed … RESULT=CRASH` — the runtime does read that copy |
| 2. Floor passes — SMOOTH at zoom 2, 4 AND 8 under the shipped recipe | `jitter_probe --reversal-eps 0.8 <shots>` | **zoom 2 `verdict=SMOOTH`** (x resid 0.85px) · **zoom 4 `SMOOTH`** (0.57px) · **zoom 8 `SMOOTH`** (1.25px), exit 0 each |
| 3. Gate fires on a real lever | `IR_PERAXIS_OVERFLOW_DISABLE=1` sweep at zoom 4, scored under the shipped flags | **NOT MET as originally written — plan's documented fallback taken.** The control reports `SMOOTH` (x `reversals=0, max_residual=0.73px`): it now presents as a smooth 11.13px migration, not a residual excursion. No eps separates it (see above). Fallback shipped per the criterion's own text: residual-axis gate + limitation recorded in `CLAUDE.md` + analytic floor as the hard check — the pre-#2427 defect record (residual 2.93px, Δmax 5.37) fails the 1.50px bar by ~2×. Tracked properly by **#2606**. |
| 4. Untouched twin stays green | `--spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 --zoom 4` | **NOT MET as originally written — same master-drift class as criterion 3.** The criterion's text requires SMOOTH under **default** flags; measured `JITTER` under defaults (y reversals=2). That is master's own pre-existing state, not a regression from this PR — the diff is docs-only and cannot change render behavior. **Met under the shipped `--reversal-eps 0.8`: `SMOOTH`.** Unlike criterion 3, criterion 4 carries no pre-authorized fallback clause, so the re-scope to the shipped flags is a deliberate deviation, recorded in "What the measurements changed about the plan" above. |
| 5. Cardinal byte-identity untouched by construction | — | Satisfied by construction: the shipped diff is docs-only (`git diff --stat` = 2 markdown files + the plan file) |

Supporting control — the defect-free SDF twin (continuous geometry, no voxel store) reads resid **1.43px** at zoom 4 and 8, i.e. *higher* than the voxel path at every zoom. The residual is a shared probe floor, not a per-axis excess. The plan's second bail path (SDF ≤ 0.5px while voxel reads high) is therefore not met — no bail.

## Test plan
- [x] Frac-lane A/B byte-identity at zoom 4 and 8 (plus the two controls above)
- [x] Canonical yaw-sweep SMOOTH at zoom 2/4/8 under the shipped flags
- [x] Pan-sweep twin green under the shipped flags
- [x] Every run exited `RESULT=CLEAN`; staged shader restored to pristine and verified (`diff -q` vs source)
- [x] No source-tree shader edits — the diagnostic lived only in the build's staged dir

## Notes for reviewer
- The residual **improved** since the issue was filed (zoom 8: 1.57px → 1.25px) without anyone chasing it — master moved. The accept decision is unaffected; the gate numbers in the docs are re-measured on this branch.
- I deliberately did **not** hand-tune the eps to make criterion 3 pass. Making the control fire would require an eps below the healthy floor, which would re-break criterion 2. The honest outcome is a residual-axis gate with a documented blind spot plus #2606, rather than a number picked to make the table look green.
- `--reversal-eps 0.8` sits at the top of the observed per-frame delta range by design — it retires the criterion for these probes rather than calibrating a floor. The docs say so explicitly so nobody reads it as a tuned budget.

Closes #2469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

