### PR TITLE
script: give codegen'd components a Lua attach path (#2446)

### DIFF
--- a/.fleet/plans/issue-2446.md
+++ b/.fleet/plans/issue-2446.md
@@ -1,0 +1,75 @@
+<!--
+Plan file for #2446 (per #1932 — committed as the first commit of the
+implementer's PR). This is the `## Plan` comment posted on issue #2446 on
+2026-07-20; the architect granted approach sign-off on 2026-07-28 and cleared
+`human:review-plan`. Reproduced verbatim below; the issue thread is the
+canonical source.
+-->
+
+## Plan: Lua attach path for codegen'd components + Lua-typed accessor guards
+
+- **Issue:** #2446
+- **Model:** opus
+- **Date:** 2026-07-20
+
+### Scope
+
+Make `IREntity.addLuaComponent` / `IREntity.deferredCreate` attach codegen'd (C++-typed) components with overrides honored; convert every blind `IComponentDataLuaTyped` cast in the `IREntity.*Lua*` accessors into a routed check with an actionable Lua error; correct the misleading `deferredCreate` comment; document the accessor asymmetry in `engine/script/CLAUDE.md`.
+
+### Verified current state (source-verified 2026-07-20, worktree @ 5c53d2e5)
+
+- `IComponentData::appendDefaultRow()` defaults to `false` (`engine/entity/include/irreden/entity/i_component_data.hpp:44`) and `IComponentDataImpl<T>` does **not** override it — the only override is `IComponentDataLuaTyped` (`lua_component_data.hpp:254`). So `EntityManager::addComponentByIdImpl` (`entity_manager.cpp:621`) asserts for every C++-typed impl, exactly as reported. This default is deliberate: some C++ components have deleted default ctors (the comment cites `C_CanvasAOTexture`), so a blanket default-row at the entity layer was ruled out by design.
+- Both `addLuaComponent` (`lua_script.cpp:542`) and `deferredCreate` (`lua_script.cpp:589`; attach runs at flush inside `stageStructuralChange`) route through the shared `attachDynamicComponent` helper (`lua_script.cpp:175`), which then `static_cast`s to `IComponentDataLuaTyped` for the overrides write. **`deferredCreate`'s componentList hits the same wall** — confirmed by code reading, and worse: the assert fires at `flushStructuralChanges`, far from the Lua call site.
+- Negative claim exhaustively verified: the complete `IREntity` Lua surface is `addLuaComponent` / `getLuaComponent` / `removeLuaComponent` / `hasLuaComponent` / `deferredCreate` / `deferredDestroy` / `bindPoint` / `singleton` / `getLuaField` / `setLuaField` (grep of `m_lua["IREntity"][` across `lua_script.cpp`). **No typed setComponent binding exists**; the two attach paths above are the only ones.
+- **Additional latent UB, pulled into scope:** `getLuaComponent` (`:551`), `getLuaField` (`:674`), `setLuaField` (`:691`) blind-`static_cast` any `IComponentData*` to `IComponentDataLuaTyped*` with no assert at all. A codegen'd component attached from C++ (spawn factory, `setComponent<T>`) then read via `getLuaComponent` is undefined behavior **today**, before any fix. Fixing attach makes this path much easier to reach, so the guards land in the same PR.
+- No routing discriminator exists yet: `LuaScript::m_componentByLuaName` records only C++-bound types (`recordComponentLuaName<T>` from `registerType`); the `IRComponent.register` path records the Lua-typed id nowhere.
+- Infrastructure to reuse: the prefab declarative-components factory (`prefab_component_factory.hpp`) proves the "default-construct + setFields(table) + typed `setComponent`" shape; `IRScript::vec3FromLua` / `ivec3FromLua` already exist in `ir_script_utils.hpp`; the `registerCodegenComponents` emission (`cmake/lua_codegen/main.cpp:842`) already has both `em` and `luaScript` in scope per component.
+- Sibling/in-flight reconciliation: no open PR touches `engine/script/`; the other needs-plan issues (#2360 Metal render, #2449 toolchain, #2462 fleet infra) do not overlap this surface.
+
+### Approach (single approach, committed)
+
+Route attach through a **per-`LuaScript`, ComponentId-keyed attach-factory registry populated by codegen emission** — NOT by generalizing `appendDefaultRow` to C++ types. Rationale: (a) preserves the entity core's "C++ types attach with an explicit value" invariant (deleted-default-ctor and side-effectful default ctors stay unrepresentable in the dynamic path); (b) overrides need per-field typed writes, which for a C++ struct only the codegen (which knows the fields) can supply; (c) mirrors the proven prefab-factory shape instead of inventing a second mechanism.
+
+**Phase 0 (repro confirm, cheap).** On a current-master-buildable host, before building the fix: add one `IREntity.addLuaComponent(e, <codegen comp>, {})` call against the existing `lua_component_codegen_fixtures` setup and confirm the `appendDefaultRow` assertion fires as documented. Bail path: if it does NOT fire, stop — comment the observed behavior on this issue and flag for re-plan; do not build the dependent phases on a refuted premise.
+
+1. **LuaScript state (`lua_script.hpp`).**
+   - `std::unordered_set<IREntity::ComponentId> m_luaTypedComponentIds` — inserted in the `IRComponent.register` lambda immediately after `registerComponentDynamic` succeeds. NOT on the coexistence carve-out early-return (that path returns the existing C++ handle).
+   - `using ComponentAttachFn = std::function<void(IREntity::EntityId, const sol::table &)>;` + `std::unordered_map<IREntity::ComponentId, ComponentAttachFn> m_componentAttachFactories` + public `registerComponentAttachFactory(ComponentId, ComponentAttachFn)`. Per-`LuaScript` members, NOT a process-singleton: ComponentIds are per-World runtime allocations, and a static registry would go stale across World re-creation (the prefab registry tolerates process lifetime only because it keys by stable *name*).
+   - Error-path helper: reverse scan of `m_componentByLuaName` for id → Lua name (diagnostics only; falls back to the numeric id).
+2. **Routing in `attachDynamicComponent` (`lua_script.cpp`).** Make the helper LuaScript-aware (member function or explicit map params). Order: (i) attach factory registered → invoke with the overrides table (or an empty table when nil); the factory body is `C c{}; setFields(c, t); IREntity::setComponent(entity, std::move(c));` (ii) id in `m_luaTypedComponentIds` → existing dynamic path, unchanged; (iii) neither → `throw sol::error` naming the component and the supported paths (Lua-registered components attach directly; codegen'd components require `registerCodegenComponents()` to have run; other C++-bound components attach from C++ via typed `setComponent`). The engine-side assertion becomes unreachable from Lua but stays as safety.
+3. **`deferredCreate` call-time validation.** Validate each marshaled componentId's eligibility (factory present ∨ Lua-typed) in the marshal loop and raise at the call site with the entry index. An ineligible entry must never reach the flush-time drain — a throw there has no Lua context. Keep the flush lambda throw-free.
+4. **Guard the read/write accessors.** `getLuaComponent` / `getLuaField` / `setLuaField`: check `m_luaTypedComponentIds` before the cast; a non-Lua-typed id raises a `sol::error` naming the supported reads for C++-typed components (archetype column views in ticks / typed C++ access). `removeLuaComponent` / `hasLuaComponent` are id-generic (no cast) — verify removal of a codegen'd component in the test rather than guarding.
+5. **Codegen emission (`cmake/lua_codegen/main.cpp`).** In the emitted `registerCodegenComponents` body, per component: capture `const IREntity::ComponentId id = em.getComponentType<IRComponents::C_X>();`, keep the `registerTypeFromTraits` call, then emit `luaScript.registerComponentAttachFactory(id, [](IREntity::EntityId entity, const sol::table &fields) { ... });` with per-field guarded reads: `int32` / `float` / `bool` / `string` via `fields.get<sol::optional<T>>("name")`; `vec3` / `ivec3` via a non-nil check + `IRScript::vec3FromLua` / `ivec3FromLua` (matching the packed-field write convention). Unknown keys are silently ignored — the same contract `writeRowFromTable` documents. Add `irreden/script/ir_script_utils.hpp` to the emitted include block.
+6. **Docs.** Correct the `deferredCreate` comment (`lua_script.cpp` ~585) to the routed semantics. In `engine/script/CLAUDE.md`: update the attach paragraphs (including the "a native C++-only component still uses the templated C++ createEntity" sentence) and add the acceptance's "which view do I get, and what can I call on it?" table — three rows (codegen'd C++ struct / `IRComponent.register` Lua-typed / hand-written `*_lua.hpp` C++ component) × (tick column view + methods, `IREntity.*Lua*` accessor support, attach path, modifier `bindingId` support). While in that file, fix the prefab-schema example that calls `IREntity.setComponent` inside `setup` — no such engine binding exists (verify intended spelling; likely doc drift or a per-creation helper).
+7. **Tests** — see acceptance.
+
+One task, one PR — the codegen emission and the runtime routing are one contract (the emitted header calls the new LuaScript API) and must land together. No stack split.
+
+### Affected files
+- `engine/script/include/irreden/script/lua_script.hpp` — attach registry, Lua-typed id set, `registerComponentAttachFactory`
+- `engine/script/src/lua_script.cpp` — routing, accessor guards, call-time validation, comment fix
+- `cmake/lua_codegen/main.cpp` — attach-factory emission + `ir_script_utils.hpp` include
+- `test/script/lua_component_codegen_test.cpp`, `test/script/lua_component_codegen_fixtures.lua` — coverage
+- `engine/script/CLAUDE.md` — accessor table + attach-path docs
+
+### Acceptance criteria (positive-fire)
+1. `addLuaComponent(e, <codegen comp>, { <field> = X })` attaches; C++-side `getComponent<C_X>` asserts the override landed AND untouched fields hold schema defaults. Include one `vec3`-field override case.
+2. `deferredCreate({ { <codegen comp>, { <field> = X } } })` + `flushStructuralChanges` materializes the entity with X asserted.
+3. Negative with positive control in the same test: the same attach call on a C++-bound component with **no** factory raises a Lua error whose message is asserted to name the supported path (not the raw `appendDefaultRow` assertion text), while the codegen-component control attach succeeds.
+4. `getLuaComponent` / `getLuaField` / `setLuaField` on a codegen'd component raise the diagnostic (message asserted) — the UB cast is unreachable.
+5. `removeLuaComponent` on an attached codegen'd component detaches it (`hasLuaComponent` flips true → false).
+6. Existing EVAL-path suites (`lua_component_register_test`, coexistence tests) stay green — the Lua-typed path is behavior-identical.
+
+### Gotchas
+- The attach map MUST live on `LuaScript` (World lifetime) — never a static/process registry (per-World ComponentIds; multi-World test fixtures would key stale ids).
+- Coexistence: `IRComponent.register`'s carve-out early-return must not insert into `m_luaTypedComponentIds`.
+- sol2 config is `SOL_ALL_SAFETIES_ON` + `SOL_EXCEPTIONS_ALWAYS_UNSAFE` — raise via `throw sol::error{...}` like sibling bindings.
+- Wiring order stays `bindLuaDrivenEcs()` → `registerCodegenComponents()` (already documented); the codegen handle at `IRComponent.<Name>` exists only after both.
+- Modifier `bindingId` for codegen'd components remains unsupported (documented coexistence limitation) — carry that row in the new table; do not attempt to fix it here.
+- Emitted struct field order is alphabetical (codegen sort); overrides are name-keyed so order is irrelevant — don't rely on positional table entries in tests.
+
+### Out of scope (explicit)
+- Unifying the column-view surfaces (`getField`/`setField` on `LuaCppColumnView`) — acceptance permits doc-only, and generic sol2-property dispatch has a silent-failure class for getter-lambda-style hand bindings. If EVAL-dispatch parity for codegen'd systems becomes load-bearing (the dual-mode tuning loop), file it as its own designed follow-up.
+- Registering codegen components into the prefab declarative-components (string-keyed) registry — a natural extension of the same emission, not required by acceptance.
+- Hand-written `*_lua.hpp` components opting into Lua attach via `registerComponentAttachFactory` — the mechanism supports it; per-component adoption is separate work.
+

--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -138,6 +138,32 @@ std::string escapeStringLiteral(std::string_view s) {
     return out;
 }
 
+// One field's override read inside an emitted attach factory. Scalars
+// read through `sol::optional<T>` so a missing key or a type-mismatched value
+// leaves the schema default in place — the same silently-ignore contract
+// `IComponentDataLuaTyped::writeRowFromTable` documents for the EVAL path.
+// Packed vec3 / ivec3 have no single `sol::optional` spelling (they accept an
+// { x, y, z } table or an IRMath userdata), so they test for a non-nil value
+// and hand it to the shared IRScript converter.
+void emitAttachFieldRead(std::ostream &os, const Field &f, const char *indent) {
+    const std::string key = escapeStringLiteral(f.name_);
+    if (f.type_ == FieldType::VEC3 || f.type_ == FieldType::IVEC3) {
+        const char *converter = f.type_ == FieldType::VEC3 ? "vec3FromLua" : "ivec3FromLua";
+        os << indent << "{\n";
+        os << indent << "    sol::object raw = fields->get<sol::object>(" << key << ");\n";
+        os << indent << "    if (raw.valid() && raw.get_type() != sol::type::lua_nil) {\n";
+        os << indent << "        value." << f.name_ << "_ = IRScript::" << converter << "(raw);\n";
+        os << indent << "    }\n";
+        os << indent << "}\n";
+        return;
+    }
+    const std::string cppType = fieldCppType(f.type_);
+    os << indent << "if (sol::optional<" << cppType << "> v = fields->get<sol::optional<"
+       << cppType << ">>(" << key << ")) {\n";
+    os << indent << "    value." << f.name_ << "_ = *v;\n";
+    os << indent << "}\n";
+}
+
 // Render a float as a valid C++ float literal — always with a decimal point
 // before the `f` suffix (`100f` is a parse error; `100.f` is fine).
 std::string renderFloatLiteral(float v) {
@@ -720,10 +746,12 @@ void writeOutput(
 
     os << "#include <cstdint>\n";
     os << "#include <string>\n";
+    os << "#include <utility>\n";
     os << "#include <vector>\n\n";
     os << "#include <irreden/ir_entity.hpp>\n";
     os << "#include <irreden/ir_math.hpp>\n";
     os << "#include <irreden/ir_system.hpp>\n";
+    os << "#include <irreden/script/ir_script_utils.hpp>\n";
     os << "#include <irreden/script/lua_binding_traits.hpp>\n";
     os << "#include <irreden/script/lua_script.hpp>\n";
     os << "#include <irreden/system/ir_system_types.hpp>\n";
@@ -808,6 +836,33 @@ void writeOutput(
             os << "        &" << structName << "::" << f.name_ << "_";
         }
         os << "\n    );\n";
+        // #2446: the Lua attach path for this component. `addComponentDynamic`
+        // refuses to append a default row for a C++-typed impl (some engine
+        // components have deleted default ctors), and applying the overrides
+        // table needs per-field typed writes that only the codegen — which
+        // knows the field set — can supply. So the factory owns both halves:
+        // default-construct, write whichever overrides are present, attach via
+        // the templated `setComponent<T>`. Registered here rather than in
+        // `registerCodegenComponents` because `bindLuaType<C_X>` is unique per
+        // component, and that registry function must stay small enough to
+        // inline.
+        os << "    luaScript.registerComponentAttachFactory(\n";
+        os << "        IREntity::getEntityManager().getComponentType<" << structName << ">(),\n";
+        // A fieldless component has nothing to read, so the overrides
+        // parameter goes unnamed rather than unused.
+        os << "        [](IREntity::EntityId entity, const sol::optional<sol::table> &"
+           << (c.fields_.empty() ? "" : "fields") << ") {\n";
+        os << "            " << structName << " value{};\n";
+        if (!c.fields_.empty()) {
+            os << "            if (fields) {\n";
+            for (const auto &f : c.fields_) {
+                emitAttachFieldRead(os, f, "                ");
+            }
+            os << "            }\n";
+        }
+        os << "            IREntity::setComponent(entity, std::move(value));\n";
+        os << "        }\n";
+        os << "    );\n";
         os << "}\n\n";
     }
     os << "} // namespace IRScript\n\n";
@@ -838,6 +893,16 @@ void writeOutput(
     // EntityManager (so its ComponentId is allocated up front, matching the
     // EVAL path's behaviour) and binds the Lua usertype via the trait. The
     // creation calls this once during init after `bindLuaDrivenEcs()`.
+    //
+    // Keep this body minimal — two statements per component. Every codegen run
+    // in a binary emits `IRScript::CodegenRegistry::registerCodegenComponents`
+    // under the same name, so the definitions only stay distinct as long as
+    // each stays small enough for the compiler to inline at its single call
+    // site. Grow it and the compiler emits an out-of-line `linkonce_odr` copy,
+    // the linker merges the runs, and every caller silently gets one arbitrary
+    // run's components (the engine test binary links three runs, so it breaks
+    // first). Per-component work belongs in the emitted `bindLuaType<C_X>`,
+    // whose name is unique — that is where the #2446 attach factory lives.
     os << "namespace IRScript::CodegenRegistry {\n\n";
     os << "inline void registerCodegenComponents(IRScript::LuaScript &luaScript) {\n";
     os << "    auto &em = IREntity::getEntityManager();\n";

--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -903,6 +903,10 @@ void writeOutput(
     // run's components (the engine test binary links three runs, so it breaks
     // first). Per-component work belongs in the emitted `bindLuaType<C_X>`,
     // whose name is unique — that is where the #2446 attach factory lives.
+    // That escape hatch holds only while component struct names are unique
+    // across the runs linked into one binary: `bindLuaType<C_X>` is emitted
+    // `template <> inline`, so two runs declaring the same component name
+    // merge the same way, swapping attach factories. #2609 owns the fix.
     os << "namespace IRScript::CodegenRegistry {\n\n";
     os << "inline void registerCodegenComponents(IRScript::LuaScript &luaScript) {\n";
     os << "    auto &em = IREntity::getEntityManager();\n";

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -155,9 +155,12 @@ IREntity.deferredDestroy(eid)   -- eid is a raw EntityId (e.g. arch.entityAt(i))
 
 The returned EntityId is reserved immediately (usable to destroy or stash the
 entity), but the entity does not materialize until the flush. Attaches any
-component addressable from Lua by `componentId`; a native C++-only component
-(no Lua-typed default-row support) still uses the templated C++
-`createEntity`. See `docs/design/lua-driven-ecs.md` §G4.
+component with a Lua attach path — `IRComponent.register` components and
+codegen'd ones (see "Which view do I get?" below); a hand-written C++ component
+with neither still uses the templated C++ `createEntity` / `setComponent<T>`.
+An ineligible entry raises at the `deferredCreate` call site, naming the entry's
+index — the attach itself runs inside the flush drain, where a raise would have
+no Lua context to point at. See `docs/design/lua-driven-ecs.md` §G4.
 
 - **Type inference:** integer literal → `int32`; float literal → `float`;
   string → `std::string`; bool → `bool`; function → `sol::function`. The
@@ -263,6 +266,35 @@ IREntity.setLuaField(entity, C_Hp, currentIdx, v + 1)
 Both accessors bounds-check `fieldIndex` and raise a Lua error on
 out-of-range. Use index-style inside any per-tick Lua system body.
 
+### Which view do I get, and what can I call on it? (#2446)
+
+How a component was *declared* — not the build flavor — decides its whole Lua
+surface. Three declaration kinds exist:
+
+| Declared as | Tick column view | `IREntity.*Lua*` accessors | Attach from Lua | Modifier `bindingId` |
+|---|---|---|---|---|
+| **Codegen'd** — `IRComponent.register` in an `irreden_lua_codegen(SOURCES ...)` file (emitted as a real C++ struct) | `LuaCppColumnView`: `:at(i)` → assignable row ref, `:setAt(i, Comp.new(...))`. **No `:getField` / `:setField`** | **Raise** — the accessors cast to `IComponentDataLuaTyped`, which a C++-typed impl is not | `addLuaComponent` / `deferredCreate`, via the emitted attach factory | ✗ — the C++-side registration doesn't populate the modifier registry |
+| **Lua-typed** — `IRComponent.register` at runtime (EVAL) | `LuaTypedColumnView`: `:getField(i, "f")` / `:setField(i, "f", v)`, `:getRow(i)` / `:setRow(i, t)` | ✓ `getLuaComponent` / `getLuaField` / `setLuaField` | `addLuaComponent` / `deferredCreate`, via a default row + per-field writes | ✓ scalar fields expose `Comp.fields.<name>.bindingId` |
+| **Hand-written C++** — a `component_<name>_lua.hpp` binding + `lua_component_pack` | `LuaCppColumnView`, as codegen'd | **Raise**, as codegen'd | ✗ by default — attach from C++ via `setComponent<T>`, or opt in with `registerComponentAttachFactory` | ✗ |
+
+`removeLuaComponent` / `hasLuaComponent` / `IREntity.singleton` are
+id-generic (no cast) and work for all three.
+
+The raising rows are deliberate: before #2446 those accessors
+`static_cast`ed any `IComponentData*` to `IComponentDataLuaTyped*` with no
+check, so reading a codegen'd component through `getLuaComponent` was
+undefined behavior. They now raise a Lua error naming the supported path.
+
+**Consequence for the dual-mode loop.** A tick body written with
+`:setField(i, 'name', v)` — the shape `cmake/lua_codegen` lowers, and what the
+in-tree CODEGEN exemplar uses — compiles fine as CODEGEN but fails if that same
+body is dispatched through LuaJIT against the codegen'd struct, which has no
+`setField`. So "the same body runs identically under EVAL and CODEGEN" does not
+hold for a system whose components are codegen'd. Pin such a system with
+`mode = 'codegen'`. Unifying the two column-view surfaces is deliberately out of
+scope for #2446 — file it as its own designed follow-up if EVAL-dispatch parity
+for codegen'd systems becomes load-bearing.
+
 The full design is in [`docs/design/lua-driven-ecs.md`](../../docs/design/lua-driven-ecs.md).
 
 ## Lua-defined enums (`IREnum.register`)
@@ -331,6 +363,24 @@ the matching `kHasLuaBinding` + `bindLuaType` specializations and a
 `IRScript::CodegenRegistry::registerCodegenComponents(LuaScript&)` helper
 that pre-registers each component with the EntityManager and binds the
 usertype.
+
+Each emitted `bindLuaType<C_Name>` also registers the component's **attach
+factory** (#2446) — a `default-construct → apply overrides → setComponent<T>`
+closure that gives `IREntity.addLuaComponent` / `deferredCreate` a path for a
+C++-typed component (the entity core refuses to append a default row for one,
+since some engine components have deleted default ctors). Unknown override keys
+and type-mismatched values are ignored, matching the EVAL path's
+`writeRowFromTable` contract.
+
+> **Do not grow `registerCodegenComponents`.** Every codegen run in a binary
+> emits that function — plus `CodegenSystemIds`, `registerCodegenSystems`, and
+> `kDefaultEcsMode` — under the *same* name in the same namespace. Distinct
+> definitions survive only because each is small enough to inline at its single
+> call site. Grow one past the inline threshold and the compiler emits an
+> out-of-line `linkonce_odr` copy, the linker merges every run into one winner,
+> and callers silently get an arbitrary run's components. The engine test binary
+> links three codegen runs and is where this bites first. Per-component work
+> belongs in `bindLuaType<C_Name>`, whose name is unique.
 
 **CODEGEN supports:** `int32` / `float` / `bool` / `string` / `vec3` / `ivec3`
 field types and both the short form (`current = 100`) and the explicit-type
@@ -540,7 +590,9 @@ the carve-out, the runtime load would create a parallel
 storage. Lua-side code that depends on `handle.fields.<name>.bindingId`
 (modifier framework) does NOT work for codegen'd-as-C++ components —
 the C++-side registration doesn't populate the modifier registry the
-way the runtime path does.
+way the runtime path does. Attaching one from Lua *does* work (#2446);
+the full per-declaration surface is the "Which view do I get, and what
+can I call on it?" table above.
 
 **Hot-reload contract.** `IRSystem.replaceSystemBody(systemId, newTick)`
 works on EVAL systems; calling it on a CODEGEN system raises a Lua
@@ -1112,7 +1164,7 @@ return {
     unbounded      = true | false,       -- OPTIONAL, default false
     canvas_size    = { x = 64, y = 64 }, -- REQUIRED when DETACHED or DETACHED_REVOXELIZE
     setup          = function(entity)    -- OPTIONAL, user-provided
-        IREntity.setComponent(entity, ...)
+        IREntity.addLuaComponent(entity, C_Hp, { current = 50 })
     end,
 }
 ```

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -380,7 +380,13 @@ and type-mismatched values are ignored, matching the EVAL path's
 > out-of-line `linkonce_odr` copy, the linker merges every run into one winner,
 > and callers silently get an arbitrary run's components. The engine test binary
 > links three codegen runs and is where this bites first. Per-component work
-> belongs in `bindLuaType<C_Name>`, whose name is unique.
+> belongs in `bindLuaType<C_Name>`, whose name is unique — but only *while*
+> component struct names are unique across the runs linked into one binary.
+> `bindLuaType<C_Name>` is emitted `template <> inline`, so two runs declaring
+> a same-named component merge exactly the way `registerCodegenComponents`
+> does, and post-#2446 that silently swaps **attach factories**, not just
+> registrations. (The emitted structs would already collide in that case — a
+> wider symptom of the same root cause, which #2609 owns.)
 
 **CODEGEN supports:** `int32` / `float` / `bool` / `string` / `vec3` / `ivec3`
 field types and both the short form (`current = 100`) and the explicit-type

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -14,6 +14,7 @@
 #include <irreden/script/lua_binding_traits.hpp>
 #include <irreden/script/lua_component_data.hpp>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -144,6 +145,25 @@ class LuaScript {
         return it->second;
     }
 
+    // #2446: default-construct a C++-typed component, apply the optional
+    // Lua overrides table field-by-field, and attach it via the templated
+    // `IREntity::setComponent<T>`. The entity core deliberately refuses to
+    // default-row a C++-typed component through `addComponentDynamic` (some
+    // have deleted default ctors), so this is how a codegen'd component
+    // becomes reachable from `IREntity.addLuaComponent` / `deferredCreate`.
+    using ComponentAttachFn =
+        std::function<void(IREntity::EntityId, const sol::optional<sol::table> &)>;
+
+    // Record the attach factory for `componentId`. Called once per
+    // codegen'd component from the emitted `registerCodegenComponents()`;
+    // a hand-written `*_lua.hpp` component may opt in the same way.
+    // Per-`LuaScript` (World lifetime) because ComponentIds are per-World
+    // runtime allocations — a process-static registry would key stale ids
+    // across World re-creation.
+    void registerComponentAttachFactory(IREntity::ComponentId componentId, ComponentAttachFn fn) {
+        m_componentAttachFactories[componentId] = std::move(fn);
+    }
+
     // Returns the column accessor pair registered for the C++ component
     // with `componentId`, or nullptr if the component does not have a
     // Lua binding (Lua-defined components go through
@@ -243,7 +263,24 @@ class LuaScript {
     // Lua-defined components go through `EntityManager`'s
     // `m_pureComponentTypes` directly; this map only covers C++ types.
     std::unordered_map<std::string, IREntity::ComponentId> m_componentByLuaName;
+    // ComponentId → Lua-visible name, for both C++-bound and Lua-typed
+    // components. Diagnostics only — the attach / accessor error paths name
+    // the offending component instead of printing a bare numeric id. Kept
+    // separate from `m_componentByLuaName` (C++ types only), which the
+    // coexistence carve-out in `IRComponent.register` keys off.
     std::unordered_map<IREntity::ComponentId, std::string> m_componentLuaName;
+
+    // ComponentIds registered through `IRComponent.register` — i.e.
+    // backed by an `IComponentDataLuaTyped` impl. The `IREntity.*Lua*`
+    // accessors `static_cast` `IComponentData*` to that type, which is UB
+    // for any other impl, so every such cast is gated on membership here.
+    // Excludes the coexistence carve-out's early-return (that path returns
+    // an existing C++-typed handle and registers no Lua-typed impl).
+    std::unordered_set<IREntity::ComponentId> m_luaTypedComponentIds;
+
+    // ComponentId → attach factory for C++-typed components,
+    // populated by the codegen-emitted `registerCodegenComponents()`.
+    std::unordered_map<IREntity::ComponentId, ComponentAttachFn> m_componentAttachFactories;
 
     // Per-C++-component-id row accessor pair (read + replace) used by
     // `LuaCppColumnView` so a Lua system tick can read or overwrite a
@@ -304,6 +341,36 @@ class LuaScript {
     // entry; the public API stays singular so creations only need one
     // init call regardless of which Lua-driven-ECS PRs land.
     void bindLuaDrivenSystems();
+
+    // Attach `componentId` to `entity`, routing on how the component
+    // is stored — attach factory (C++-typed / codegen'd) first, then the
+    // `addComponentDynamic` + `writeRowFromTable` path (Lua-typed). Raises a
+    // `sol::error` naming the supported paths when neither applies, so the
+    // engine-side `appendDefaultRow` assertion is unreachable from Lua.
+    // Shared by `IREntity.addLuaComponent` and `deferredCreate`'s flush.
+    void attachComponentFromLua(
+        IREntity::EntityId entity,
+        IREntity::ComponentId componentId,
+        const sol::optional<sol::table> &overrides
+    );
+
+    // True when `componentId` can be attached from Lua by id — i.e.
+    // `attachComponentFromLua` will not raise. `deferredCreate` checks this
+    // at marshal time so an ineligible entry raises at the Lua call site
+    // rather than inside the flush drain, where there is no Lua context.
+    bool isLuaAttachable(IREntity::ComponentId componentId) const {
+        return m_componentAttachFactories.find(componentId) != m_componentAttachFactories.end() ||
+               m_luaTypedComponentIds.find(componentId) != m_luaTypedComponentIds.end();
+    }
+
+    // Raises unless `componentId` is Lua-typed. The `IREntity.*Lua*`
+    // read/write accessors cast to `IComponentDataLuaTyped`; a C++-typed
+    // component reaching that cast is undefined behavior.
+    void requireLuaTypedComponent(IREntity::ComponentId componentId, const char *accessor) const;
+
+    // Lua-visible name recorded for `componentId`, or `component id <N>`
+    // when none was recorded. Diagnostics only.
+    std::string componentDisplayName(IREntity::ComponentId componentId) const;
 
     // Build the read/replace accessor pair for a C++ component type
     // and record it under the type's `ComponentId`. Called from

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -168,27 +168,69 @@ LuaFieldSchema buildFieldSchema(
     return s;
 }
 
-// Add a dynamic (Lua-registered / codegen'd) component to `entity` by
-// ComponentId and, when `overrides` is present, write its fields from the
-// table. Shared by the eager `IREntity.addLuaComponent` binding and the
-// deferred `IREntity.deferredCreate` attach path.
-void attachDynamicComponent(
-    IREntity::EntityManager &em,
+} // namespace
+
+std::string LuaScript::componentDisplayName(IREntity::ComponentId componentId) const {
+    auto it = m_componentLuaName.find(componentId);
+    if (it != m_componentLuaName.end()) {
+        return "'" + it->second + "'";
+    }
+    return "component id " + std::to_string(componentId);
+}
+
+void LuaScript::attachComponentFromLua(
     IREntity::EntityId entity,
     IREntity::ComponentId componentId,
     const sol::optional<sol::table> &overrides
 ) {
-    em.addComponentDynamic(entity, componentId);
-    if (!overrides) {
+    // C++-typed (codegen'd) component: the emitted factory default-
+    // constructs the struct, applies the overrides field-by-field, and
+    // attaches through the templated `setComponent<T>`. Checked first
+    // because a codegen'd component in coexistence mode is reachable under
+    // the same Lua name as its EVAL counterpart.
+    auto factory = m_componentAttachFactories.find(componentId);
+    if (factory != m_componentAttachFactories.end()) {
+        factory->second(entity, overrides);
         return;
     }
-    auto [data, row] = em.getComponentDataAndRow(entity, componentId);
-    IR_ASSERT(data != nullptr, "attachDynamicComponent: post-add lookup failed");
-    auto *typed = static_cast<IComponentDataLuaTyped *>(data);
-    typed->writeRowFromTable(row, *overrides);
+
+    // Lua-typed component: `IComponentDataLuaTyped` supports a default row,
+    // so the entity core can append one and the overrides write per field.
+    if (m_luaTypedComponentIds.find(componentId) != m_luaTypedComponentIds.end()) {
+        auto &em = IREntity::getEntityManager();
+        em.addComponentDynamic(entity, componentId);
+        if (!overrides) {
+            return;
+        }
+        auto [data, row] = em.getComponentDataAndRow(entity, componentId);
+        IR_ASSERT(data != nullptr, "attachComponentFromLua: post-add lookup failed");
+        auto *typed = static_cast<IComponentDataLuaTyped *>(data);
+        typed->writeRowFromTable(row, *overrides);
+        return;
+    }
+
+    throw sol::error{
+        "IREntity attach: " + componentDisplayName(componentId) +
+        " cannot be attached from Lua. Components declared with IRComponent.register attach "
+        "directly; codegen'd components require registerCodegenComponents() to have run first; "
+        "any other C++-bound component must be attached from C++ via the templated "
+        "setComponent<T>(entity, value)."
+    };
 }
 
-} // namespace
+void LuaScript::requireLuaTypedComponent(
+    IREntity::ComponentId componentId, const char *accessor
+) const {
+    if (m_luaTypedComponentIds.find(componentId) != m_luaTypedComponentIds.end()) {
+        return;
+    }
+    throw sol::error{
+        std::string{accessor} + ": " + componentDisplayName(componentId) +
+        " is a C++-typed component, not an IRComponent.register one — the Lua field accessors do "
+        "not support it. Read or write it from a system tick's archetype column view, or from "
+        "C++ via the templated getComponent<T> / setComponent<T>."
+    };
+}
 
 // lua_dofile runs a lua script. Global functions and variables
 // can be accessed via the lua stack.
@@ -476,6 +518,12 @@ void LuaScript::bindLuaDrivenEcs() {
             "isComponentRegistered check)",
             componentName.c_str()
         );
+        // The `IComponentDataLuaTyped` impl just registered is the only
+        // thing that makes the cast in the attach / field accessors sound.
+        // The coexistence carve-out deliberately never reaches here — it
+        // hands back an already-registered C++-typed handle.
+        m_luaTypedComponentIds.insert(componentId);
+        m_componentLuaName.emplace(componentId, componentName);
 
         sol::table handle = m_lua.create_table();
         handle["typeName"] = componentName;
@@ -545,12 +593,13 @@ void LuaScript::bindLuaDrivenEcs() {
                                                sol::optional<sol::table> overrides
                                            ) {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
-        attachDynamicComponent(IREntity::getEntityManager(), entity.entity, componentId, overrides);
+        attachComponentFromLua(entity.entity, componentId, overrides);
     };
 
     m_lua["IREntity"]["getLuaComponent"] =
         [this](IRScript::LuaEntity entity, sol::table componentDef) -> sol::object {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
+        requireLuaTypedComponent(componentId, "getLuaComponent");
         auto &em = IREntity::getEntityManager();
         auto [data, row] = em.getComponentDataAndRow(entity.entity, componentId);
         if (!data)
@@ -584,8 +633,13 @@ void LuaScript::bindLuaDrivenEcs() {
     // optional array of `{ componentDef, overridesTableOrNil }` entries:
     // `componentDef` is the table from `IRComponent.register` / a codegen'd
     // component binding (it carries `componentId`), and the optional overrides
-    // are applied exactly like `addLuaComponent`. Both Lua-registered and
-    // codegen'd components share the ComponentId space, so either attaches.
+    // are applied exactly like `addLuaComponent`. Lua-registered and codegen'd
+    // components attach through different mechanisms — a default row for the
+    // former, the #2446 attach factory for the latter — but both are routed by
+    // `attachComponentFromLua`, so either spelling attaches here. A component
+    // that is neither (a C++-bound type with no attach factory) is rejected at
+    // marshal time, naming the offending entry's index: the attach itself runs
+    // inside the flush drain, where a raise would have no Lua context.
     m_lua["IREntity"]["deferredCreate"] =
         [this](sol::optional<sol::table> componentList) -> IREntity::EntityId {
         auto &em = IREntity::getEntityManager();
@@ -600,17 +654,26 @@ void LuaScript::bindLuaDrivenEcs() {
             for (std::size_t i = 1; i <= count; ++i) {
                 sol::table entry = componentList->get<sol::table>(i);
                 sol::table componentDef = entry.get<sol::table>(1);
-                pending.emplace_back(
-                    componentDef.get<lua_Integer>("componentId"),
-                    entry.get<sol::optional<sol::table>>(2)
-                );
+                const IREntity::ComponentId componentId =
+                    componentDef.get<lua_Integer>("componentId");
+                if (!isLuaAttachable(componentId)) {
+                    throw sol::error{
+                        "IREntity.deferredCreate: componentList entry " + std::to_string(i) +
+                        " is " + componentDisplayName(componentId) +
+                        ", which cannot be attached from Lua. Components declared with "
+                        "IRComponent.register attach directly; codegen'd components require "
+                        "registerCodegenComponents() to have run first; any other C++-bound "
+                        "component must be attached from C++ via the templated "
+                        "setComponent<T>(entity, value)."
+                    };
+                }
+                pending.emplace_back(componentId, entry.get<sol::optional<sol::table>>(2));
             }
         }
         const IREntity::EntityId entity = em.createEntityDeferred();
-        em.stageStructuralChange([entity, pending = std::move(pending)]() {
-            auto &mgr = IREntity::getEntityManager();
+        em.stageStructuralChange([this, entity, pending = std::move(pending)]() {
             for (const auto &[componentId, overrides] : pending) {
-                attachDynamicComponent(mgr, entity, componentId, overrides);
+                attachComponentFromLua(entity, componentId, overrides);
             }
         });
         return entity;
@@ -674,6 +737,7 @@ void LuaScript::bindLuaDrivenEcs() {
     m_lua["IREntity"]["getLuaField"] =
         [this](IRScript::LuaEntity entity, sol::table componentDef, int fieldIndex) -> sol::object {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
+        requireLuaTypedComponent(componentId, "getLuaField");
         auto &em = IREntity::getEntityManager();
         auto [data, row] = em.getComponentDataAndRow(entity.entity, componentId);
         if (!data)
@@ -695,6 +759,7 @@ void LuaScript::bindLuaDrivenEcs() {
                                            sol::object value
                                        ) {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
+        requireLuaTypedComponent(componentId, "setLuaField");
         auto &em = IREntity::getEntityManager();
         auto [data, row] = em.getComponentDataAndRow(entity.entity, componentId);
         if (!data)

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -671,6 +671,11 @@ void LuaScript::bindLuaDrivenEcs() {
             }
         }
         const IREntity::EntityId entity = em.createEntityDeferred();
+        // Capturing `this` is sound for the queue's whole lifetime: the queue
+        // is an EntityManager member and World declares m_lua ahead of
+        // m_entityManager, so the manager — and every lambda staged on it —
+        // is destroyed while the LuaScript is still alive. That member order
+        // is load-bearing; see the comment on it in world.hpp before moving it.
         em.stageStructuralChange([this, entity, pending = std::move(pending)]() {
             for (const auto &[componentId, overrides] : pending) {
                 attachComponentFromLua(entity, componentId, overrides);

--- a/engine/world/include/irreden/world.hpp
+++ b/engine/world/include/irreden/world.hpp
@@ -42,7 +42,12 @@ class World {
     // m_lua must lead the manager block: EntityManager's archetype columns
     // can hold sol::object refs (Lua-typed components, see T-100). Members
     // destruct in reverse declaration order, so sol::state has to outlive
-    // EntityManager or those refs UAF on shutdown.
+    // EntityManager or those refs UAF on shutdown. A second consumer rides
+    // the same ordering (#2446): EntityManager's staged structural-change
+    // queue holds lambdas capturing `LuaScript *` (IREntity.deferredCreate's
+    // attach op), which a reorder would leave dangling. That queue is
+    // normally empty at teardown, so no test would catch the regression —
+    // treat this order as load-bearing for both reasons.
     IRScript::LuaScript m_lua;
     IREntity::EntityManager m_entityManager;
     IRSystem::SystemManager m_systemManager;

--- a/test/script/lua_component_codegen_test.cpp
+++ b/test/script/lua_component_codegen_test.cpp
@@ -204,6 +204,173 @@ TEST_F(LuaComponentCodegenTest, LuaFieldAccessorReturnsValue) {
     EXPECT_EQ(max, 11);
 }
 
+// ---- #2446: Lua attach path for codegen'd components -----------------------
+
+TEST_F(LuaComponentCodegenTest, AddLuaComponentAttachesCodegenComponentWithOverrides) {
+    auto &lua = m_lua.lua();
+    const IREntity::EntityId e = IREntity::createEntity();
+    lua["testEntity"] = IRScript::LuaEntity{e};
+    auto result = lua.safe_script(R"lua(
+        IREntity.addLuaComponent(testEntity, IRComponent.CodegenHp, { current = 42 })
+    )lua");
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+
+    auto &hp = IREntity::getComponent<IRComponents::C_CodegenHp>(e);
+    EXPECT_EQ(hp.current_, 42);
+    // Untouched fields keep the schema default rather than a zeroed row.
+    EXPECT_EQ(hp.max_, 100);
+}
+
+TEST_F(LuaComponentCodegenTest, AddLuaComponentHonorsVec3Override) {
+    auto &lua = m_lua.lua();
+    const IREntity::EntityId e = IREntity::createEntity();
+    lua["testEntity"] = IRScript::LuaEntity{e};
+    auto result = lua.safe_script(R"lua(
+        IREntity.addLuaComponent(testEntity, IRComponent.CodegenTransform, {
+            position = { x = 1.25, y = 2.5, z = 3.75 },
+        })
+    )lua");
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+
+    auto &t = IREntity::getComponent<IRComponents::C_CodegenTransform>(e);
+    EXPECT_FLOAT_EQ(t.position_.x, 1.25f);
+    EXPECT_FLOAT_EQ(t.position_.y, 2.5f);
+    EXPECT_FLOAT_EQ(t.position_.z, 3.75f);
+    // The omitted ivec3 field keeps its schema default.
+    EXPECT_EQ(t.cell_.x, 4);
+    EXPECT_EQ(t.cell_.y, 5);
+    EXPECT_EQ(t.cell_.z, 6);
+}
+
+TEST_F(LuaComponentCodegenTest, AddLuaComponentWithNoOverridesUsesSchemaDefaults) {
+    auto &lua = m_lua.lua();
+    const IREntity::EntityId e = IREntity::createEntity();
+    lua["testEntity"] = IRScript::LuaEntity{e};
+    auto result = lua.safe_script("IREntity.addLuaComponent(testEntity, IRComponent.CodegenHp)");
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+
+    auto &hp = IREntity::getComponent<IRComponents::C_CodegenHp>(e);
+    EXPECT_EQ(hp.current_, 100);
+    EXPECT_EQ(hp.max_, 100);
+}
+
+TEST_F(LuaComponentCodegenTest, DeferredCreateMaterializesCodegenComponent) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(R"lua(
+        return IREntity.deferredCreate({ { IRComponent.CodegenHp, { current = 30 } } })
+    )lua");
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    const auto entity = result.get<IREntity::EntityId>();
+
+    m_entity_manager.flushStructuralChanges();
+
+    auto &hp = IREntity::getComponent<IRComponents::C_CodegenHp>(entity);
+    EXPECT_EQ(hp.current_, 30);
+    EXPECT_EQ(hp.max_, 100);
+}
+
+// Negative case with a positive control in the same test: a C++-bound
+// component with no attach factory must raise a Lua error naming the
+// supported path (not the raw `appendDefaultRow` engine assertion), while the
+// codegen'd control attaches in the same script.
+TEST_F(LuaComponentCodegenTest, AttachWithoutFactoryRaisesActionableLuaError) {
+    auto &lua = m_lua.lua();
+    const IREntity::EntityId e = IREntity::createEntity();
+    lua["testEntity"] = IRScript::LuaEntity{e};
+
+    // Positive control: the codegen'd component still attaches.
+    auto control =
+        lua.safe_script("IREntity.addLuaComponent(testEntity, IRComponent.CodegenScore)");
+    ASSERT_TRUE(control.valid()) << sol::error{control}.what();
+    EXPECT_EQ(IREntity::getComponent<IRComponents::C_CodegenScore>(e).value_, 0);
+
+    // A component id the LuaScript never saw — the shape a hand-written
+    // C++-bound component (no `registerComponentAttachFactory`) presents.
+    lua["unattachable"] = lua.create_table_with(
+        "typeName",
+        "NotAttachable",
+        "componentId",
+        static_cast<lua_Integer>(m_entity_manager.getComponentType<ArchetypeMoveCodegenMarker>())
+    );
+    auto result = lua.safe_script(
+        "IREntity.addLuaComponent(testEntity, unattachable)",
+        sol::script_pass_on_error
+    );
+    ASSERT_FALSE(result.valid());
+    const std::string message = sol::error{result}.what();
+    EXPECT_NE(message.find("setComponent<T>"), std::string::npos) << message;
+    EXPECT_EQ(message.find("appendDefaultRow"), std::string::npos)
+        << "the raw engine assertion should be unreachable from Lua: " << message;
+}
+
+// deferredCreate rejects an ineligible entry at the call site, naming the
+// entry index — a raise inside the flush drain would have no Lua context.
+TEST_F(LuaComponentCodegenTest, DeferredCreateRejectsIneligibleEntryAtCallSite) {
+    auto &lua = m_lua.lua();
+    lua["unattachable"] = lua.create_table_with(
+        "typeName",
+        "NotAttachable",
+        "componentId",
+        static_cast<lua_Integer>(m_entity_manager.getComponentType<ArchetypeMoveCodegenMarker>())
+    );
+    auto result = lua.safe_script(
+        R"lua(
+            return IREntity.deferredCreate({
+                { IRComponent.CodegenHp },
+                { unattachable },
+            })
+        )lua",
+        sol::script_pass_on_error
+    );
+    ASSERT_FALSE(result.valid());
+    const std::string message = sol::error{result}.what();
+    EXPECT_NE(message.find("entry 2"), std::string::npos) << message;
+
+    // The rejection happened before any structural change was staged.
+    m_entity_manager.flushStructuralChanges();
+}
+
+// The `IREntity.*Lua*` field accessors `static_cast` to IComponentDataLuaTyped;
+// reaching that cast with a codegen'd (C++-typed) component is UB. Each
+// accessor must raise instead.
+TEST_F(LuaComponentCodegenTest, FieldAccessorsRejectCodegenComponent) {
+    auto &lua = m_lua.lua();
+    const IREntity::EntityId e = IREntity::createEntity();
+    lua["testEntity"] = IRScript::LuaEntity{e};
+    ASSERT_TRUE(
+        lua.safe_script("IREntity.addLuaComponent(testEntity, IRComponent.CodegenHp)").valid()
+    );
+
+    for (const char *script :
+         {"IREntity.getLuaComponent(testEntity, IRComponent.CodegenHp)",
+          "IREntity.getLuaField(testEntity, IRComponent.CodegenHp, 0)",
+          "IREntity.setLuaField(testEntity, IRComponent.CodegenHp, 0, 5)"}) {
+        auto result = lua.safe_script(script, sol::script_pass_on_error);
+        ASSERT_FALSE(result.valid()) << script;
+        const std::string message = sol::error{result}.what();
+        EXPECT_NE(message.find("C++-typed component"), std::string::npos)
+            << script << ": " << message;
+    }
+}
+
+// removeLuaComponent / hasLuaComponent are id-generic (no cast), so they work
+// on a codegen'd component unchanged — verified rather than guarded.
+TEST_F(LuaComponentCodegenTest, RemoveLuaComponentDetachesCodegenComponent) {
+    auto &lua = m_lua.lua();
+    const IREntity::EntityId e = IREntity::createEntity();
+    lua["testEntity"] = IRScript::LuaEntity{e};
+    auto result = lua.safe_script(R"lua(
+        IREntity.addLuaComponent(testEntity, IRComponent.CodegenHp)
+        local attached = IREntity.hasLuaComponent(testEntity, IRComponent.CodegenHp)
+        IREntity.removeLuaComponent(testEntity, IRComponent.CodegenHp)
+        return attached, IREntity.hasLuaComponent(testEntity, IRComponent.CodegenHp)
+    )lua");
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    auto [attached, stillAttached] = result.get<std::tuple<bool, bool>>();
+    EXPECT_TRUE(attached);
+    EXPECT_FALSE(stillAttached);
+}
+
 // ---- Schema-error coverage (subprocess invocation) -------------------------
 
 // #1403: CodegenDevice.kind defaults to CodegenDeviceType.SYNTH (0-based


### PR DESCRIPTION
## Summary
- Codegen'd components can now be attached from Lua. Each emitted `bindLuaType<C_X>` registers an **attach factory** — default-construct, apply whichever overrides the table carries, attach via the templated `setComponent<T>` — and `IREntity.addLuaComponent` / `deferredCreate` route through it. The entity core keeps its "C++ types attach with an explicit value" invariant, so components with deleted default ctors stay unrepresentable in the dynamic path.
- Attaching something with neither an attach factory nor an `IComponentDataLuaTyped` impl now raises a Lua error naming the supported path, instead of tripping the raw `appendDefaultRow` engine assertion.
- `deferredCreate` validates eligibility at **marshal time**, naming the offending entry's index. The attach itself runs inside the flush drain, where a raise would have no Lua context to point at.
- **Latent UB fixed in passing:** `getLuaComponent` / `getLuaField` / `setLuaField` blind-`static_cast`ed any `IComponentData*` to `IComponentDataLuaTyped*` with no check. Reading a codegen'd component through them was undefined behavior *before* this PR; fixing attach makes that path much easier to reach, so the guards land here.
- Corrected the misleading `deferredCreate` doc comment ("Both Lua-registered and codegen'd components share the ComponentId space, so either attaches" — the second half was false), and documented the per-declaration surface in `engine/script/CLAUDE.md`.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `fleet-run IrredenEngineTest` — **1369/1369 pass**
- [x] `fleet-build --target IRLuaPerfGrid` — the in-tree codegen-using demo still builds against the changed emission
- [x] Phase 0 of the plan: confirmed the reported assertion fires on unmodified master before building the fix (`addComponentDynamic: impl for componentId=255 does not support appendDefaultRow`)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1 — `addLuaComponent` with overrides attaches; untouched fields keep schema defaults; includes a `vec3` case | `fleet-run IrredenEngineTest --gtest_filter='*AddLuaComponent*'` | `OK ] AddLuaComponentAttachesCodegenComponentWithOverrides` (asserts `current_==42`, `max_==100`), `OK ] AddLuaComponentHonorsVec3Override` (asserts `position_` written, `cell_` default), `OK ] AddLuaComponentWithNoOverridesUsesSchemaDefaults` |
| 2 — `deferredCreate` + `flushStructuralChanges` materializes with the override | same filter | `OK ] DeferredCreateMaterializesCodegenComponent` (asserts `current_==30`, `max_==100`) |
| 3 — negative + positive control in one test; message names the supported path, not `appendDefaultRow` | same filter | `OK ] AttachWithoutFactoryRaisesActionableLuaError` — control attach succeeds, error message asserted to contain `setComponent<T>` and **not** `appendDefaultRow` |
| 4 — the three field accessors raise on a codegen'd component | same filter | `OK ] FieldAccessorsRejectCodegenComponent` — all three asserted to contain `C++-typed component` |
| 5 — `removeLuaComponent` detaches (`hasLuaComponent` true → false) | same filter | `OK ] RemoveLuaComponentDetachesCodegenComponent` |
| 6 — existing EVAL suites + coexistence tests stay green | `fleet-run IrredenEngineTest` | `[  PASSED  ] 1369 tests.` (includes `LuaComponentRegisterTest.*`, `LuaSystemCoexistenceTest.*`) |
| plan step 3 — ineligible `deferredCreate` entry rejected at the call site with its index | same filter | `OK ] DeferredCreateRejectsIneligibleEntryAtCallSite` — message asserted to contain `entry 2` |

## Notes for reviewer

**Why the factory registers in `bindLuaType<C_X>` and not `registerCodegenComponents`.** This is the one non-obvious placement, and it cost a debugging round-trip worth flagging. Every codegen run in a binary emits `IRScript::CodegenRegistry::registerCodegenComponents` under the *same* name in the same namespace — an ODR violation that survives only because each definition is small enough for the compiler to inline at its single call site (`nm build/IrredenEngineTest | grep -c registerCodegenComponents` → `0`, on master and on this branch). My first cut put the factory registration in that function; the body grew past the inline threshold, clang emitted an out-of-line `linkonce_odr` copy, the linker merged all three of the test binary's codegen runs into one winner, and `LuaSystemCoexistenceTest` silently began loading the T-106 fixture's components. Three tests failed. Moving the per-component work into `bindLuaType<C_X>` — whose name *is* unique per component — keeps the registry function byte-small and the symbol count at zero. I've left a comment at the emission site and a callout in `engine/script/CLAUDE.md` so the next person doesn't rediscover it.

That ODR landmine is pre-existing and larger than this ticket (it also covers `CodegenSystemIds`, `registerCodegenSystems`, `kDefaultEcsMode`) — I'm filing it as a separate follow-up rather than widening this PR, since fixing it properly means changing the registry's namespace and every creation's call site.

**`deferredCreate`'s staged lambda now captures `this`.** The lambda already captured `sol::optional<sol::table>` values — Lua references into the same `LuaScript`'s state — so the lifetime coupling to `LuaScript` predates this change and is not worsened by the `this` capture. The attach map lives on `LuaScript` (World lifetime) rather than a process-static registry deliberately: ComponentIds are per-World runtime allocations, and a static map would key stale ids across World re-creation.

**No `optimize` pass.** The change isn't on a per-frame critical path — attach is a structural-change surface, and the new codegen route replaces a strictly more expensive dynamic path (virtual `addComponentDynamic` + per-field variant dispatch) with a typed `setComponent<T>`. The added cost on `deferredCreate` is two hash lookups per component entry at marshal time, dominated by the existing sol marshaling and vector allocation.

**`cmake/lua_codegen/main.cpp` is outside clang-format's scope** (`irreden_collect_quality_files` globs only `engine/`, `creations/`, `test/`), so its hunks follow the file's existing style rather than the repo `.clang-format`. Running the formatter over it would have produced a 352-line whole-file reformat unrelated to this change.

Closes #2446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
