### PR TITLE
demos(lua_perf_grid): fix --auto-screenshot hang from late arg read

### DIFF
--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -155,12 +155,19 @@ void registerArgs() {
     );
 }
 
-// Read the parsed flags into g_autoProfileFrames + g_cliOverrides. Runs inside
-// the lua-bindings callback (which fires during init, after the parse) so
-// g_cliOverrides is populated before applyCliOverrides() consumes it. Replaces
-// the retired hand-rolled parseArgs.
+// Read the parsed flags into g_autoWarmupFrames + g_autoProfileFrames +
+// g_cliOverrides. Runs inside the lua-bindings callback (which fires during
+// init, after the parse) so g_cliOverrides is populated before
+// applyCliOverrides() consumes it. Replaces the retired hand-rolled parseArgs.
 void applyArgs() {
     const IRArgs::Parser &args = IREngine::args();
+    // registerLuaBindings() builds the RENDER pipeline — including the
+    // auto-screenshot system — from inside the binding callback, which runs
+    // during IREngine::init. So the warmup count must land here, at callback
+    // time: assigning it after init returns leaves that guard reading 0, and
+    // --auto-screenshot then hangs forever with no capture system to call
+    // closeWindow() and no diagnostic (#2502).
+    g_autoWarmupFrames = args.autoScreenshotWarmupFrames();
     if (args.wasProvided("--auto-profile")) {
         g_autoProfileFrames = args.getInt("--auto-profile");
     }
@@ -517,7 +524,6 @@ int main(int argc, char **argv) {
     );
     registerLuaBindings();
     IREngine::init(argc, argv);
-    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
     }

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -93,6 +93,17 @@ Wire-up order in `main.cpp`:
 Reference callers: `creations/demos/shape_debug/main.cpp` and
 `creations/demos/metal_clear_test/main.cpp`.
 
+**Creations that compose the RENDER pipeline inside a Lua-bindings
+callback** (`IREngine::registerLuaBindings`) must read the warmup count
+*inside that callback* instead — the callback fires from
+`World::setupLuaBindings` partway through `IREngine::init`, so a step-1 read
+placed after `init` returns lands after the pipeline is already built. The
+failure is silent and total: the `warmupFrames > 0` guard sees 0, no capture
+system is ever created, nothing calls `IRWindow::closeWindow()`, and the run
+hangs to the harness timeout with no screenshot and no error (#2502). A
+creation that instead builds its pipeline in `main()` after `init` (the
+step-1–3 order above) is unaffected.
+
 ## Commands and components (prefabs/irreden/video)
 
 - `command_take_screenshot` → `requestScreenshot()`.


### PR DESCRIPTION
## Summary

`IRLuaPerfGrid --auto-screenshot N` never captured and never exited — it ran
until the harness timeout (`rc=124`), with no screenshot, no `RESULT=` verdict,
and a steady stream of `Update took ~10ms` warnings.

**Root cause (bisected).** The demo composes its RENDER pipeline — including the
auto-screenshot system — inside the `IREngine::registerLuaBindings` callback,
which fires from `World::setupLuaBindings` *partway through* `IREngine::init`.
The IRArgs migration `3cb1376a` (#2076) replaced the pre-init
`parseArgs(argc, argv)` that populated `g_autoWarmupFrames` with a read placed
**after** `IREngine::init` returns:

```diff
-    parseArgs(argc, argv);          // populated g_autoWarmupFrames BEFORE init
     registerLuaBindings();
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();   // too late
```

By the time that assignment ran, the callback had already evaluated
`if (g_autoWarmupFrames > 0)` as false. **The capture system was never
created at all** — so nothing ever requested a screenshot and nothing ever
called `IRWindow::closeWindow()`. The direct evidence is that the run logs
zero `AutoScreenshot i/N:` lines, which that system emits on its first
post-warmup frame.

The issue's secondary symptom has the same cause: with no capture system,
`IRVideo::isAutoCaptureActive()` stayed false, so `gameLoop` never called
`enableFixedStep()` and the 262144-entity update ran the variable catch-up
path — hence the `Update took ~10ms` warnings. (The issue hypothesised "the
warmup counter never reaches 30, or RENDER isn't ticking"; RENDER ticks fine,
the counter simply never existed.)

**Not Windows-specific.** This is plain C++ initialization ordering with no
platform dependency, and it reproduces identically on macOS/Metal — see below.
Windows was just the host whose platform-catchup ran after `3cb1376a` landed.

**Fix.** Move the read into `applyArgs()`, which already exists to pull this
demo's flags at callback time, alongside the `--auto-profile` / `--grid-size`
reads that #2103 migrated correctly. `autoScreenshotWarmupFrames()` returns 0
when the flag is absent, so interactive runs are unaffected.

**Scope.** `lua_perf_grid` is the only demo with this shape — audited all five
demos that mix `registerLuaBindings` with `createAutoScreenshotSystem`
(`audio_playback`, `collision_overlap_demo`, `lua_pipeline_demo`, `sprite_demo`
all evaluate the guard after `init` returns, so all are correct).

Also documented the callback-composed exception in `engine/video/CLAUDE.md`,
whose "Wire-up order in `main.cpp`" described only the compose-in-`main()`
shape — following it literally is what produced this bug.

## Test plan

Verified on macOS/Metal (arm64). Both acceptance criteria met:

- [x] **Reproduced the failure first** on this host at `origin/master`:
      killed at >180s, `0` screenshots, `0` `AutoScreenshot` lines, `0`
      `RESULT=`, log tail = `Update took 10.7ms` warnings — byte-for-byte the
      reported Windows symptom.
- [x] **After the fix:** `RESULT=CLEAN exit=0` in **6s** (bar: <60s), **2**
      screenshots saved (bar: >=1).
- [x] **Root cause named** — bisected to `3cb1376a`, mechanism above (not a
      timeout bump).
- [x] Captured PNG inspected directly: correct 64^3 lit lattice with visible
      wave displacement and the blue emissive source — a real render, not a
      blank frame or a merely-clean exit.
- [x] Sibling flags still plumb through `applyArgs`:
      `--grid-size 8 --auto-screenshot 12` → `entity_count=512`, `RESULT=CLEAN`,
      2 shots.
- [x] `format-changed` clean; `fleet-build --target IRLuaPerfGrid` green.

**On screenshots:** no `attach-screenshots` A/B — the "before" side is
structurally uncapturable (on `master` the demo produces *zero* screenshots;
that is the defect). The change touches no rendering code, so the rendered
output is unchanged from what the demo always should have produced; I verified
the "after" capture by inspecting the PNG directly instead.

**Not verified on Windows** (no Windows host on this pane). The mechanism is
host-independent and reproduced + fixed on macOS, so the Windows acceptance run
should follow, but the literal acceptance criterion names the Windows fleet
host — flagging that as the one unverified line.

## Follow-up (not in this PR)

This bug class fails silently and totally: `--auto-screenshot` was *provided*
yet no capture armed, and the only symptom is an infinite hang. An engine-side
diagnostic (warn at `gameLoop` entry when the flag was provided but
`isAutoCaptureActive()` is false) would turn that into an immediate, greppable
error for all ~30 auto-screenshot demos. Deliberately left out — it touches
shared engine surface well beyond this issue's scope. Happy to file it.

Closes #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)
