### PR TITLE
editor: fix printf %d in fmt-style add-frame log (#2491)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2717,7 +2717,7 @@ void initCommands() {
                 std::size_t{0}
             );
             IRVoxelEditor::loadFrameToLive(anim.activeFrame_);
-            IR_LOG_INFO("Added blank frame %d / %d", anim.activeFrame_ + 1, anim.frameCount());
+            IR_LOG_INFO("Added blank frame {} / {}", anim.activeFrame_ + 1, anim.frameCount());
         }
     );
 


### PR DESCRIPTION
## Summary
- `IR_LOG_INFO` is fmt-style (`{}` placeholders); the A-key add-frame command's log line used printf-style `%d` conversions, so it printed the literal string instead of substituting the frame numbers.
- Swapped `%d` / `%d` for `{}` / `{}`.

## Test plan
- [x] `fleet-build --target IRVoxelEditor` — clean build.
- [x] Log-only, one-line change — no runtime behavior change beyond the printed string.

Closes #2491

🤖 Generated with [Claude Code](https://claude.com/claude-code)