### PR TITLE
lua_perf_grid: fail loudly instead of ticking a fabricated SystemId{0}

### DIFF
--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -349,14 +349,12 @@ IRSystem::SystemId resolveLuaWaveTickId(IRScript::LuaScript &script) {
         return waveTickFromIds(ids);
     } else {
         const sol::object obj = script.lua()["LuaWaveTickSysId"];
-        if (!obj.valid() || !obj.is<lua_Integer>()) {
-            IR_LOG_ERROR(
-                "lua_perf_grid: LuaWaveTickSysId missing after main.lua "
-                "(EVAL build expects IRSystem.registerSystem to return a "
-                "non-zero SystemId and main.lua to assign it to the global)."
-            );
-            return IRSystem::SystemId{0};
-        }
+        IR_ASSERT(
+            obj.valid() && obj.is<lua_Integer>(),
+            "lua_perf_grid: LuaWaveTickSysId missing after main.lua "
+            "(EVAL build expects IRSystem.registerSystem to return a "
+            "non-zero SystemId and main.lua to assign it to the global)."
+        );
         return static_cast<IRSystem::SystemId>(obj.as<lua_Integer>());
     }
 }


### PR DESCRIPTION
## Summary
- `resolveLuaWaveTickId`'s EVAL error path fabricated `SystemId{0}` and spliced it into the UPDATE pipeline when `main.lua` failed to set `LuaWaveTickSysId` — since `SystemId`s count up from 0, that's the first system registered in the process, so the error path silently ran the wrong system instead of failing.
- Replaced the log-and-return-zero path with `IR_ASSERT`, so an EVAL build with a broken `main.lua` now fails loudly at init with a diagnostic message instead of mis-ticking an unrelated pipeline entry.
- The CODEGEN branch (the demo's default build mode) is unchanged.

## Test plan
- [x] `fleet-build --target IRLuaPerfGrid` (default CODEGEN mode) — green.
- [x] `fleet-build --target format-changed` — no changes needed.
- [x] Positive EVAL-mode check (separate scratch build with `-DIR_LUA_ECS_DEFAULT_MODE=EVAL`): demo runs normally, `LuaWaveTick` registers via `main.lua`, no assertion.
- [x] Negative EVAL-mode check: with `LuaWaveTickSysId` deliberately unset, the assert fires with the diagnostic message and the process terminates loudly (`std::runtime_error`), instead of silently mis-ticking an unrelated system.

Closes #2599

🤖 Generated with [Claude Code](https://claude.com/claude-code)