### PR TITLE
editor(voxel_editor): fix duplicate-frame log format specifiers

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2752,7 +2752,7 @@ void initCommands() {
                 editor.perFrameUndoBytes_.begin() + anim.activeFrame_,
                 std::size_t{0}
             );
-            IR_LOG_INFO("Duplicated frame %d / %d", anim.activeFrame_ + 1, anim.frameCount());
+            IR_LOG_INFO("Duplicated frame {} / {}", anim.activeFrame_ + 1, anim.frameCount());
         }
     );
 


### PR DESCRIPTION
## Summary
- `IR_LOG_INFO`'s D-key duplicate-frame log used printf-style `%d` conversions instead of `{}` placeholders, so frame numbers never substituted into the message.

## Test plan
- [x] `fleet-build --target IRVoxelEditor` clean.
- [x] Read the fixed line to confirm `{}` placeholders match `IR_LOG_INFO`'s fmt-style formatting.

Closes #2625

🤖 Generated with [Claude Code](https://claude.com/claude-code)