### PR TITLE
editor: fix printf-style format specifier in delete-frame log

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2789,7 +2789,7 @@ void initCommands() {
                 editor.perFrameUndoBytes_[newFrame] = 0;
             }
             IRVoxelEditor::loadFrameToLive(anim.activeFrame_);
-            IR_LOG_INFO("Deleted frame (now %d / %d)", anim.activeFrame_ + 1, anim.frameCount());
+            IR_LOG_INFO("Deleted frame (now {} / {})", anim.activeFrame_ + 1, anim.frameCount());
         }
     );
 


### PR DESCRIPTION
## Summary
- Fixed the Backspace-key delete-frame log in the voxel editor, which used printf-style `%d` conversions with the fmt-style `IR_LOG_INFO` macro, so frame numbers were never substituted into the log line.

## Test plan
- [x] `fleet-build --target IRVoxelEditor` — clean build.
- [x] `fleet-build --target format-changed` — no additional drift.

## Acceptance evidence

Verified at PR head `030f9d98` on macOS-arm64 (Metal backend, `macos-debug` preset).

| Criterion (issue #2633) | Evidence |
|---|---|
| `fleet-build --target IRVoxelEditor` green | `fleet-build --target IRVoxelEditor` → **exit 0**, `[100%] Built target IRVoxelEditor`, 0 errors / 0 format warnings. (The `ld: warning: ignoring duplicate libraries` line is the known-benign static-cycle warning, unrelated to this diff.) |
| Line 2792 prints correct frame numbers on Backspace | Observed output below. |

`IR_LOG_INFO` routes through `IRProfile::formatRuntimeString`, which calls
`fmt::format(fmt::runtime(format), ...)` (`engine/profile/include/irreden/profile/ir_profile.tpp:16`).
Because the format string goes through `fmt::runtime`, fmt performs **no
compile-time** format checking — so a green build alone does not demonstrate
correct substitution. Exercising that exact call form with representative
delete-frame state (`activeFrame_ + 1 == 3`, `frameCount() == 7`) against the
repo's vendored fmt gives the direct evidence:

```
BEFORE (master, printf-style): "Deleted frame (now %d / %d)"
AFTER  (PR #2634, fmt-style):  "Deleted frame (now 3 / 7)"
```

The `%d` conversions were emitted verbatim as literal text (the reported bug);
the `{}` placeholders substitute the frame numbers correctly (the fix). Argument
count and order are unchanged, so no `fmt::format_error` is reachable on this
path.

Closes #2633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
