### PR TITLE
test: backfill #2404 cadence coverage — Lua seam + System<N> spec members (#2450)

### DIFF
--- a/.fleet/plans/issue-2450.md
+++ b/.fleet/plans/issue-2450.md
@@ -1,0 +1,95 @@
+## Plan: test: backfill cadence coverage — Lua binding surface + System<N> kCadence spec-member path (#2425 follow-up)
+
+- **Issue:** #2450
+- **Model:** sonnet — tests against a merged, documented API; every file, fixture, expected value, and pitfall is pinned below
+- **Date:** 2026-07-29
+
+### Scope
+
+Close the two coverage gaps #2425 (per-system cadence, #2404) shipped with, exactly as the pre-merge coverage-request comment on PR #2425 enumerated them:
+
+1. The six `IRSystem.*` Lua cadence bindings (`lua_pipeline_bindings.hpp`) — set/get round-trip, a throttled Lua-registered system observably firing 1-in-N with `getAccumulatedTicks` read from its tick body, and both throw paths.
+2. The `System<N>` spec-member detection path (`kCadence` / `kCadenceOffset` via `registerSystem<N>`), including the absent-members defaults.
+
+One task, one PR. No production-code behavior changes.
+
+### Verified current state (2026-07-29, origin/master 06883364)
+
+- The six bindings live at `engine/script/include/irreden/script/lua_pipeline_bindings.hpp:348-391`. The two throw paths are binding-side guards: `cadence < 1` throws at :357-358, `offset < 0` at :370-373. Note the deliberate asymmetry (flagged and accepted in #2425's review): Lua throws, while the C++ manager *normalizes* (cadence 0 → 1; offset reduced mod cadence into `[0, cadence)`). Tests must assert the throw on the Lua seam, not normalization.
+- Spec-member detection: concepts + `cadenceOf` / `cadenceOffsetOf` detectors at `engine/system/include/irreden/ir_system.hpp:333-361`, consumed by `registerSystem<N, Cs...>` at :425-430. **Zero tests exercise it** — `grep -rn "kCadence|cadenceOf" test/` returns nothing, and all 13 `SystemCadenceTest` cases construct via the `createSystem` free-function trailing params. The issue's negative claim holds.
+- `accumulatedDeltaTime` (`ir_system.hpp:700-710`) multiplies `getAccumulatedTicks` by `IRTime::deltaTime(UPDATE)`, which asserts on a null `g_timeManager` (`engine/time/src/ir_time.cpp:7-10`). A bare `IRTime::TimeManager` constructs standalone — no window/GL, ctor just stamps the global (`engine/time/src/time_manager.cpp:8-16`) — and `deltaTime<UPDATE>()` returns the *fixed* step `1.0 / IRConstants::kFPS` (`time_manager.cpp:44-46`, `event_profiler.hpp:21`), so the value is deterministic in a unit test with a TimeManager fixture member.
+- Precedents: `test/system/register_system_test.cpp:19-67` (test-reserved `System<N>` specs in `namespace IRSystem` + readback via `getSystemParams<System<N>>`, :104-105); `test/script/lua_pipeline_register_test.cpp:28-40` (Lua fixture shape) and :381-420 (attaching a Lua component to an entity and proving a Lua system ticks under `executePipeline`); `test/CLAUDE.md` §"Lua seam tests" (fixture member order is load-bearing).
+- `SystemName` tail (`engine/system/include/irreden/system/ir_system_types.hpp:227-231`) ends with the test-reserved block `TEST_REGISTER_SYSTEM_A/B`. Test-reserved entries are **not** mirrored into the Lua `IR_BIND_SYS` table (verified: no `TEST_*` among the 88 entries), so the new entries below don't touch the binding table.
+- Both target test files are already registered in `test/CMakeLists.txt` (:78, :90) — **no CMake edit needed** (deliberate: open PR #2573 touches `test/CMakeLists.txt`; this plan avoids that conflict surface entirely).
+
+No phase-0 probe needed: no phase below rests on a runtime mechanism claim — every premise above was source-verified, and expected fire patterns are derived from the gate semantics the existing 13 tests already pin (join seeds `lastRun = counter + offset`; due when `now >= lastRun + cadence`).
+
+### Approach
+
+**1. Two test-reserved `SystemName` entries** — `engine/system/include/irreden/system/ir_system_types.hpp`, appended inside the existing "Reserved for tests" block (comma after `TEST_REGISTER_SYSTEM_B`):
+
+```cpp
+    TEST_CADENCE_SPEC_MEMBER,   // declares kCadence / kCadenceOffset
+    TEST_CADENCE_SPEC_DEFAULT   // declares neither (defaults path)
+```
+
+The issue's "No engine-source changes expected" misses this one necessity: a `System<N>` specialization requires its own `SystemName` entry (engine/CLAUDE.md §"SystemName enum is authoritative"; precedent `TEST_REGISTER_SYSTEM_A/B`). Additive, test-reserved, not Lua-bound.
+
+**2. Spec-member tests** — append to `test/system/system_cadence_test.cpp` (the cadence home; keeps `register_system_test.cpp` untouched, which open PR #2596 is editing). After the existing anonymous namespace, add a `namespace IRSystem` block (mirroring `register_system_test.cpp`'s layout) with two specs:
+
+- `System<TEST_CADENCE_SPEC_MEMBER>`: `static constexpr std::uint32_t kCadence = 3; static constexpr std::uint32_t kCadenceOffset = 1;`, an `int execCount_ = 0;` bumped in `beginTick()` (fires once per due execution even with zero matched entities — the suite's established counting convention), a trivial `tick(C_CadA &)`, and `create()` returning `registerSystem<TEST_CADENCE_SPEC_MEMBER, C_CadA>("CadenceSpecMember")`.
+- `System<TEST_CADENCE_SPEC_DEFAULT>`: same shape, **no** cadence members.
+
+Then two `SystemCadenceTest` cases (fixture is visible across the TU):
+
+- `SpecMemberCadenceDetectedAndDrivesGate` — `IRSystem::createSystem<TEST_CADENCE_SPEC_MEMBER>()`, register into UPDATE, assert `getSystemCadence(sys) == 3u` and `getSystemCadenceOffset(sys) == 1u`, run 12 `executePipeline(UPDATE)` calls, read the instance via `getSystemParams<System<TEST_CADENCE_SPEC_MEMBER>>(sys)` and assert `execCount_ == 3` (join seeds `lastRun = 0 + 1`; fires at phase ticks 4, 7, 10 — same arithmetic `OffsetStaggersSiblings` pins for cadence 2 / offset 1).
+- `SpecWithoutCadenceMembersDefaultsToEveryTick` — `createSystem<TEST_CADENCE_SPEC_DEFAULT>()`, assert getters return 1u / 0u, run 5 ticks, assert `execCount_ == 5`.
+
+**3. Lua seam tests** — append to `test/script/lua_pipeline_register_test.cpp` under a **new** fixture (existing tests untouched):
+
+```cpp
+class LuaCadenceTest : public testing::Test {
+  protected:
+    LuaCadenceTest() { m_lua.bindLuaDrivenEcs(); }
+    IRScript::LuaScript m_lua;            // FIRST → destroyed last (test/CLAUDE.md)
+    IRTime::TimeManager m_time_manager;   // makes accumulatedDeltaTime assert-free + deterministic
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+```
+
+Five cases:
+
+- `SetGetRoundTripThroughLua` — register a Lua system (Lua-defined marker component, empty tick), then via `safe_script`: `setSystemCadence(sysId, 4)` → `getSystemCadence == 4`; `setSystemCadenceOffset(sysId, 3)` → `getSystemCadenceOffset == 3`; then `setSystemCadence(sysId, 5)` + `setSystemCadenceOffset(sysId, 7)` → `getSystemCadenceOffset == 2` (manager normalization passes through the seam intact).
+- `ThrottledLuaSystemFiresOneInNAndReadsAccumulatedTicks` — Lua system whose tick body bumps `g_tickCount` and stores `IRSystem.getAccumulatedTicks(sysId)` into `g_acc` (capture `sysId` as a Lua local upvalue assigned at registration); `IRSystem.registerPipeline(IRTime.UPDATE, { sysId })` from Lua; attach the marker to an entity (`IREntity.addLuaComponent(LuaEntity.new(g_entity), Marker)` — precedent :409-415; **without a matched entity the archetype-batched body never runs**); `IRSystem.setSystemCadence(sysId, 3)`; then 9 × `m_system_manager.executePipeline(IRTime::Events::UPDATE)` from C++. Assert `g_tickCount == 3` (fires at phase ticks 3, 6, 9) and `g_acc == 3`.
+- `AccumulatedDeltaTimeScalesTicksByFixedStep` — after an identical throttled run, `IRSystem.accumulatedDeltaTime(sysId)` returned to C++ `EXPECT_DOUBLE_EQ`s `3.0 / static_cast<double>(IRConstants::kFPS)`.
+- `CadenceBelowOneRaisesLuaError` — `safe_script("IRSystem.setSystemCadence(sysId, 0)", sol::script_pass_on_error)` → `EXPECT_FALSE(result.valid())`; optionally assert the message contains `"cadence must be >= 1"`.
+- `NegativeOffsetRaisesLuaError` — same shape for `setSystemCadenceOffset(sysId, -1)`, message `"offset must be >= 0"`.
+
+Coverage map for the six functions: `setSystemCadence` (round-trip + throttle + throw), `getSystemCadence` (round-trip), `setSystemCadenceOffset` (round-trip + throw), `getSystemCadenceOffset` (round-trip + normalization), `getAccumulatedTicks` (read from inside the throttled tick body), `accumulatedDeltaTime` (fixed-step scaling).
+
+**4. Plan file** — commit this plan as `.fleet/plans/issue-2450.md` in the implementation PR's first commit (#1932).
+
+### Affected files
+
+- `engine/system/include/irreden/system/ir_system_types.hpp` — +2 test-reserved `SystemName` entries in the existing reserved block
+- `test/system/system_cadence_test.cpp` — two `System<N>` specs + 2 tests
+- `test/script/lua_pipeline_register_test.cpp` — `LuaCadenceTest` fixture + 5 tests
+- `.fleet/plans/issue-2450.md` — this plan (first commit)
+
+### Acceptance criteria (positive-fire)
+
+- All six Lua cadence functions exercised through the sol2 seam, with the throttled Lua system **observably firing** (`g_tickCount == 3` over 9 ticks — a count > 0, not a pass-at-default) and `g_acc == 3` read from inside its tick body; both throw paths surface as invalid `safe_script` results.
+- The spec-member path **observably drives the gate**: detected 3/1 via public getters *and* 3 fires in 12 ticks read back from the spec instance; the defaults spec reports 1/0 and fires every tick.
+- Full suite green locally: `fleet-build --target IrredenEngineTest && fleet-run IrredenEngineTest` (spot-check with `--gtest_filter='SystemCadenceTest.*:LuaCadenceTest.*'` while iterating); CI (quality.yml) green on the PR.
+
+### Gotchas
+
+- **Fixture member order is load-bearing** — `LuaScript` first, managers after (`test/CLAUDE.md` §"Lua seam tests"); backwards order crashes at fixture teardown, not at an assertion.
+- **`accumulatedDeltaTime` asserts without a TimeManager** — that's why `LuaCadenceTest` carries one. Do *not* add a TimeManager to `system_cadence_test.cpp`; the spec tests only need `getAccumulatedTicks`-free counting.
+- **Set cadence before offset** in round-trips — `setSystemCadenceOffset` reduces into `[0, cadence)` against the *current* cadence.
+- **Lua-vs-C++ guard asymmetry is deliberate** (accepted #2425 review nit): don't "align" the C++ side to throw, and don't expect Lua `cadence = 0` to normalize.
+- **The Lua throttle test needs a matched entity** — a dynamic system's body fires per matched archetype; zero entities = zero invocations = a vacuously green test.
+- **In-flight PR reconciliation:** #2596 edits `ir_system_types.hpp` / `ir_system.hpp` / `register_system_test.cpp` (SystemId miss sentinel) — this plan deliberately avoids `register_system_test.cpp`; if #2596 merges first, the 2-line enum addition rebases trivially (insertion point is the reserved tail block). #2573 edits `test/CMakeLists.txt` — this plan makes no CMake edit. #2608 touches only `lua_component_codegen_test.cpp`. No other open PR touches these files.
+- **Non-vacuity check** (the bar #2425's own history set): while iterating, perturb one expected constant per new test (e.g. build once with `kCadence = 1`) and confirm the paired test goes red before finalizing.
+

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -227,7 +227,13 @@ enum SystemName {
     // Reserved for tests of the registerSystem<> member-on-System<N>
     // helper. Do not use from a creation or prefab system.
     TEST_REGISTER_SYSTEM_A,
-    TEST_REGISTER_SYSTEM_B
+    TEST_REGISTER_SYSTEM_B,
+
+    // Reserved for tests of the #2404 kCadence / kCadenceOffset
+    // spec-member detection path. Do not use from a creation or prefab
+    // system.
+    TEST_CADENCE_SPEC_MEMBER, // declares kCadence / kCadenceOffset
+    TEST_CADENCE_SPEC_DEFAULT // declares neither (defaults path)
 };
 
 template <typename... RelationComponents> struct RelationParams {

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -56,7 +56,9 @@ it.
 `IRSystem.*Cadence*` Lua bindings, and the `kCadence` / `kCadenceOffset`
 spec-member detection path on `System<N>`. Both are public, both are how
 downstream code actually consumes the feature, and "a new test exists" hid
-them. Count surfaces, not tests.
+them. Count surfaces, not tests. (Both gaps were backfilled in #2450 —
+`LuaCadenceTest` and the `TEST_CADENCE_SPEC_*` specs; the lesson is that they
+had to be backfilled at all.)
 
 ## Lua seam tests
 

--- a/test/script/lua_pipeline_register_test.cpp
+++ b/test/script/lua_pipeline_register_test.cpp
@@ -4,11 +4,15 @@
 #include <irreden/common/components/component_local_transform_lua.hpp>
 #include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/modifier.hpp>
+#include <irreden/ir_constants.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_time.hpp>
 #include <irreden/script/lua_script.hpp>
+#include <irreden/time/time_manager.hpp>
 #include <irreden/update/systems/system_lifetime.hpp>
+
+#include <string>
 
 namespace {
 
@@ -481,6 +485,180 @@ TEST_F(LuaPipelineRegisterTest, AppendSystemRejectsInvalidEvent) {
     auto &lua = m_lua.lua();
     auto result = lua.safe_script("IRSystem.appendSystem(999, 0)", sol::script_pass_on_error);
     EXPECT_FALSE(result.valid());
+}
+
+// ---- Cadence bindings — the #2404 Lua seam --------------------------------
+
+// The six `IRSystem.*` cadence functions are a surface of their own: driving
+// `SystemManager` directly (test/system/system_cadence_test.cpp) proves
+// nothing about the sol2 layer in front of it. Own fixture so the file's
+// existing cases stay untouched; it additionally carries a TimeManager because
+// `accumulatedDeltaTime` reads `IRTime::deltaTime(UPDATE)`, which asserts on a
+// null `g_timeManager`. A bare TimeManager constructs standalone (no window /
+// GL) and its UPDATE dt is the constant fixed step, so the value is
+// deterministic here.
+class LuaCadenceTest : public testing::Test {
+  protected:
+    LuaCadenceTest() {
+        m_lua.bindLuaDrivenEcs();
+    }
+
+    // Registers a Lua system throttled to cadence 3 with ONE matched entity,
+    // then runs `ticks` UPDATE ticks. The matched entity is mandatory — a Lua
+    // system's body fires per matched *archetype*, so with zero entities the
+    // body never runs and any fire-count assertion passes vacuously.
+    //
+    // The body writes back what it observes from inside the throttled tick:
+    // `g_tickCount` counts fires, `g_acc` / `g_dt` snapshot the accumulated
+    // readbacks. Cadence is set AFTER the pipeline join, so the join seeds
+    // `lastRun = 0` and the system is due at `now >= lastRun + 3`.
+    void runThrottledLuaSystem(int ticks) {
+        auto &lua = m_lua.lua();
+        lua["g_tickCount"] = 0;
+        lua["g_acc"] = 0;
+        lua["g_dt"] = 0.0;
+        lua["g_entity"] = static_cast<lua_Integer>(IREntity::createEntity(C_Modifiers{}));
+
+        auto setup = lua.safe_script(
+            R"(
+            Marker = IRComponent.register("CadenceThrottleMarker", { dummy = 0 })
+            g_sys = IRSystem.registerSystem({
+                name = "CadenceThrottleSys",
+                components = { Marker },
+                tick = function(arch)
+                    g_tickCount = g_tickCount + 1
+                    g_acc = IRSystem.getAccumulatedTicks(g_sys)
+                    g_dt = IRSystem.accumulatedDeltaTime(g_sys)
+                end,
+            })
+            IREntity.addLuaComponent(LuaEntity.new(g_entity), Marker)
+            IRSystem.registerPipeline(IRTime.UPDATE, { g_sys })
+            IRSystem.setSystemCadence(g_sys, 3)
+        )",
+            sol::script_pass_on_error
+        );
+        ASSERT_TRUE(setup.valid()) << sol::error{setup}.what();
+
+        for (int i = 0; i < ticks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        }
+    }
+
+    // Registers a tickless Lua system into the `g_sys` global — just something
+    // for the guard tests to aim a bad argument at.
+    void registerBareLuaSystem() {
+        auto setup = m_lua.lua().safe_script(
+            R"(
+            local Marker = IRComponent.register("CadenceGuardMarker", { dummy = 0 })
+            g_sys = IRSystem.registerSystem({
+                name = "CadenceGuardSys",
+                components = { Marker },
+                tick = function(arch) end,
+            })
+        )",
+            sol::script_pass_on_error
+        );
+        ASSERT_TRUE(setup.valid()) << sol::error{setup}.what();
+    }
+
+    // Member order is load-bearing: LuaScript FIRST so it is destroyed LAST —
+    // sol::function references captured in dynamic-system bodies lua_unref
+    // during manager teardown. See test/CLAUDE.md §"Lua seam tests".
+    IRScript::LuaScript m_lua;
+    IRTime::TimeManager m_time_manager;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(LuaCadenceTest, SetGetRoundTripThroughLua) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        local Marker = IRComponent.register("CadenceRoundTripMarker", { dummy = 0 })
+        local sys = IRSystem.registerSystem({
+            name = "CadenceRoundTripSys",
+            components = { Marker },
+            tick = function(arch) end,
+        })
+
+        IRSystem.setSystemCadence(sys, 4)
+        IRSystem.setSystemCadenceOffset(sys, 3)
+        g_cadence = IRSystem.getSystemCadence(sys)
+        g_offset = IRSystem.getSystemCadenceOffset(sys)
+
+        -- The offset setter reduces into [0, cadence) against the CURRENT
+        -- cadence, so the manager's normalization has to survive the seam
+        -- intact: 7 against cadence 5 reads back as 2.
+        IRSystem.setSystemCadence(sys, 5)
+        IRSystem.setSystemCadenceOffset(sys, 7)
+        g_cadence_after = IRSystem.getSystemCadence(sys)
+        g_offset_normalized = IRSystem.getSystemCadenceOffset(sys)
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+
+    EXPECT_EQ(lua["g_cadence"].get<int>(), 4);
+    EXPECT_EQ(lua["g_offset"].get<int>(), 3);
+    EXPECT_EQ(lua["g_cadence_after"].get<int>(), 5);
+    EXPECT_EQ(lua["g_offset_normalized"].get<int>(), 2);
+}
+
+TEST_F(LuaCadenceTest, ThrottledLuaSystemFiresOneInNAndReadsAccumulatedTicks) {
+    runThrottledLuaSystem(/*ticks=*/9);
+
+    auto &lua = m_lua.lua();
+    // Due at now >= lastRun + 3: fires on phase ticks 3, 6, 9 — an observable
+    // count, not a pass-at-default.
+    EXPECT_EQ(lua["g_tickCount"].get<int>(), 3);
+    // Read from inside the throttled body: each run covers 3 phase ticks.
+    EXPECT_EQ(lua["g_acc"].get<int>(), 3);
+}
+
+TEST_F(LuaCadenceTest, AccumulatedDeltaTimeScalesTicksByFixedStep) {
+    runThrottledLuaSystem(/*ticks=*/9);
+
+    auto &lua = m_lua.lua();
+    ASSERT_EQ(lua["g_tickCount"].get<int>(), 3);
+    // The seam must return ticks SCALED by the fixed UPDATE step, not the raw
+    // tick count. DOUBLE_EQ, not EQ: the engine computes 3 * (1/60) while the
+    // expectation writes 3/60, which can differ by an ULP.
+    EXPECT_DOUBLE_EQ(lua["g_dt"].get<double>(), 3.0 / static_cast<double>(IRConstants::kFPS));
+}
+
+TEST_F(LuaCadenceTest, CadenceBelowOneRaisesLuaError) {
+    registerBareLuaSystem();
+    auto &lua = m_lua.lua();
+
+    // The Lua seam THROWS on cadence < 1 where the C++ manager normalizes
+    // 0 -> 1 — a deliberate asymmetry accepted in #2425's review. Assert the
+    // throw, not the normalization.
+    auto result = lua.safe_script("IRSystem.setSystemCadence(g_sys, 0)", sol::script_pass_on_error);
+    ASSERT_FALSE(result.valid());
+    const std::string message = sol::error{result}.what();
+    EXPECT_NE(message.find("cadence must be >= 1"), std::string::npos) << message;
+
+    // Positive control: the guard rejects the ARGUMENT, not the call. Without
+    // this, a broken `g_sys` would produce the same red-to-green reading,
+    // since the binding throws before it ever reaches the manager.
+    auto legal = lua.safe_script("IRSystem.setSystemCadence(g_sys, 1)", sol::script_pass_on_error);
+    EXPECT_TRUE(legal.valid()) << sol::error{legal}.what();
+}
+
+TEST_F(LuaCadenceTest, NegativeOffsetRaisesLuaError) {
+    registerBareLuaSystem();
+    auto &lua = m_lua.lua();
+
+    auto result =
+        lua.safe_script("IRSystem.setSystemCadenceOffset(g_sys, -1)", sol::script_pass_on_error);
+    ASSERT_FALSE(result.valid());
+    const std::string message = sol::error{result}.what();
+    EXPECT_NE(message.find("offset must be >= 0"), std::string::npos) << message;
+
+    // Positive control, as above: the same sysId accepts a legal offset.
+    auto legal =
+        lua.safe_script("IRSystem.setSystemCadenceOffset(g_sys, 0)", sol::script_pass_on_error);
+    EXPECT_TRUE(legal.valid()) << sol::error{legal}.what();
 }
 
 } // namespace

--- a/test/system/system_cadence_test.cpp
+++ b/test/system/system_cadence_test.cpp
@@ -27,6 +27,52 @@ struct C_CadB {
     int m_ = 0;
 };
 
+} // namespace
+
+namespace IRSystem {
+
+// #2450 — the second registration path onto the same gate. The suite's other
+// cases all drive the `createSystem` trailing-parameter spelling; these two
+// specs cover `registerSystem<N>`'s constexpr-member detection
+// (`detail::cadenceOf` / `cadenceOffsetOf`), which no test exercised.
+// Execution counting rides beginTick, matching the file's convention.
+template <> struct System<TEST_CADENCE_SPEC_MEMBER> {
+    static constexpr std::uint32_t kCadence = 3;
+    static constexpr std::uint32_t kCadenceOffset = 1;
+
+    int execCount_ = 0;
+
+    void beginTick() {
+        execCount_++;
+    }
+
+    void tick(C_CadA &) {}
+
+    static SystemId create() {
+        return registerSystem<TEST_CADENCE_SPEC_MEMBER, C_CadA>("CadenceSpecMember");
+    }
+};
+
+// The same shape declaring NEITHER member — the detectors must fall back to
+// cadence 1 / offset 0 so every legacy spec keeps its every-tick behavior.
+template <> struct System<TEST_CADENCE_SPEC_DEFAULT> {
+    int execCount_ = 0;
+
+    void beginTick() {
+        execCount_++;
+    }
+
+    void tick(C_CadA &) {}
+
+    static SystemId create() {
+        return registerSystem<TEST_CADENCE_SPEC_DEFAULT, C_CadA>("CadenceSpecDefault");
+    }
+};
+
+} // namespace IRSystem
+
+namespace {
+
 class SystemCadenceTest : public testing::Test {
   protected:
     SystemCadenceTest()
@@ -452,6 +498,51 @@ TEST_F(SystemCadenceTest, FirstEverJoinToRenderIsSilentWhenUpdateHostsAnotherSys
     // UPDATE's pipeline exists but lists only `resident` — sys has never joined
     // anything, so the prior-pipeline lookup must find it absent.
     EXPECT_NO_THROW(m_system_manager.appendToPipeline(IRTime::RENDER, sys));
+}
+
+// #2450: a System<N> spec's `kCadence` / `kCadenceOffset` members are both
+// DETECTED (readable through the public getters) and DRIVE the gate (an
+// observable fire count), with no createSystem trailing-parameter spelling
+// anywhere in the path.
+TEST_F(SystemCadenceTest, SpecMemberCadenceDetectedAndDrivesGate) {
+    auto sys = IRSystem::createSystem<IRSystem::TEST_CADENCE_SPEC_MEMBER>();
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys}); // stamp: lastRun = 0 + 1 = 1
+
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 3u);
+    EXPECT_EQ(m_system_manager.getSystemCadenceOffset(sys), 1u);
+
+    for (int i = 0; i < 12; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_CADENCE_SPEC_MEMBER>>(sys);
+    ASSERT_NE(params, nullptr);
+    // Due at now >= lastRun + cadence: fires on phase ticks 4, 7, 10.
+    EXPECT_EQ(params->execCount_, 3);
+    EXPECT_EQ(m_system_manager.getAccumulatedTicks(sys), 3u);
+}
+
+// #2450: the absent-members default. A spec that declares neither member
+// must register at cadence 1 / offset 0 and fire every tick — the guarantee
+// that made the detectors safe to add to every legacy spec.
+TEST_F(SystemCadenceTest, SpecWithoutCadenceMembersDefaultsToEveryTick) {
+    auto sys = IRSystem::createSystem<IRSystem::TEST_CADENCE_SPEC_DEFAULT>();
+    m_system_manager.registerPipeline(IRTime::UPDATE, {sys});
+
+    EXPECT_EQ(m_system_manager.getSystemCadence(sys), 1u);
+    EXPECT_EQ(m_system_manager.getSystemCadenceOffset(sys), 0u);
+
+    for (int i = 0; i < 5; ++i) {
+        m_system_manager.executePipeline(IRTime::UPDATE);
+    }
+
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_CADENCE_SPEC_DEFAULT>>(
+            sys
+        );
+    ASSERT_NE(params, nullptr);
+    EXPECT_EQ(params->execCount_, 5);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- Backfills the two public surfaces #2425 (per-system cadence, #2404) shipped bare. Test-only; no production behavior change.
- **Lua seam** — new `LuaCadenceTest` in `test/script/lua_pipeline_register_test.cpp` drives all six `IRSystem.*` cadence bindings through sol2: set/get round-trip (including the manager's offset normalization surviving the seam), a throttled Lua system observably firing 1-in-3 with `getAccumulatedTicks` / `accumulatedDeltaTime` read from **inside** its tick body, and both binding-side throw paths.
- **`System<N>` spec members** — two specs + two tests in `test/system/system_cadence_test.cpp` cover the `kCadence` / `kCadenceOffset` detection path (`detail::cadenceOf` / `cadenceOffsetOf`), which no test exercised: one spec declaring 3 / 1, one declaring neither. Each asserts detection (public getters) **and** dispatch (observed fire count).
- **Only engine-source change:** two test-reserved `SystemName` entries (`TEST_CADENCE_SPEC_MEMBER` / `TEST_CADENCE_SPEC_DEFAULT`) appended to the existing reserved tail block — a `System<N>` specialization requires its own enum entry. Not Lua-bound (no `IR_BIND_SYS` entry), consistent with `TEST_REGISTER_SYSTEM_A/B`.
- No CMake edit: both target test files are already listed in `test/CMakeLists.txt`.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean (macOS / Metal host).
- [x] `fleet-run IrredenEngineTest` — **1368/1368 passed**, whole suite.
- [x] Non-vacuity perturbation pass (the plan's explicit bar — a coverage backfill can pass at defaults). Each perturbation turned the paired test **red**, then was reverted:
  - `kCadence 3 → 1` on the spec, and `kCadence = 3` added to the defaults spec → both spec tests fail.
  - Dropped `IRSystem.setSystemCadence(g_sys, 3)` → `g_tickCount` 9 (not 3), `g_acc` 1 (not 3).
  - Dropped the `addLuaComponent` attach → `g_tickCount` 0: a Lua body fires per matched *archetype*, so a missing entity is the silent-vacuity mode this guards.
- [ ] CI (quality.yml) green on the PR.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| All six Lua cadence functions exercised through the sol2 seam; throttled system observably fires (`g_tickCount == 3` over 9 ticks), `g_acc == 3` read from inside the body; both throw paths surface as invalid `safe_script` results | `fleet-run IrredenEngineTest --gtest_filter='LuaCadenceTest.*'` | `[  PASSED  ]` ×5 — `SetGetRoundTripThroughLua`, `ThrottledLuaSystemFiresOneInNAndReadsAccumulatedTicks`, `AccumulatedDeltaTimeScalesTicksByFixedStep`, `CadenceBelowOneRaisesLuaError`, `NegativeOffsetRaisesLuaError` |
| Spec-member path observably drives the gate: detected 3/1 via public getters + 3 fires in 12 ticks read back from the instance; defaults spec reports 1/0 and fires 5-in-5 | `fleet-run IrredenEngineTest --gtest_filter='SystemCadenceTest.Spec*'` | `[  PASSED  ]` ×2 — `SpecMemberCadenceDetectedAndDrivesGate`, `SpecWithoutCadenceMembersDefaultsToEveryTick` |
| Full suite green on at least one platform locally | `fleet-build --target IrredenEngineTest && fleet-run IrredenEngineTest` | `1368 tests from 244 test suites ran. [  PASSED  ] 1368 tests.` (macOS) |

## Notes for reviewer
- **Fire-count arithmetic.** Spec test: `stampCadenceJoin` seeds `lastRun = 0 + offset(1) = 1`, due at `now >= lastRun + 3` → fires at phase ticks 4, 7, 10 = 3 in 12. Lua test: join seeds `lastRun = 0` (cadence is set *after* the pipeline join, and `setSystemCadence` deliberately does not re-seed `lastRunTick`) → fires at 3, 6, 9 = 3 in 9, each covering 3 ticks.
- **The Lua/C++ guard asymmetry is deliberate**, accepted in #2425's review: the binding throws on `cadence < 1` where the manager normalizes `0 → 1`. The tests assert the throw, not the normalization — please don't read that as a bug to align.
- **Both throw tests carry a positive control** (a legal call on the same `sysId` must succeed). Without it the negatives would pass even against a broken `g_sys`, since the guards reject the argument before ever reaching the manager.
- `test/CLAUDE.md`'s #2425 worked example asserted both surfaces are uncovered; that claim is now stale, so it gained a one-clause backfill note. The lesson it teaches (count surfaces, not tests) is untouched.
- Plan file `.fleet/plans/issue-2450.md` is the first commit, per #1932.

Closes #2450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
