### PR TITLE
render(pivot-verify): report the SDF twin, don't gate on it (#2645)

### DIFF
--- a/docs/design/camera-yaw-pivot.md
+++ b/docs/design/camera-yaw-pivot.md
@@ -150,8 +150,10 @@ whole-silhouette invariance; no reference images) enumerates the defects it has
 found in the contract above — all invisible at cardinal yaw 0, so the
 "Empirically verified" section below remains true for what it measured while the
 pivot is still wrong under rotation. #2545 (deviation 1), #2546 (deviation 3),
-and #2547 (deviation 2) are now fixed; deviation 4 is open. Fixed entries are
-retained below until the epic closes:
+and #2547 (deviation 2) are now fixed; deviation 4 turned out not to be a pivot
+defect at all (#2645 — a destination-grid quantization floor, see the
+subsection after this list). Fixed entries are retained below until the epic
+closes:
 
 1. **Half-cell rotation-anchor mismatch — FIXED (#2545).** The voxel raster
    rotated content about `position + (0.5,0.5,0.5)` while the SDF path and
@@ -255,13 +257,17 @@ retained below until the epic closes:
    and the store/RESOLVE/overflow paths are untouched — pure screen-XY
    registration.
 
-4. **SDF-twin silhouette wobble — OPEN (#2645).** `focus-ctr-sdf` scores DRIFT
-   2.00 px at zoom 4 and 8 while its voxel twin holds 0.94/1.27 with the same
-   explicit focus. Both take an explicit `setRotationPivotFocus`, so the #2547
-   derive never runs for them and this is not a default-pivot deviation; it is
-   either the analytical solver's continuous silhouette re-forming per yaw (in
-   which case the twin is a comparison, not a 1.5 px gate) or an SDF-side
-   rotation-anchor delta that #2545 did not cover. #2645 settles which.
+4. **SDF-twin silhouette wobble — NOT A DEVIATION (#2645).** `focus-ctr-sdf`
+   scores DRIFT 2.00 px at zoom 4 and 8 while its voxel twin holds 0.94/1.27
+   with the same explicit focus. Both take an explicit `setRotationPivotFocus`,
+   so the #2547 derive never runs for them and this is not a default-pivot
+   deviation. Of the two candidate readings — the analytical solver's
+   continuous silhouette re-forming per yaw (a comparison, not a 1.5 px gate)
+   versus an SDF-side rotation-anchor delta #2545 did not cover — #2645 settled
+   it on the first by zoom sweep: the deviation is flat at exactly 2.00 px over
+   a 16x zoom range, which a world-space anchor delta cannot be. The twin is
+   reported rather than gated; see §"Not a deviation: the SDF twin's flat
+   2.00px floor (#2645)" below.
 
 Fix chain and acceptance gates: epic #2544 (P1 #2545 → P2 #2546 → P3 #2547 →
 P4 #2548, cursor-pivot true-depth latch + indicator). Each child flips its
@@ -269,6 +275,69 @@ pivot-verify block(s) to its own gate — PINNED for the blocks whose probe
 rotates about a point on its own axis, `[pivot-focus-assert]` FOCUS-OK for the
 default-pivot blocks whose silhouette legitimately orbits (see deviation 2).
 This section shrinks as they land.
+
+### Not a deviation: the SDF twin's flat 2.00px floor (#2645)
+
+`focus-ctr`'s SDF twin (`--pivot-verify-sdf`) draws a DRIFT verdict from
+`jitter_probe` at 2.00px while the voxel twin on the same explicit focus pins
+at ~1px. This is **not** a pivot defect and no pivot fix can move it — it is
+the SDF path's rasterization quantum, so the twin is **reported, not gated**
+(`SDF_GATED` in `scripts/pivot-verify.py`) and the harness prints it as
+`REPORT` rather than failing the run.
+
+The discriminator is zoom. A rotation-anchor delta of Δ world units projects to
+Δ·zoom screen px, so it must scale with zoom; a destination-grid quantization
+floor must not. Measured on macOS/Metal against `origin/master` @ `13094837`, one
+full-circle 9-yaw sweep per cell:
+
+| zoom | voxel dev_x / dev_y | SDF dev_x / dev_y |
+|---|---|---|
+| 1 | 0.99 / 1.35 | **2.00** / 2.00 |
+| 2 | 0.98 / 1.36 | **2.00** / 2.00 |
+| 4 | 0.94 / 1.27 | **2.00** / 2.00 |
+| 8 | 0.96 / 1.31 | **2.00** / 2.00 |
+| 16 | 0.06 / 0.53 | **2.00** / 1.34 |
+
+`dev_x` is **exactly 2.00px at every zoom over a 16x range** — flat, so the
+anchor-delta reading is ruled out by measurement rather than by argument.
+
+That 2.00px is not an arbitrary number: it is **one whole game-resolution
+pixel**. `shape_debug` renders a 1280x720 game resolution
+(`creations/demos/shape_debug/config.lua`) into a 2560x1440 HiDPI framebuffer
+(confirmed from the captured PNG headers), so `outputScaleFactor == 2` and the
+smallest step the destination grid can represent is 2.00 framebuffer px. The
+raw centroids sit right at that quantum — at zoom 4 they take only two discrete
+values per axis, exactly 2.00px apart (x ∈ {1277.50, 1279.50}: the frame-centre
+pixel and the one game-pixel step next to it).
+
+Because the quantum is one *game-resolution* pixel, the framebuffer figure is
+host-dependent: on a 1x (non-HiDPI) host the same floor should read ~1.00px and
+fall under the 1.5px threshold on its own. A Linux/GL re-measure that reports
+~1.00px is therefore agreeing with this entry, not contradicting it — the
+un-gating is keyed on the floor being a floor, not on the specific number.
+
+The voxel twin has a lattice of its own to land on: its cells sit on exact
+integer world positions, so its silhouette re-forms identically at each yaw and
+it pins sub-pixel. The SDF twin is a *continuous* solved surface with no such
+lattice, so as it rotates its silhouette edge crosses destination-pixel
+boundaries and the centroid steps by the one-pixel quantum. That is the
+sampling floor of rasterizing continuous geometry to a fixed grid: you cannot
+pin a continuously-moving analytic silhouette better than the destination pixel.
+
+This agrees with the independent #2469 measurement in
+[`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Accepted sub-pixel
+yaw-sweep centroid residual", which records the same 2.00px x-excursion for the
+SDF cylinder at zoom 4/8 under the unrelated `--yaw-sweep` harness and already
+treats the SDF twin as the *defect-free control* whose residual is "a floor the
+probe itself carries". Two harnesses, one number.
+
+Closing it would mean resolving the silhouette below one destination pixel —
+supersampling / conservative rasterization on the SDF path, which is the same
+principled root fix already deferred to epic **#1933** for the #1883 corner
+drift and the #2469 centroid residual. It is not reachable by any change to the
+pivot math, which is what this harness exists to gate. The twin keeps running
+because the A/B against the voxel path is the useful signal; only its
+contribution to the exit code is dropped.
 
 ## History
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -533,7 +533,10 @@ that is valid for it: `jitter_probe --stationary` whole-silhouette invariance
 where the probe rotates about a point on its own axis, and the demo's
 `[pivot-focus-assert]` pinned-point check — derived focus vs the analytic
 ray/surface intersection — for the default-pivot blocks, whose silhouettes
-legitimately orbit the pin. No reference images. Contract + known deviations:
+legitimately orbit the pin. The SDF twin is **reported, not gated** — with no
+voxel lattice to land on, its silhouette is quantized by the destination pixel
+grid alone, a flat 2.00px (one game-resolution pixel) at every zoom that no
+pivot fix can move (#2645). No reference images. Contract + known deviations:
 [`docs/design/camera-yaw-pivot.md`](../../docs/design/camera-yaw-pivot.md)
 (epic #2544).
 

--- a/scripts/pivot-verify.py
+++ b/scripts/pivot-verify.py
@@ -23,6 +23,7 @@ Blocks (see ``g_pivotVerifyBlock`` in ``creations/demos/shape_debug/main.cpp``):
 
 ``focus-ctr`` additionally runs an SDF-probe twin (``--pivot-verify-sdf``)
 so the voxel-pool and SDF render paths' pivot conventions are compared A/B.
+The twin is REPORTED, never gated — see ``SDF_GATED`` (#2645).
 
 Two oracles, applied per block:
 
@@ -38,7 +39,8 @@ Two oracles, applied per block:
   gated only for the blocks in ``CENTROID_GATED_BLOCKS``: those rotate their
   probe about a point on the probe's own axis, so a correct pivot maps the
   silhouette onto itself. Every other block's deviation is measured and
-  reported but not gated.
+  reported but not gated. The SDF twin is exempt even on a gated block
+  (``SDF_GATED``, #2645) — no lattice, so no pin to hold.
 
 Why a block falls in one bucket or the other — and what the reported-but-not-
 gated deviations mean — is ``docs/design/camera-yaw-pivot.md`` §"Known
@@ -76,6 +78,19 @@ DEFAULT_PIVOT_BLOCKS = {"center-column", "center-depth", "background-center",
 # silhouette onto itself. For every other block the deviation is reported but
 # not gated — see the module docstring.
 CENTROID_GATED_BLOCKS = {"focus-ctr", "focus-off", "background-center"}
+# The SDF twin is a continuous-geometry A/B control, NOT a pin gate (#2645).
+# Its analytic silhouette has no voxel lattice to snap to, so its centroid is
+# quantized only by the destination pixel grid: dev_x measures exactly 2.00px
+# at zoom 1, 2, 4, 8 AND 16 — flat over a 16x range. That 2.00px is one whole
+# game-resolution pixel (1280x720 game res rendered to a 2560x1440 HiDPI
+# framebuffer, so outputScaleFactor == 2), i.e. the smallest step the screen
+# can represent. A pivot-anchor error is a world-space offset and must scale
+# with zoom; a destination-grid quantization floor cannot, so no pivot fix can
+# move it and gating on it is a permanent false red. The voxel twin stays
+# gated and pins at <= 1.4px across the same sweep. This exemption is what
+# keeps `focus-ctr` gated for its voxel pass while its SDF twin only reports,
+# even though the block itself is in CENTROID_GATED_BLOCKS.
+SDF_GATED = False
 # Frame indices of the cardinal yaws (0, pi/2, pi, 3pi/2) within the demo's
 # 9-yaw sweep table (`yaws[]` in creations/demos/shape_debug/main.cpp).
 CARDINAL_FRAME_INDICES = (0, 3, 5, 7)
@@ -225,17 +240,24 @@ def main(argv: list[str] | None = None) -> int:
                       file=sys.stderr)
 
         # Whole-silhouette oracle. Always measured; gated only where it is a
-        # valid pin (CENTROID_GATED_BLOCKS).
+        # valid pin (CENTROID_GATED_BLOCKS), and never for the SDF twin, whose
+        # continuous silhouette rides a destination-grid floor (SDF_GATED).
         centroid, dev_x, dev_y, _ = _score_pass(probe_exe, frames,
                                                 args.max_deviation)
-        if block in CENTROID_GATED_BLOCKS:
+        centroid_gated = (block in CENTROID_GATED_BLOCKS
+                          and (SDF_GATED if sdf else True))
+        if centroid_gated:
             verdict = centroid if focus in ("-", "OK") else "FOCUS-BAD"
+        elif focus == "-":
+            # Neither oracle gates this pass — the SDF twin (#2645). Its real
+            # numbers still print; it just cannot fail the run.
+            verdict = "REPORT"
         else:
             verdict = {"OK": "FOCUS-OK", "BAD": "FOCUS-BAD",
                        "NONE": "NO-ASSERT"}[focus]
         results.append((label, verdict, dev_x, dev_y, len(frames), focus))
 
-    passing = {"PINNED", "FOCUS-OK"}
+    passing = {"PINNED", "FOCUS-OK", "REPORT"}
     print()
     print(f"{'pass':<28} {'verdict':<10} {'dev_x(px)':>10} {'dev_y(px)':>10} "
           f"{'frames':>7} {'focus':>7}")
@@ -249,7 +271,8 @@ def main(argv: list[str] | None = None) -> int:
     print("verdicts: PINNED = silhouette held (threshold "
           f"{args.max_deviation}px) · FOCUS-OK = derived focus matched the "
           "analytic pin; the silhouette deviation is reported, not gated "
-          "(see the module docstring)")
+          "· REPORT = SDF twin, measured but ungated (see the module "
+          "docstring)")
     if failed:
         print(f"pivot-verify: {failed}/{len(results)} passes FAILED")
         return 1


### PR DESCRIPTION
## Summary

`focus-ctr`'s SDF twin (`--pivot-verify-sdf`) scored DRIFT at 2.00px while the
voxel twin on the same explicit focus pinned at ~1px, keeping `pivot-verify`
permanently red for a reason no pivot fix can address. This roots-causes it and
un-gates the twin.

**Zoom is the discriminator.** A rotation-anchor delta is a world-space offset
and must scale with zoom; a destination-grid quantization floor cannot.
Measured on macOS/Metal against `origin/master` @ `13094837`:

| zoom | voxel dev_x / dev_y | SDF dev_x / dev_y |
|---|---|---|
| 1 | 0.99 / 1.35 | **2.00** / 2.00 |
| 2 | 0.98 / 1.36 | **2.00** / 2.00 |
| 4 | 0.94 / 1.27 | **2.00** / 2.00 |
| 8 | 0.96 / 1.31 | **2.00** / 2.00 |
| 16 | 0.06 / 0.53 | **2.00** / 1.34 |

`dev_x` is exactly 2.00px at every zoom — flat over a 16x range — so **reading 2
(a real convention/anchor delta) is ruled out by measurement**, not by argument.

That 2.00px is one whole *game-resolution* pixel: `shape_debug` renders 1280x720
into a 2560x1440 HiDPI framebuffer (`outputScaleFactor == 2`), so it is the
smallest step the destination grid can represent. The voxel twin has an integer
lattice to land on; the SDF twin is a continuous solved surface with none, so
its silhouette centroid steps by that one-pixel quantum as it rotates — the
sampling floor of rasterizing continuous geometry to a fixed grid. **Reading 1
holds.**

This corroborates the independent #2469 measurement in `engine/render/CLAUDE.md`,
which records the same 2.00px x-excursion for the SDF cylinder under the
unrelated `--yaw-sweep` harness and already treats the twin as the *defect-free
control*. Two harnesses, one number.

**Change:** exempt the SDF twin from the centroid gate (`SDF_GATED`) and report
its real numbers instead. No engine, shader, or render-path code is touched.

## Rebased 2026-08-01 onto `0b6b7d89` (semantic conflict resolved)

Master moved under this PR, so several claims in the original body no longer
hold and have been re-stated here against fresh measurements:

- **`scripts/pivot-verify.py`** — master (#2547 via #2585) replaced the single
  report/gate split this PR was written against with a **per-block two-oracle**
  model (`CENTROID_GATED_BLOCKS` + the `[pivot-focus-assert]` pinned-point
  check). Resolved as a union, not a pick: master's two oracles are kept intact
  and this PR's un-gating becomes one added condition on the centroid gate
  (`block in CENTROID_GATED_BLOCKS and (SDF_GATED if sdf else True)`), plus a
  `REPORT` verdict for the resulting no-oracle pass. That third branch is
  load-bearing — `focus-ctr` is *in* `CENTROID_GATED_BLOCKS`, so under a naive
  union its SDF twin reaches master's `{"OK","BAD","NONE"}[focus]` lookup with
  `focus == "-"` and raises `KeyError`.
- **`engine/render/CLAUDE.md`** — kept master's newer per-block-oracle prose and
  folded in this PR's reported-not-gated sentence. Dropped this PR's trailing
  "the assertion is pure temporal invariance", which master's own edit has since
  made false (there are now two oracles, not one).
- **`docs/design/camera-yaw-pivot.md`** auto-merged, but left a contradiction the
  merge could not see: master had added **deviation 4, "SDF-twin silhouette
  wobble — OPEN (#2645)"** — the exact question this PR answers — so the
  document would have shipped an open defect next to its own resolution.
  Deviation 4 is now marked NOT A DEVIATION with a pointer to the new
  subsection, and the section preamble ("deviation 4 is open") updated to match.

**#2547 has since merged**, which retires the original body's "the harness's red
now means the open #2547 defect alone" — there is no remaining red. Re-measured
on macOS/Metal against the rebased branch:

| run | result |
|---|---|
| `--blocks focus-ctr --zoom 4 --zoom 8` | **exit 0** — voxel PINNED 0.94/1.27 (z4), 0.96/1.31 (z8); SDF twin `REPORT` 2.00/2.00 at both |
| full default set `--zoom 4` (7 passes) | **exit 0**, "all 7 passes met their gate" — `center-depth` is now `FOCUS-OK` (was the 320px red) because #2547 shipped |
| positive control `--blocks focus-ctr --zoom 4 --max-deviation 0.5` | **exit 1**, "1/2 passes FAILED" |

The control is threshold-based rather than defect-based because the full set is
now green. It is the stronger check for this diff: at a 0.5px bar the **voxel**
twin fails at 0.94px while the SDF twin still passes at 2.00px — 4x the same
bar. So the gate demonstrably still fires, and the exemption is specific to the
twin rather than a blanket disable.

The frame dump also corroborates the quantum claim directly: `focus-ctr-sdf`'s
centroid takes exactly two x values across the 9-yaw sweep, 1279.50 and 1277.50
— one 2.00px step, as the doc entry predicts.

## Test plan

- [x] **Acceptance 1 — reproduced against `origin/master`**: `focus-ctr-sdf`
      2.00/2.00 DRIFT, voxel twin PINNED 0.94/1.27 (z4) and 0.96/1.31 (z8) —
      byte-identical to the numbers reported from the #2585 branch, confirming
      it predates the epic's open PRs. Re-confirmed post-rebase (table above).
- [x] **Acceptance 2 — discriminated the two readings** by zoom sweep (1/2/4/8/16
      above); anchor-delta ruled out, floor confirmed, mechanism identified.
- [x] **Acceptance 3 — un-gated with the justifying measurement recorded** in
      `docs/design/camera-yaw-pivot.md` §"Known deviations".
- [x] `pivot-verify.py --blocks focus-ctr --zoom 4 --zoom 8` → **exit 0**
      (SDF twin verdict `REPORT`, voxel PINNED).
- [x] **Positive control** (post-rebase): `--blocks focus-ctr --zoom 4
      --max-deviation 0.5` → **exit 1**, "1/2 passes FAILED" — voxel twin gated
      and failing, SDF twin still exempt at 4x the bar.
- [x] Full default set at zoom 4 → **exit 0**, "all 7 passes met their gate".
- [x] `fleet-build --target IRShapeDebug` clean on the rebased tree.
- [x] `ruff check scripts/pivot-verify.py` clean; `py_compile` clean.

## Notes for the reviewer

- The quantum is one *game-resolution* pixel, so the framebuffer figure is
  host-dependent: on a 1x host the same floor should read ~1.00px and fall under
  the 1.5px threshold on its own. A Linux/GL re-measure reporting ~1.00px agrees
  with this PR rather than contradicting it — the un-gating is keyed on the floor
  being a floor, not on the specific number. This is called out in the doc entry.
- Closing the 2px properly would mean supersampling / conservative rasterization
  on the SDF path — already deferred to epic #1933 — and is unreachable from the
  pivot math this harness exists to gate.

Closes #2645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
