### PR TITLE
fleet: native stack creation via gh stack link (migration phase 1)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -409,17 +409,6 @@ exit cleanly:
       base PR by its head ref with the step-2.5 base-lookup query. The
       base might be OPEN, MERGED, or CLOSED without merging.
 
-      **Native-stack override.** If the candidate is in step 2.4's
-      **native-stacked set**, only the label-side sub-cases apply:
-      sub-case i (base OPEN → park with `fleet:awaiting-base`) and
-      sub-case iii (base CLOSED unmerged → `fleet:needs-info` handoff)
-      run as written — they are comment + label only. Sub-case ii
-      (base MERGED → retarget + rebase) must NOT run: GitHub retargets
-      native children synchronously with the parent's merge, so
-      observing a native PR with a merged base is a transient race at
-      worst — log `... skip #<N>: native stack, GitHub owns retarget`
-      and jump to step f.
-
       Three sub-cases. Sub-cases i and iii skip the normal rebase
       (step b–d) and jump directly to step f (reset to scratch). Sub-
       case ii performs its OWN re-target + rebase inline (the rebase
@@ -433,6 +422,17 @@ exit cleanly:
       (removing an absent label returns non-zero and would abort a
       chained add) but collapses the adds into a single `gh pr edit`
       call where possible.
+
+      **Native-stack override — read before executing any sub-case.**
+      If the candidate is in step 2.4's **native-stacked set**, only the
+      label-side sub-cases apply: sub-case i (base OPEN → park with
+      `fleet:awaiting-base`) and sub-case iii (base CLOSED unmerged →
+      `fleet:needs-info` handoff) run as written — they are comment +
+      label only. Sub-case ii (base MERGED → retarget + rebase) must
+      NOT run: GitHub retargets native children synchronously with the
+      parent's merge, so observing a native PR with a merged base is a
+      transient race at worst — log `... skip #<N>: native stack,
+      GitHub owns retarget` and jump to step f.
 
       **i. Base PR is OPEN.** The child can't safely rebase onto master
          until the base lands; skip this iteration.

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -136,6 +136,24 @@ exit cleanly:
    stacked-PR check need. (Cached equivalent of the previous
    `gh pr list --state open --json number,title,mergeable,labels,headRefName,baseRefName,updatedAt`.)
 
+2.4. **Fetch the native-stack membership set (one API call per repo
+   pass).** PRs linked into a **native GitHub stack** (created via the
+   `commit-and-push` link step — see
+   [`docs/design/native-stacked-prs-migration.md`](../../docs/design/native-stacked-prs-migration.md))
+   have GitHub itself as their base-management authority: retargeting
+   happens server-side synchronously with the parent's merge, cascade
+   rebases are server-side, and merges couple bottom-up. The merger
+   must never retarget, cascade-rebase, or strip markers on them —
+   only the label-side policy steps (parking, orphan handoff) still
+   apply. Fetch the set once:
+
+   `gh api "repos/jakildev/IrredenEngine/stacks" --jq '[.[] | select(.open) | .pull_requests[] | select(.merged_at == null) | .number] | unique'`
+
+   Store the resulting PR numbers as this pass's **native-stacked
+   set**. An empty array (or a 404 while the preview is repo-disabled)
+   means no native stacks — the legacy steps below then own every
+   stacked PR, as before.
+
 2.5. **Reconcile stacked PRs whose base has merged or closed —
    retarget proactively, label-independent.** Two failure modes this
    step covers: (1) **labeled stacked PRs** — `fleet:awaiting-base`
@@ -152,6 +170,9 @@ exit cleanly:
 
    From `repos.engine.prs[]`, collect every PR where:
    - `baseRefName != "master"` (stacked PR), AND
+   - the PR is NOT in step 2.4's **native-stacked set** (GitHub owns
+     native retargeting; log `... skip #<N>: native stack` and move
+     on), AND
    - `labels` contains NONE of `fleet:wip`, `human:wip`,
      `fleet:fork-of-other-pr`, `fleet:merger-cooldown`,
      `fleet:semantic-conflict`.
@@ -215,6 +236,11 @@ exit cleanly:
 
    From `repos.engine.prs[]`, collect every PR where:
    - `baseRefName != "master"` (stacked PR), AND
+   - the PR is NOT in step 2.4's **native-stacked set** (server-side
+     cascade rebases own native stacks; the author runs
+     `gh stack sync` when a mid-review upstream push needs
+     propagating — the merger hand-rebasing here would race the
+     server), AND
    - `labels` contains NONE of `fleet:wip`, `human:wip`,
      `fleet:blocker`, `human:needs-fix`, `human:blocker`,
      `human:re-review`, `fleet:semantic-conflict`,
@@ -382,6 +408,17 @@ exit cleanly:
       Otherwise (stacked PR — base is a feature branch), look up the
       base PR by its head ref with the step-2.5 base-lookup query. The
       base might be OPEN, MERGED, or CLOSED without merging.
+
+      **Native-stack override.** If the candidate is in step 2.4's
+      **native-stacked set**, only the label-side sub-cases apply:
+      sub-case i (base OPEN → park with `fleet:awaiting-base`) and
+      sub-case iii (base CLOSED unmerged → `fleet:needs-info` handoff)
+      run as written — they are comment + label only. Sub-case ii
+      (base MERGED → retarget + rebase) must NOT run: GitHub retargets
+      native children synchronously with the parent's merge, so
+      observing a native PR with a merged base is a transient race at
+      worst — log `... skip #<N>: native stack, GitHub owns retarget`
+      and jump to step f.
 
       Three sub-cases. Sub-cases i and iii skip the normal rebase
       (step b–d) and jump directly to step f (reset to scratch). Sub-
@@ -803,15 +840,18 @@ worktree, and `gh` target change.
 2g. **Gather + filter candidates** — same candidate rule and skip-label
     set as step 3 (CONFLICTING, or UNKNOWN updated >5m ago), over
     `repos.game.prs[]`.
-2.5g. **Reconcile + cascade-rebase stacked game PRs** — run steps 2.5
+2.5g. **Reconcile + cascade-rebase stacked game PRs** — first run step
+    2.4 for the game repo
+    (`gh api "repos/jakildev/irreden/stacks" --jq …`, same filter) to
+    build the game pass's **native-stacked set**, then run steps 2.5
     (reconcile stacked PRs whose base merged or closed — re-target to
     `master` + `fleet:stacked`→`fleet:stacked-rebase`) and 2.6
     (cascade-rebase stacked children whose still-open base force-pushed)
-    over `repos.game.prs[]`, exactly as the engine pass, with the game
-    deltas: cwd = your game twin worktree, every `gh` call carries `--repo
-    jakildev/irreden`, and re-target/rebase run against the game
-    `origin`. Force-push rebases done here count toward the shared
-    ≤2-rebase budget.
+    over `repos.game.prs[]`, exactly as the engine pass — including the
+    native-stack skips — with the game deltas: cwd = your game twin
+    worktree, every `gh` call carries `--repo jakildev/irreden`, and
+    re-target/rebase run against the game `origin`. Force-push rebases
+    done here count toward the shared ≤2-rebase budget.
 3g. **Resolve each candidate (within the shared cap)** — run step 5's
     core resolution: **a** (detached checkout in the game worktree,
     **including a.5 stacked-PR check and a.6 fork detection**),

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -384,6 +384,12 @@ Do the work, then exit cleanly:
        whichever the PR is actually based on, NOT always master:
        `git fetch origin <baseRefName>`
        `git rebase origin/<baseRefName>`
+       For a PR in a **native GitHub stack** (stack badge on the PR
+       header; membership via `gh api "repos/{owner}/{repo}/stacks"`),
+       this per-PR rebase against its *current* base is still fine —
+       but never retarget its base or replay it onto master by hand:
+       GitHub owns retarget-on-merge and cascade rebases for native
+       stacks (see `docs/design/native-stacked-prs-migration.md`).
     d'. **Inherited-prefix shortcut — check before resolving by hand.** If
        every conflicted file is one your branch *inherited* from a parent PR
        that has since merged (stale inherited copy vs master's now-merged
@@ -635,8 +641,9 @@ Do the work, then exit cleanly:
    tasks with multiple `Blocked by:` entries (Q3 decision: multi-blocker
    not eligible in v1). Pick the oldest eligible task by task ID. **For a
    `repo == "game"` task, `cd` into your game worktree and prefix the
-   claim with `--repo game`** — the merger's game pass now cascade-
-   rebases stacked game PRs, so the stack is maintained.
+   claim with `--repo game`** — stacks are native GitHub stacks in both
+   repos (commit-and-push links the PR after open), so the chain is
+   maintained server-side either way.
 
    If a stackable-blocked task is found, claim it with `--stackable-on`:
    `fleet-claim claim "<task-id>" <your-worktree-name> --stackable-on <stackable_blocker_pr.number>`

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -51,6 +51,9 @@ there.
   stacking via `branch.<name>.cursor-stack-base`.
 - [`procedures/stackable-on.md`](procedures/stackable-on.md) — single-task
   base resolution + `--stackable-on`.
+- [`procedures/native-stack-link.md`](procedures/native-stack-link.md) —
+  the post-open `gh stack link` step every stack mode runs (native GitHub
+  stacks own retarget-on-merge and cascade rebases).
 - [`procedures/pr-body.md`](procedures/pr-body.md) — PR body templates +
   stack-mode deltas.
 - [`procedures/host-label.md`](procedures/host-label.md) — the

--- a/.claude/skills/commit-and-push/procedures/cursor-stack.md
+++ b/.claude/skills/commit-and-push/procedures/cursor-stack.md
@@ -11,25 +11,20 @@ git config --get branch.$(git branch --show-current).cursor-stack-base
 ```
 
 - Output is empty / exit 1 → not cursor-stacked. Proceed with the normal single-PR flow in [`SKILL.md`](../SKILL.md).
-- Output names a branch (e.g. `claude/render-glow-pulse`) → the current branch is cursor-stacked on that branch. Note the value; step 8 uses it as `--base` and writes a `Stacked on:` line to the PR body.
+- Output names a branch (e.g. `claude/render-glow-pulse`) → the current branch is cursor-stacked on that branch. Note the value; step 8 uses it as `--base` and the post-open link step registers the native stack.
 
 ## Deltas vs. the single-PR flow
 
 - **Step 8 PR base** is the recorded `cursor-stack-base` instead of `master`. Pass it to `gh pr create` as `--base <base>`.
-- **PR body** includes a `Stacked on: <PR URL>` line. Look up the parent PR URL once at PR-open time:
-  ```bash
-  parent_branch=$(git config --get branch.$(git branch --show-current).cursor-stack-base)
-  parent_pr_url=$(gh pr list --head "$parent_branch" --state all --json url -q '.[0].url' --limit 1)
-  ```
-  If the parent has no PR yet (e.g. the human hasn't run `commit-and-push` on it — unusual but possible), use the branch name instead: `Stacked on: <parent_branch>` and warn the user.
+- **After the PR opens**, link it into the native GitHub stack: run the [native-stack-link.md](native-stack-link.md) step with the recorded `cursor-stack-base` as `$base` and the new PR number. No `Stacked on:` body line — the stack badge on the PR header is the chain record. If the parent branch has no open PR yet (the human hasn't run `commit-and-push` on it — unusual but possible), the link step skips itself; warn the user and re-run the link after the parent PR exists.
 - **Title** uses the normal cursor-flow shape (no issue-number prefix — cursor flow branches are named `claude/<area>-<topic>`).
-- **No labels** beyond what the normal flow adds. The `fleet:stacked` label is fleet-only; cursor flow just relies on `Stacked on:` in the PR body.
+- **No labels** beyond what the normal flow adds. The `fleet:stacked` label is fleet-only; cursor flow relies on the native stack object alone.
 
 ## After the PR opens
 
 Do NOT clear the `cursor-stack-base` config — leave it as a record of the chain. The config is local-only and doesn't need cleanup; the next `commit-and-push` on a non-stacked branch (no config set) takes the standard path automatically.
 
-When the parent PR merges, change this PR's base to `master` in the GitHub UI (or `gh pr edit <N> --base master`) — same step as in any manual stacked-PR workflow.
+When the parent PR merges, GitHub re-targets and rebases this PR onto `master` server-side — no manual `gh pr edit --base` step. Merging this PR from the stack UI pulls any unmerged parents in with it (coupled bottom-up merge), so the human can also just merge the top of whatever sub-chain is ready.
 
 ## macOS sandbox note
 

--- a/.claude/skills/commit-and-push/procedures/fleet-stack.md
+++ b/.claude/skills/commit-and-push/procedures/fleet-stack.md
@@ -19,12 +19,12 @@ fleet-claim stack-pr-state <your-worktree-name>
 
 - **Step 2 branch name** is `claude/<issue#>-<short-topic>` (e.g. `claude/1234-occupancy-grid`). The issue-number prefix lets reviewers and `stack-base` resolve the chain.
 - **Step 8 PR base** is `fleet-claim stack-base <agent> <task-id>` instead of `master`. For the first task this still returns `master`; for subsequent tasks it returns the previous task's branch.
-- **After `gh pr create`** record the PR in the stack so the next task can chain off it:
+- **After `gh pr create`** record the PR in the stack so the next task can chain off it, then link it into the native GitHub stack (skip the link for the first task — its base is `master`):
   ```bash
   fleet-claim stack-set-pr <agent> <task-id> <branch> <pr-url>
   ```
-- **PR body** includes a `## Stack context` block with a `Stacked on:` line (the previous PR URL, or `master` for the first task in the chain) and a `Full chain:` line listing the task IDs the molecule covers. Reviewers use this to navigate sibling PRs without leaving the diff.
-- **Labels** include `fleet:stacked` whenever `--base != master` (i.e. every PR in the chain except the first). The merger reads `baseRefName` directly for routing decisions; the label is a derived convenience for human visibility and cheap GitHub-side filtering.
+  Link step: [native-stack-link.md](native-stack-link.md), with `$base` from `stack-base` and the new PR number. GitHub then owns retarget-on-merge and cascade rebases for the chain; the PR header's stack badge is the chain navigation (no `Stacked on:` / `Full chain:` body lines — legacy markers went stale and misrouted review, #2231).
+- **Labels** include `fleet:stacked` whenever `--base != master` (i.e. every PR in the chain except the first). The merger reads `baseRefName` directly for routing decisions and skips native-stacked PRs; the label is a derived convenience for human visibility and cheap GitHub-side filtering during the migration.
 - **Title** starts with a scope prefix per the commit-message style guide; the issue number goes in the `Closes #N` line so reviewers can trace the chain.
 
 ## After the PR opens

--- a/.claude/skills/commit-and-push/procedures/native-stack-link.md
+++ b/.claude/skills/commit-and-push/procedures/native-stack-link.md
@@ -1,0 +1,58 @@
+# Native stack link (commit-and-push procedure)
+
+After opening a PR whose base is a feature branch (any stack mode), register
+the parent→child relationship as a **native GitHub stack**. From then on
+GitHub owns base management: when the parent merges the child retargets and
+rebases server-side, cascade rebases are one `gh stack sync` (or the UI's
+"Rebase stack" button), and merges couple bottom-up — merging a child pulls
+its unmerged parents in, so a child can never land on a stale base. Design +
+evaluation evidence:
+[`docs/design/native-stacked-prs-migration.md`](../../../../docs/design/native-stacked-prs-migration.md).
+
+## The link step (idempotent)
+
+Run after the PR exists (fresh `gh pr create` or the idempotent
+`gh pr edit` reconcile), from inside the repo the PR belongs to — the
+`{owner}/{repo}` placeholders resolve from the working directory's remote:
+
+```bash
+base=<the PR's base branch>            # already resolved by the stack mode
+child_pr=<the just-opened PR number>
+parent_pr=$(gh pr list --head "$base" --state open --json number -q '.[0].number')
+if [[ -z "$parent_pr" ]]; then
+    echo "native-stack-link: no open PR for base $base — skipping link" >&2
+else
+    stack=$(gh api "repos/{owner}/{repo}/stacks" \
+        --jq "[.[] | select(.open) | select(any(.pull_requests[]; .number == ${parent_pr}))][0].number")
+    if [[ -n "$stack" && "$stack" != "null" ]]; then
+        gh stack link "$stack" "$child_pr"      # append to the parent's existing stack
+    else
+        gh stack link "$parent_pr" "$child_pr"  # create a new two-PR stack
+    fi
+fi
+```
+
+Skipping the link (parent PR missing, extension unavailable) is safe but
+second-best: the PR still works as an ordinary branch-based PR and the
+merger's legacy stacked handling services it. Prefer fixing the link over
+falling back — surface the skip in your report.
+
+## Notes
+
+- `gh stack link` accepts PR numbers or branch names and auto-corrects
+  mismatched bases; the child's base (the parent's branch) is already
+  correct here, so the link is pure registration.
+- Requires the `gh-stack` CLI extension (`gh extension install
+  github/gh-stack` — `scripts/fleet/install.sh` bootstraps it). Exit code 9
+  means Stacked PRs isn't enabled for this repo; surface to the human, don't
+  retry.
+- Do **not** write `Stacked on:` body lines or `Full chain:` lists — stack
+  membership is a server object and the PR header's stack badge shows the
+  chain. Body markers were the legacy mechanism and produced stale-marker
+  misrouting (#2231).
+- Keep applying `fleet:stacked` where the stack mode says so — transition-
+  period readers still filter by it. The label retires with the legacy
+  machinery (migration Phase 2).
+- Never run the legacy re-stack dance (`gh pr edit --base master` after a
+  parent merge) on a linked PR — GitHub already did it, synchronously with
+  the merge.

--- a/.claude/skills/commit-and-push/procedures/pr-body.md
+++ b/.claude/skills/commit-and-push/procedures/pr-body.md
@@ -44,35 +44,22 @@ evidence` proves the ticket's named criteria actually fired.
 
 ## Fleet stack delta
 
-Insert after `## Summary`, before `## Test plan`:
-
-```
-## Stack context
-This PR is part of a stack. Reviewers: review this PR on its own;
-the chain is coordinated in the PR body's "Stacked on" line.
-
-Stacked on: <previous PR URL, or "master" for the first PR>
-Full chain: #<A>, #<B>, #<C>
-```
+No body block. Stack membership, chain navigation, and merge sequencing all
+live in the native GitHub stack (the [native-stack-link.md](native-stack-link.md)
+step registers it after PR open; the PR header's stack badge shows the
+chain). Never write `Stacked on:` or `Full chain:` lines — the legacy body
+markers went stale after retargets and misrouted review (#2231).
 
 Drop `## Notes for reviewer`. The `Closes #<issue-N>` line is already in the
-canonical template above — keep it as written.
+canonical template above — keep it as written (each fleet-stack task has its
+own issue).
 
 ## Cursor stack delta
 
-Insert after `## Summary`, before `## Test plan`:
+No body block either — same native-stack rule as the fleet stack delta.
 
-```
-## Stack context
-Stacked on: $parent_pr_ref
-
-When the parent PR merges, change this PR's base to `master`
-(via the GitHub UI or `gh pr edit <N> --base master`).
-```
-
-No `Full chain:` line. **Drop the `Closes #<issue-N>` line** — the parent PR
-closes the shared issue when it merges to master. Avoid duplicating `Closes #N`
-on the child while the parent is still in review. The parent PR (which targets
-master directly via the canonical template) carries the `Closes` line and closes
-the shared issue when it merges first. Drop `## Notes for reviewer`.
-`$parent_pr_ref` is the parent PR URL (or branch name if no PR exists yet). Use `<<EOF` (no quotes) in the HEREDOC so that `$parent_pr_ref` expands; `<<'EOF'` suppresses expansion and embeds the literal string.
+**Drop the `Closes #<issue-N>` line** — cursor-stack slices usually share
+one issue, and the parent PR (which targets master directly via the
+canonical template) carries the `Closes` line. Avoid duplicating `Closes #N`
+on the child while the parent is still in review. Drop `## Notes for
+reviewer`.

--- a/.claude/skills/commit-and-push/procedures/stackable-on.md
+++ b/.claude/skills/commit-and-push/procedures/stackable-on.md
@@ -52,19 +52,17 @@ else
     gh pr create --base "$base" "${labels[@]}" \
         --title "<scope>: <title> (#<N>)" \
         --body "$(cat <<EOF
-<single-task body — procedures/pr-body.md; include the Stacked on: line below when base != master>
+<single-task body — procedures/pr-body.md>
 EOF
 )"
 fi
 ```
 
-When `base != master`, add a `Stacked on:` line to the body, pointing at the
-upstream PR (look it up once — same pattern as cursor-stack.md):
-
-```bash
-upstream_pr=$(gh pr list --head "$base" --state all --json url -q '.[0].url')
-# body: "Stacked on: ${upstream_pr:-$base (no PR yet)}"
-```
+When `base != master`, link the PR into the native GitHub stack — run the
+[native-stack-link.md](native-stack-link.md) step with `$base` and the PR
+number. Do NOT write a `Stacked on:` body line; stack membership is the
+server object (the legacy body marker produced stale-marker misrouting,
+#2231).
 
 ## Notes / non-goals
 
@@ -72,10 +70,13 @@ upstream_pr=$(gh pr list --head "$base" --state all --json url -q '.[0].url')
   Single-task mode writes no claim state — it only *reads* `claim-base`.
 - **`fleet:wip` is unchanged.** The claim-time PR is WIP; the finalize step
   removes `fleet:wip` for reviewer pickup, leaving `fleet:stacked` in place.
-- **Don't fight the merger.** When the upstream PR merges, the merger
-  re-targets this PR to `master` and removes `fleet:stacked`. Only set the
-  base/label from the *current* `claim-base` value at push time; never
-  re-stack a PR the merger has already re-targeted.
+- **GitHub owns the base after the link.** When the upstream PR merges,
+  GitHub re-targets and rebases this PR server-side, synchronously with the
+  merge. Only set the base/label from the *current* `claim-base` value at
+  push time; never re-stack a PR that GitHub (or, for unlinked legacy PRs,
+  the merger) has already re-targeted.
 - The merger routes stacked PRs by `baseRefName != "master"` regardless of the
-  label; `fleet:stacked` is the human-visibility / cheap-filter convenience
-  this procedure guarantees is present.
+  label, and skips PRs that are in a native stack; `fleet:stacked` is the
+  human-visibility / cheap-filter convenience this procedure guarantees is
+  present during the migration (it retires with the legacy machinery —
+  see `docs/design/native-stacked-prs-migration.md`).

--- a/.claude/skills/review-pr/procedures/stacked-pr-review.md
+++ b/.claude/skills/review-pr/procedures/stacked-pr-review.md
@@ -8,12 +8,12 @@ Every fleet PR today is single-task. When workers claim a dependency chain via `
 
 Detect stacking from the metadata already fetched in `SKILL.md` step 1:
 
-- **Base branch** (`baseRefName`) is not `master` → stacked on the PR whose head is that branch.
-- **Body** contains a `Stacked on:` line → confirms it, and the line gives you the parent PR URL for the review-body callout.
+- **Base branch** (`baseRefName`) is not `master` → stacked on the PR whose head is that branch. This is the authoritative signal.
+- PRs created since the native-stack migration carry **no body marker** — the chain lives in GitHub's stack object (stack badge on the PR header). Legacy PRs may still carry a `Stacked on:` body line; treat it as confirmation only, never as the detection signal.
 
 If the base is `master` and there's no `Stacked on:` line, this is a standalone PR — return to `SKILL.md` step 1c (churn audit) and continue normally.
 
-If the base is `master` but the body **still carries** a `Stacked on:` line, the marker is stale — the PR was un-stacked (parent merged, base re-targeted) and the strip step was missed. Review it as a standalone PR, and flag the stale line as a nit so it gets removed.
+If the base is `master` but the body **still carries** a `Stacked on:` line, the marker is stale legacy state — the PR was un-stacked (parent merged, base re-targeted) and the strip step was missed. Review it as a standalone PR, and flag the stale line as a nit so it gets removed.
 
 ## What changes when the PR is stacked
 

--- a/.github/workflows/auto-rereview.yml
+++ b/.github/workflows/auto-rereview.yml
@@ -15,15 +15,18 @@ name: Auto re-review on push to approved PR
 #     again."
 #
 # Why the mechanical-rebase guard (the `classify` step below):
-#   A push whose *content* is unchanged does not need re-review. The
-#   fleet merger re-targets a stacked PR onto master and force-pushes
-#   the replayed child commits (see role-merger.md — "verdict labels
-#   survive a mechanical rebase that doesn't change the PR's content
-#   intent"). That force-push fires `synchronize` but introduces no new
-#   content, so stripping fleet:approved there is wrong. We cannot rely
-#   on a `fleet:stacked-rebase` label guard because the merger applies
-#   that label *after* it pushes — the synchronize event payload
-#   captures labels at push time and races ahead of it. Instead we
+#   A push whose *content* is unchanged does not need re-review. Two
+#   producers of such pushes exist: GitHub's native stacked PRs
+#   re-target + rebase a child server-side when its parent merges (and
+#   on stack-wide cascade rebases), and the fleet merger does the same
+#   by hand for legacy pre-native stacks (see role-merger.md — "verdict
+#   labels survive a mechanical rebase that doesn't change the PR's
+#   content intent"). Either force-push fires `synchronize` but
+#   introduces no new content, so stripping fleet:approved there is
+#   wrong. We cannot rely on a label guard (e.g. the legacy
+#   `fleet:stacked-rebase`): the merger applies labels *after* it
+#   pushes — the synchronize event payload captures labels at push time
+#   and races ahead of it — and native rebases set no label at all. So we
 #   compare the PR's net-diff patch-id (reduced by `git patch-id --stable`,
 #   which is invariant across rebases/SHAs) before vs after the push, each
 #   tip against its *own* base. Identical patch-id => mechanical rebase =>

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -306,8 +306,9 @@ Mechanics:
    `branch.<new>.cursor-stack-base = <A's branch>` to git config.
 3. Iterate on B, then "commit and push" → `commit-and-push` reads
    the `cursor-stack-base` config; if set, opens the PR with
-   `--base <A's branch>` and adds `Stacked on: <PR A URL>` to the
-   PR body.
+   `--base <A's branch>` and links it into the **native GitHub
+   stack** (the `native-stack-link.md` procedure). The PR header's
+   stack badge shows the chain; no body markers.
 4. Repeat for C, D, …
 
 Stacks usually live in one Cursor chat (ship A → start B → ship B
@@ -316,10 +317,11 @@ config is per-branch and persists, so a fresh chat that lands on
 `claude/slice-c` finds its `cursor-stack-base` automatically and
 `commit-and-push` does the right thing.
 
-When PR A merges, change PR B's base to `master` in the GitHub UI
-(or `gh pr edit B --base master`) — same step as in any stacked-PR
-workflow. The `cursor-stack-base` config is local-only; nothing
-upstream needs cleanup.
+When PR A merges, GitHub re-targets and rebases PR B onto `master`
+server-side — no manual base edit. Merging any PR in the stack
+pulls its unmerged parents in with it (coupled bottom-up merge).
+The `cursor-stack-base` config is local-only; nothing upstream
+needs cleanup.
 
 If a chat lands on a branch that already has `cursor-stack-base`
 set and the human cues a non-specific "next slice" without saying
@@ -708,6 +710,21 @@ requires `Bash(fleet-edit:*)` in `.claude/settings.json`.
 
 Stacked PRs let downstream work start before an upstream dependency
 merges, keeping each task's diff scoped to its own branch and PR.
+
+**Stack mechanics are GitHub-native.** Every stack mode below ends
+with the `commit-and-push` link step
+([`native-stack-link.md`](../../.claude/skills/commit-and-push/procedures/native-stack-link.md)),
+which registers the chain as a native GitHub stack. GitHub then owns
+base management: when a parent merges, its children re-target and
+rebase server-side, synchronously; cascade rebases are one
+`gh stack sync` (or the PR page's "Rebase stack" button); and merges
+couple bottom-up — merging a child pulls its unmerged parents in, so
+a child can never land on a stale base. Design + evaluation:
+[`docs/design/native-stacked-prs-migration.md`](../design/native-stacked-prs-migration.md).
+PRs opened before the migration (no native stack object) are **legacy
+stacks**; the merger's retarget/cascade machinery services only those
+until they drain.
+
 Two stacking modes exist in this fleet:
 
 - **Cursor stacking** — human-driven; described under
@@ -717,8 +734,7 @@ Two stacking modes exist in this fleet:
 - **Cross-author stacking (scheduler)** — autonomous; described
   below. A free worker picks up a blocked issue when the blocker
   already has an open PR, branches off the blocker's branch, and
-  opens a stacked PR. The merger keeps the chain in sync as the
-  upstream PR evolves.
+  opens a stacked PR.
 
 ### Cross-author stacking (scheduler)
 
@@ -733,53 +749,47 @@ Two stacking modes exist in this fleet:
 3. Worker B reads `fleet-claim claim-base <Y>` → returns
    `claude/<X>-…` (not `master`). It fetches and branches off
    `origin/claude/<X>-…`, then opens PR #101 with
-   `--base claude/<X>-…` and adds `fleet:stacked`. PR #101's diff
-   shows only #Y's changes; #X's commits are part of the base.
-4. **Reviewer** sees `fleet:stacked` on #101 and checks #100's
-   approval state. If #100 is not yet approved, the reviewer defers
-   with `fleet:awaiting-upstream-review`. Once #100 is approved, the
-   reviewer evaluates #101's delta only and notes the cross-author
-   topology in the review body.
+   `--base claude/<X>-…`, adds `fleet:stacked`, and links #100→#101
+   into a native stack (the `native-stack-link.md` step). PR #101's
+   diff shows only #Y's changes; #X's commits are part of the base.
+4. **Reviewer** sees `fleet:stacked` on #101 (or the stack badge)
+   and checks #100's approval state. If #100 is not yet approved,
+   the reviewer defers with `fleet:awaiting-upstream-review`. Once
+   #100 is approved, the reviewer evaluates #101's delta only and
+   notes the cross-author topology in the review body.
 5. **Worker A** pushes a feedback fix to #100 (new commits on
-   `claude/<X>-…`). The **merger** detects that #101's upstream tip
-   moved on its next iteration:
-   - **Clean rebase** → force-push #101, post a confirmation
-     comment, leave existing approval labels intact.
-   - **Conflict** → add `fleet:needs-base-update` to #101, name
-     the conflict files, leave it for Worker B (or any opus+-class worker)
-     to reconcile manually with `git rebase origin/<baseRefName>`;
-     the label clears when they push a clean rebase or when the
-     upstream merges.
-6. **PR #100 merges.** The merger re-targets #101's base from
-   `claude/<X>-…` to `master` (existing re-target logic, unchanged)
-   and removes `fleet:stacked`. PR #101 is now a standard PR vs
-   `master`. The merger also adds `fleet:stacked-rebase` and
-   `fleet:changes-made` — the reviewer's re-eval of the re-targeted
-   diff is the action `fleet:stacked-rebase` is waiting for.
+   `claude/<X>-…`). Propagating that into #101 is one
+   `gh stack sync` (Worker A, from the stack) or the "Rebase stack"
+   button — server-side cascade, conflict-safe replay. A sync whose
+   replay conflicts pauses with exit code 3; whoever ran it resolves
+   and `gh stack rebase --continue`s, or surfaces to the human.
+6. **PR #100 merges.** GitHub re-targets #101 to `master` and
+   rebases it server-side, synchronously with the merge — the
+   content-based auto-rereview classifier recognizes the
+   content-identical force-push and preserves the verdict label.
+   PR #101 is now a standard PR vs `master`. (Merging #101 directly
+   from the stack UI would instead pull #100 in with it, bottom-up.)
 
-**Design decisions (v1):**
+**Design decisions:**
 
 - **Q1 — Aggression.** Two-tier pickup: workers exhaust the normal
   unblocked list first; cross-author stacking is a fallback only for
-  otherwise-idle panes. The coordination tax (rebase cascades,
-  reviewer gating on upstream state) makes the simple path
-  preferable by default.
-- **Q2 — Cascade rebase.** Merger-driven hybrid. When the upstream
-  PR force-pushes, the merger (which has no claim conflicts on the
-  child) attempts the rebase. The upstream's author does not rebase
-  the child — that would require cross-worktree gymnastics that
-  introduce ownership conflicts.
+  otherwise-idle panes. The coordination tax (reviewer gating on
+  upstream state) makes the simple path preferable by default.
+- **Q2 — Cascade rebase.** GitHub-native. Server-side cascade
+  rebases replaced the v1 merger-driven hybrid; the merger's
+  cascade machinery services only pre-migration legacy stacks.
 - **Q3 — Multi-blocker.** Single-blocker issues only. An issue
   blocked by both #A and #B is never eligible for the fallback tier
   even if all blockers have open PRs. Picking a single base branch
-  from multiple blockers is a design call the v1 merger machinery
-  does not handle.
+  from multiple blockers is a design call the offer machinery does
+  not handle (native stacks are linear chains anyway).
 
 Engine **and** game tasks are both stackable: the scout enriches
 blocked tasks in both repos, worker pickup claims `--stackable-on` in
-either (game with `--repo game`), and the merger's game pass runs the
-same stacked-base re-target / cascade-rebase / fork-detection (steps
-2.5/2.6/a.5/a.6) as the engine pass.
+either (game with `--repo game`), and native stacks work identically
+in both repos. The merger's game pass services legacy game stacks
+(steps 2.5/2.6/a.5/a.6) until they drain.
 
 **v1 limitations:**
 
@@ -880,28 +890,29 @@ For the current issue in the stack (first `(pending)` row in
 3. Do the issue's work in that branch. Commit as normal — no special
    commit-subject prefix is required; one issue per branch means the
    branch name IS the per-issue anchor.
-4. **Open the PR with `--base "$base"` and record it in the stack.**
-   When `$base` is a feature branch (not `master`), add
-   `--label "fleet:stacked"` so the merger and reviewer can filter
-   by label without an extra `gh pr view --json baseRefName` call:
+4. **Open the PR with `--base "$base"`, record it in the stack, and
+   link it natively.** When `$base` is a feature branch (not
+   `master`), add `--label "fleet:stacked"` so the merger and
+   reviewer can filter by label without an extra
+   `gh pr view --json baseRefName` call:
    `gh pr create --base "$base" --title "<title> (#<N>)" --body "..." --label "fleet:wip" --label "fleet:stacked"`
    `fleet-claim stack-set-pr <your-worktree-name> <issue-number> "$(git branch --show-current)" "<pr-url>"`
-   For the first issue in the chain (`$base == master`), omit
-   `fleet:stacked` — that PR merges into master normally.
+   Then run the
+   [`native-stack-link.md`](../../.claude/skills/commit-and-push/procedures/native-stack-link.md)
+   step so GitHub owns the chain. For the first issue in the chain
+   (`$base == master`), omit `fleet:stacked` and skip the link —
+   that PR merges into master normally (it becomes the stack's
+   bottom when the second PR links onto it).
 
 **Stacked PR title + body format.** Use a descriptive title with the
 issue number in parentheses (standard GitHub convention) so reviewers
-can find the source issue. The body includes a `Stacked on:` line
-pointing at the previous PR (or `master` for the first) and a
-`Closes #N` line so the issue auto-closes when the PR merges.
+can find the source issue. Include a `Closes #N` line so the issue
+auto-closes when the PR merges. No stack markers in the body — the
+PR header's stack badge is the chain navigation.
 
 ```markdown
 ## Summary
 - <what this issue does>
-
-## Stack context
-Stacked on: <previous PR URL, or "master" for the first>
-Full chain: #1195 → #1196 → #1197
 
 ## Test plan
 - [ ] <issue-specific checks>
@@ -911,16 +922,15 @@ Closes #<N>
 
 The `commit-and-push` skill's "Stack-aware mode" section walks
 through the branch + PR creation; let it drive — it already knows
-to call `stack-base` and `stack-set-pr`.
+to call `stack-base`, `stack-set-pr`, and the native link.
 
-**When an earlier PR in the stack merges:** GitHub auto-rebases the
-next PR's base to master. Pull the latest master into the next
-branch before continuing work on it:
-`git fetch origin master`
-`git rebase origin/master`
-Force-push with `--force-with-lease` (never `--force`). The
-reviewer's approval on the unchanged commits carries over unless a
-conflict actually modified them.
+**When an earlier PR in the stack merges:** GitHub re-targets and
+rebases the remaining PRs server-side, synchronously with the
+merge — no manual pull/rebase needed. Run `gh stack sync` from the
+stack before continuing local work on a downstream branch so your
+local refs match the server-side rebase. The reviewer's approval
+carries over: the auto-rereview classifier recognizes the
+content-identical force-push and leaves the verdict label alone.
 
 **Addressing review feedback on a stacked PR:** commit the fix on
 the same branch, push, and comment as usual. No cross-issue
@@ -946,18 +956,20 @@ automatically when the PR merges:
 `gh pr create --title "<issue title> (#<N>)" --body "Claiming issue. Work in progress.\n\nCloses #<N>" --label "fleet:wip"`
 
 For a stackable-on claim (base is a feature branch), open with
-`--base <upstream-branch>` and add `fleet:stacked`:
+`--base <upstream-branch>`, add `fleet:stacked`, and link natively:
 
-First look up the upstream PR URL:
-`gh pr view <stackable_blocker_pr.number> --json url --jq .url`
+`gh pr create --base <upstream-branch> --title "<issue title> (#<N>)" --body "Work in progress.\n\nCloses #<N>" --label "fleet:wip" --label "fleet:stacked"`
 
-Then open the PR:
-`gh pr create --base <upstream-branch> --title "<issue title> (#<N>)" --body "Stacked on: <upstream PR URL>\n\nWork in progress.\n\nCloses #<N>" --label "fleet:wip" --label "fleet:stacked"`
+Then run the
+[`native-stack-link.md`](../../.claude/skills/commit-and-push/procedures/native-stack-link.md)
+step (parent = `<stackable_blocker_pr.number>`) so GitHub owns the
+chain from the start. No `Stacked on:` body line.
 
 > You don't have to get this exactly right by hand: **`commit-and-push`
-> resolves the base via `claim-base` and applies `fleet:stacked`
-> automatically for single-task claims** (idempotent edit-or-create), so a
-> missed `--base`/label here is repaired before review — see
+> resolves the base via `claim-base`, applies `fleet:stacked`, and runs
+> the native link automatically for single-task claims** (idempotent
+> edit-or-create), so a missed `--base`/label/link here is repaired
+> before review — see
 > [`commit-and-push/procedures/stackable-on.md`](../../.claude/skills/commit-and-push/procedures/stackable-on.md).
 
 ---

--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -65,7 +65,7 @@ Three modes, detected at the start in priority order:
    One PR per task, chained by `--base`. Detected via `<claim-tool>
    stack-pr-state <worktree>`. See the **procedures** `fleet-stack.md` for
    the deltas (issue-number-prefixed branch name, `stack-base` lookup,
-   `Stack context` body block, stacked label, `stack-set-pr` after PR open).
+   stacked label, `stack-set-pr` + native-stack link after PR open).
 2. **Cursor stack mode** — current branch has `branch.<name>.cursor-stack-base`
    git config (written by `start-next-task` when the human cued stacking).
    PRs target the parent branch instead of the default branch. See the
@@ -283,8 +283,9 @@ common no-screenshot case.
 For the **single-task flow** (default), resolve the base via `<claim-tool>
 claim-base` — the **default branch** for a normal claim or plain human PR
 (common case below), or the blocker's branch for a stackable claim (also
-gets the stacked label). The idempotent edit-or-create and the `Stacked on:`
-body line live in the **procedures** `stackable-on.md`. Common case:
+gets the stacked label). The idempotent edit-or-create and the post-open
+native-stack link live in the **procedures** `stackable-on.md` /
+`native-stack-link.md`. Common case:
 
 ```bash
 pr_body="$(cat <<'EOF'

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -666,6 +666,26 @@ else
 fi
 
 # ----------------------------------------------------------------------
+# Step 3b: gh-stack extension (native stacked PRs)
+# ----------------------------------------------------------------------
+# Stack modes link PRs into native GitHub stacks after open (see
+# docs/design/native-stacked-prs-migration.md); the link step needs the
+# gh-stack CLI extension. Best-effort: skipped without gh, auth, or network.
+
+if command -v gh >/dev/null 2>&1; then
+    if gh extension list 2>/dev/null | grep -q 'github/gh-stack'; then
+        echo "gh-stack extension already installed."
+    elif gh extension install github/gh-stack >/dev/null 2>&1; then
+        echo "installed gh extension github/gh-stack (native stacked PRs)."
+    else
+        echo "note: could not install the gh-stack extension (offline or gh unauthenticated)."
+        echo "      install it later with: gh extension install github/gh-stack"
+    fi
+else
+    echo "note: gh not found — skipping gh-stack extension install."
+fi
+
+# ----------------------------------------------------------------------
 # Step 4: PATH sanity check
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `commit-and-push/procedures/native-stack-link.md` — the shared idempotent post-open `gh stack link` step; all three stack modes (fleet-stack, cursor-stack, stackable-on) now register chains as native GitHub stacks and stop writing `Stacked on:` / `Full chain:` body markers (#2231 class).
- Merger: new step 2.4 fetches a per-pass native-stacked set; steps 2.5 / 2.6 / 5a.5-ii skip native PRs (GitHub owns retarget + cascade), while label-only parking (5a.5-i) and the closed-unmerged handoff (5a.5-iii) still apply. Game pass mirrors the guard.
- Worker: native-stack notes in the resolving flow; stackable fallback tier text updated.
- FLEET.md: §Stacked PRs rewritten native-first (legacy machinery services pre-migration stacks until they drain); cursor-flow stacking + per-task command sequence + claim-base snippets updated.
- `install.sh`: bootstraps the `gh-stack` extension (best-effort).
- auto-rereview: comment updated — the patch-id classifier already covers native server-side rebases; no behavioral change.
- review-pr stacked procedure: `baseRefName` stays the authoritative detection; body marker demoted to legacy confirmation.

## Test plan
- [x] jq expressions in `native-stack-link.md` and merger step 2.4 validated against the **live** `stacks` endpoint (better than a sample payload): link lookup for parent #2649 → `2653`; no-match (`999999`) → empty; merger 2.4 membership set → `[2649,2652,2656,2657]`; game-repo mirror → `[]` (the documented no-native-stacks path). Note: the no-match case emits **empty**, not the literal `null` — the link step's `[[ -n "$stack" && "$stack" != "null" ]]` guard covers both, so it correctly falls through to creating a new two-PR stack.
- [x] This PR chain itself is linked as a native stack using the new procedure — stack **#2653** now holds #2649 → #2652 → #2656 → #2657. (The coupled-merge + server-side-retarget half of the pilot still validates at merge time, by construction.)
- [x] Cross-links resolve — every relative markdown link in the 11 touched `.md` files was resolved against the filesystem; 0 broken.

## Notes for reviewer
Phase 1 of `docs/design/native-stacked-prs-migration.md` (PR below this one in the stack). Legacy stacked PRs (one open per repo) are unaffected — the merger keeps servicing them until they drain; Phase 2 retirement is the next PR up the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

