### PR TITLE
fleet: escalate persistent clone-freshness skips + heal claude/* parks (#2363)

### DIFF
--- a/.fleet/plans/issue-2363.md
+++ b/.fleet/plans/issue-2363.md
@@ -57,22 +57,39 @@ test file; no caller edits, sourcing interface unchanged.
 **A. Escalate-then-quiet for persistent identical skips** in `advance_main_clone`
 — the load-bearing half: nothing in the loop noticed the 07-15 freeze.
 
-**B. Self-heal scope decision (committed):** extend the tick-time self-heal to a
-clean-tree park on any **fleet-namespace (`claude/*`) branch whose HEAD is
-provably recoverable** — ancestor of (or equal to) `origin/master` or its own
-`origin/<branch>` counterpart — with the branch **ref preserved** (no `-D`
-outside the existing reviewer-scratch case). Non-`claude/*` branches, dirty
-trees, and unpushed local commits keep the current warn+skip behavior (now
-escalated by A instead of spamming).
+**B. Self-heal scope decision (committed):** keep the tick-time self-heal inside
+the fleet's **scratch namespace** — `claude/*-scratch`, which covers the pool
+worktrees' `claude/pool-<N>-scratch`, its `claude/game-pool-<N>-scratch` twin,
+and the legacy `claude/<role>-reviewer-scratch` — gated on a clean tree AND a
+HEAD already contained by `origin/master` (no unique commits). That is the
+issue's literal AC. The heal drops the junk ref (`-D`), as #2381 shipped.
+Every other park — non-`claude/*`, a `claude/*` feature branch, a dirty tree, or
+a scratch ref carrying a unique commit — keeps the warn+skip behavior, now
+escalated by A instead of spamming.
 
-Scope-line rationale: every scripted-drift park observed (reviewer scratch 07-09,
-feature branch `claude/2428-frac-edge-coverage` 07-15) is in the fleet's
-`claude/*` branch namespace — a non-`claude/*` checkout in the main clone is a
-human's deliberate session, and switching that out from under a human is the one
-case with real surprise cost; those get the alert instead. Because the heal is
-checkout-only with the ref preserved and requires a clean tree + no unpushed
-commits, a wrong guess costs a re-checkout, never data. "Stranded junk" is
-distinguished from "live work" by unpushed commits.
+Scope-line rationale (**corrected 2026-07-30**, PR #2668 opus recheck): an
+earlier draft of this plan widened the heal to any `claude/*` branch with a
+"provably recoverable" HEAD, on the premise that *non*-`claude/*` is the human
+case. That premise is false. `docs/agents/FLEET.md` rule 1 states Cursor /
+ad-hoc work uses `claude/<area>-<topic>`, so a human's deliberate session is
+**inside** `claude/*`; and `commit-and-push` leaves exactly that session clean
+and pushed while the human sits on the PR, which is precisely the state the
+recoverability check green-lights. Healing it sends the human's next commit to
+`master` (violating rule 1) or splits one slice across two PRs, with no notice
+they ever see. Recoverability proves *git loses nothing*; it does not prove
+*no session is using this checkout*. Only the scratch namespace — a
+per-iteration throwaway that belongs solely in `.claude/worktrees/*` — proves
+the latter, so the scope stays there. Genuine feature-branch parks (the 07-15
+`claude/2428-frac-edge-coverage` case) are handled by A's alert, which is what
+the issue prescribes: *"Keep skipping … when the tree is dirty or the branch is
+a real WIP feature branch."*
+
+Folding the tiers also retires dead code: the shipped tier-1 pattern
+`claude/*-reviewer-scratch` matches nothing the live fleet produces (reviewer
+and worker scratch refs are `claude/pool-<N>-scratch`; `grep -rn reviewer-scratch`
+outside this script and its tests returns nothing), so every real scratch park
+was already falling through to the over-wide tier 2. One `claude/*-scratch`
+glob covers both spellings.
 
 ## Approach
 
@@ -121,33 +138,36 @@ All in `scripts/fleet/fleet-clone-freshness.sh`.
    - Self-heal success paths fall through to the tail, so the clear happens
      there; no separate call needed.
 
-3. **Generalized self-heal (tier 2) in Guard 1.** Keep the shipped
-   reviewer-scratch case first and byte-for-byte (clean → checkout + `branch -D`,
-   per #2381's reviewed judgment that scratch refs are junk). Then:
-   `elif [[ "$branch" == claude/* && -z "$dirty" ]] && _head_recoverable "$root" "$branch"`
-   → `git checkout master --quiet` (ref **kept**), one heal line
-   (`fleet-clone-freshness: self-healed <root> — was on '<branch>' (fleet branch,
-   clean, no unpushed commits); restored master, branch ref preserved.`), set
+3. **Scratch-namespace self-heal in Guard 1** (one tier, replacing #2381's
+   `claude/*-reviewer-scratch` arm):
+   `if [[ "$branch" == claude/*-scratch && -z "$dirty" ]] && git -C "$root"
+   merge-base --is-ancestor HEAD origin/master`
+   → `git checkout master --quiet`, `branch -D` the junk ref (per #2381's
+   reviewed judgment that scratch refs hold nothing), one heal line, set
    `branch=master`, fall through to Guard 2 + tail.
-   `_head_recoverable`: `git -C "$root" merge-base --is-ancestor HEAD
-   origin/master` OR (`git -C "$root" rev-parse --verify --quiet
-   "refs/remotes/origin/$branch"` succeeds AND `git -C "$root" merge-base
-   --is-ancestor HEAD "refs/remotes/origin/$branch"`).
-   Any other branch (or unrecoverable HEAD) → the step-2 `parked` warn (unchanged
-   skip). Checkout failure → the existing `checkout-failed` warn + `return 0`
-   (unchanged semantics).
+   Any other branch, a dirty tree, or a scratch HEAD holding a unique commit →
+   the step-2 `parked` warn (unchanged skip). Checkout failure → the existing
+   `checkout-failed` warn + `return 0` (unchanged semantics). No
+   `_head_recoverable` helper: its `origin/<branch>`-contains-HEAD arm is exactly
+   the clean-and-pushed live-session state, and a scratch ref is never pushed, so
+   the ancestor check alone is both necessary and sufficient here.
 
 4. **Tests** — extend `scripts/fleet/tests/test_clone_freshness.sh` (reuse the
    fixture and `reset_rate_limit`; add `export FLEET_ALERTS_DIR="$TMPROOT/alerts"`
    alongside the existing `FLEET_STATE_DIR` isolation):
-   - **T15 heal-pushed:** clean `claude/123-x` park with HEAD pushed to
-     `origin/claude/123-x`, origin/master ahead → healed to master, ff-advanced,
-     **branch ref still exists**, exactly one self-heal line.
-   - **T16 heal-stale-ancestor:** clean `claude/124-y` at an old master commit
-     (ancestor of origin/master, no origin counterpart) → healed.
-   - **T17 unpushed-commit park:** clean `claude/125-z` with one local commit on
-     no origin ref → untouched: "not master" warn, branch + HEAD unchanged.
-   - **T18 dirty `claude/*` park** → untouched (T5c pattern).
+   - **T15 live-session regression:** clean `claude/render-glow-pulse` park whose
+     HEAD is pushed to `origin/<branch>` (recoverable, but NOT an ancestor of
+     origin/master) → **untouched**: branch + HEAD unchanged, no self-heal line,
+     "not master" warn. This is the fixture the widened scope healed.
+   - **T16 heal pool scratch:** clean `claude/pool-7-scratch` at an ancestor of
+     origin/master → healed to master, ff-advanced, **junk ref deleted**,
+     exactly one self-heal line.
+   - **T17 scratch with a unique commit:** clean `claude/pool-8-scratch` holding
+     one commit origin/master doesn't contain → untouched: "not master" warn,
+     branch + HEAD unchanged.
+   - **T18 dirty scratch park** → untouched (T5c pattern).
+   - **T5b/T5c regression:** the legacy `claude/<role>-reviewer-scratch`
+     spelling still heals / still refuses when dirty under the folded glob.
    - **T5 regression:** non-claude `feature/x` clean park → still skipped, still
      warns (already asserted — must stay green).
    - **T19 escalation:** `FLEET_FRESHNESS_SKIP_ESCALATE_N=3`; three warn-eligible
@@ -163,7 +183,8 @@ All in `scripts/fleet/fleet-clone-freshness.sh`.
 
 ## Affected files
 
-- `scripts/fleet/fleet-clone-freshness.sh` — helpers + guard wiring + tier-2 heal
+- `scripts/fleet/fleet-clone-freshness.sh` — helpers + guard wiring + the
+  scratch-namespace heal
 - `scripts/fleet/tests/test_clone_freshness.sh` — T15–T21
 - Nothing else: no caller edits (`fleet-up` / `fleet-dispatcher` / `fleet-claim`
   source the same functions), `install.sh` already symlinks the file,
@@ -171,16 +192,19 @@ All in `scripts/fleet/fleet-clone-freshness.sh`.
 
 ## Acceptance criteria
 
-1. Clean `claude/*` park with recoverable HEAD (pushed, or ancestor of
-   origin/master): next warn-eligible tick restores master, ff-advances,
-   preserves the branch ref, logs exactly one self-heal line (T15/T16 fire).
-2. Unpushed commits / dirty tree / non-`claude/*` branch: no mutation, warn+skip
-   preserved (T17/T18/T5).
+1. Clean `claude/*-scratch` park whose HEAD is contained by origin/master: next
+   warn-eligible tick restores master, ff-advances, deletes the junk ref, logs
+   exactly one self-heal line (T16, T5b fire).
+2. Anything else — a `claude/*` feature branch (even clean and pushed), a dirty
+   tree, a scratch ref with a unique commit, a non-`claude/*` branch: no
+   mutation, warn+skip preserved (T15/T17/T18/T5/T5c).
 3. The same skip persisting N warn-eligible ticks: exactly one ESCALATION line +
    an alert file with host/root/branch/reason/count/since/remedy; identical warns
-   suppressed afterwards; counter + alert removed when the condition clears
-   (T19/T21 fire — positive-fire on file presence and fields).
-4. `bash scripts/fleet/tests/test_clone_freshness.sh` fully green (T1–T21) on
+   suppressed afterwards; the alert **refreshed every subsequent tick** (honest
+   `count=`, and a human-cleared alert re-appears while the condition holds);
+   counter + alert removed when the condition clears (T19/T21/T22 fire —
+   positive-fire on file presence and fields).
+4. `bash scripts/fleet/tests/test_clone_freshness.sh` fully green (T1–T22) on
    macOS bash 3.2 and Linux.
 5. `restore_main_clone_to_master` behavior byte-identical (fleet-up path
    untouched); every entry point still always returns 0 under `set -e` callers.

--- a/.fleet/plans/issue-2363.md
+++ b/.fleet/plans/issue-2363.md
@@ -1,0 +1,217 @@
+# fleet-clone-freshness — persistent-skip escalation + recoverable-park self-heal (re-plan after #2381)
+
+**Issue:** #2363
+**Repo:** jakildev/IrredenEngine
+**Model:** opus — every-tick mutating guard on the shared main clones of all
+hosts, plus bash-3.2 portability; fully specified below, but the blast radius of
+a wrong unattended mutation keeps it above sonnet. No novel design → not fable.
+No C++ build is required (pure bash + the existing test harness), so any host —
+including macOS — can implement and verify this.
+**Date:** 2026-07-20 (plan), implemented 2026-07-30
+
+**Supersedes the 2026-07-13 `## Plan` comment on the issue.** That plan predates
+PR #2381 (merged 2026-07-14), which shipped its Fix part 1 (reviewer-scratch
+self-heal + loud FROZEN warn). The remaining scope is (1) persistent-skip
+escalation and (2) the self-heal scope decision for the 2026-07-15 recurrence
+(clean feature-branch park). This plan covers exactly those two.
+
+## Verified current state (origin/master, 2026-07-20)
+
+- `scripts/fleet/fleet-clone-freshness.sh` `advance_main_clone`: 60s fetch
+  sentinel (`${FLEET_STATE_DIR:-~/.fleet/state}/.${repo_tag}-clone-advanced`,
+  `repo_tag="$(basename "$root")"`) → Guard 1 self-heals only
+  `claude/*-reviewer-scratch` with fully-clean porcelain (checkout master,
+  `branch -D` the junk ref, fall through); **any other** non-master branch → loud
+  `… is on '<branch>' (not master) — skipping advance. master is FROZEN …` +
+  `return 0`, re-emitted every warn-eligible tick forever. Guard 2's dirty warn
+  likewise repeats. The diverged warn lives in the shared tail
+  `_ff_advance_to_origin_master`, which `restore_main_clone_to_master` (the
+  fleet-up path) also calls.
+- No rate-limit, no escalation, no alert file anywhere in the guard — the only
+  durable signal is stderr spam.
+- Callers (interface unchanged by this plan): `fleet-dispatcher` (per tick,
+  ENGINE then GAME), `fleet-up` (`restore_main_clone_to_master`, both repos),
+  `fleet-claim` (`assert_clone_fresh` on `FLEET_ENGINE_ROOT` — a
+  stale/parked/diverged *engine* clone refuses **every claim on both repos**;
+  confirmed live in the 2026-07-15 thread datapoint, ~30 min fleet-wide freeze).
+- Alerts-dir conventions (shipped): `fleet-up` creates `~/.fleet/alerts`;
+  `witness` owns `<agent>.stuck` / `fleet-dispatcher.stuck` and self-clears them;
+  `fleet-rebase` (#2362, merged) writes a flat
+  `${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}/fleet-rebase-hung-lock` file — single
+  `printf` of `key=value` fields, best-effort `|| true`. A
+  `clone-freshness-<repo_tag>` filename cannot collide with either.
+- Test harness: `scripts/fleet/tests/test_clone_freshness.sh` T1–T14, local
+  `file://` origin fixture, `FLEET_STATE_DIR` isolation, `reset_rate_limit`
+  helper for the 60s sentinel — extend it, don't invent a new harness.
+- Cadence measurement (grounds the N choice): warn-eligible ticks are gated by
+  the 60s fetch sentinel → ~1/min steady-state from the dispatcher. Observed
+  incidents: game clone parked ~2.5 days (issue body); engine clone parked
+  **30 min** with claims refused fleet-wide until an unrelated fleet-up cleared
+  it (2026-07-15 comments).
+
+## Scope
+
+Two changes in one PR, both inside `scripts/fleet/fleet-clone-freshness.sh` + its
+test file; no caller edits, sourcing interface unchanged.
+
+**A. Escalate-then-quiet for persistent identical skips** in `advance_main_clone`
+— the load-bearing half: nothing in the loop noticed the 07-15 freeze.
+
+**B. Self-heal scope decision (committed):** extend the tick-time self-heal to a
+clean-tree park on any **fleet-namespace (`claude/*`) branch whose HEAD is
+provably recoverable** — ancestor of (or equal to) `origin/master` or its own
+`origin/<branch>` counterpart — with the branch **ref preserved** (no `-D`
+outside the existing reviewer-scratch case). Non-`claude/*` branches, dirty
+trees, and unpushed local commits keep the current warn+skip behavior (now
+escalated by A instead of spamming).
+
+Scope-line rationale: every scripted-drift park observed (reviewer scratch 07-09,
+feature branch `claude/2428-frac-edge-coverage` 07-15) is in the fleet's
+`claude/*` branch namespace — a non-`claude/*` checkout in the main clone is a
+human's deliberate session, and switching that out from under a human is the one
+case with real surprise cost; those get the alert instead. Because the heal is
+checkout-only with the ref preserved and requires a clean tree + no unpushed
+commits, a wrong guess costs a re-checkout, never data. "Stranded junk" is
+distinguished from "live work" by unpushed commits.
+
+## Approach
+
+All in `scripts/fleet/fleet-clone-freshness.sh`.
+
+1. **Helpers (new, file-local).**
+   - `_freshness_warn <root> <key> <message>` — escalate-then-quiet emitter for
+     `advance_main_clone`'s skip warns. Counter file
+     `${FLEET_STATE_DIR:-$HOME/.fleet/state}/.${repo_tag}-freshness-skip` holds
+     one line `<count> <first_seen_epoch> <key>` (bash-3.2-safe
+     `read -r count first key`; key = `<reason>|<branch>` with reasons `parked` /
+     `checkout-failed` / `dirty` / `diverged`). Same key → increment; different
+     key → reset to `1 <now> <newkey>`. count < N → emit `<message>` to stderr
+     exactly as today. count == N → emit one loud `ESCALATION` line (naming the
+     alert path, the remedy, and "suppressing further identical warns until the
+     condition clears") and write the alert file. count > N → emit nothing. N
+     defaults to **15** (~15 min of continuous skip at the measured ~1/min
+     cadence — chosen against the 30-min 07-15 outage, which the issue body's
+     "say 60" ≈ 1 h would have missed entirely); env override
+     `FLEET_FRESHNESS_SKIP_ESCALATE_N` for tests/operators. All state writes
+     best-effort (`|| true`); always returns 0.
+   - `_freshness_all_clear <root>` — `rm -f` counter + alert file, best-effort.
+   - Alert file:
+     `${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}/clone-freshness-<repo_tag>` (flat
+     filename per the shipped `fleet-rebase-hung-lock` convention; honor
+     `FLEET_ALERTS_DIR` like `fleet-rebase` does, for test isolation). Content is
+     a single printf line:
+     `clone-freshness skip: host=… root=… branch=… reason=… count=… since=<ISO8601 from first_seen> remedy='…'`.
+     `mkdir -p` the dir best-effort first.
+
+2. **Wire the guards through the emitter** — in `advance_main_clone` only
+   (`restore_main_clone_to_master` is a fleet-up one-shot and stays untouched;
+   after any restore, the alert clears one tick later via the healthy path):
+   - Guard 1 non-healed park → `_freshness_warn "$root" "parked|$branch"
+     "<existing FROZEN line verbatim>"` (keep the literal "not master" text — T5
+     greps it and operators grep logs for it).
+   - Guard 1 checkout-failure → `_freshness_warn … "checkout-failed|$branch" …`.
+   - Guard 2 dirty → `_freshness_warn … "dirty|master" …`.
+   - Shared tail: add an optional second arg
+     `_ff_advance_to_origin_master <root> [count_skips]`, passed only by
+     `advance_main_clone`. When set: diverged → `_freshness_warn …
+     "diverged|master" …`; advanced / already-current → `_freshness_all_clear
+     "$root"`. When unset (restore path): byte-identical behavior to today. The
+     transient "ff-only refused (concurrent git op)" warn stays uncounted and
+     unclearing — the next tick resolves it either way.
+   - Self-heal success paths fall through to the tail, so the clear happens
+     there; no separate call needed.
+
+3. **Generalized self-heal (tier 2) in Guard 1.** Keep the shipped
+   reviewer-scratch case first and byte-for-byte (clean → checkout + `branch -D`,
+   per #2381's reviewed judgment that scratch refs are junk). Then:
+   `elif [[ "$branch" == claude/* && -z "$dirty" ]] && _head_recoverable "$root" "$branch"`
+   → `git checkout master --quiet` (ref **kept**), one heal line
+   (`fleet-clone-freshness: self-healed <root> — was on '<branch>' (fleet branch,
+   clean, no unpushed commits); restored master, branch ref preserved.`), set
+   `branch=master`, fall through to Guard 2 + tail.
+   `_head_recoverable`: `git -C "$root" merge-base --is-ancestor HEAD
+   origin/master` OR (`git -C "$root" rev-parse --verify --quiet
+   "refs/remotes/origin/$branch"` succeeds AND `git -C "$root" merge-base
+   --is-ancestor HEAD "refs/remotes/origin/$branch"`).
+   Any other branch (or unrecoverable HEAD) → the step-2 `parked` warn (unchanged
+   skip). Checkout failure → the existing `checkout-failed` warn + `return 0`
+   (unchanged semantics).
+
+4. **Tests** — extend `scripts/fleet/tests/test_clone_freshness.sh` (reuse the
+   fixture and `reset_rate_limit`; add `export FLEET_ALERTS_DIR="$TMPROOT/alerts"`
+   alongside the existing `FLEET_STATE_DIR` isolation):
+   - **T15 heal-pushed:** clean `claude/123-x` park with HEAD pushed to
+     `origin/claude/123-x`, origin/master ahead → healed to master, ff-advanced,
+     **branch ref still exists**, exactly one self-heal line.
+   - **T16 heal-stale-ancestor:** clean `claude/124-y` at an old master commit
+     (ancestor of origin/master, no origin counterpart) → healed.
+   - **T17 unpushed-commit park:** clean `claude/125-z` with one local commit on
+     no origin ref → untouched: "not master" warn, branch + HEAD unchanged.
+   - **T18 dirty `claude/*` park** → untouched (T5c pattern).
+   - **T5 regression:** non-claude `feature/x` clean park → still skipped, still
+     warns (already asserted — must stay green).
+   - **T19 escalation:** `FLEET_FRESHNESS_SKIP_ESCALATE_N=3`; three warn-eligible
+     parked ticks (`reset_rate_limit` between) → first two warn normally, third
+     emits the ESCALATION line AND the alert file exists containing
+     `reason=parked` and `count=3`; a fourth tick emits **no** skip line.
+     Positive-fire: asserts the alert file's presence + fields, not just absence
+     of spam.
+   - **T20 key-change reset:** switch the park to a different branch → counter
+     resets, warn re-emitted normally.
+   - **T21 clear:** fix the clone (checkout master) → next tick advances and both
+     counter + alert file are gone.
+
+## Affected files
+
+- `scripts/fleet/fleet-clone-freshness.sh` — helpers + guard wiring + tier-2 heal
+- `scripts/fleet/tests/test_clone_freshness.sh` — T15–T21
+- Nothing else: no caller edits (`fleet-up` / `fleet-dispatcher` / `fleet-claim`
+  source the same functions), `install.sh` already symlinks the file,
+  `~/.fleet/alerts` is already created by `fleet-up`.
+
+## Acceptance criteria
+
+1. Clean `claude/*` park with recoverable HEAD (pushed, or ancestor of
+   origin/master): next warn-eligible tick restores master, ff-advances,
+   preserves the branch ref, logs exactly one self-heal line (T15/T16 fire).
+2. Unpushed commits / dirty tree / non-`claude/*` branch: no mutation, warn+skip
+   preserved (T17/T18/T5).
+3. The same skip persisting N warn-eligible ticks: exactly one ESCALATION line +
+   an alert file with host/root/branch/reason/count/since/remedy; identical warns
+   suppressed afterwards; counter + alert removed when the condition clears
+   (T19/T21 fire — positive-fire on file presence and fields).
+4. `bash scripts/fleet/tests/test_clone_freshness.sh` fully green (T1–T21) on
+   macOS bash 3.2 and Linux.
+5. `restore_main_clone_to_master` behavior byte-identical (fleet-up path
+   untouched); every entry point still always returns 0 under `set -e` callers.
+
+## Gotchas
+
+- "Consecutive ticks" = **warn-eligible** ticks (the 60s fetch sentinel
+  early-returns otherwise) — tests MUST `reset_rate_limit` between calls or the
+  counter never moves.
+- bash 3.2 (macOS): no associative arrays; `[[ $branch == claude/* ]]` glob
+  matching is fine; `read -r count first key` handles the 3-field counter line.
+- The guard fetches **`origin master` only**, so `origin/<branch>` may be locally
+  stale for the recoverability check — safe *because the branch ref is never
+  deleted*: a wrong staleness guess costs a re-checkout, never commits. Do not
+  "fix" this by fetching all refs; the guard must stay cheap on every tick.
+- Keep the literal "not master" / FROZEN warn text on the non-healed park path —
+  T5 greps it.
+- Do not wire counting into `restore_main_clone_to_master` — it's a fleet-up
+  one-shot; counting there would double-count or spuriously clear. The alert
+  clears on the next dispatcher tick's healthy pass after any restore.
+- Alert and counter writes are best-effort (`|| true`) — a read-only `$HOME` must
+  never break the advance path.
+- Bootstrap irony (#1810): the merged fix is inert until each host's main clone
+  advances past the merge once — after merge, run `fleet-up` (or
+  `git -C <main-clone> merge --ff-only origin/master`) on any host currently
+  wedged in the skip loop. Note this in the PR body.
+
+## Plan-review
+
+Vetted 2026-07-20 (opus plan-review pass): `fleet-plan-lint` PASS, load-bearing
+citations spot-checked against `origin/master`, approach assessed design-sound.
+`human:review-plan` was flagged for two approach calls — the scope of unattended
+mutation on the shared main clones, and the deliberate N=15 vs the issue body's
+"say 60" — and has since been cleared, along with `fleet:plan-review`.

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -76,7 +76,12 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   file, then go silent until a healthy pass clears both. Size N against the
   outage you're catching, not a round number, and keep every counter/alert
   write best-effort (`|| true`) so a read-only `$HOME` can't break the path
-  being guarded.
+  being guarded. **Keep rewriting the alert on every tick past N**, not just
+  at N: once stderr goes quiet the file is the only standing signal, so a
+  write-once alert freezes its `count=`/age at the escalation instant and —
+  worse — lets a human triaging the alerts inbox silence a still-live
+  condition permanently (nothing would ever recreate it). `fleet-rebase`'s
+  `escalate_if_hung_lock` is the reference shape (#2363).
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -65,6 +65,18 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   Mutating git wrappers (`fleet-pr-amend-push`, `fleet-review-verdict --agent`)
   call `fleet-assert-worktree`; scout / ingest / claim / rebase legitimately run
   from the main clone and are deliberately NOT asserted.
+- **An every-tick guard that warns must escalate-then-quiet.** A skip
+  condition in an unattended loop (`advance_main_clone`, the dispatcher's
+  per-tick guards) persists until a human acts, so a plain `echo … >&2`
+  re-emits identically forever — spam that hides the outage instead of
+  reporting it (#2363: a parked main clone froze every claim on both repos
+  for 30 min behind one line repeated per minute). Count consecutive
+  identical skips keyed by `<reason>|<subject>`; at the Nth emit one loud
+  line plus a flat `${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}/<tool>-<tag>`
+  file, then go silent until a healthy pass clears both. Size N against the
+  outage you're catching, not a round number, and keep every counter/alert
+  write best-effort (`|| true`) so a read-only `$HOME` can't break the path
+  being guarded.
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,

--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -271,7 +271,7 @@ advance_main_clone() {
     # two PRs, with no notice the human ever sees. Proving git loses nothing is
     # a different invariant from proving no session is using the checkout; only
     # the scratch namespace establishes the latter. See #2363.
-    local branch dirty checkout_failed_msg
+    local branch dirty checkout_failed_msg ref_note
     branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
     if [[ "$branch" != "master" ]]; then
         dirty="$(git -C "$root" status --porcelain 2>/dev/null || echo SKIP)"
@@ -279,8 +279,18 @@ advance_main_clone() {
         if [[ "$branch" == claude/*-scratch && -z "$dirty" ]] \
             && git -C "$root" merge-base --is-ancestor HEAD origin/master 2>/dev/null; then
             if git -C "$root" checkout master --quiet 2>/dev/null; then
-                git -C "$root" branch -D "$branch" --quiet 2>/dev/null || true
-                echo "fleet-clone-freshness: $root was parked on scratch branch '$branch' (clean tree, no unique commits) — self-healed back to master and deleted the junk branch." >&2
+                # The delete is best-effort: `branch -D` refuses a ref another
+                # worktree holds (claude/pool-<N>-scratch is exactly that) or
+                # one whose refs/heads entry a killed git process left locked.
+                # The freeze is already cleared by then, so report which of the
+                # two happened rather than claiming a delete git refused — the
+                # operator reading this mid-outage acts on the ref.
+                if git -C "$root" branch -D "$branch" --quiet 2>/dev/null; then
+                    ref_note="deleted the junk branch"
+                else
+                    ref_note="left the junk branch in place (delete refused — a worktree holds it or the ref is locked)"
+                fi
+                echo "fleet-clone-freshness: $root was parked on scratch branch '$branch' (clean tree, no unique commits) — self-healed back to master and $ref_note." >&2
                 branch=master
             else
                 _freshness_warn "$root" "checkout-failed|$branch" "$checkout_failed_msg"

--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -37,16 +37,16 @@
 #   advance_main_clone  <repo_root>  — guarded, rate-limited fetch + ff-only
 #                                     advance of a clean on-master clone. Never
 #                                     resets --hard; never switches branches
-#                                     except the two self-heal cases: a clean
-#                                     tree parked on a claude/*-reviewer-scratch
-#                                     branch (provably junk from a reviewer cwd
-#                                     drift) is put back on master and the ref
-#                                     dropped; a clean tree parked on any other
-#                                     claude/* branch whose HEAD is provably
-#                                     recoverable (pushed, or an ancestor of
-#                                     origin/master) is put back on master with
-#                                     the branch ref PRESERVED. Persistent skips
-#                                     escalate once, then go quiet (#2363).
+#                                     except one self-heal case: a clean tree
+#                                     parked on the fleet's scratch namespace
+#                                     (claude/*-scratch) with no unique commits
+#                                     is provably junk from a role's cwd drift,
+#                                     so it is put back on master and the ref
+#                                     dropped. Every other park — including a
+#                                     clean, pushed claude/* feature branch,
+#                                     which is exactly what a live Cursor
+#                                     session looks like — is left alone and
+#                                     escalated instead (#2363).
 #   restore_main_clone_to_master <repo_root>
 #                                   — fleet-up-time stronger variant: returns a
 #                                     clone parked off-master (PR branch from a
@@ -185,11 +185,9 @@ _freshness_warn() {
     mkdir -p "$(dirname "$counter")" 2>/dev/null || true
     printf '%s %s %s\n' "$count" "$first" "$key" > "$counter" 2>/dev/null || true
 
-    if (( count > n )); then
-        return 0   # already escalated — the alert file is the standing signal
-    fi
-    echo "$msg" >&2
+    # Below the threshold: the ordinary per-tick warn, no alert yet.
     if (( count < n )); then
+        echo "$msg" >&2
         return 0
     fi
 
@@ -199,7 +197,16 @@ _freshness_warn() {
     branch="${key#*|}"
     since="$(_freshness_iso8601 "$first")"
     remedy="git -C $root checkout master && git -C $root merge --ff-only origin/master  (or rerun fleet-up)"
-    echo "fleet-clone-freshness: ESCALATION — $root has skipped its advance $count consecutive times (reason=$reason branch='$branch') since $since. Wrote $alert. Remedy: $remedy. Suppressing further identical warns until the condition clears." >&2
+    # stderr goes quiet after the one loud escalation, so the alert is the only
+    # standing signal — hence rewritten every tick past N, not stamped once at
+    # it. Write-once would freeze count= at the escalation instant, and would
+    # let a human triaging the alerts inbox silence a still-live condition
+    # forever (warns stay suppressed, so nothing recreates the file). Same shape
+    # as fleet-rebase's escalate_if_hung_lock (#2362).
+    if (( count == n )); then
+        echo "$msg" >&2
+        echo "fleet-clone-freshness: ESCALATION — $root has skipped its advance $count consecutive times (reason=$reason branch='$branch') since $since. Wrote $alert. Remedy: $remedy. Suppressing further identical warns until the condition clears." >&2
+    fi
     mkdir -p "$(dirname "$alert")" 2>/dev/null || true
     printf "clone-freshness skip: host=%s root=%s branch=%s reason=%s count=%s since=%s remedy='%s'\n" \
         "$(hostname 2>/dev/null || echo '?')" "$root" "$branch" "$reason" "$count" "$since" "$remedy" \
@@ -215,28 +222,12 @@ _freshness_all_clear() {
     return 0
 }
 
-# _head_recoverable <repo_root> <branch>
-# Is the parked HEAD provably reachable from somewhere other than this local
-# ref — i.e. does checking master out lose nothing? True when HEAD is already
-# an ancestor of origin/master (a stale park at an old master), or when the
-# branch has an origin counterpart that contains HEAD (the work is pushed).
-# A local commit on a branch with no origin ref is unpushed work: not
-# recoverable, so the park is left alone.
-_head_recoverable() {
-    local root="$1" branch="$2"
-    if git -C "$root" merge-base --is-ancestor HEAD origin/master 2>/dev/null; then
-        return 0
-    fi
-    git -C "$root" rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1 || return 1
-    git -C "$root" merge-base --is-ancestor HEAD "refs/remotes/origin/$branch" 2>/dev/null
-}
-
 # advance_main_clone <repo_root>
 # Guarded, rate-limited fast-forward of the main clone's master. Safe on the
 # shared main checkout: advances ONLY when the clone is on branch master, has a
 # clean working tree, and master is a strict pure-ancestor of origin/master
 # (i.e. a real fast-forward). Any guard miss → skip + warn, never mutate —
-# except the reviewer-scratch self-heal in guard 1 (see comment there). Mirrors
+# except the scratch-namespace self-heal in guard 1 (see comment there). Mirrors
 # fleet-up's reset_worktree dirty-guard idiom. Always returns 0 so a `set -e`
 # caller is never aborted by a skipped advance.
 advance_main_clone() {
@@ -261,37 +252,35 @@ advance_main_clone() {
 
     # Guard 1: must be on branch master (never touch a checked-out feature
     # branch — agents occasionally check one out in the shared main clone).
-    # Exception: a reviewer scratch branch (claude/<role>-reviewer-scratch) is a
-    # per-iteration throwaway that only ever belongs in .claude/worktrees/* —
-    # one parked HERE is provably junk left by a reviewer whose shell cwd
-    # drifted into the main clone, and it freezes master (blocking every claim
-    # on this repo via assert_clone_fresh) until fixed. Self-heal: with a clean
-    # tree, put the clone back on master, drop the junk branch, and fall
-    # through to the normal advance.
+    # Exception: the fleet's scratch namespace, claude/*-scratch — the pool
+    # worktrees' per-iteration scratch refs (claude/pool-<N>-scratch, its
+    # claude/game-pool-<N>-scratch twin, the legacy claude/<role>-reviewer-scratch).
+    # A scratch ref only ever belongs in .claude/worktrees/*, so one parked HERE
+    # is junk left by a role whose shell cwd drifted into the main clone, and it
+    # freezes master (blocking every claim on this repo via assert_clone_fresh)
+    # until fixed. Self-heal: clean tree AND a HEAD already contained by
+    # origin/master (no unique commits, so the ref holds nothing) → back to
+    # master, drop the junk ref, fall through to the normal advance.
     #
-    # Tier 2: scripted cwd drift parks the clone anywhere in the fleet's own
-    # claude/* namespace, not just on scratch refs, so heal those too when the
-    # tree is clean AND the HEAD is provably recoverable — but keep the branch
-    # ref, since unlike a scratch ref it may be someone's work. A non-claude/*
-    # checkout is a human's deliberate session: alert on it (via the skip
-    # counter), never switch it out from under them. See #2363.
+    # Everything else is left alone and escalated via the skip counter instead —
+    # INCLUDING a clean claude/* branch whose HEAD is pushed. "Recoverable" is
+    # not "idle": FLEET.md rule 1 puts Cursor / ad-hoc sessions on
+    # claude/<area>-<topic>, and commit-and-push leaves exactly that session
+    # clean-and-pushed while the human sits on the PR. Healing it would send
+    # their next commit to master (violating rule 1) or split the slice across
+    # two PRs, with no notice the human ever sees. Proving git loses nothing is
+    # a different invariant from proving no session is using the checkout; only
+    # the scratch namespace establishes the latter. See #2363.
     local branch dirty checkout_failed_msg
     branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
     if [[ "$branch" != "master" ]]; then
         dirty="$(git -C "$root" status --porcelain 2>/dev/null || echo SKIP)"
         checkout_failed_msg="fleet-clone-freshness: $root parked on '$branch' but 'git checkout master' failed — master is FROZEN and every claim on this repo will be refused until a human fixes it (git -C $root checkout master)."
-        if [[ "$branch" == claude/*-reviewer-scratch && -z "$dirty" ]]; then
+        if [[ "$branch" == claude/*-scratch && -z "$dirty" ]] \
+            && git -C "$root" merge-base --is-ancestor HEAD origin/master 2>/dev/null; then
             if git -C "$root" checkout master --quiet 2>/dev/null; then
                 git -C "$root" branch -D "$branch" --quiet 2>/dev/null || true
-                echo "fleet-clone-freshness: $root was parked on reviewer scratch branch '$branch' (clean tree) — self-healed back to master and deleted the junk branch." >&2
-                branch=master
-            else
-                _freshness_warn "$root" "checkout-failed|$branch" "$checkout_failed_msg"
-                return 0
-            fi
-        elif [[ "$branch" == claude/* && -z "$dirty" ]] && _head_recoverable "$root" "$branch"; then
-            if git -C "$root" checkout master --quiet 2>/dev/null; then
-                echo "fleet-clone-freshness: self-healed $root — was on '$branch' (fleet branch, clean, no unpushed commits); restored master, branch ref preserved." >&2
+                echo "fleet-clone-freshness: $root was parked on scratch branch '$branch' (clean tree, no unique commits) — self-healed back to master and deleted the junk branch." >&2
                 branch=master
             else
                 _freshness_warn "$root" "checkout-failed|$branch" "$checkout_failed_msg"

--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -37,10 +37,16 @@
 #   advance_main_clone  <repo_root>  — guarded, rate-limited fetch + ff-only
 #                                     advance of a clean on-master clone. Never
 #                                     resets --hard; never switches branches
-#                                     except the one self-heal case: a clean
+#                                     except the two self-heal cases: a clean
 #                                     tree parked on a claude/*-reviewer-scratch
 #                                     branch (provably junk from a reviewer cwd
-#                                     drift) is put back on master.
+#                                     drift) is put back on master and the ref
+#                                     dropped; a clean tree parked on any other
+#                                     claude/* branch whose HEAD is provably
+#                                     recoverable (pushed, or an ancestor of
+#                                     origin/master) is put back on master with
+#                                     the branch ref PRESERVED. Persistent skips
+#                                     escalate once, then go quiet (#2363).
 #   restore_main_clone_to_master <repo_root>
 #                                   — fleet-up-time stronger variant: returns a
 #                                     clone parked off-master (PR branch from a
@@ -53,8 +59,15 @@
 #   FLEET_SKIP_CLONE_FRESHNESS=1  — disable the assert_clone_fresh claim gate
 #                                   (the claim test harness sets this; also an
 #                                   operator escape hatch).
-#   FLEET_STATE_DIR               — where the per-repo rate-limit sentinel lives
-#                                   (defaults to ~/.fleet/state).
+#   FLEET_STATE_DIR               — where the per-repo rate-limit sentinel and
+#                                   the persistent-skip counter live (defaults
+#                                   to ~/.fleet/state).
+#   FLEET_ALERTS_DIR              — where the escalation alert file is dropped
+#                                   (defaults to ~/.fleet/alerts, same
+#                                   convention as fleet-rebase, #2362).
+#   FLEET_FRESHNESS_SKIP_ESCALATE_N
+#                                 — consecutive identical skips before the one
+#                                   loud line + alert file (default 15).
 
 # clone_behind_count <repo_root>
 # How many commits the clone's local master is behind its tracked
@@ -100,6 +113,124 @@ assert_clone_fresh() {
     return 0
 }
 
+# --- persistent-skip escalation ----------------------------------------------
+# advance_main_clone runs unattended on every dispatcher tick, so a guard that
+# skips keeps skipping — and a repeating stderr line is not a signal anyone
+# reads. Count consecutive identical skips; at the Nth emit one loud line and
+# drop a flat alert file (the durable signal), then go quiet until the
+# condition clears. See #2363.
+#
+# Counter: ${FLEET_STATE_DIR:-~/.fleet/state}/.<repo_tag>-freshness-skip
+#          one line, "<count> <first_seen_epoch> <reason>|<branch>"
+# Alert:   ${FLEET_ALERTS_DIR:-~/.fleet/alerts}/clone-freshness-<repo_tag>
+#          one printf'd key=value line, the flat shape fleet-rebase's
+#          fleet-rebase-hung-lock established (#2362).
+# Every state write is best-effort: a read-only $HOME must never break the
+# advance path, and every helper here returns 0 for `set -e` callers.
+
+# Consecutive warn-eligible skips before escalating. Warn-eligible ticks run
+# ~1/min (the 60s fetch sentinel gates the rest), so 15 ≈ 15 min of continuous
+# skip — sized under the 30-min whole-fleet claim freeze this exists to catch,
+# which an hour-scale threshold would have missed entirely.
+_freshness_escalate_n() {
+    local n="${FLEET_FRESHNESS_SKIP_ESCALATE_N:-15}"
+    if [[ ! "$n" =~ ^[0-9]+$ ]] || (( n < 1 )); then
+        n=15
+    fi
+    echo "$n"
+}
+
+_freshness_counter_path() {
+    echo "${FLEET_STATE_DIR:-$HOME/.fleet/state}/.$(basename "$1")-freshness-skip"
+}
+
+_freshness_alert_path() {
+    echo "${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}/clone-freshness-$(basename "$1")"
+}
+
+# _freshness_iso8601 <epoch>
+# BSD (macOS) spells it `date -r`, GNU spells it `date -d @…`; -r on GNU tries
+# to stat a file and fails, so the chain lands on the right one either way.
+_freshness_iso8601() {
+    date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || echo "$1"
+}
+
+# _freshness_warn <repo_root> <reason>|<branch> <message>
+# Emit a skip warning, escalating-then-quieting on repetition. Same key as the
+# last tick → increment; a different key → restart the count, since a changed
+# condition is news again.
+_freshness_warn() {
+    local root="$1" key="$2" msg="$3"
+    local counter n now count first prev_key
+    counter="$(_freshness_counter_path "$root")"
+    n="$(_freshness_escalate_n)"
+    now="$(date +%s)"
+
+    count=0
+    first="$now"
+    prev_key=""
+    if [[ -f "$counter" ]]; then
+        read -r count first prev_key < "$counter" 2>/dev/null || true
+    fi
+    [[ "${count:-}" =~ ^[0-9]+$ ]] || count=0
+    [[ "${first:-}" =~ ^[0-9]+$ ]] || first="$now"
+    if [[ "${prev_key:-}" != "$key" ]]; then
+        count=0
+        first="$now"
+    fi
+    count=$(( count + 1 ))
+
+    mkdir -p "$(dirname "$counter")" 2>/dev/null || true
+    printf '%s %s %s\n' "$count" "$first" "$key" > "$counter" 2>/dev/null || true
+
+    if (( count > n )); then
+        return 0   # already escalated — the alert file is the standing signal
+    fi
+    echo "$msg" >&2
+    if (( count < n )); then
+        return 0
+    fi
+
+    local alert reason branch since remedy
+    alert="$(_freshness_alert_path "$root")"
+    reason="${key%%|*}"
+    branch="${key#*|}"
+    since="$(_freshness_iso8601 "$first")"
+    remedy="git -C $root checkout master && git -C $root merge --ff-only origin/master  (or rerun fleet-up)"
+    echo "fleet-clone-freshness: ESCALATION — $root has skipped its advance $count consecutive times (reason=$reason branch='$branch') since $since. Wrote $alert. Remedy: $remedy. Suppressing further identical warns until the condition clears." >&2
+    mkdir -p "$(dirname "$alert")" 2>/dev/null || true
+    printf "clone-freshness skip: host=%s root=%s branch=%s reason=%s count=%s since=%s remedy='%s'\n" \
+        "$(hostname 2>/dev/null || echo '?')" "$root" "$branch" "$reason" "$count" "$since" "$remedy" \
+        > "$alert" 2>/dev/null || true
+    return 0
+}
+
+# _freshness_all_clear <repo_root>
+# The condition cleared (advanced, or already current on master): drop the
+# counter and any alert file so the next persistent skip escalates from scratch.
+_freshness_all_clear() {
+    rm -f "$(_freshness_counter_path "$1")" "$(_freshness_alert_path "$1")" 2>/dev/null || true
+    return 0
+}
+
+# _head_recoverable <repo_root> <branch>
+# Is the parked HEAD provably reachable from somewhere other than this local
+# ref — i.e. does checking master out lose nothing? True when HEAD is already
+# an ancestor of origin/master (a stale park at an old master), or when the
+# branch has an origin counterpart that contains HEAD (the work is pushed).
+# A local commit on a branch with no origin ref is unpushed work: not
+# recoverable, so the park is left alone.
+_head_recoverable() {
+    local root="$1" branch="$2"
+    if git -C "$root" merge-base --is-ancestor HEAD origin/master 2>/dev/null; then
+        return 0
+    fi
+    git -C "$root" rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1 || return 1
+    git -C "$root" merge-base --is-ancestor HEAD "refs/remotes/origin/$branch" 2>/dev/null
+}
+
 # advance_main_clone <repo_root>
 # Guarded, rate-limited fast-forward of the main clone's master. Safe on the
 # shared main checkout: advances ONLY when the clone is on branch master, has a
@@ -137,55 +268,93 @@ advance_main_clone() {
     # on this repo via assert_clone_fresh) until fixed. Self-heal: with a clean
     # tree, put the clone back on master, drop the junk branch, and fall
     # through to the normal advance.
-    local branch dirty
+    #
+    # Tier 2: scripted cwd drift parks the clone anywhere in the fleet's own
+    # claude/* namespace, not just on scratch refs, so heal those too when the
+    # tree is clean AND the HEAD is provably recoverable — but keep the branch
+    # ref, since unlike a scratch ref it may be someone's work. A non-claude/*
+    # checkout is a human's deliberate session: alert on it (via the skip
+    # counter), never switch it out from under them. See #2363.
+    local branch dirty checkout_failed_msg
     branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
     if [[ "$branch" != "master" ]]; then
         dirty="$(git -C "$root" status --porcelain 2>/dev/null || echo SKIP)"
+        checkout_failed_msg="fleet-clone-freshness: $root parked on '$branch' but 'git checkout master' failed — master is FROZEN and every claim on this repo will be refused until a human fixes it (git -C $root checkout master)."
         if [[ "$branch" == claude/*-reviewer-scratch && -z "$dirty" ]]; then
             if git -C "$root" checkout master --quiet 2>/dev/null; then
                 git -C "$root" branch -D "$branch" --quiet 2>/dev/null || true
                 echo "fleet-clone-freshness: $root was parked on reviewer scratch branch '$branch' (clean tree) — self-healed back to master and deleted the junk branch." >&2
                 branch=master
             else
-                echo "fleet-clone-freshness: $root parked on '$branch' but 'git checkout master' failed — master is FROZEN and every claim on this repo will be refused until a human fixes it (git -C $root checkout master)." >&2
+                _freshness_warn "$root" "checkout-failed|$branch" "$checkout_failed_msg"
+                return 0
+            fi
+        elif [[ "$branch" == claude/* && -z "$dirty" ]] && _head_recoverable "$root" "$branch"; then
+            if git -C "$root" checkout master --quiet 2>/dev/null; then
+                echo "fleet-clone-freshness: self-healed $root — was on '$branch' (fleet branch, clean, no unpushed commits); restored master, branch ref preserved." >&2
+                branch=master
+            else
+                _freshness_warn "$root" "checkout-failed|$branch" "$checkout_failed_msg"
                 return 0
             fi
         else
-            echo "fleet-clone-freshness: $root is on '$branch' (not master) — skipping advance. master is FROZEN and every claim on this repo will be refused until it is put back (git -C $root checkout master)." >&2
+            _freshness_warn "$root" "parked|$branch" "fleet-clone-freshness: $root is on '$branch' (not master) — skipping advance. master is FROZEN and every claim on this repo will be refused until it is put back (git -C $root checkout master)."
             return 0
         fi
     fi
     # Guard 2: clean working tree (never clobber uncommitted work).
     dirty="$(git -C "$root" status --porcelain 2>/dev/null || echo SKIP)"
     if [[ -n "$dirty" && "$dirty" != "SKIP" ]]; then
-        echo "fleet-clone-freshness: $root has uncommitted changes — skipping advance." >&2
+        _freshness_warn "$root" "dirty|master" "fleet-clone-freshness: $root has uncommitted changes — skipping advance."
         return 0
     fi
-    # Guard 3 + the ff itself live in the shared tail.
-    _ff_advance_to_origin_master "$root"
+    # Guard 3 + the ff itself live in the shared tail. The second arg opts this
+    # (unattended, every-tick) path into skip counting; the fleet-up one-shot
+    # deliberately does not count.
+    _ff_advance_to_origin_master "$root" count
     return 0
 }
 
-# _ff_advance_to_origin_master <repo_root>
+# _ff_advance_to_origin_master <repo_root> [count_skips]
 # Shared tail of advance_main_clone / restore_main_clone_to_master: guarded
 # ff-only advance of an on-master clone whose origin/master ref is current
 # (callers own the fetch). Diverged or up-to-date → no-op. Always returns 0.
+#
+# count_skips (non-empty) routes the diverged warn through the escalate-then-
+# quiet counter and clears it on a healthy pass; unset, the tail just warns and
+# keeps no state. Only advance_main_clone passes it: restore_main_clone_to_master
+# is a fleet-up one-shot, so counting there would double-count or spuriously
+# clear.
 _ff_advance_to_origin_master() {
-    local root="$1"
+    local root="$1" count_skips="${2:-}"
     if ! git -C "$root" merge-base --is-ancestor master origin/master 2>/dev/null; then
-        echo "fleet-clone-freshness: $root master has diverged from origin/master — skipping advance (human fixup needed)." >&2
+        local diverged_msg="fleet-clone-freshness: $root master has diverged from origin/master — skipping advance (human fixup needed)."
+        if [[ -n "$count_skips" ]]; then
+            _freshness_warn "$root" "diverged|master" "$diverged_msg"
+        else
+            echo "$diverged_msg" >&2
+        fi
         return 0
     fi
     local behind
     behind="$(git -C "$root" rev-list --count master..origin/master 2>/dev/null || echo 0)"
     if [[ "${behind:-0}" -le 0 ]]; then
-        return 0  # already current (or ahead — left to the human)
+        # Already current (or ahead — left to the human): a healthy pass.
+        if [[ -n "$count_skips" ]]; then
+            _freshness_all_clear "$root"
+        fi
+        return 0
     fi
     # ff-only refuses on its own rather than clobber a tracked modification
     # that overlaps the incoming commits; a disjoint dirty tree advances fine.
     if git -C "$root" merge --ff-only origin/master --quiet 2>/dev/null; then
         echo "fleet-clone-freshness: advanced $root master by $behind commit(s) to origin/master." >&2
+        if [[ -n "$count_skips" ]]; then
+            _freshness_all_clear "$root"
+        fi
     else
+        # Transient (concurrent git op) — deliberately neither counted nor
+        # cleared; the next tick resolves it either way.
         echo "fleet-clone-freshness: ff-only advance of $root refused (overlapping local changes or concurrent git op) — leaving as-is." >&2
     fi
     return 0

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -399,6 +399,55 @@ grep -q "count=3" "$ALERT3" 2>/dev/null && ok "refreshed alert carries the curre
 git_q "$CLONE3" checkout master
 unset FLEET_FRESHNESS_SKIP_ESCALATE_N
 
+# --- T23: a refused `branch -D` is reported honestly, not as a delete --------
+# The delete is refusable two ways: another worktree holds the ref (the live
+# pool worktree owning claude/pool-<N>-scratch, reachable through the
+# checkout-master→delete window or a stale worktree admin entry), or a
+# refs/heads lock survives a killed git process — the fixture here. The heal
+# itself still succeeded, so the line must say the ref was LEFT: an operator
+# reading it mid-outage acts on that claim. See #2668.
+echo "T23: heal with a refused branch -D -> reports the ref as left, not deleted"
+reset_skip_counter
+git_q "$CLONE3" checkout master
+reset_rate_limit
+advance_main_clone "$CLONE3" 2>/dev/null                   # sync origin/master first
+git_q "$CLONE3" checkout -B claude/pool-6-scratch origin/master
+push_new_commit t23                                        # origin/master moves ahead
+: > "$CLONE3/.git/refs/heads/claude/pool-6-scratch.lock"   # killed-git-process leftover
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "healed to master despite the refused delete" || fail "still on $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+if git -C "$CLONE3" rev-parse --verify --quiet refs/heads/claude/pool-6-scratch >/dev/null; then ok "ref survives the refusal (fixture reproduces it)"; else fail "ref deleted — fixture did not reproduce the refusal"; fi
+echo "$out" | grep -q "left the junk branch in place" && ok "line reports the ref as left" || fail "wrong heal line: $out"
+! echo "$out" | grep -q "deleted the junk branch" && ok "no false delete claim" || fail "claimed a delete git refused: $out"
+behind=$(clone_behind_count "$CLONE3")
+[[ "$behind" == "0" ]] && ok "advance continued past the refusal (behind 0)" || fail "behind=$behind after the refused delete"
+rm -f "$CLONE3/.git/refs/heads/claude/pool-6-scratch.lock"
+
+# --- T24: the namespace conjunct, isolated from the containment one ----------
+# T15's session carries a commit origin/master does not, so the containment
+# check alone already refuses it — leaving the scratch-namespace half of the
+# predicate unproven. A session branched at origin/master's tip with nothing
+# committed yet is clean AND contained, so only the namespace glob can refuse
+# it. That shape is the common one (branch, get pulled away, come back), and
+# healing it switches the human's branch out from under them: recoverable is
+# not idle. See #2668.
+echo "T24: clean claude/<area>-<topic> at origin/master's tip -> left alone"
+reset_skip_counter
+git_q "$CLONE3" checkout master
+reset_rate_limit
+advance_main_clone "$CLONE3" 2>/dev/null                   # sync origin/master first
+git_q "$CLONE3" checkout -B claude/editor-timeline-polish origin/master
+session_head=$(git -C "$CLONE3" rev-parse HEAD)
+push_new_commit t24                                        # origin/master moves ahead
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/editor-timeline-polish" ]] && ok "contained-HEAD session park untouched" || fail "healed a contained session onto $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+[[ "$(git -C "$CLONE3" rev-parse HEAD)" == "$session_head" ]] && ok "session HEAD unmoved" || fail "HEAD moved under a contained session"
+! echo "$out" | grep -q "self-healed" && ok "namespace refuses it (containment alone would not)" || fail "self-healed a contained session: $out"
+echo "$out" | grep -q "not master" && ok "warns (escalates) instead of healing" || fail "no park warning: $out"
+git_q "$CLONE3" checkout master
+
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -257,7 +257,7 @@ out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
 grep -q "disjoint-wip" "$CLONE2/other" && ok "on-master WIP preserved" || fail "WIP lost"
 echo "$out" | grep -q "live WIP wins" && ok "warns loudly on-master too" || fail "no WIP warning: $out"
 
-# --- generalized claude/* self-heal + persistent-skip escalation (#2363) -----
+# --- scratch-namespace self-heal + persistent-skip escalation (#2363) --------
 # Fresh fixture again: CLONE is diverged (T7) and CLONE2 carries the T14 WIP.
 CLONE3="$TMPROOT/clone3"
 git clone -q "$ORIGIN" "$CLONE3"
@@ -266,40 +266,52 @@ git -C "$CLONE3" config user.name test
 COUNTER3="$FLEET_STATE_DIR/.$(basename "$CLONE3")-freshness-skip"
 ALERT3="$FLEET_ALERTS_DIR/clone-freshness-$(basename "$CLONE3")"
 
-# --- T15: claude/* park, HEAD pushed to origin -> healed, branch ref kept -----
-echo "T15: claude/* park with pushed HEAD -> self-healed, ref preserved"
+# --- T15: live-Cursor-session shape -> NEVER healed --------------------------
+# The regression guard for #2668's review: FLEET.md rule 1 puts Cursor / ad-hoc
+# sessions on claude/<area>-<topic>, and commit-and-push leaves that session
+# clean-and-pushed while the human sits on the PR. That HEAD is "recoverable"
+# (contained by origin/<branch>) yet emphatically live, so recoverability must
+# NOT authorize a heal — only the scratch namespace does.
+echo "T15: clean, pushed claude/<area>-<topic> (live Cursor session) -> left alone"
 reset_skip_counter
-git_q "$CLONE3" checkout -b claude/123-x
+git_q "$CLONE3" checkout -b claude/render-glow-pulse
 echo "branch-work" >> "$CLONE3/file"
 git_q "$CLONE3" add file
 git_q "$CLONE3" commit -m branch-work
-git_q "$CLONE3" push -u origin claude/123-x   # HEAD now recoverable from origin/<branch>
-push_new_commit t15                            # origin/master moves ahead
+git_q "$CLONE3" push -u origin claude/render-glow-pulse   # clean + pushed: the steady state
+session_head=$(git -C "$CLONE3" rev-parse HEAD)
+push_new_commit t15                                        # origin/master moves ahead
 reset_rate_limit
 out=$(advance_main_clone "$CLONE3" 2>&1 || true)
-[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "pushed claude/* park healed to master" || fail "still on $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/render-glow-pulse" ]] && ok "live cursor-session park untouched" || fail "healed a live session onto $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+[[ "$(git -C "$CLONE3" rev-parse HEAD)" == "$session_head" ]] && ok "session HEAD unmoved" || fail "HEAD moved under a live session"
+! echo "$out" | grep -q "self-healed" && ok "no self-heal attempted" || fail "self-healed a live session: $out"
+echo "$out" | grep -q "not master" && ok "warns (escalates) instead of healing" || fail "no park warning: $out"
+
+# --- T16: pool scratch ref -> healed, junk ref dropped -----------------------
+# The namespace that IS junk: claude/pool-<N>-scratch (and its game twin /
+# the legacy claude/<role>-reviewer-scratch) only ever belongs in a worktree.
+echo "T16: claude/pool-N-scratch park -> self-healed, junk ref deleted"
+reset_skip_counter
+git_q "$CLONE3" checkout master
+reset_rate_limit
+advance_main_clone "$CLONE3" 2>/dev/null                   # sync origin/master first
+git_q "$CLONE3" checkout -B claude/pool-7-scratch origin/master
+push_new_commit t16                                        # origin/master moves ahead
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "pool scratch park healed to master" || fail "still on $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
 behind=$(clone_behind_count "$CLONE3")
-[[ "$behind" == "0" ]] && ok "advance continued after tier-2 heal (behind 0)" || fail "behind=$behind after tier-2 heal"
-if git -C "$CLONE3" rev-parse --verify --quiet refs/heads/claude/123-x >/dev/null; then ok "branch ref preserved (not deleted)"; else fail "tier-2 heal deleted the branch ref"; fi
+[[ "$behind" == "0" ]] && ok "advance continued after the heal (behind 0)" || fail "behind=$behind after heal"
+if git -C "$CLONE3" rev-parse --verify --quiet refs/heads/claude/pool-7-scratch >/dev/null; then fail "junk scratch ref not deleted"; else ok "junk scratch ref deleted"; fi
 [[ "$(echo "$out" | grep -c "self-healed")" == "1" ]] && ok "exactly one self-heal line" || fail "expected 1 self-heal line, got: $out"
 
-# --- T16: claude/* park at an old master commit (ancestor) -> healed ---------
-echo "T16: claude/* park at an ancestor of origin/master -> self-healed"
+# --- T17: scratch ref carrying a unique commit -> untouched ------------------
+# Clean + in-namespace is not enough: a scratch ref holding a commit that
+# origin/master does not contain is not provably junk, so leave it.
+echo "T17: claude/*-scratch with a unique local commit -> left alone"
 reset_skip_counter
-stale_point=$(git -C "$CLONE3" rev-parse master~1)
-git_q "$CLONE3" checkout -b claude/124-y "$stale_point"   # no origin counterpart
-push_new_commit t16
-reset_rate_limit
-out=$(advance_main_clone "$CLONE3" 2>&1 || true)
-[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "stale-ancestor park healed to master" || fail "still on $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
-if git -C "$CLONE3" rev-parse --verify --quiet refs/heads/claude/124-y >/dev/null; then ok "stale-ancestor branch ref preserved"; else fail "heal deleted the branch ref"; fi
-echo "$out" | grep -q "self-healed" && ok "logs the tier-2 self-heal" || fail "no self-heal log: $out"
-
-# --- T17: claude/* park with an UNPUSHED commit -> untouched -----------------
-# The line between "stranded junk" and "live work": an unrecoverable HEAD.
-echo "T17: claude/* park with an unpushed local commit -> left alone"
-reset_skip_counter
-git_q "$CLONE3" checkout -b claude/125-z
+git_q "$CLONE3" checkout -b claude/pool-8-scratch
 echo "unpushed" >> "$CLONE3/file"
 git_q "$CLONE3" add file
 git_q "$CLONE3" commit -m unpushed
@@ -307,20 +319,22 @@ unpushed_head=$(git -C "$CLONE3" rev-parse HEAD)
 push_new_commit t17
 reset_rate_limit
 out=$(advance_main_clone "$CLONE3" 2>&1 || true)
-[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/125-z" ]] && ok "unpushed claude/* park untouched" || fail "branch switched to $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
-[[ "$(git -C "$CLONE3" rev-parse HEAD)" == "$unpushed_head" ]] && ok "unpushed commit preserved" || fail "HEAD moved under an unpushed commit"
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/pool-8-scratch" ]] && ok "scratch ref with unique commit untouched" || fail "branch switched to $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+[[ "$(git -C "$CLONE3" rev-parse HEAD)" == "$unpushed_head" ]] && ok "unique commit preserved" || fail "HEAD moved under a unique commit"
 echo "$out" | grep -q "not master" && ok "warns about the unhealed park" || fail "no park warning: $out"
 
-# --- T18: claude/* park with a dirty tree -> untouched -----------------------
-echo "T18: claude/* park with a dirty tree -> left alone"
+# --- T18: scratch ref with a dirty tree -> untouched -------------------------
+echo "T18: claude/*-scratch with a dirty tree -> left alone"
 reset_skip_counter
 git_q "$CLONE3" checkout master
-git_q "$CLONE3" checkout -b claude/126-w
+reset_rate_limit
+advance_main_clone "$CLONE3" 2>/dev/null                   # sync origin/master first
+git_q "$CLONE3" checkout -B claude/pool-9-scratch origin/master
 echo "dirt" >> "$CLONE3/file"
 push_new_commit t18
 reset_rate_limit
 out=$(advance_main_clone "$CLONE3" 2>&1 || true)
-[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/126-w" ]] && ok "dirty claude/* park untouched" || fail "branch switched on a dirty claude/* park"
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/pool-9-scratch" ]] && ok "dirty scratch park untouched" || fail "branch switched on a dirty scratch park"
 echo "$out" | grep -q "not master" && ok "warns about the dirty park" || fail "no park warning: $out"
 git_q "$CLONE3" checkout -- file
 
@@ -333,14 +347,17 @@ export FLEET_FRESHNESS_SKIP_ESCALATE_N=3
 reset_rate_limit; esc1=$(advance_main_clone "$CLONE3" 2>&1 || true)
 reset_rate_limit; esc2=$(advance_main_clone "$CLONE3" 2>&1 || true)
 reset_rate_limit; esc3=$(advance_main_clone "$CLONE3" 2>&1 || true)
+# Snapshot the alert AT the escalation tick: ticks past N deliberately refresh
+# it (T22), so its count= advances from here on.
+alert_at_n=$(cat "$ALERT3" 2>/dev/null || true)
 reset_rate_limit; esc4=$(advance_main_clone "$CLONE3" 2>&1 || true)
 echo "$esc1" | grep -q "not master" && ! echo "$esc1" | grep -q "ESCALATION" && ok "tick 1 warns normally" || fail "tick 1 wrong: $esc1"
 echo "$esc2" | grep -q "not master" && ! echo "$esc2" | grep -q "ESCALATION" && ok "tick 2 warns normally" || fail "tick 2 wrong: $esc2"
 echo "$esc3" | grep -q "ESCALATION" && ok "tick 3 (== N) escalates" || fail "tick 3 did not escalate: $esc3"
-[[ -f "$ALERT3" ]] && ok "alert file written" || fail "no alert file at $ALERT3"
-grep -q "reason=parked" "$ALERT3" 2>/dev/null && ok "alert records reason=parked" || fail "alert missing reason: $(cat "$ALERT3" 2>/dev/null)"
-grep -q "count=3" "$ALERT3" 2>/dev/null && ok "alert records count=3" || fail "alert missing count: $(cat "$ALERT3" 2>/dev/null)"
-grep -q "branch=feature/persistent" "$ALERT3" 2>/dev/null && ok "alert records the parked branch" || fail "alert missing branch: $(cat "$ALERT3" 2>/dev/null)"
+[[ -n "$alert_at_n" ]] && ok "alert file written" || fail "no alert file at $ALERT3"
+echo "$alert_at_n" | grep -q "reason=parked" && ok "alert records reason=parked" || fail "alert missing reason: $alert_at_n"
+echo "$alert_at_n" | grep -q "count=3" && ok "alert records count=3" || fail "alert missing count: $alert_at_n"
+echo "$alert_at_n" | grep -q "branch=feature/persistent" && ok "alert records the parked branch" || fail "alert missing branch: $alert_at_n"
 [[ -z "$esc4" ]] && ok "tick 4 (> N) is silent" || fail "tick 4 still warned: $esc4"
 
 # --- T20: a different skip key restarts the count ---------------------------
@@ -361,6 +378,25 @@ behind=$(clone_behind_count "$CLONE3")
 [[ "$behind" == "0" ]] && ok "clone advanced once back on master" || fail "behind=$behind after restoring master"
 [[ ! -f "$COUNTER3" ]] && ok "skip counter removed on the healthy pass" || fail "counter survived: $(cat "$COUNTER3" 2>/dev/null)"
 [[ ! -f "$ALERT3" ]] && ok "alert file removed on the healthy pass" || fail "alert survived: $(cat "$ALERT3" 2>/dev/null)"
+
+# --- T22: the alert is refreshed past N, not stamped once --------------------
+# Past N stderr goes quiet, so the alert file is the ONLY standing signal. If it
+# were written once at count == N, a human triaging ~/.fleet/alerts would
+# silence a still-live condition forever, and count= would freeze at the
+# escalation instant. Delete it mid-outage and assert it comes back, current.
+echo "T22: alert refreshes past N (cleared inbox re-arms, count stays honest)"
+reset_skip_counter
+git_q "$CLONE3" checkout -b feature/refresh
+export FLEET_FRESHNESS_SKIP_ESCALATE_N=2
+reset_rate_limit; advance_main_clone "$CLONE3" 2>/dev/null || true   # count=1
+reset_rate_limit; advance_main_clone "$CLONE3" 2>/dev/null || true   # count=2 == N
+[[ -f "$ALERT3" ]] && ok "alert written at N" || fail "no alert at N"
+rm -f "$ALERT3"                                                      # human clears the inbox
+reset_rate_limit; out=$(advance_main_clone "$CLONE3" 2>&1 || true)   # count=3 > N
+[[ -f "$ALERT3" ]] && ok "alert re-created past N" || fail "alert stayed gone past N — condition permanently silent"
+grep -q "count=3" "$ALERT3" 2>/dev/null && ok "refreshed alert carries the current count" || fail "stale count: $(cat "$ALERT3" 2>/dev/null)"
+[[ -z "$out" ]] && ok "refresh stays silent on stderr past N" || fail "tick past N warned: $out"
+git_q "$CLONE3" checkout master
 unset FLEET_FRESHNESS_SKIP_ESCALATE_N
 
 echo ""

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -32,9 +32,11 @@ cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
 trap cleanup EXIT
 TMPROOT=$(mktemp -d)
 
-# Isolate the rate-limit sentinel from the real ~/.fleet/state.
+# Isolate the rate-limit sentinel and the persistent-skip counter from the real
+# ~/.fleet/state, and the escalation alert file from the real ~/.fleet/alerts.
 export FLEET_STATE_DIR="$TMPROOT/state"
-mkdir -p "$FLEET_STATE_DIR"
+export FLEET_ALERTS_DIR="$TMPROOT/alerts"
+mkdir -p "$FLEET_STATE_DIR" "$FLEET_ALERTS_DIR"
 
 ok()   { echo "  ok: $1";   PASS=$((PASS+1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
@@ -70,6 +72,11 @@ push_new_commit() {  # $1 = content tag
 }
 
 reset_rate_limit() { rm -f "$FLEET_STATE_DIR"/.*-clone-advanced 2>/dev/null || true; }
+
+# Skip-counter + alert reset, so each escalation test starts from count 0.
+reset_skip_counter() {
+    rm -f "$FLEET_STATE_DIR"/.*-freshness-skip "$FLEET_ALERTS_DIR"/clone-freshness-* 2>/dev/null || true
+}
 
 # --- T1: fresh clone -> behind 0, assert passes ------------------------------
 echo "T1: fresh clone (master == origin/master)"
@@ -249,6 +256,112 @@ out=$(restore_main_clone_to_master "$CLONE2" 2>&1 || true)
     && ok "on-master disjoint-dirty clone NOT advanced" || fail "advanced master under uncommitted WIP"
 grep -q "disjoint-wip" "$CLONE2/other" && ok "on-master WIP preserved" || fail "WIP lost"
 echo "$out" | grep -q "live WIP wins" && ok "warns loudly on-master too" || fail "no WIP warning: $out"
+
+# --- generalized claude/* self-heal + persistent-skip escalation (#2363) -----
+# Fresh fixture again: CLONE is diverged (T7) and CLONE2 carries the T14 WIP.
+CLONE3="$TMPROOT/clone3"
+git clone -q "$ORIGIN" "$CLONE3"
+git -C "$CLONE3" config user.email t@t
+git -C "$CLONE3" config user.name test
+COUNTER3="$FLEET_STATE_DIR/.$(basename "$CLONE3")-freshness-skip"
+ALERT3="$FLEET_ALERTS_DIR/clone-freshness-$(basename "$CLONE3")"
+
+# --- T15: claude/* park, HEAD pushed to origin -> healed, branch ref kept -----
+echo "T15: claude/* park with pushed HEAD -> self-healed, ref preserved"
+reset_skip_counter
+git_q "$CLONE3" checkout -b claude/123-x
+echo "branch-work" >> "$CLONE3/file"
+git_q "$CLONE3" add file
+git_q "$CLONE3" commit -m branch-work
+git_q "$CLONE3" push -u origin claude/123-x   # HEAD now recoverable from origin/<branch>
+push_new_commit t15                            # origin/master moves ahead
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "pushed claude/* park healed to master" || fail "still on $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+behind=$(clone_behind_count "$CLONE3")
+[[ "$behind" == "0" ]] && ok "advance continued after tier-2 heal (behind 0)" || fail "behind=$behind after tier-2 heal"
+if git -C "$CLONE3" rev-parse --verify --quiet refs/heads/claude/123-x >/dev/null; then ok "branch ref preserved (not deleted)"; else fail "tier-2 heal deleted the branch ref"; fi
+[[ "$(echo "$out" | grep -c "self-healed")" == "1" ]] && ok "exactly one self-heal line" || fail "expected 1 self-heal line, got: $out"
+
+# --- T16: claude/* park at an old master commit (ancestor) -> healed ---------
+echo "T16: claude/* park at an ancestor of origin/master -> self-healed"
+reset_skip_counter
+stale_point=$(git -C "$CLONE3" rev-parse master~1)
+git_q "$CLONE3" checkout -b claude/124-y "$stale_point"   # no origin counterpart
+push_new_commit t16
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "master" ]] && ok "stale-ancestor park healed to master" || fail "still on $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+if git -C "$CLONE3" rev-parse --verify --quiet refs/heads/claude/124-y >/dev/null; then ok "stale-ancestor branch ref preserved"; else fail "heal deleted the branch ref"; fi
+echo "$out" | grep -q "self-healed" && ok "logs the tier-2 self-heal" || fail "no self-heal log: $out"
+
+# --- T17: claude/* park with an UNPUSHED commit -> untouched -----------------
+# The line between "stranded junk" and "live work": an unrecoverable HEAD.
+echo "T17: claude/* park with an unpushed local commit -> left alone"
+reset_skip_counter
+git_q "$CLONE3" checkout -b claude/125-z
+echo "unpushed" >> "$CLONE3/file"
+git_q "$CLONE3" add file
+git_q "$CLONE3" commit -m unpushed
+unpushed_head=$(git -C "$CLONE3" rev-parse HEAD)
+push_new_commit t17
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/125-z" ]] && ok "unpushed claude/* park untouched" || fail "branch switched to $(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)"
+[[ "$(git -C "$CLONE3" rev-parse HEAD)" == "$unpushed_head" ]] && ok "unpushed commit preserved" || fail "HEAD moved under an unpushed commit"
+echo "$out" | grep -q "not master" && ok "warns about the unhealed park" || fail "no park warning: $out"
+
+# --- T18: claude/* park with a dirty tree -> untouched -----------------------
+echo "T18: claude/* park with a dirty tree -> left alone"
+reset_skip_counter
+git_q "$CLONE3" checkout master
+git_q "$CLONE3" checkout -b claude/126-w
+echo "dirt" >> "$CLONE3/file"
+push_new_commit t18
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+[[ "$(git -C "$CLONE3" rev-parse --abbrev-ref HEAD)" == "claude/126-w" ]] && ok "dirty claude/* park untouched" || fail "branch switched on a dirty claude/* park"
+echo "$out" | grep -q "not master" && ok "warns about the dirty park" || fail "no park warning: $out"
+git_q "$CLONE3" checkout -- file
+
+# --- T19: persistent identical skip escalates once, then goes quiet ----------
+echo "T19: persistent skip -> one ESCALATION + alert file, then silence"
+reset_skip_counter
+git_q "$CLONE3" checkout master
+git_q "$CLONE3" checkout -b feature/persistent   # non-claude/*: never healed
+export FLEET_FRESHNESS_SKIP_ESCALATE_N=3
+reset_rate_limit; esc1=$(advance_main_clone "$CLONE3" 2>&1 || true)
+reset_rate_limit; esc2=$(advance_main_clone "$CLONE3" 2>&1 || true)
+reset_rate_limit; esc3=$(advance_main_clone "$CLONE3" 2>&1 || true)
+reset_rate_limit; esc4=$(advance_main_clone "$CLONE3" 2>&1 || true)
+echo "$esc1" | grep -q "not master" && ! echo "$esc1" | grep -q "ESCALATION" && ok "tick 1 warns normally" || fail "tick 1 wrong: $esc1"
+echo "$esc2" | grep -q "not master" && ! echo "$esc2" | grep -q "ESCALATION" && ok "tick 2 warns normally" || fail "tick 2 wrong: $esc2"
+echo "$esc3" | grep -q "ESCALATION" && ok "tick 3 (== N) escalates" || fail "tick 3 did not escalate: $esc3"
+[[ -f "$ALERT3" ]] && ok "alert file written" || fail "no alert file at $ALERT3"
+grep -q "reason=parked" "$ALERT3" 2>/dev/null && ok "alert records reason=parked" || fail "alert missing reason: $(cat "$ALERT3" 2>/dev/null)"
+grep -q "count=3" "$ALERT3" 2>/dev/null && ok "alert records count=3" || fail "alert missing count: $(cat "$ALERT3" 2>/dev/null)"
+grep -q "branch=feature/persistent" "$ALERT3" 2>/dev/null && ok "alert records the parked branch" || fail "alert missing branch: $(cat "$ALERT3" 2>/dev/null)"
+[[ -z "$esc4" ]] && ok "tick 4 (> N) is silent" || fail "tick 4 still warned: $esc4"
+
+# --- T20: a different skip key restarts the count ---------------------------
+echo "T20: changing the skip condition re-arms the warning"
+git_q "$CLONE3" checkout -b feature/other
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+echo "$out" | grep -q "not master" && ok "new key warns again (not suppressed)" || fail "new key stayed suppressed: $out"
+! echo "$out" | grep -q "ESCALATION" && ok "new key does not re-escalate immediately" || fail "re-escalated on a fresh key: $out"
+
+# --- T21: clearing the condition removes the counter and the alert ----------
+echo "T21: healthy pass clears the counter + alert file"
+git_q "$CLONE3" checkout master
+push_new_commit t21
+reset_rate_limit
+out=$(advance_main_clone "$CLONE3" 2>&1 || true)
+behind=$(clone_behind_count "$CLONE3")
+[[ "$behind" == "0" ]] && ok "clone advanced once back on master" || fail "behind=$behind after restoring master"
+[[ ! -f "$COUNTER3" ]] && ok "skip counter removed on the healthy pass" || fail "counter survived: $(cat "$COUNTER3" 2>/dev/null)"
+[[ ! -f "$ALERT3" ]] && ok "alert file removed on the healthy pass" || fail "alert survived: $(cat "$ALERT3" 2>/dev/null)"
+unset FLEET_FRESHNESS_SKIP_ESCALATE_N
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- **Escalate-then-quiet for persistent skips.** `advance_main_clone` runs unattended every dispatcher tick, so a skip condition re-emits the same warn line forever — spam that hides the outage rather than reporting it. Consecutive identical skips are now counted (keyed `<reason>|<branch>`); at the Nth (default **15**, ~15 min at the warn-eligible ~1/min cadence) it emits one loud `ESCALATION` line plus a flat alert file, then goes silent until a healthy pass clears both. Past N the alert is **rewritten every tick**, so a cleared inbox re-arms and `count=` stays honest.
- **Self-heal scoped to the fleet's scratch namespace, `claude/*-scratch`.** #2381 shipped it for `claude/*-reviewer-scratch`, a spelling the live fleet never produces; scripted cwd drift parks the clone on the real scratch refs (`claude/pool-<N>-scratch` and its `claude/game-pool-<N>-scratch` twin). A clean park there whose HEAD is already contained by `origin/master` — no unique commits, so the ref holds nothing — is restored to master, the junk ref dropped, and the normal advance continues.
- **Everything else is left alone and escalated instead — including a clean, pushed `claude/<area>-<topic>` park.** FLEET.md rule 1 puts Cursor / ad-hoc sessions on that namespace and `commit-and-push` leaves exactly that session clean-and-pushed while the human sits on the PR. Proving git loses nothing ("recoverable") is a different invariant from proving no session is using the checkout ("idle"); only the namespace establishes the latter, so `_head_recoverable` was deleted outright rather than narrowed.
- **The ref delete is best-effort, and the log line says which happened.** `git branch -D` refuses a ref another worktree holds (`claude/pool-<N>-scratch` is owned by a live pool worktree) or one whose `refs/heads` entry a killed git process left locked. The heal is still correct there — HEAD is back on master, the freeze is cleared — so the line reports the ref as *left* rather than claiming a delete git refused; an operator reading it mid-outage acts on that claim.
- **Scope line held deliberately.** Unpushed commits, a dirty tree, and non-`claude/*` branches keep the existing warn-and-skip. A non-`claude/*` checkout is a human's deliberate session, so it gets the alert instead of having its branch switched out from under it.
- **New authoring rule** in `scripts/fleet/CLAUDE.md`: an every-tick guard that warns must escalate-then-quiet — the reusable half of this fix.
- Alert file adopts the flat `key=value` shape `fleet-rebase` established in #2362 (`${FLEET_ALERTS_DIR:-~/.fleet/alerts}/clone-freshness-<repo_tag>`); counter and alert writes are best-effort so a read-only `$HOME` cannot break the advance path.

## Test plan
- [x] `bash scripts/fleet/tests/test_clone_freshness.sh` — **74/74, T1–T24**, under both bash **5.3.9** and macOS `/bin/bash` **3.2.57**
- [x] Positive controls, each re-derived against the current 74-assertion suite (not carried over from an earlier count):
  - restore the wide `[[ claude/* && clean ]]` predicate → **63/11** — T15 (live session healed), T17 (unique commit clobbered), T24 (contained session healed) all fire
  - widen **only** the namespace glob, containment conjunct kept → **70/4** — T24 alone fires; that is the assertion isolating the namespace half, and its absence is why the earlier control passed the glob-only revert
  - revert the heal line to the unconditional "deleted the junk branch" → **72/2** (T23)
- [x] `bash -n` clean on both bash versions, after the amendment
- [x] All 6 `fleet-claim` consumer suites (`blockers` 21, `branch_check`, `host_gate` 9, `model_gate` 11, `safety_guards` 25, `stackable_live_resolve` 12) + `test_poll_topology.py` + `ruff check scripts/` — run at `df371f4f`; the amendment since touches only the heal's log line and its own tests (no Python, no consumer-visible surface, `restore_main_clone_to_master` still byte-identical)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| **1.** Clean `claude/*-scratch` park with a contained HEAD → restores master, ff-advances, drops the junk ref, exactly one self-heal line | T16 / T5b | `ok: pool scratch park healed to master` · `ok: advance continued after the heal (behind 0)` · `ok: junk scratch ref deleted` · `ok: exactly one self-heal line` · `ok: clone put back on master` · `ok: logs the self-heal` |
| **1b.** …and when `git branch -D` is refused, the heal still lands and the line says the ref was left | T23 (`refs/heads` lock fixture) | `ok: healed to master despite the refused delete` · `ok: ref survives the refusal (fixture reproduces it)` · `ok: line reports the ref as left` · `ok: no false delete claim` · `ok: advance continued past the refusal (behind 0)` |
| **2.** Live session / contained session / unique commit / dirty tree / non-`claude/*` → no mutation, warn+skip preserved | T15 / T24 / T17 / T18 / T5, T5c | `ok: live cursor-session park untouched` · `ok: session HEAD unmoved` · `ok: contained-HEAD session park untouched` · `ok: namespace refuses it (containment alone would not)` · `ok: scratch ref with unique commit untouched` · `ok: unique commit preserved` · `ok: dirty scratch park untouched` · `ok: feature branch HEAD untouched` · `ok: loud frozen-master warning` |
| **3.** N consecutive skips → exactly one ESCALATION line + alert file with host/root/branch/reason/count/since/remedy; suppressed after; refreshed past N; cleared when the condition clears | T19 / T20 / T21 / T22, plus a live 4-tick run at `N=3` | `ok: tick 3 (== N) escalates` · `ok: alert records reason=parked` · `ok: alert records count=3` · `ok: tick 4 (> N) is silent` · `ok: alert re-created past N` · `ok: refreshed alert carries the current count` · `ok: skip counter removed on the healthy pass` · `ok: alert file removed on the healthy pass`. Live alert file: `clone-freshness skip: host=… root=… branch=feature/human-session reason=parked count=3 since=2026-07-30T18:44:40Z remedy='git -C … checkout master && git -C … merge --ff-only origin/master  (or rerun fleet-up)'` |
| **4.** Suite fully green (T1–T24) on macOS bash 3.2 **and Linux** | `/bin/bash scripts/fleet/tests/test_clone_freshness.sh` | macOS bash **3.2.57** (native, this host): `PASS: 74  FAIL: 0`; bash 5.3.9: `PASS: 74  FAIL: 0`. **Linux half still unverifiable on this host** (macOS pane) — no bash-3.2-only constructs are used. The GNU `date -d @…` arm is no longer unexercised: the opus recheck ran it under a GNU-semantics `date` shim and both arms resolved the same epoch to the same ISO string. A real Linux run is confirmation, not a gap. |
| **5.** `restore_main_clone_to_master` byte-identical; every entry point still returns 0 under `set -e` | function-body `diff` vs `origin/master` (re-run after the amendment); T9–T14 | Function body **IDENTICAL** to master, 34 lines both sides (skip counting is opt-in via a new optional 2nd arg to the shared tail that only `advance_main_clone` passes). T9–T14 green; the whole suite sources the helper under `set -euo pipefail`. |

## Notes for reviewer
- **N=15 deviates from the issue body's "say 60"** — deliberate, and signed off at plan review. 60 warn-eligible ticks ≈ 1 h, which would have missed the measured 30-min freeze entirely.
- The tier-2 heal reads `origin/<branch>`, but the guard fetches `origin master` only, so that ref can be locally stale. Safe because the heal only ever acts on a HEAD contained by `origin/master`: a wrong staleness guess costs a re-checkout, never commits. Deliberately not "fixed" by fetching all refs — the guard must stay cheap on every tick.
- This file's test harness predates `tests/lib_assert.sh`; T15–T24 follow the file's existing local `ok`/`fail` idiom rather than churning the whole file to migrate.
- **Nit 3 from the opus recheck is deferred to #2691** (`fleet:nit-of-pr`, filed by the reviewer with a full repro and patch sketch): the `ff-only refused` branch is the one warn path still outside the skip counter, so a stale `.git/index.lock` can hold a clone behind forever without escalating. Real, and out of this PR's diff by the reviewer's own offer.
- **Bookkeeping for the merger/human:** #2363's issue body still specifies the liveness condition as "no live claim/reviewing label references that worktree", while the shipped predicate substitutes a structural proof (HEAD contained by `origin/master` + the scratch namespace). The plan file already matches what landed; the issue body is worth a one-line edit at merge. Workers don't edit issue bodies, so it is flagged rather than applied.
- **Bootstrap irony (#1810):** this fix is inert until each host's main clone advances past the merge once. After merge, run `fleet-up` (or `git -C <main-clone> merge --ff-only origin/master`) on any host currently wedged in the skip loop — including, specifically, any host this PR is meant to unwedge.

Closes #2363

🤖 Generated with [Claude Code](https://claude.com/claude-code)
