### PR TITLE
build: cover top-level tools/ in format targets + count examined files

### DIFF
--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -13,6 +13,7 @@ function(irreden_collect_quality_files out_var)
         "${PROJECT_SOURCE_DIR}/engine"
         "${PROJECT_SOURCE_DIR}/creations"
         "${PROJECT_SOURCE_DIR}/test"
+        "${PROJECT_SOURCE_DIR}/tools"
     )
 
     set(globbed_files "")

--- a/cmake/run_clang_format_changed.cmake
+++ b/cmake/run_clang_format_changed.cmake
@@ -83,7 +83,9 @@ if(_untracked_rc EQUAL 0 AND NOT _untracked_out STREQUAL "")
 endif()
 
 if(NOT _changed_files)
-    message(STATUS "clang-format (changed): no diff vs ${_diff_base}; nothing to format.")
+    message(STATUS
+        "clang-format (changed): no diff vs ${_diff_base} in ${PROJECT_ROOT}; "
+        "nothing to format.")
     return()
 endif()
 
@@ -106,7 +108,11 @@ foreach(_rel IN LISTS _changed_files)
 endforeach()
 
 if(NOT _targets)
-    message(STATUS "clang-format (changed): diff vs ${_diff_base} touches no formattable sources.")
+    list(LENGTH _changed_files _changed_count)
+    message(STATUS
+        "clang-format (changed): diff vs ${_diff_base} touches no formattable "
+        "sources (${_changed_count} changed file(s) examined, 0 on the "
+        "quality list).")
     return()
 endif()
 


### PR DESCRIPTION
## Summary
- Adds `${PROJECT_SOURCE_DIR}/tools` to `irreden_collect_quality_files`'s search roots, closing the silent-no-op hole where `format` / `format-check` / `format-changed` never saw top-level `tools/` sources.
- Both early-return paths in `run_clang_format_changed.cmake` now report what they examined (repo root on the no-diff path; changed-file count on the no-formattable path), so "I looked nowhere" is no longer indistinguishable from "I looked and it was clean" — this makes the creation-worktree wrong-diff-basis variant (#2675) self-evident when it recurs.

Second PR of the 2026-07-30 triage-coding-improvements batch (docs bundle: #2678), split out per the flow because an automated-check change wants isolated verification.

## Test plan
- [x] Re-configured `macos-debug`: generated `build/irreden_quality_files.cmake` grew 791 → 793 entries, with `tools/img_diff/main.cpp` and `tools/jitter_probe/main.cpp` both present (they were absent before, verified by grep).
- [x] Ran `fleet-build --target format-changed` on this branch: printed `diff vs origin/master touches no formattable sources (2 changed file(s) examined, 0 on the quality list).` — the new count print observed firing on the exact path #2556's recurrence comment asked to make self-evident.

## Acceptance evidence
| Criterion (from #2556) | Check run | Observed |
|---|---|---|
| `tools/` covered by the format targets | `grep '/tools/' build/irreden_quality_files.cmake` after reconfigure | `tools/img_diff/main.cpp`, `tools/jitter_probe/main.cpp` listed (791 → 793) |
| Target states how many files it examined | `fleet-build --target format-changed` | `(2 changed file(s) examined, 0 on the quality list)` |

Closes #2556

🤖 Generated with [Claude Code](https://claude.com/claude-code)