### PR TITLE
engine/command: declarative default-binding manifest for key suites (#2666)

### DIFF
--- a/.fleet/plans/issue-2666.md
+++ b/.fleet/plans/issue-2666.md
@@ -1,0 +1,133 @@
+## Plan: Command suites — declarative default-binding manifest (enumerate, opt out, rebind)
+
+- **Issue:** #2666
+- **Model:** opus
+- **Date:** 2026-07-30
+
+### Scope
+
+Replace the two imperative engine command suites with declarative
+default-binding manifests, add registration-time omit/remap overrides, and
+expose enumeration + override-aware registration to Lua. Zero-arg suite
+registration stays byte-identical; `voxel_editor` migrates onto the omit form
+as the in-tree proof.
+
+### Verified current state
+
+- `command_suite_camera.hpp` registers 11 bindings (3 PRESSED singles + 4
+  PRESSED/RELEASED WASD pairs); `command_suite_capture.hpp` registers 3.
+- `bindPrefabCommand`'s hand-listed switch (`engine/command/src/ir_command.cpp`)
+  covers every one of the 14 suite commands — the runtime loop needs no new
+  dispatch machinery.
+- `CommandManager::createCommand` stamps `m_commandRegistrations` only for
+  **named PRESSED** bindings (`command_manager.hpp:55`) — so the registration
+  map cannot serve as the manifest (it omits the RELEASED `*_END` rows and is
+  populated only after registration). The manifest must be its own constexpr
+  source.
+- `creations/editors/voxel_editor/main.cpp:2532` hand-duplicates the camera
+  suite minus CLOSE_WINDOW — the migration target.
+- `IRPrefab::Camera::registerStandardKeyboardCommands()`
+  (`engine/prefabs/irreden/render/camera_controls.hpp`) wraps
+  `registerCameraCommands()` — needs an override pass-through.
+
+### Approach
+
+1. **Types + generic primitive**
+   (`engine/command/include/irreden/command/ir_command_types.hpp` +
+   `ir_command.hpp`): add `struct DefaultBinding { CommandNames command;
+   IRInput::InputTypes inputType; IRInput::ButtonStatuses status; int button;
+   IRInput::KeyModifierMask requiredModifiers; }`, `enum class Suite { CAMERA,
+   CAPTURE }`, and `struct BindingOverrides { std::vector<CommandNames> omit;
+   std::vector<std::pair<int, int>> remap; }` (or span-friendly equivalents).
+   Then the one registration primitive in the command module:
+   `IRCommand::registerBindings(std::span<const DefaultBinding>,
+   const BindingOverrides & = {})` — skip rows whose command is in `omit`,
+   substitute `button` per `remap` (a remap hits every row with that button,
+   so PRESSED + RELEASED pairs move together), dispatch each surviving row
+   through `bindPrefabCommand`. **Deliberately registration-time, not a
+   mutable unbind/rebind registry**: `CommandId` is a vector index (removal
+   invalidates ids / needs tombstones on the dispatch loop), `CommandNames`
+   is not unique in the live registry (rebind-by-command is ambiguous), and
+   never-bound keeps #2570's query + the overlay consistent for free. It
+   needs only `DefaultBinding` + `bindPrefabCommand`, so it lives in
+   `engine/command` with no prefab dependency, and any creation-authored
+   binding table can use it.
+2. **Manifests** (`engine/prefabs/irreden/common/command_suite_camera.hpp` /
+   `command_suite_capture.hpp`): `constexpr DefaultBinding kCameraSuite[]` /
+   `kCaptureSuite[]` (constexpr namespace-scope tables are program constants —
+   allowed by `.claude/rules/cpp-globals.md`). `registerCameraCommands()` /
+   `registerCaptureCommands()` become thin wrappers:
+   `registerBindings(kCameraSuite, overrides)`, with the zero-arg overloads
+   unchanged. Assert (debug) / log when a manifest row returns
+   `kInvalidCommandId` — a future suite command missing from the
+   `bindPrefabCommand` switch must fail loudly at registration, not silently
+   thin the suite.
+3. **Enumeration**: `IRCommand::suiteDefaults(Suite)` returning a span/const
+   ref over the matching table, in a small
+   `engine/prefabs/irreden/common/command_suite_registry.hpp` (it must see both
+   tables; the prefab layer owns suite composition). Add the override
+   pass-through to `IRPrefab::Camera::registerStandardKeyboardCommands`.
+4. **Lua** (`engine/script/.../lua_command_bindings.hpp` + input enum
+   bindings): `IRCommand.Suite` integer table (cpp-lua-enums rule — never
+   string-matched suite names), `IRCommand.suiteDefaults(suite)` → array of
+   `{command, inputType, status, button, modifiers}` tables,
+   `IRCommand.registerSuite(suite, {omit = {...}, remap = {{from, to}, ...}})`
+   (sugar over the same `registerBindings` primitive; suite identity is the
+   integer enum, never a string). Extend the short `IRInput.Key` table with
+   the keypad entries (KPAdd, KPSubtract, KP0–KP9, KPEnter, …) so remap
+   targets are nameable from Lua.
+5. **Migrate `voxel_editor`**: replace the hand-rolled subset at
+   `main.cpp:2532` with the omit form (`omit = {CLOSE_WINDOW}`); delete the
+   duplicated registrations and update the comment.
+6. **Docs**: `engine/command/CLAUDE.md` (manifest + overrides section, Lua
+   surface), `engine/prefabs/irreden/common/CLAUDE.md` (the Commands bullet).
+
+Suggested slicing if two PRs: (1)–(3)+(5)+(6) C++ manifest/overrides/migration,
+then (4) Lua exposure stacked on it.
+
+### Affected files
+
+- `engine/command/include/irreden/command/ir_command_types.hpp` — DefaultBinding, Suite, BindingOverrides
+- `engine/command/include/irreden/ir_command.hpp` + `src/ir_command.cpp` — generic `registerBindings(span, overrides)` primitive
+- `engine/prefabs/irreden/common/command_suite_camera.hpp` — constexpr manifest + loop + overrides overload
+- `engine/prefabs/irreden/common/command_suite_capture.hpp` — same
+- `engine/prefabs/irreden/common/command_suite_registry.hpp` (new) — `suiteDefaults(Suite)`
+- `engine/prefabs/irreden/render/camera_controls.hpp` — override pass-through
+- `engine/script/include/irreden/script/lua_command_bindings.hpp` — Suite table, suiteDefaults, registerSuite
+- `engine/script/` input enum binding site (`bindInputEnums`) — keypad `IRInput.Key` entries
+- `creations/editors/voxel_editor/main.cpp` — migrate onto omit form
+- `engine/command/CLAUDE.md`, `engine/prefabs/irreden/common/CLAUDE.md` — docs
+
+### Acceptance criteria
+
+- Zero-arg suite registration byte-identical (same registrations, same debug
+  help overlay output; build + run a demo that uses both suites).
+- `suiteDefaults(CAMERA)` = 11 rows incl. RELEASED `*_END`; `CAPTURE` = 3.
+- Omit test: camera suite `omit = {CLOSE_WINDOW}` → Escape unbound, rest bound.
+- Remap test: WASD→arrows moves both statuses per key; no WASD rows remain.
+- Lua: `suiteDefaults` rows match C++; `registerSuite` honors omit/remap;
+  keypad keys resolvable in `IRInput.Key`.
+- Generality: a caller-authored `DefaultBinding` table registers through
+  `registerBindings` with the same omit/remap semantics (unit-style check or
+  demo usage) — the mechanism is not suite-specific.
+- `voxel_editor` builds and behaves unchanged on the omit form.
+
+### Gotchas
+
+- **The registration map is not the manifest.** `m_commandRegistrations` only
+  captures named PRESSED binds — deriving enumeration from it silently drops
+  the RELEASED camera rows. Keep the constexpr tables authoritative.
+- **`bindPrefabCommand` is a hand-listed switch.** A suite row whose command
+  case is missing logs and returns `kInvalidCommandId` — surface that as a
+  loud registration failure (assert/log), and note in the CLAUDE.md that
+  adding a suite command requires the switch case first.
+- **Overlay parity.** Verify the loop path stamps the same command names into
+  `m_commandRegistrations` as the old `createCommand<NAME>` calls so
+  `buildCommandListText()` output is unchanged.
+- **No dedup policy.** Per #2570's contract, `createCommand` keeps appending
+  unconditionally; omit/remap shape what the suite *requests*, they impose no
+  collision policy on other registrations.
+- **cpp-lua-enums.** Suite identity crosses the Lua boundary as an integer
+  table, never a string compared in C++.
+- **Cross-platform.** Pure C++/Lua; no backend or host coupling.
+

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -857,7 +857,7 @@ constexpr IRVideo::GuiInputEvent kHelpCloseEvents[] = {
 };
 
 // Escape toggles the settings menu in this demo (#2551) — the camera suite is
-// registered with bindEscapeCloseWindow=false, so it no longer quits.
+// registered with `{.omit_ = {CLOSE_WINDOW}}`, so it no longer quits.
 constexpr IRVideo::GuiInputEvent kMenuOpenEvents[] = {
     {0,
      IRVideo::GuiInputEvent::Type::PRESS,
@@ -1849,8 +1849,11 @@ void initSystems() {
 void initCommands() {
     // Escape opens the settings menu instead of quitting (#2551); the menu's
     // QUIT button is the replacement exit, so quitting is two inputs away
-    // rather than one. Every other camera binding is unchanged.
-    IRPrefab::Camera::registerStandardKeyboardCommands(/*bindEscapeCloseWindow=*/false);
+    // rather than one. Omitting the one row leaves every other camera binding
+    // unchanged.
+    IRPrefab::Camera::registerStandardKeyboardCommands(
+        {.omit_ = {IRCommand::CLOSE_WINDOW}}
+    );
     IRCommand::registerCaptureCommands();
     // Interactive cull-freeze toggle (#1438): freeze the cull viewport at the
     // current camera pose, then free-fly (WASD pan / mouse drag / scroll zoom,

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2532,7 +2532,7 @@ void initSystems() {
 void initCommands() {
     // The full camera suite minus Escape→CLOSE_WINDOW, which would conflict
     // with the drag-cancel handler below — we handle Escape ourselves.
-    IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
+    IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 
     IRCommand::createCommand(
         IRInput::InputTypes::KEY_MOUSE,

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2530,59 +2530,9 @@ void initSystems() {
 }
 
 void initCommands() {
-    // Register camera commands individually so we can own the Escape binding.
-    // (registerCameraCommands() also binds Escape→CLOSE_WINDOW, which conflicts
-    // with the drag-cancel handler below — we handle Escape ourselves.)
-    IRCommand::createCommand<IRCommand::ZOOM_IN>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::PRESSED,
-        IRInput::KeyMouseButtons::kKeyButtonEqual
-    );
-    IRCommand::createCommand<IRCommand::ZOOM_OUT>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::PRESSED,
-        IRInput::KeyMouseButtons::kKeyButtonMinus
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_UP_START>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::PRESSED,
-        IRInput::KeyMouseButtons::kKeyButtonW
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_DOWN_START>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::PRESSED,
-        IRInput::KeyMouseButtons::kKeyButtonS
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_LEFT_START>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::PRESSED,
-        IRInput::KeyMouseButtons::kKeyButtonA
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_RIGHT_START>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::PRESSED,
-        IRInput::KeyMouseButtons::kKeyButtonD
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_UP_END>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::RELEASED,
-        IRInput::KeyMouseButtons::kKeyButtonW
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_DOWN_END>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::RELEASED,
-        IRInput::KeyMouseButtons::kKeyButtonS
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_LEFT_END>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::RELEASED,
-        IRInput::KeyMouseButtons::kKeyButtonA
-    );
-    IRCommand::createCommand<IRCommand::MOVE_CAMERA_RIGHT_END>(
-        IRInput::InputTypes::KEY_MOUSE,
-        IRInput::ButtonStatuses::RELEASED,
-        IRInput::KeyMouseButtons::kKeyButtonD
-    );
+    // The full camera suite minus Escape→CLOSE_WINDOW, which would conflict
+    // with the drag-cancel handler below — we handle Escape ourselves.
+    IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 
     IRCommand::createCommand(
         IRInput::InputTypes::KEY_MOUSE,

--- a/docs/design/lua-input-commands.md
+++ b/docs/design/lua-input-commands.md
@@ -298,6 +298,10 @@ generic `"C++ exception"`.
 
 ## Public Lua API
 
+> This is the surface T-193 locked, not a running inventory — later work
+> has added to it (`IRCommand.{Suite, suiteDefaults, registerSuite}`).
+> `engine/script/CLAUDE.md` §"Commands and input" is the living reference.
+
 ```lua
 -- Bind a prefab command (most common — replaces the C++ initCommands block):
 IRCommand.bindPrefab(

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -69,9 +69,11 @@ It filters by `overrides.omit_`, substitutes buttons per
 own `DefaultBinding` table gets the same omit/remap machinery:
 
 ```cpp
-// Everything except Escape, for a creation that owns its own Escape handling.
-// (voxel_editor wants exactly this, and spells it through the forwarding
-// wrapper IRPrefab::Camera::registerStandardKeyboardCommands.)
+// Everything except Escape, for a creation that owns its own Escape handling
+// (voxel_editor wants exactly this). A creation already on the camera-control
+// bundle passes the same overrides through the forwarding wrapper
+// IRPrefab::Camera::registerStandardKeyboardCommands instead — that is how
+// shape_debug frees Escape for the settings menu.
 IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 
 // Pan on the arrow keys instead of WASD.

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -47,6 +47,65 @@ IRCommand::createCommand<IRCommand::CommandNames::ZOOM_IN>(
     Command<ZOOM_IN>::create());
 ```
 
+## Default-binding manifests (#2666)
+
+The engine's default keys are **data**, not imperative suite bodies.
+`constexpr DefaultBinding kCameraSuite[]` / `kCaptureSuite[]` in
+[`engine/prefabs/irreden/common/command_suite_registry.hpp`](../prefabs/irreden/common/command_suite_registry.hpp)
+are the single definition site per suite; `registerCameraCommands()` /
+`registerCaptureCommands()` are loops over them.
+
+One primitive drives all of it:
+
+```cpp
+void IRCommand::registerBindings(
+    std::span<const DefaultBinding> bindings,
+    const BindingOverrides &overrides = {});
+```
+
+It filters by `overrides.omit_`, substitutes buttons per
+`overrides.remap_`, and dispatches each surviving row through
+`bindPrefabCommand`. Nothing about it is suite-specific — a creation's
+own `DefaultBinding` table gets the same omit/remap machinery:
+
+```cpp
+// Everything except Escape (voxel_editor owns its own Escape handling).
+IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
+
+// Pan on the arrow keys instead of WASD.
+IRCommand::registerCameraCommands({.remap_ = {
+    {IRInput::kKeyButtonW, IRInput::kKeyButtonUp},
+    {IRInput::kKeyButtonA, IRInput::kKeyButtonLeft}, /* ... */}});
+```
+
+Semantics worth knowing before you use it:
+
+- **`omit_` matches on command, `remap_` matches on button.** A pan axis
+  is two *distinct* commands sharing one button
+  (`MOVE_CAMERA_UP_START` + `MOVE_CAMERA_UP_END` on `W`), so one remap
+  entry moves both rows, while omitting `MOVE_CAMERA_UP_START` leaves
+  the RELEASED row bound. Omit both to drop the axis.
+- **Remaps never chain.** The first matching pair wins per row, so
+  `{W→A, A→UP}` leaves `W` on `A`.
+- **Registration-time, not a mutable rebind registry.** There is
+  deliberately no `unbind(command)` / `rebind(command, key)`:
+  `CommandId` is an index into an append-only vector (removal would
+  invalidate outstanding ids or force tombstones onto the per-tick
+  dispatch loop), and `CommandNames` is not a unique key in the live
+  registry, so rebind-by-command is ambiguous by construction.
+  Never-bound also keeps the help overlay and
+  `getCommandRegistrations()` consistent for free. A true *runtime*
+  rebind surface (settings menu, persisted keymaps) is a separate
+  design and stays reachable via in-place `CommandId` mutation.
+- **The registration map is not the manifest.**
+  `getCommandRegistrations()` is populated only after registration and
+  only for *named PRESSED* binds — it cannot see the RELEASED
+  `MOVE_CAMERA_*_END` rows. Enumerate defaults via
+  `IRCommand::suiteDefaults(Suite)`, which reads the constexpr tables.
+
+Lua parity is `IRCommand.{Suite, suiteDefaults, registerSuite}` — see
+`engine/script/CLAUDE.md` §"Commands and input".
+
 ## `CommandManager`
 
 Owns three registries: button commands (keyboard/mouse/gamepad), MIDI note
@@ -187,3 +246,9 @@ for prefab command bodies. PR 2 does not delete any existing command.
   formats the same registry without descriptions. Kept working as #2551's
   declared fallback and per the engine API removal rule; new code reads
   `getCommandRegistrations()` directly.
+- **A manifest row needs its `bindPrefabCommand` case first.** Adding a
+  command to `kCameraSuite` / `kCaptureSuite` (or any `DefaultBinding`
+  table) without the matching case in `bindPrefabCommand` makes
+  `registerBindings` log an error and assert in debug — deliberately
+  loud, so a missing case can't silently thin a suite. Add the switch
+  case before the manifest row.

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -69,7 +69,9 @@ It filters by `overrides.omit_`, substitutes buttons per
 own `DefaultBinding` table gets the same omit/remap machinery:
 
 ```cpp
-// Everything except Escape (voxel_editor owns its own Escape handling).
+// Everything except Escape, for a creation that owns its own Escape handling.
+// (voxel_editor wants exactly this, and spells it through the forwarding
+// wrapper IRPrefab::Camera::registerStandardKeyboardCommands.)
 IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 
 // Pan on the arrow keys instead of WASD.

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -69,11 +69,12 @@ It filters by `overrides.omit_`, substitutes buttons per
 own `DefaultBinding` table gets the same omit/remap machinery:
 
 ```cpp
-// Everything except Escape, for a creation that owns its own Escape handling
-// (voxel_editor wants exactly this). A creation already on the camera-control
-// bundle passes the same overrides through the forwarding wrapper
-// IRPrefab::Camera::registerStandardKeyboardCommands instead — that is how
-// shape_debug frees Escape for the settings menu.
+// Everything except Escape, for a creation that owns its own Escape handling.
+// Every in-tree creation spells this through the forwarding wrapper
+// IRPrefab::Camera::registerStandardKeyboardCommands — voxel_editor and
+// shape_debug (Escape opens the settings menu, #2551) pass these exact
+// overrides to it; outside that wrapper only the manifest tests call the
+// bare form below.
 IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 
 // Pan on the arrow keys instead of WASD.

--- a/engine/command/include/irreden/command/ir_command_types.hpp
+++ b/engine/command/include/irreden/command/ir_command_types.hpp
@@ -1,7 +1,11 @@
 #ifndef IR_COMMAND_TYPES_H
 #define IR_COMMAND_TYPES_H
 
+#include <irreden/input/ir_input_types.hpp>
+
 #include <cstdint>
+#include <utility>
+#include <vector>
 
 namespace IRCommand {
 
@@ -57,6 +61,47 @@ enum CommandNames {
 /// row is a compile error there, not a silent "UNKNOWN" at render time.
 /// Update alongside the last enumerator when extending the enum.
 inline constexpr int kCommandNameCount = static_cast<int>(TOGGLE_SETTINGS_MENU) + 1;
+
+/// One declarative row of a default-binding manifest: "this command, on this
+/// trigger". Pure data — a manifest never names a `Command<NAME>` body, so a
+/// table of these can be declared (and enumerated) without pulling the prefab
+/// command headers into scope. @ref registerBindings turns a row into a live
+/// registration via the runtime `bindPrefabCommand` dispatch.
+///
+/// Engine-shipped manifests live in
+/// `engine/prefabs/irreden/common/command_suite_registry.hpp`; a creation is
+/// free to declare its own table of the same type and feed it to the same
+/// registration primitive.
+struct DefaultBinding {
+    CommandNames command_;
+    IRInput::InputTypes inputType_;
+    IRInput::ButtonStatuses status_;
+    int button_;
+    IRInput::KeyModifierMask requiredModifiers_ = IRInput::kModifierNone;
+};
+
+/// Registration-time customization of a @ref DefaultBinding manifest, applied
+/// by @ref registerBindings.
+///
+/// - `omit_` drops every row whose `command_` appears in the list. Matching is
+///   by command identity, so a command bound on several rows (the camera
+///   suite's PRESSED + RELEASED pairs are *distinct* commands) drops only the
+///   rows naming that exact command.
+/// - `remap_` substitutes buttons as `{from, to}` pairs, applied to `button_`
+///   after the omit filter. A remap matches on the button, so it moves **every**
+///   row using that button — `{kKeyButtonW, kKeyButtonUp}` carries both
+///   `MOVE_CAMERA_UP_START` (PRESSED) and `MOVE_CAMERA_UP_END` (RELEASED)
+///   across together. At most one substitution is applied per row (the first
+///   matching pair wins), so remaps never chain.
+///
+/// Deliberately registration-time rather than a mutable unbind/rebind registry:
+/// `CommandId` is an index into an append-only vector, and `CommandNames` is
+/// not a unique key in the live registry — see `engine/command/CLAUDE.md`
+/// §"Default-binding manifests".
+struct BindingOverrides {
+    std::vector<CommandNames> omit_;
+    std::vector<std::pair<int, int>> remap_;
+};
 
 /// Type-tag struct; specialised per command to provide a `create()` factory
 /// that returns the `std::function<void()>` for that command.

--- a/engine/command/include/irreden/command/ir_command_types.hpp
+++ b/engine/command/include/irreden/command/ir_command_types.hpp
@@ -72,6 +72,13 @@ inline constexpr int kCommandNameCount = static_cast<int>(TOGGLE_SETTINGS_MENU) 
 /// `engine/prefabs/irreden/common/command_suite_registry.hpp`; a creation is
 /// free to declare its own table of the same type and feed it to the same
 /// registration primitive.
+///
+/// A row carries `requiredModifiers_` but deliberately **no blocked-modifier
+/// field**, so the manifest is narrower than the primitive it feeds:
+/// @ref registerBindings passes only `requiredModifiers_` through to
+/// `bindPrefabCommand`, leaving its `blockedModifiers` at the default. A
+/// binding that must be *suppressed* while a modifier is held stays a
+/// hand-written `bindPrefabCommand` call rather than a manifest row.
 struct DefaultBinding {
     CommandNames command_;
     IRInput::InputTypes inputType_;

--- a/engine/command/include/irreden/ir_command.hpp
+++ b/engine/command/include/irreden/ir_command.hpp
@@ -7,6 +7,7 @@
 #include <irreden/command/command_manager.hpp>
 
 #include <iterator>
+#include <span>
 #include <string>
 #include <utility>
 
@@ -136,6 +137,23 @@ static_assert(
     commandInfoRowsAligned(),
     "kCommandInfo rows must appear in CommandNames declaration order — the table is indexed "
     "by enum value"
+);
+
+/// Register a declarative @ref DefaultBinding manifest, honoring @p overrides.
+///
+/// The one registration primitive behind the engine's default-key suites and
+/// any caller-authored binding table: filter by `overrides.omit`, substitute
+/// buttons per `overrides.remap`, then dispatch each surviving row through
+/// @ref bindPrefabCommand. Rows register in manifest order, so the debug help
+/// overlay (which lists `PRESSED` registrations in registration order) reads
+/// the same as the equivalent hand-written `createCommand<NAME>` sequence.
+///
+/// A row whose command has no `Command<NAME>` specialization logs an error via
+/// `bindPrefabCommand` and asserts in debug — a manifest naming a command that
+/// is missing from that switch must fail loudly at registration rather than
+/// silently thinning the suite.
+void registerBindings(
+    std::span<const DefaultBinding> bindings, const BindingOverrides &overrides = {}
 );
 
 /// Returns a short human-readable label for @p name (e.g. "ZOOM IN").

--- a/engine/command/src/ir_command.cpp
+++ b/engine/command/src/ir_command.cpp
@@ -32,6 +32,8 @@
 #include <irreden/voxel/commands/command_randomize_voxels.hpp>
 #include <irreden/voxel/commands/command_spawn_particle_mouse_position.hpp>
 
+#include <algorithm>
+
 namespace IRCommand {
 
 CommandManager *g_commandManager = nullptr;
@@ -42,6 +44,35 @@ CommandManager &getCommandManager() {
 
 void fire(CommandId id) {
     getCommandManager().fireUserCommand(id);
+}
+
+void registerBindings(std::span<const DefaultBinding> bindings, const BindingOverrides &overrides) {
+    for (const DefaultBinding &binding : bindings) {
+        if (std::ranges::find(overrides.omit_, binding.command_) != overrides.omit_.end()) {
+            continue;
+        }
+        // First matching pair wins, so a remap list never chains one
+        // substitution into another (W->A, A->Up leaves W on A).
+        int button = binding.button_;
+        const auto remap = std::ranges::find(overrides.remap_, button, &std::pair<int, int>::first);
+        if (remap != overrides.remap_.end()) {
+            button = remap->second;
+        }
+        const CommandId id = bindPrefabCommand(
+            binding.command_,
+            binding.inputType_,
+            binding.status_,
+            button,
+            binding.requiredModifiers_
+        );
+        // bindPrefabCommand already logged the specifics; assert so a manifest
+        // row whose command is missing from that switch fails loudly at
+        // registration instead of silently thinning the suite.
+        IR_ASSERT(
+            id != kInvalidCommandId,
+            "registerBindings: manifest row has no Command<NAME> specialization"
+        );
+    }
 }
 
 CommandId bindPrefabCommand(

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -362,9 +362,25 @@ runtime work and architect-gated decisions.
 
 ## Commands
 
-- `command_suite_camera.hpp` — registers `ZOOM_IN`, `ZOOM_OUT`,
-  `MOVE_CAMERA_*`, `CLOSE_WINDOW`. A convenience bundle creations pick
-  up en masse.
+- `command_suite_registry.hpp` — the engine's default keybindings **as
+  data**: `constexpr DefaultBinding kCameraSuite[]` (11 rows) and
+  `kCaptureSuite[]` (3 rows), plus `Suite` and
+  `suiteDefaults(Suite)` for enumeration. One definition site per
+  suite. Deliberately data-only (no `Command<NAME>` body includes), so
+  `engine/script` can expose the suites on the Lua surface without
+  dragging the render/video command headers in.
+- `command_suite_camera.hpp` / `command_suite_capture.hpp` —
+  registration entry points. `registerCameraCommands()` binds
+  `CLOSE_WINDOW`, `ZOOM_IN`/`ZOOM_OUT`, and the WASD
+  `MOVE_CAMERA_*_START`/`_END` pairs; `registerCaptureCommands()` binds
+  F7/F8/F9. Both are loops over their manifest via
+  `IRCommand::registerBindings`, and both take an optional
+  `BindingOverrides` for registration-time omit/remap —
+  `registerCameraCommands({.omit_ = {CLOSE_WINDOW}})` is the shape a
+  creation that owns Escape wants instead of hand-copying the suite
+  (`creations/editors/voxel_editor` is the in-tree example). Full
+  semantics: [`engine/command/CLAUDE.md`](../../../command/CLAUDE.md)
+  §"Default-binding manifests (#2666)".
 
 ## Gotchas
 

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -377,13 +377,13 @@ runtime work and architect-gated decisions.
   `IRCommand::registerBindings`, and both take an optional
   `BindingOverrides` for registration-time omit/remap —
   `registerCameraCommands({.omit_ = {CLOSE_WINDOW}})` is the shape a
-  creation that owns Escape wants instead of hand-copying the suite
-  (`creations/editors/voxel_editor` is the in-tree example). A creation
-  already on the camera-control bundle passes the same overrides through
-  the prefab wrapper instead —
+  creation that owns Escape wants instead of hand-copying the suite.
+  In-tree that shape always goes through the prefab wrapper —
   `IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ =
-  {CLOSE_WINDOW}})`, which is how `creations/demos/shape_debug` frees
-  Escape for `IRPrefab::SettingsMenu` (#2551). Full semantics:
+  {CLOSE_WINDOW}})` — as both `creations/editors/voxel_editor` and
+  `creations/demos/shape_debug` (which frees Escape for
+  `IRPrefab::SettingsMenu`, #2551) do; outside that wrapper only the
+  manifest unit tests call the bare form. Full semantics:
   [`engine/command/CLAUDE.md`](../../../command/CLAUDE.md)
   §"Default-binding manifests (#2666)".
 

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -377,9 +377,13 @@ runtime work and architect-gated decisions.
   `IRCommand::registerBindings`, and both take an optional
   `BindingOverrides` for registration-time omit/remap —
   `registerCameraCommands({.omit_ = {CLOSE_WINDOW}})` is the shape a
-  creation that owns Escape wants instead of hand-copying the suite
-  (`creations/editors/voxel_editor` is the in-tree example). Full
-  semantics: [`engine/command/CLAUDE.md`](../../../command/CLAUDE.md)
+  creation that owns Escape wants instead of hand-copying the suite.
+  A creation already on the camera-control bundle passes the same
+  overrides through the prefab wrapper —
+  `IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ =
+  {CLOSE_WINDOW}})`, which `creations/editors/voxel_editor` is the
+  in-tree example of. Full semantics:
+  [`engine/command/CLAUDE.md`](../../../command/CLAUDE.md)
   §"Default-binding manifests (#2666)".
 
 ## Gotchas

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -377,12 +377,13 @@ runtime work and architect-gated decisions.
   `IRCommand::registerBindings`, and both take an optional
   `BindingOverrides` for registration-time omit/remap —
   `registerCameraCommands({.omit_ = {CLOSE_WINDOW}})` is the shape a
-  creation that owns Escape wants instead of hand-copying the suite.
-  A creation already on the camera-control bundle passes the same
-  overrides through the prefab wrapper —
+  creation that owns Escape wants instead of hand-copying the suite
+  (`creations/editors/voxel_editor` is the in-tree example). A creation
+  already on the camera-control bundle passes the same overrides through
+  the prefab wrapper instead —
   `IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ =
-  {CLOSE_WINDOW}})`, which `creations/editors/voxel_editor` is the
-  in-tree example of. Full semantics:
+  {CLOSE_WINDOW}})`, which is how `creations/demos/shape_debug` frees
+  Escape for `IRPrefab::SettingsMenu` (#2551). Full semantics:
   [`engine/command/CLAUDE.md`](../../../command/CLAUDE.md)
   §"Default-binding manifests (#2666)".
 

--- a/engine/prefabs/irreden/common/command_suite_camera.hpp
+++ b/engine/prefabs/irreden/common/command_suite_camera.hpp
@@ -1,6 +1,13 @@
 #ifndef COMMAND_SUITE_CAMERA_H
 #define COMMAND_SUITE_CAMERA_H
 
+// The camera suite's bindings are declared as data in `kCameraSuite`
+// (`command_suite_registry.hpp`); this header is just the registration entry
+// point. The command-body headers below are what give `bindPrefabCommand` the
+// `Command<NAME>::create()` specializations it dispatches each manifest row to.
+
+#include <irreden/common/command_suite_registry.hpp>
+
 #include <irreden/input/commands/command_close_window.hpp>
 #include <irreden/render/commands/command_zoom_in.hpp>
 #include <irreden/render/commands/command_zoom_out.hpp>
@@ -8,72 +15,23 @@
 
 namespace IRCommand {
 
-/// Registers the standard camera keyboard bundle: WASD pan, +/- zoom, and
-/// Escape to close the window.
+/// Registers the engine's default camera controls, honoring @p overrides.
 ///
-/// @param bindEscapeCloseWindow Leave `true` (the default) for the historical
-///   behavior. Pass `false` when the creation wants Escape for something else
-///   — `IRPrefab::SettingsMenu` binds it to open the menu (#2551), and puts a
-///   QUIT button inside the menu so quitting stays two inputs away. Every
-///   other binding here is unaffected either way.
-inline void registerCameraCommands(bool bindEscapeCloseWindow = true) {
-    if (bindEscapeCloseWindow) {
-        createCommand<CLOSE_WINDOW>(
-            InputTypes::KEY_MOUSE,
-            ButtonStatuses::PRESSED,
-            KeyMouseButtons::kKeyButtonEscape
-        );
-    }
-    createCommand<ZOOM_IN>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonEqual
-    );
-    createCommand<ZOOM_OUT>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonMinus
-    );
-    createCommand<MOVE_CAMERA_UP_START>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonW
-    );
-    createCommand<MOVE_CAMERA_DOWN_START>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonS
-    );
-    createCommand<MOVE_CAMERA_LEFT_START>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonA
-    );
-    createCommand<MOVE_CAMERA_RIGHT_START>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonD
-    );
-    createCommand<MOVE_CAMERA_UP_END>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::RELEASED,
-        KeyMouseButtons::kKeyButtonW
-    );
-    createCommand<MOVE_CAMERA_DOWN_END>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::RELEASED,
-        KeyMouseButtons::kKeyButtonS
-    );
-    createCommand<MOVE_CAMERA_LEFT_END>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::RELEASED,
-        KeyMouseButtons::kKeyButtonA
-    );
-    createCommand<MOVE_CAMERA_RIGHT_END>(
-        InputTypes::KEY_MOUSE,
-        ButtonStatuses::RELEASED,
-        KeyMouseButtons::kKeyButtonD
-    );
+/// `registerCameraCommands({.omit_ = {CLOSE_WINDOW}})` binds everything except
+/// Escape — the shape a creation that owns its own Escape handling wants,
+/// instead of hand-copying the rest of the suite. `IRPrefab::SettingsMenu` is
+/// the in-engine case (#2551): it binds Escape to open the menu and puts a QUIT
+/// button inside, so quitting stays two inputs away.
+/// `registerCameraCommands({.remap_ = {{IRInput::kKeyButtonW, IRInput::kKeyButtonUp}, …}})`
+/// moves pan onto the arrow keys, carrying each key's PRESSED + RELEASED rows
+/// together. Exact matching semantics: @ref BindingOverrides.
+inline void registerCameraCommands(const BindingOverrides &overrides) {
+    registerBindings(kCameraSuite, overrides);
+}
+
+/// Registers the engine's default camera controls unmodified.
+inline void registerCameraCommands() {
+    registerBindings(kCameraSuite);
 }
 
 } // namespace IRCommand

--- a/engine/prefabs/irreden/common/command_suite_capture.hpp
+++ b/engine/prefabs/irreden/common/command_suite_capture.hpp
@@ -1,25 +1,29 @@
 #ifndef COMMAND_SUITE_CAPTURE_H
 #define COMMAND_SUITE_CAPTURE_H
 
+// The capture suite's bindings are declared as data in `kCaptureSuite`
+// (`command_suite_registry.hpp`); this header is just the registration entry
+// point. The command-body headers below are what give `bindPrefabCommand` the
+// `Command<NAME>::create()` specializations it dispatches each manifest row to.
+
+#include <irreden/common/command_suite_registry.hpp>
+
 #include <irreden/video/commands/command_take_screenshot.hpp>
 #include <irreden/video/commands/command_take_screenshot_canvas.hpp>
 #include <irreden/video/commands/command_toggle_recording.hpp>
 
 namespace IRCommand {
 
+/// Registers the engine's default capture keys, honoring @p overrides.
+/// `registerCaptureCommands({.omit_ = {RECORD_TOGGLE}})` takes the screenshot
+/// keys without F9. Exact matching semantics: @ref BindingOverrides.
+inline void registerCaptureCommands(const BindingOverrides &overrides) {
+    registerBindings(kCaptureSuite, overrides);
+}
+
+/// Registers the engine's default capture keys unmodified.
 inline void registerCaptureCommands() {
-    createCommand<SCREENSHOT>(
-        InputTypes::KEY_MOUSE, ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonF8
-    );
-    createCommand<SCREENSHOT_CANVAS>(
-        InputTypes::KEY_MOUSE, ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonF7
-    );
-    createCommand<RECORD_TOGGLE>(
-        InputTypes::KEY_MOUSE, ButtonStatuses::PRESSED,
-        KeyMouseButtons::kKeyButtonF9
-    );
+    registerBindings(kCaptureSuite);
 }
 
 } // namespace IRCommand

--- a/engine/prefabs/irreden/common/command_suite_registry.hpp
+++ b/engine/prefabs/irreden/common/command_suite_registry.hpp
@@ -1,0 +1,82 @@
+#ifndef COMMAND_SUITE_REGISTRY_H
+#define COMMAND_SUITE_REGISTRY_H
+
+// The engine's default keybindings, as data.
+//
+// Each engine-shipped suite has exactly ONE definition site: a `constexpr`
+// `DefaultBinding` table here. `registerCameraCommands()` /
+// `registerCaptureCommands()` (the neighbouring `command_suite_*.hpp` headers)
+// are loops over these tables via `IRCommand::registerBindings`, so "what does
+// the engine bind by default" is answerable without reading a suite body —
+// from C++ via `suiteDefaults(Suite)` and from Lua via
+// `IRCommand.suiteDefaults(IRCommand.Suite.CAMERA)`.
+//
+// This header is deliberately DATA-ONLY: it names `CommandNames` values but
+// never the `Command<NAME>::create()` bodies, so enumerating the defaults does
+// not drag the render / video / input command headers into scope. That is what
+// lets `engine/script` expose the suites on the Lua surface. The bodies are
+// resolved at registration time by `bindPrefabCommand`'s runtime dispatch.
+//
+// The complementary query — what IS bound right now, across every registration
+// including a creation's own — is `CommandManager::getCommandRegistrations()`.
+// That map is NOT a substitute for these tables: it is populated only after
+// registration and only for *named PRESSED* binds, so it cannot see the
+// RELEASED `MOVE_CAMERA_*_END` rows.
+
+#include <irreden/command/ir_command_types.hpp>
+#include <irreden/input/ir_input_types.hpp>
+
+#include <span>
+
+namespace IRCommand {
+
+/// Identifies an engine-shipped default-binding manifest. Crosses the Lua
+/// boundary as an integer (`IRCommand.Suite.CAMERA`) per
+/// `.claude/rules/cpp-lua-enums.md` — never as a string name.
+enum class Suite { CAMERA, CAPTURE };
+
+/// Camera control defaults: Escape closes, `=`/`-` zoom, WASD pans.
+///
+/// The WASD rows come in PRESSED/RELEASED pairs because camera movement is a
+/// start/stop pair of *distinct* commands (`MOVE_CAMERA_UP_START` /
+/// `MOVE_CAMERA_UP_END`), not one command with two statuses. An `omit_` of
+/// `MOVE_CAMERA_UP_START` therefore leaves the `_END` row bound; omit both to
+/// drop the axis. A `remap_` keys on the button, so it moves the pair together.
+inline constexpr DefaultBinding kCameraSuite[] = {
+    {CLOSE_WINDOW, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonEscape},
+    {ZOOM_IN, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonEqual},
+    {ZOOM_OUT, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonMinus},
+    {MOVE_CAMERA_UP_START, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonW},
+    {MOVE_CAMERA_DOWN_START, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonS},
+    {MOVE_CAMERA_LEFT_START, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonA},
+    {MOVE_CAMERA_RIGHT_START, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonD},
+    {MOVE_CAMERA_UP_END, IRInput::KEY_MOUSE, IRInput::RELEASED, IRInput::kKeyButtonW},
+    {MOVE_CAMERA_DOWN_END, IRInput::KEY_MOUSE, IRInput::RELEASED, IRInput::kKeyButtonS},
+    {MOVE_CAMERA_LEFT_END, IRInput::KEY_MOUSE, IRInput::RELEASED, IRInput::kKeyButtonA},
+    {MOVE_CAMERA_RIGHT_END, IRInput::KEY_MOUSE, IRInput::RELEASED, IRInput::kKeyButtonD},
+};
+
+/// Screen-capture defaults: F7 canvas-only shot, F8 full-screen shot, F9
+/// recording toggle.
+inline constexpr DefaultBinding kCaptureSuite[] = {
+    {SCREENSHOT, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonF8},
+    {SCREENSHOT_CANVAS, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonF7},
+    {RECORD_TOGGLE, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonF9},
+};
+
+/// The default-binding manifest @p suite would register, in registration order.
+/// Reports what the engine binds *by default*, independent of what any
+/// particular creation actually registered.
+inline std::span<const DefaultBinding> suiteDefaults(Suite suite) {
+    switch (suite) {
+    case Suite::CAMERA:
+        return kCameraSuite;
+    case Suite::CAPTURE:
+        return kCaptureSuite;
+    }
+    return {};
+}
+
+} // namespace IRCommand
+
+#endif /* COMMAND_SUITE_REGISTRY_H */

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -378,7 +378,7 @@ inputPipeline.splice(inputPipeline.end(), IRPrefab::SettingsMenu::inputSystems()
 renderPipeline.splice(renderPipeline.end(), IRPrefab::SettingsMenu::renderSystems());
 
 // initCommands() — Escape opens the menu, so the camera suite must not quit on it:
-IRPrefab::Camera::registerStandardKeyboardCommands(/*bindEscapeCloseWindow=*/false);
+IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 IRPrefab::SettingsMenu::registerToggleCommand();
 
 // after initEntities() — one call per togglable mode:
@@ -392,10 +392,12 @@ IRPrefab::Settings::registerBool("CHECKERBOARD", getter, setter);
   `CommandManager`'s registry, which the overlay renders; the menu links to it
   with a one-line `CONTROLS: <key>` read back out of that registry rather than
   re-rendering the list.
-- **Escape is the toggle**, which is why `registerCameraCommands` grew a
-  defaulted `bindEscapeCloseWindow` opt-out. The default is unchanged, so every
-  non-adopting demo still quits on Escape; an adopting demo passes `false` and
-  gets a QUIT button in the panel instead.
+- **Escape is the toggle**, so an adopting demo drops that one row from the
+  camera suite with `registerStandardKeyboardCommands({.omit_ =
+  {IRCommand::CLOSE_WINDOW}})` (#2666's declarative manifest — see
+  `engine/command/CLAUDE.md` §"Default-binding manifests"). The no-argument
+  form is unchanged, so every non-adopting demo still quits on Escape; an
+  adopting demo gets a QUIT button in the panel instead.
 - **Zero-cost closed.** The menu owns no entities until it opens, so the widget
   systems iterate empty archetypes and existing captures stay byte-identical.
   Measured on `shape_debug`: +0.022 ms/frame against an 8.92 ms frame.

--- a/engine/prefabs/irreden/render/camera_controls.hpp
+++ b/engine/prefabs/irreden/render/camera_controls.hpp
@@ -52,10 +52,16 @@ inline std::list<IRSystem::SystemId> standardControlSystems() {
 }
 
 // Pairs with standardControlSystems(); wraps IRCommand::registerCameraCommands.
-// Pass `bindEscapeCloseWindow = false` to keep Escape free for the creation —
-// see `registerCameraCommands` for the contract.
-inline void registerStandardKeyboardCommands(bool bindEscapeCloseWindow = true) {
-    IRCommand::registerCameraCommands(bindEscapeCloseWindow);
+// Takes the same registration-time overrides — a creation that owns Escape
+// itself passes `{.omit_ = {IRCommand::CLOSE_WINDOW}}` rather than dropping to
+// hand-registering the rest of the suite. That is how a `IRPrefab::SettingsMenu`
+// adopter keeps Escape free for the menu (#2551).
+inline void registerStandardKeyboardCommands(const IRCommand::BindingOverrides &overrides) {
+    IRCommand::registerCameraCommands(overrides);
+}
+
+inline void registerStandardKeyboardCommands() {
+    IRCommand::registerCameraCommands();
 }
 
 } // namespace IRPrefab::Camera

--- a/engine/prefabs/irreden/render/settings_menu.hpp
+++ b/engine/prefabs/irreden/render/settings_menu.hpp
@@ -16,7 +16,7 @@
 //
 //   // initCommands() — Escape opens the menu, so the camera suite must not
 //   // also bind it to quit; the menu's QUIT button replaces that path:
-//   IRPrefab::Camera::registerStandardKeyboardCommands(/*bindEscapeCloseWindow=*/false);
+//   IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
 //   IRPrefab::SettingsMenu::registerToggleCommand();
 //
 //   // initEntities() — one call per togglable mode:
@@ -53,8 +53,8 @@
 
 namespace IRPrefab::SettingsMenu {
 
-// Escape. Repurposing it is the reason `registerCameraCommands` grew an
-// opt-out: every demo historically quit on Escape, and a pause menu that
+// Escape. Repurposing it is why an adopting demo omits `CLOSE_WINDOW` from the
+// camera suite: every demo historically quit on Escape, and a pause menu that
 // opens on anything else is not the key people reach for. Quitting stays
 // reachable through the menu's QUIT button.
 inline constexpr int kDefaultToggleButton = IRInput::KeyMouseButtons::kKeyButtonEscape;

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -1458,6 +1458,27 @@ IRCommand.fireByName(CN.SCREENSHOT)
   ids log + return.
 - `IRCommand.fireByName(commandName)` — invoke a prefab command's
   body without registering it first.
+- `IRCommand.suiteDefaults(suite) -> {rows}` — what the engine binds
+  **by default** for `suite`, in registration order. Each row is
+  `{command, inputType, status, button, modifiers}`. Includes the
+  `RELEASED` `MOVE_CAMERA_*_END` rows, which the live registration map
+  never sees. An out-of-range suite logs and returns an empty table.
+- `IRCommand.registerSuite(suite, overrides?)` — register a suite with
+  registration-time `{omit = {CommandName, ...}, remap = {{from, to},
+  ...}}`. `omit` drops rows by command; `remap` moves every row using
+  `from` onto `to` (so one entry carries a pan key's PRESSED +
+  RELEASED pair), applied at most once per row. Sugar over the same
+  `IRCommand::registerBindings` primitive the C++ suites use — see
+  `engine/command/CLAUDE.md` §"Default-binding manifests (#2666)".
+
+```lua
+-- Full camera controls minus Escape, with pan moved to the numpad.
+IRCommand.registerSuite(IRCommand.Suite.CAMERA, {
+    omit  = {IRCommand.CommandName.CLOSE_WINDOW},
+    remap = {{IRInput.Key.W, IRInput.Key.KP_8},
+             {IRInput.Key.S, IRInput.Key.KP_2}},
+})
+```
 
 **Enum tables.** All integer tables; spell every value through them
 in Lua (never bare integer literals).
@@ -1472,13 +1493,21 @@ in Lua (never bare integer literals).
 - `IRInput.InputType.{KEY_MOUSE, GAMEPAD, MIDI_NOTE, MIDI_CC}`
 - `IRInput.ButtonStatus.{NOT_HELD, PRESSED, HELD, RELEASED,
   PRESSED_AND_RELEASED}`
+- `IRCommand.Suite.{CAMERA, CAPTURE}` — which engine-shipped
+  default-binding manifest `suiteDefaults` / `registerSuite` act on.
+  Mirrors `IRCommand::Suite` in
+  `engine/prefabs/irreden/common/command_suite_registry.hpp`.
 - `IRInput.Key.{A..Z, NUM_0..NUM_9, F1..F12, SPACE, ENTER, TAB,
   BACKSPACE, ESCAPE, INSERT, DELETE, HOME, END, PAGE_UP, PAGE_DOWN,
   UP, DOWN, LEFT, RIGHT, LEFT_SHIFT/CONTROL/ALT, RIGHT_SHIFT/CONTROL/
   ALT, MINUS, EQUAL, COMMA, PERIOD, SLASH, SEMICOLON, APOSTROPHE,
   LEFT_BRACKET, RIGHT_BRACKET, BACKSLASH, GRAVE, CAPS_LOCK,
+  KP_0..KP_9, KP_DECIMAL, KP_DIVIDE, KP_MULTIPLY, KP_SUBTRACT,
+  KP_ADD, KP_ENTER, KP_EQUAL,
   MOUSE_LEFT, MOUSE_RIGHT, MOUSE_MIDDLE}`. Drops the engine-internal
-  `kKeyButton` / `kMouseButton` prefixes for readability.
+  `kKeyButton` / `kMouseButton` prefixes for readability. The table is
+  a subset of `KeyMouseButtons` — `IRInput.KeyMouseButtons` (see
+  `engine/input/CLAUDE.md`) carries the full enum under its C++ names.
 - `IRInput.Modifier.{NONE, SHIFT, CONTROL, ALT}` — bitmask bits.
   Compose with LuaJIT `bit.bor(a, b, ...)`.
 - `IRInput.GamepadButton.{A, B, X, Y, LEFT_BUMPER, RIGHT_BUMPER,

--- a/engine/script/include/irreden/script/lua_command_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_command_bindings.hpp
@@ -18,6 +18,7 @@
 #define SOL_ALL_SAFETIES_ON 1
 #include <sol/sol.hpp>
 
+#include <irreden/common/command_suite_registry.hpp>
 #include <irreden/ir_command.hpp>
 #include <irreden/ir_input.hpp>
 #include <irreden/script/lua_script.hpp>
@@ -82,6 +83,77 @@ inline void bindCommandNameEnum(LuaScript &script) {
     IR_BIND_CMD(TOGGLE_SETTINGS_MENU);
 #undef IR_BIND_CMD
     lua["IRCommand"]["CommandName"] = t;
+
+    // `IRCommand.Suite.X` — which engine-shipped default-binding manifest to
+    // enumerate or register. An integer table, never a string suite name, per
+    // `.claude/rules/cpp-lua-enums.md`.
+    sol::table suite = lua.create_table();
+#define IR_BIND_SUITE(name) suite[#name] = static_cast<lua_Integer>(IRCommand::Suite::name)
+    IR_BIND_SUITE(CAMERA);
+    IR_BIND_SUITE(CAPTURE);
+#undef IR_BIND_SUITE
+    lua["IRCommand"]["Suite"] = suite;
+}
+
+// Validates a Lua-supplied `IRCommand.Suite` integer. Out-of-range values log
+// and report failure rather than throwing — same "log and keep the VM running"
+// contract as `bindPrefab` / `fireByName`.
+inline bool toSuite(lua_Integer value, IRCommand::Suite &out) {
+    switch (static_cast<IRCommand::Suite>(value)) {
+    case IRCommand::Suite::CAMERA:
+    case IRCommand::Suite::CAPTURE:
+        out = static_cast<IRCommand::Suite>(value);
+        return true;
+    }
+    IRE_LOG_ERROR(
+        "IRCommand suite binding: {} is not a valid IRCommand.Suite value",
+        static_cast<int>(value)
+    );
+    return false;
+}
+
+// Reads a Lua `{omit = {CommandName, ...}, remap = {{from, to}, ...}}` table
+// into a `BindingOverrides`. A missing or nil table yields the zero-override
+// default; malformed rows are logged and skipped.
+inline IRCommand::BindingOverrides toBindingOverrides(const sol::optional<sol::table> &table) {
+    IRCommand::BindingOverrides overrides;
+    if (!table) {
+        return overrides;
+    }
+    if (sol::optional<sol::table> omit = (*table)["omit"]) {
+        for (const auto &[key, value] : *omit) {
+            if (!value.is<lua_Integer>()) {
+                IRE_LOG_ERROR(
+                    "IRCommand.registerSuite: omit entries must be IRCommand.CommandName "
+                    "integers"
+                );
+                continue;
+            }
+            overrides.omit_.push_back(
+                static_cast<IRCommand::CommandNames>(value.as<lua_Integer>())
+            );
+        }
+    }
+    if (sol::optional<sol::table> remap = (*table)["remap"]) {
+        constexpr const char *kRemapShapeError =
+            "IRCommand.registerSuite: remap entries must be {from, to} pairs of IRInput.Key "
+            "integers";
+        for (const auto &[key, value] : *remap) {
+            sol::optional<sol::table> pair = value.as<sol::optional<sol::table>>();
+            if (!pair) {
+                IRE_LOG_ERROR("{}", kRemapShapeError);
+                continue;
+            }
+            sol::optional<lua_Integer> from = (*pair)[1];
+            sol::optional<lua_Integer> to = (*pair)[2];
+            if (!from || !to) {
+                IRE_LOG_ERROR("{}", kRemapShapeError);
+                continue;
+            }
+            overrides.remap_.emplace_back(static_cast<int>(*from), static_cast<int>(*to));
+        }
+    }
+    return overrides;
 }
 
 // Populate `IRInput.{InputType, ButtonStatus, Key, Modifier,
@@ -222,6 +294,25 @@ inline void bindInputEnums(LuaScript &script) {
     IR_BIND_KEY(RIGHT_BRACKET, kKeyButtonRightBracket);
     IR_BIND_KEY(BACKSLASH, kKeyButtonBackslash);
     IR_BIND_KEY(GRAVE, kKeyButtonGraveAccent);
+    // Keypad — nameable so a Lua-authored `IRCommand.registerSuite` remap can
+    // target the numpad.
+    IR_BIND_KEY(KP_0, kKeyButtonKP0);
+    IR_BIND_KEY(KP_1, kKeyButtonKP1);
+    IR_BIND_KEY(KP_2, kKeyButtonKP2);
+    IR_BIND_KEY(KP_3, kKeyButtonKP3);
+    IR_BIND_KEY(KP_4, kKeyButtonKP4);
+    IR_BIND_KEY(KP_5, kKeyButtonKP5);
+    IR_BIND_KEY(KP_6, kKeyButtonKP6);
+    IR_BIND_KEY(KP_7, kKeyButtonKP7);
+    IR_BIND_KEY(KP_8, kKeyButtonKP8);
+    IR_BIND_KEY(KP_9, kKeyButtonKP9);
+    IR_BIND_KEY(KP_DECIMAL, kKeyButtonKPDecimal);
+    IR_BIND_KEY(KP_DIVIDE, kKeyButtonKPDivide);
+    IR_BIND_KEY(KP_MULTIPLY, kKeyButtonKPMultiply);
+    IR_BIND_KEY(KP_SUBTRACT, kKeyButtonKPSubtract);
+    IR_BIND_KEY(KP_ADD, kKeyButtonKPAdd);
+    IR_BIND_KEY(KP_ENTER, kKeyButtonKPEnter);
+    IR_BIND_KEY(KP_EQUAL, kKeyButtonKPEqual);
     // Mouse
     IR_BIND_KEY(MOUSE_LEFT, kMouseButtonLeft);
     IR_BIND_KEY(MOUSE_RIGHT, kMouseButtonRight);
@@ -342,6 +433,43 @@ inline void bindCommandFunctions(LuaScript &script) {
             description.value_or(std::string{})
         );
         return static_cast<lua_Integer>(id);
+    };
+
+    // What the engine binds BY DEFAULT for a suite — not what is bound right
+    // now. Returns an array of `{command, inputType, status, button,
+    // modifiers}` rows in registration order, including the RELEASED
+    // `MOVE_CAMERA_*_END` rows that the live registration map never sees.
+    lua["IRCommand"]["suiteDefaults"] = [](sol::this_state L,
+                                           lua_Integer suiteValue) -> sol::table {
+        sol::state_view lua_view(L);
+        sol::table rows = lua_view.create_table();
+        IRCommand::Suite suite{};
+        if (!toSuite(suiteValue, suite)) {
+            return rows;
+        }
+        for (const IRCommand::DefaultBinding &binding : IRCommand::suiteDefaults(suite)) {
+            sol::table row = lua_view.create_table();
+            row["command"] = static_cast<lua_Integer>(binding.command_);
+            row["inputType"] = static_cast<lua_Integer>(binding.inputType_);
+            row["status"] = static_cast<lua_Integer>(binding.status_);
+            row["button"] = static_cast<lua_Integer>(binding.button_);
+            row["modifiers"] = static_cast<lua_Integer>(binding.requiredModifiers_);
+            rows.add(row);
+        }
+        return rows;
+    };
+
+    // Sugar over the same `registerBindings` primitive the C++ suites use, so
+    // a Lua-driven creation gets omit / remap without re-declaring the suite:
+    //   IRCommand.registerSuite(IRCommand.Suite.CAMERA,
+    //                           {omit = {IRCommand.CommandName.CLOSE_WINDOW}})
+    lua["IRCommand"]["registerSuite"] = [](lua_Integer suiteValue,
+                                           sol::optional<sol::table> overrides) {
+        IRCommand::Suite suite{};
+        if (!toSuite(suiteValue, suite)) {
+            return;
+        }
+        IRCommand::registerBindings(IRCommand::suiteDefaults(suite), toBindingOverrides(overrides));
     };
 
     lua["IRCommand"]["fire"] = [](lua_Integer commandId) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(IrredenEngineTest
   audio/audio_playback_test.cpp
   audio/midi_multiport_test.cpp
   audio/music_theory_test.cpp
+  command/default_binding_manifest_test.cpp
   common/command_registry_test.cpp
   common/ir_args_test.cpp
   common/ir_platform_test.cpp

--- a/test/command/default_binding_manifest_test.cpp
+++ b/test/command/default_binding_manifest_test.cpp
@@ -80,15 +80,17 @@ TEST_F(DefaultBindingManifestTest, CameraSuiteZeroArgMatchesPreManifestRegistrat
 TEST_F(DefaultBindingManifestTest, CaptureSuiteZeroArgMatchesPreManifestRegistrations) {
     IRCommand::registerCaptureCommands();
 
-    // SCREENSHOT_CANVAS renders as "UNKNOWN" because it has no
-    // `commandNameToString` case — asserted deliberately rather than
-    // papered over, so the overlay text stays pinned until someone fixes
-    // the label on purpose.
+    // Pinning the exact rendered sequence, same as the camera suite above.
+    // SCREENSHOT_CANVAS used to render as "UNKNOWN" here — it had no
+    // `commandNameToString` case, and this test asserted that deliberately
+    // rather than papering over it. #2550 replaced that hand-listed switch
+    // with the `kCommandInfo` catalog, which gives every enum value a real
+    // label by static_assert, so the label is now the fixed one.
     EXPECT_EQ(
         pressedRegistrations(),
         (std::vector<std::string>{
             "F8: SCREENSHOT",
-            "F7: UNKNOWN",
+            "F7: SCREENSHOT CANVAS",
             "F9: RECORD TOGGLE",
         })
     );

--- a/test/command/default_binding_manifest_test.cpp
+++ b/test/command/default_binding_manifest_test.cpp
@@ -1,0 +1,266 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_command.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <irreden/common/command_suite_camera.hpp>
+#include <irreden/common/command_suite_capture.hpp>
+#include <irreden/common/command_suite_registry.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace {
+
+using IRCommand::BindingOverrides;
+using IRCommand::DefaultBinding;
+using IRCommand::Suite;
+
+// CommandManager stamps g_commandManager in its ctor; EntityManager is needed
+// by any prefab command body that touches ECS state. Nothing here fires a
+// command, so no render/video manager is required.
+class DefaultBindingManifestTest : public testing::Test {
+  protected:
+    // "NAME: KEY" for every PRESSED registration, in registration order — the
+    // same projection `buildCommandListText()` renders into the debug help
+    // overlay, so an unchanged vector here IS unchanged overlay text.
+    std::vector<std::string> pressedRegistrations() const {
+        std::vector<std::string> rows;
+        for (const auto &reg : IRCommand::getCommandManager().getCommandRegistrations()) {
+            rows.push_back(
+                IRCommand::modifierString(reg.requiredModifiers) +
+                IRCommand::keyButtonToString(reg.button) + ": " + reg.name
+            );
+        }
+        return rows;
+    }
+
+    // Total rows registered since the fixture was built, INCLUDING the
+    // RELEASED `MOVE_CAMERA_*_END` rows that never reach the registration map.
+    // `createCommand` returns `m_userCommands.size() - 1`, so a probe binding's
+    // id is exactly the number of rows registered before it.
+    int totalRowsRegistered() const {
+        return static_cast<int>(IRCommand::createCommand(
+            IRInput::KEY_MOUSE,
+            IRInput::PRESSED,
+            IRInput::kKeyButtonF24,
+            []() {}
+        ));
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRCommand::CommandManager m_command_manager;
+};
+
+// ---- Zero-arg suites are unchanged ----------------------------------------
+
+TEST_F(DefaultBindingManifestTest, CameraSuiteZeroArgMatchesPreManifestRegistrations) {
+    IRCommand::registerCameraCommands();
+
+    // The engine's default camera keys, spelled out. Pinning the exact
+    // sequence is the point: the manifest and the help overlay it feeds are
+    // user-visible surface, so a reordering or dropped row must fail here.
+    EXPECT_EQ(
+        pressedRegistrations(),
+        (std::vector<std::string>{
+            "ESC: CLOSE WINDOW",
+            "=: ZOOM IN",
+            "-: ZOOM OUT",
+            "W: CAMERA UP",
+            "S: CAMERA DOWN",
+            "A: CAMERA LEFT",
+            "D: CAMERA RIGHT",
+        })
+    );
+    // 11 total: the 7 above plus the 4 RELEASED MOVE_CAMERA_*_END rows.
+    EXPECT_EQ(totalRowsRegistered(), 11);
+}
+
+TEST_F(DefaultBindingManifestTest, CaptureSuiteZeroArgMatchesPreManifestRegistrations) {
+    IRCommand::registerCaptureCommands();
+
+    // SCREENSHOT_CANVAS renders as "UNKNOWN" because it has no
+    // `commandNameToString` case — asserted deliberately rather than
+    // papered over, so the overlay text stays pinned until someone fixes
+    // the label on purpose.
+    EXPECT_EQ(
+        pressedRegistrations(),
+        (std::vector<std::string>{
+            "F8: SCREENSHOT",
+            "F7: UNKNOWN",
+            "F9: RECORD TOGGLE",
+        })
+    );
+    EXPECT_EQ(totalRowsRegistered(), 3);
+}
+
+// ---- Enumeration ----------------------------------------------------------
+
+TEST_F(DefaultBindingManifestTest, SuiteDefaultsReportsEveryRowIncludingReleased) {
+    const auto camera = IRCommand::suiteDefaults(Suite::CAMERA);
+    ASSERT_EQ(camera.size(), 11u);
+
+    int releasedRows = 0;
+    for (const DefaultBinding &binding : camera) {
+        if (binding.status_ == IRInput::RELEASED) {
+            ++releasedRows;
+        }
+    }
+    // The four MOVE_CAMERA_*_END rows — invisible to getCommandRegistrations(),
+    // which is why the manifest and not the registration map is the source of
+    // truth for enumeration.
+    EXPECT_EQ(releasedRows, 4);
+
+    EXPECT_EQ(IRCommand::suiteDefaults(Suite::CAPTURE).size(), 3u);
+}
+
+TEST_F(DefaultBindingManifestTest, CameraPanPairsShareOneButtonPerAxis) {
+    // The property that makes a single remap entry carry a pan axis's PRESSED
+    // and RELEASED rows together (see the remap test below).
+    for (const int button :
+         {IRInput::kKeyButtonW, IRInput::kKeyButtonA, IRInput::kKeyButtonS, IRInput::kKeyButtonD}) {
+        int rowsOnButton = 0;
+        for (const DefaultBinding &binding : IRCommand::suiteDefaults(Suite::CAMERA)) {
+            if (binding.button_ == button) {
+                ++rowsOnButton;
+            }
+        }
+        EXPECT_EQ(rowsOnButton, 2) << "button " << IRCommand::keyButtonToString(button);
+    }
+}
+
+// ---- Omit -----------------------------------------------------------------
+
+TEST_F(DefaultBindingManifestTest, OmitDropsOnlyTheNamedCommand) {
+    IRCommand::registerCameraCommands({.omit_ = {IRCommand::CLOSE_WINDOW}});
+
+    // Escape is gone; everything else binds, in the same order — the
+    // voxel_editor migration's exact shape.
+    EXPECT_EQ(
+        pressedRegistrations(),
+        (std::vector<std::string>{
+            "=: ZOOM IN",
+            "-: ZOOM OUT",
+            "W: CAMERA UP",
+            "S: CAMERA DOWN",
+            "A: CAMERA LEFT",
+            "D: CAMERA RIGHT",
+        })
+    );
+    EXPECT_EQ(totalRowsRegistered(), 10);
+}
+
+TEST_F(DefaultBindingManifestTest, OmitOfAPressedHalfLeavesTheReleasedRowBound) {
+    // The pan pair is two DISTINCT commands, so omitting the START half does
+    // not take the END half with it. Documented in BindingOverrides; asserted
+    // here so the semantics can't drift silently.
+    IRCommand::registerCameraCommands({.omit_ = {IRCommand::MOVE_CAMERA_UP_START}});
+
+    const auto rows = pressedRegistrations();
+    EXPECT_EQ(std::ranges::count(rows, std::string{"W: CAMERA UP"}), 0);
+    EXPECT_EQ(totalRowsRegistered(), 10);
+}
+
+// ---- Remap ----------------------------------------------------------------
+
+TEST_F(DefaultBindingManifestTest, RemapMovesWasdOntoArrowsAndLeavesNoWasdRows) {
+    IRCommand::registerCameraCommands(
+        {.remap_ = {
+             {IRInput::kKeyButtonW, IRInput::kKeyButtonUp},
+             {IRInput::kKeyButtonA, IRInput::kKeyButtonLeft},
+             {IRInput::kKeyButtonS, IRInput::kKeyButtonDown},
+             {IRInput::kKeyButtonD, IRInput::kKeyButtonRight},
+         }}
+    );
+
+    EXPECT_EQ(
+        pressedRegistrations(),
+        (std::vector<std::string>{
+            "ESC: CLOSE WINDOW",
+            "=: ZOOM IN",
+            "-: ZOOM OUT",
+            "UP: CAMERA UP",
+            "DOWN: CAMERA DOWN",
+            "LEFT: CAMERA LEFT",
+            "RIGHT: CAMERA RIGHT",
+        })
+    );
+    // Row count is unchanged — a remap moves rows, it never drops them.
+    EXPECT_EQ(totalRowsRegistered(), 11);
+}
+
+TEST_F(DefaultBindingManifestTest, RemapMovesEveryRowSharingTheButton) {
+    // Why one `{W, UP}` entry carries both the PRESSED and RELEASED pan rows:
+    // remap matches on the button, so every row using it moves. Spelled with
+    // two PRESSED rows here so both are observable in the registration map.
+    static constexpr DefaultBinding kTwoOnOneButton[] = {
+        {IRCommand::ZOOM_IN, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonW},
+        {IRCommand::ZOOM_OUT, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonW},
+    };
+    IRCommand::registerBindings(
+        kTwoOnOneButton,
+        {.remap_ = {{IRInput::kKeyButtonW, IRInput::kKeyButtonUp}}}
+    );
+
+    EXPECT_EQ(pressedRegistrations(), (std::vector<std::string>{"UP: ZOOM IN", "UP: ZOOM OUT"}));
+}
+
+TEST_F(DefaultBindingManifestTest, RemapDoesNotChain) {
+    // First matching pair wins per row, so {W->A, A->UP} leaves W on A rather
+    // than carrying it through to UP.
+    static constexpr DefaultBinding kOneRow[] = {
+        {IRCommand::ZOOM_IN, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonW},
+    };
+    IRCommand::registerBindings(
+        kOneRow,
+        {.remap_ = {
+             {IRInput::kKeyButtonW, IRInput::kKeyButtonA},
+             {IRInput::kKeyButtonA, IRInput::kKeyButtonUp},
+         }}
+    );
+
+    EXPECT_EQ(pressedRegistrations(), (std::vector<std::string>{"A: ZOOM IN"}));
+}
+
+// ---- Generality: the mechanism is not suite-specific -----------------------
+
+TEST_F(DefaultBindingManifestTest, CallerAuthoredManifestHonorsOmitAndRemap) {
+    // A creation's own table, not one of the two engine suites, through the
+    // same primitive with the same override semantics.
+    static constexpr DefaultBinding kCreationBindings[] = {
+        {IRCommand::TOGGLE_GUI, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonG},
+        {IRCommand::GUI_ZOOM_IN, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonEqual},
+        {IRCommand::GUI_ZOOM_OUT, IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonMinus},
+    };
+    IRCommand::registerBindings(
+        kCreationBindings,
+        {.omit_ = {IRCommand::GUI_ZOOM_OUT},
+         .remap_ = {{IRInput::kKeyButtonG, IRInput::kKeyButtonF1}}}
+    );
+
+    EXPECT_EQ(
+        pressedRegistrations(),
+        (std::vector<std::string>{"F1: TOGGLE GUI", "=: GUI ZOOM IN"})
+    );
+}
+
+TEST_F(DefaultBindingManifestTest, RequiredModifiersSurviveRegistration) {
+    static constexpr DefaultBinding kModifierBinding[] = {
+        {IRCommand::TOGGLE_GUI,
+         IRInput::KEY_MOUSE,
+         IRInput::PRESSED,
+         IRInput::kKeyButtonG,
+         IRInput::kModifierShift | IRInput::kModifierControl},
+    };
+    IRCommand::registerBindings(kModifierBinding);
+
+    EXPECT_EQ(pressedRegistrations(), (std::vector<std::string>{"SHIFT+CTRL+G: TOGGLE GUI"}));
+}
+
+TEST_F(DefaultBindingManifestTest, EmptyOverridesRegisterTheWholeManifest) {
+    IRCommand::registerBindings(IRCommand::suiteDefaults(Suite::CAPTURE), {});
+    EXPECT_EQ(totalRowsRegistered(), 3);
+}
+
+} // namespace

--- a/test/script/lua_command_test.cpp
+++ b/test/script/lua_command_test.cpp
@@ -289,6 +289,140 @@ TEST_F(LuaCommandTest, BindPrefabAcceptsBitOrModifierMask) {
     );
 }
 
+// ---- IRCommand.Suite / suiteDefaults / registerSuite ----------------------
+
+TEST_F(LuaCommandTest, SuiteEnumIsAnIntegerTable) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        return type(IRCommand.Suite.CAMERA) == 'number'
+           and type(IRCommand.Suite.CAPTURE) == 'number'
+           and IRCommand.Suite.CAMERA ~= IRCommand.Suite.CAPTURE
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_TRUE(result.get<bool>());
+}
+
+TEST_F(LuaCommandTest, SuiteDefaultsRowsMatchTheCppManifest) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        local rows = IRCommand.suiteDefaults(IRCommand.Suite.CAMERA)
+        local released = 0
+        for _, row in ipairs(rows) do
+            if row.status == IRInput.ButtonStatus.RELEASED then released = released + 1 end
+        end
+        return #rows, released,
+               rows[1].command, rows[1].button, rows[1].inputType, rows[1].modifiers
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_EQ(result.get<int>(0), 11);
+    EXPECT_EQ(result.get<int>(1), 4);
+    EXPECT_EQ(result.get<int>(2), static_cast<int>(IRCommand::CLOSE_WINDOW));
+    EXPECT_EQ(result.get<int>(3), static_cast<int>(IRInput::kKeyButtonEscape));
+    EXPECT_EQ(result.get<int>(4), static_cast<int>(IRInput::KEY_MOUSE));
+    EXPECT_EQ(result.get<int>(5), static_cast<int>(IRInput::kModifierNone));
+}
+
+TEST_F(LuaCommandTest, SuiteDefaultsCaptureHasThreeRows) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "return #IRCommand.suiteDefaults(IRCommand.Suite.CAPTURE)",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_EQ(result.get<int>(), 3);
+}
+
+TEST_F(LuaCommandTest, SuiteDefaultsRejectsAnOutOfRangeSuite) {
+    // Logs and returns an empty table rather than throwing — same contract as
+    // bindPrefab on an unimplemented command name.
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script("return #IRCommand.suiteDefaults(99)", sol::script_pass_on_error);
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_EQ(result.get<int>(), 0);
+}
+
+TEST_F(LuaCommandTest, RegisterSuiteHonorsOmit) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRCommand.registerSuite(IRCommand.Suite.CAMERA,
+                                {omit = {IRCommand.CommandName.CLOSE_WINDOW}})
+        return true
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+
+    const auto &regs = IRCommand::getCommandManager().getCommandRegistrations();
+    ASSERT_EQ(regs.size(), 6u); // 7 PRESSED camera rows minus CLOSE_WINDOW
+    for (const auto &reg : regs) {
+        EXPECT_NE(reg.button, IRInput::kKeyButtonEscape);
+    }
+}
+
+TEST_F(LuaCommandTest, RegisterSuiteHonorsRemapOntoKeypad) {
+    // Also covers the keypad additions to IRInput.Key — the remap target is
+    // only nameable from Lua because those entries now exist.
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRCommand.registerSuite(IRCommand.Suite.CAMERA, {
+            omit = {IRCommand.CommandName.CLOSE_WINDOW,
+                    IRCommand.CommandName.ZOOM_IN,
+                    IRCommand.CommandName.ZOOM_OUT},
+            remap = {{IRInput.Key.W, IRInput.Key.KP_8},
+                     {IRInput.Key.S, IRInput.Key.KP_2},
+                     {IRInput.Key.A, IRInput.Key.KP_4},
+                     {IRInput.Key.D, IRInput.Key.KP_6}},
+        })
+        return true
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+
+    const auto &regs = IRCommand::getCommandManager().getCommandRegistrations();
+    ASSERT_EQ(regs.size(), 4u);
+    EXPECT_EQ(regs[0].button, IRInput::kKeyButtonKP8);
+    EXPECT_EQ(regs[1].button, IRInput::kKeyButtonKP2);
+    EXPECT_EQ(regs[2].button, IRInput::kKeyButtonKP4);
+    EXPECT_EQ(regs[3].button, IRInput::kKeyButtonKP6);
+}
+
+TEST_F(LuaCommandTest, RegisterSuiteWithNoOverridesBindsTheWholeSuite) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "IRCommand.registerSuite(IRCommand.Suite.CAPTURE); return true",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_EQ(IRCommand::getCommandManager().getCommandRegistrations().size(), 3u);
+}
+
+TEST_F(LuaCommandTest, KeypadKeysAreNameable) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        return IRInput.Key.KP_0, IRInput.Key.KP_9, IRInput.Key.KP_ADD,
+               IRInput.Key.KP_ENTER, IRInput.Key.KP_DECIMAL, IRInput.Key.KP_EQUAL
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_EQ(result.get<int>(0), static_cast<int>(IRInput::kKeyButtonKP0));
+    EXPECT_EQ(result.get<int>(1), static_cast<int>(IRInput::kKeyButtonKP9));
+    EXPECT_EQ(result.get<int>(2), static_cast<int>(IRInput::kKeyButtonKPAdd));
+    EXPECT_EQ(result.get<int>(3), static_cast<int>(IRInput::kKeyButtonKPEnter));
+    EXPECT_EQ(result.get<int>(4), static_cast<int>(IRInput::kKeyButtonKPDecimal));
+    EXPECT_EQ(result.get<int>(5), static_cast<int>(IRInput::kKeyButtonKPEqual));
+}
+
 // ---- Idempotence ----------------------------------------------------------
 
 TEST_F(LuaCommandTest, BindLuaCommandsIsIdempotent) {


### PR DESCRIPTION
## Summary
- Engine default keys become **data**: `constexpr DefaultBinding kCameraSuite[]` (11 rows) / `kCaptureSuite[]` (3 rows) in a new `engine/prefabs/irreden/common/command_suite_registry.hpp`. `registerCameraCommands()` / `registerCaptureCommands()` are now loops over them.
- One generic primitive, not a suite-specific one: `IRCommand::registerBindings(std::span<const DefaultBinding>, const BindingOverrides &)` — `omit_` filters by command, `remap_` substitutes buttons, then each surviving row goes through the existing `bindPrefabCommand` runtime dispatch. A creation's own binding table gets the same machinery.
- Enumeration: `IRCommand::suiteDefaults(Suite)` in C++; `IRCommand.{Suite, suiteDefaults, registerSuite}` in Lua, plus the missing keypad entries in the short `IRInput.Key` table so numpad remap targets are nameable from Lua.
- `voxel_editor`'s hand-rolled camera-suite copy (50 lines) collapses to one `IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ = {IRCommand::CLOSE_WINDOW}})` call (the prefab wrapper over `registerCameraCommands`).
- Docs: `engine/command/CLAUDE.md` §"Default-binding manifests", the `engine/prefabs/irreden/common` Commands bullet, and the `engine/script` Lua API section.

## Test plan

Re-measured on the **current** base (rebased onto `34c7f7f46`, macOS/Metal):

- [x] `fleet-build --target IRShapeDebug` — clean. `fleet-build --target IRVoxelEditor` — clean (the two creations that consume the migrated registration forms).
- [x] `IrredenEngineTest` — **1493/1494 pass**, including all 12 `DefaultBindingManifestTest` and 8 `LuaCommandTest` cases. The single failure is `SaveTrait.InventoryIsComplete`, which is **[#2834](https://github.com/jakildev/IrredenEngine/issues/2834) — already red on `origin/master`, not introduced here.** Proof it is inherited: `engine/world/include/irreden/world/save_component_inventory.hpp` and `test/world/save_trait_test.cpp` are both **byte-identical to `origin/master`** on this branch (`git diff origin/master HEAD --` on each is empty), and master's own `AllEngineComponents` already carries 169 entries against the pinned `kExpectedEngineComponentCount = 167`. This PR touches no file under `engine/world/` or `test/world/`.
- [x] `python3 scripts/gui-verify.py IRShapeDebug -- --gui-test` — **30/30 assertions pass**, `RESULT=CLEAN exit=0`. This is the behavioural proof that the Escape migration below preserved #2624's semantics.

Measured on the pre-`#2624` base and unchanged by this rebase (the diff to those paths did not move):

- [x] `fleet-build` — all targets (every demo + both editors) clean on macOS/Metal.
- [x] `fleet-run IRVoxelEditor --auto-screenshot` → `RESULT=CLEAN exit=0` on the migrated omit form.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Zero-arg suites byte-identical (same registrations + overlay text) | `IrredenEngineTest --gtest_filter='DefaultBindingManifestTest.*ZeroArg*'` | `OK CameraSuiteZeroArgMatchesPreManifestRegistrations`, `OK CaptureSuiteZeroArgMatchesPreManifestRegistrations` — both assert the exact `NAME: KEY` sequence (the `buildCommandListText()` projection) transcribed from the pre-change suite bodies, plus total row count 11 / 3 |
| `suiteDefaults(CAMERA)` = 11 rows incl. RELEASED `*_END`; `CAPTURE` = 3 | same target, `SuiteDefaultsReportsEveryRowIncludingReleased` | `OK` — asserts `size()==11`, exactly 4 `RELEASED` rows, and `CAPTURE` size 3 |
| Omit: `omit = {CLOSE_WINDOW}` → Escape unbound, rest bound | `OmitDropsOnlyTheNamedCommand` | `OK` — 6 PRESSED rows, Escape absent, 10 total rows |
| Remap: WASD→arrows moves both statuses per key; no WASD rows remain | `RemapMovesWasdOntoArrowsAndLeavesNoWasdRows` + `RemapMovesEveryRowSharingTheButton` | `OK`/`OK` — arrows in the PRESSED list, row count still 11 (nothing dropped); the second test proves a single remap entry moves *every* row on that button, which is what carries the RELEASED half |
| Lua: rows match C++, `registerSuite` honors omit/remap, keypad nameable | `IrredenEngineTest --gtest_filter='LuaCommandTest.Suite*:LuaCommandTest.Register*:LuaCommandTest.Keypad*'` | 8× `OK` — `SuiteDefaultsRowsMatchTheCppManifest` (11 rows / 4 RELEASED / row-0 fields), `RegisterSuiteHonorsOmit`, `RegisterSuiteHonorsRemapOntoKeypad`, `KeypadKeysAreNameable` |
| Generality: caller-authored table, same omit/remap semantics | `CallerAuthoredManifestHonorsOmitAndRemap` | `OK` — a 3-row non-suite table registers through `registerBindings` with both overrides applied |
| `voxel_editor` builds and behaves unchanged on the omit form | `fleet-build --target IRVoxelEditor`; `fleet-run IRVoxelEditor --auto-screenshot` | build clean; `RESULT=CLEAN exe=IRVoxelEditor exit=0`. Behavioural equivalence is pinned by `OmitDropsOnlyTheNamedCommand`, which asserts the omit form produces exactly the registration list the deleted hand-rolled block produced. **No interactive editor session was driven** — that part is build + headless boot + unit-level equivalence, not a human-in-the-loop check. |

## Rebase / semantic-conflict resolution

Rebased onto master after #2550 (registry-driven help overlay) landed on the
same files. The merger flagged four conflicted files; **all four were
additive-vs-additive** and both sides are preserved in full:

| File | Master (#2550) | This PR (#2666) |
|---|---|---|
| `command/ir_command_types.hpp` | `kCommandNameCount` | `DefaultBinding` / `BindingOverrides` |
| `ir_command.hpp` | `CommandInfo` + `kCommandInfo` catalog + its two `static_assert`s, `<iterator>` | `registerBindings` decl, `<span>` |
| `test/CMakeLists.txt` | `common/command_registry_test.cpp` | `command/default_binding_manifest_test.cpp` |
| `engine/command/CLAUDE.md` | overlay gotchas (NAMED `PRESSED`, `buildCommandListText()` legacy) | manifest gotcha (`bindPrefabCommand` case first) |

For the CLAUDE.md overlay bullet the two sides described the *same* fact at
different accuracy — master's ("only **NAMED** `PRESSED`") supersedes this
PR's ("only `PRESSED`"), so master's is kept and this PR's unique manifest
bullet is appended.

**One genuine collision, in `default_binding_manifest_test.cpp`** (its own
commit, `af2f31b`): the capture-suite test pinned `"F7: UNKNOWN"`. That
literal was correct when written and is wrong after #2550. Keeping it would
have put this file in **direct contradiction** with master's own
`test/common/command_registry_test.cpp:148`, which asserts that *no* enum
value falls back to `"UNKNOWN"`. Updated to `"F7: SCREENSHOT CANVAS"`; the
test's intent — manifest registration reproduces the pre-manifest sequence,
exactly and in order — is unchanged, and the byte-identical-overlay
acceptance criterion still holds against *current* master (both the manifest
and the hand-written path draw the label from the same catalog).

Re-verified on that base on macOS/Metal: `IrredenEngineTest` **1494/1494**,
`fleet-build --target IRShapeDebug` clean.

### Second round — rebased onto `34c7f7f46` after #2624 (settings menu) landed

The merger flagged two conflicted files, both the *same* collision seen from
two sides: master's #2624 gave `registerCameraCommands` a defaulted
`bindEscapeCloseWindow` boolean so `IRPrefab::SettingsMenu` could take Escape,
while this PR replaced that function body with the declarative manifest.

**Both intents are preserved, because master's boolean is a strict special case
of this PR's `omit_` set.** `bindEscapeCloseWindow = false` *is*
`{.omit_ = {CLOSE_WINDOW}}` — same one row dropped, every other binding
untouched. So the manifest is kept as the single mechanism and master's caller
is migrated onto it rather than a second parallel opt-out being carried:

| File | Master (#2624) | Resolution |
|---|---|---|
| `common/command_suite_camera.hpp` | `bool bindEscapeCloseWindow = true` guarding the `CLOSE_WINDOW` row | manifest kept; the #2551 rationale master's doc comment carried is folded into the `overrides` doc |
| `render/camera_controls.hpp` | same boolean, forwarded | `BindingOverrides` + zero-arg overloads kept; comment names the settings-menu case |
| `demos/shape_debug/main.cpp` | `registerStandardKeyboardCommands(/*bindEscapeCloseWindow=*/false)` | migrated to `({.omit_ = {IRCommand::CLOSE_WINDOW}})` |
| `render/settings_menu.hpp`, `render/CLAUDE.md` | doc/comment references to the boolean | updated to the omit form |

The boolean could not be silently mis-resolved: `BindingOverrides` is an
aggregate of two vectors with no converting constructor, so a leftover
`(false)` call site is a hard compile error, not a quiet behaviour change.

**Behavioural evidence, not just a green build.** #2624 shipped a `--gui-test`
shot table that drives Escape through the real input path. It passes 30/30 on
the resolved branch, and the table is **self-controlling** for exactly this
migration: if `CLOSE_WINDOW` were still bound to Escape, shot 2 would have
closed the window and shots 3–14 could not have run. They all ran —
`settings_menu_open` (5 rows spawned), both ENUM dropdowns, `settings_menu_closed`,
`settings_menu_reopened`, and `settings_menu_quit` (`close-requested`).

Two follow-on doc commits. The first (`bd31a7bd4`) asserted that
`voxel_editor` calls `IRCommand::registerCameraCommands` directly and
re-pointed both CLAUDE.md files' bare-form examples at it. **That assertion was
false** and the fleet review caught it: `voxel_editor/main.cpp:2535` calls
`IRPrefab::Camera::registerStandardKeyboardCommands({.omit_ =
{IRCommand::CLOSE_WINDOW}})` — the wrapper, the same form `shape_debug` uses.
The second commit (`9e090ccd7`) corrects both docs. Grepping both spellings
across `creations/`, `engine/` and `test/`: no creation calls the bare form
(all 25 creation call sites use the wrapper), `voxel_editor:2535` and
`shape_debug:1855` pass exactly the `{.omit_ = {CLOSE_WINDOW}}` overrides the
docs show, and outside `camera_controls.hpp`'s forwarding body the bare form's
only callers are `test/command/default_binding_manifest_test.cpp`. Both docs
now name the wrapper as the in-tree spelling with those two creations as its
examples, and say where the bare primitive is actually called.

## Notes for reviewer
- **Two deviations from the plan, both deliberate.** (1) The plan put the `constexpr` tables in each `command_suite_*.hpp`; they live in a separate data-only `command_suite_registry.hpp` instead, because those suite headers pull the `Command<NAME>` bodies (and through them `ir_video.hpp` / `ir_render.hpp`) — `engine/script` must not inherit that to expose `suiteDefaults` on the Lua surface. The suite headers keep their body includes, so no existing consumer loses a transitive include. (2) `DefaultBinding` / `BindingOverrides` members carry the trailing `_` the naming table and clang-tidy require, so the spellings are `.omit_` / `.remap_`, not the plan's bare `omit` / `remap`. The Lua row keys stay as specified (`command`, `inputType`, `status`, `button`, `modifiers`).
- **No screenshots.** Three paths in the diff now fall under the visual glob, none of them a render change: `render/camera_controls.hpp` (one added inline overload plus a comment; the zero-arg path is untouched), `render/settings_menu.hpp` (comment text only), and `demos/shape_debug/main.cpp` (a command-registration call plus a comment — the second-round rebase widened the diff to this file, which the pre-rebase version of this note predated). Nothing touches a shader, a pipeline stage, or an entity's visual state, so this remains the "mechanical refactor" skip in AUTHOR-PIPELINE.md § Verify visual output. `IRShapeDebug` was run anyway — `RESULT=CLEAN exit=0` — and the input-path change carries the 30/30 `--gui-test` behavioural evidence above, which is the stronger check for a keybinding edit than a pixel diff would be.
- **~~Pre-existing gap left in place~~ — fixed on master, no longer applicable.** This PR originally noted that `SCREENSHOT_CANVAS` had no `commandNameToString` case and rendered as `UNKNOWN`, and pinned that string in the capture test pending "a one-line follow-up". #2550 landed that fix on master while this PR was open: the hand-listed switch is now the `kCommandInfo` catalog, which gives every enum value a real label by `static_assert` and named `SCREENSHOT_CANVAS` as one of the two values that had shipped rendering as `UNKNOWN`. **No follow-up is owed.** The capture test now pins `"F7: SCREENSHOT CANVAS"` — see the rebase note below.
- `optimize` was not run: registration happens once at creation init and touches no system tick, render stage, shader, or math hot path.

Closes #2666

🤖 Generated with [Claude Code](https://claude.com/claude-code)




