### PR TITLE
docs/fleet: backlog-drain thresholds + extended sweep + assess self-close

### DIFF
--- a/.claude/skills/review-fleet-feedback/SKILL.md
+++ b/.claude/skills/review-fleet-feedback/SKILL.md
@@ -12,7 +12,10 @@ description: >-
   fleet feedback", "check fleet snags", "summarize fleet feedback", "what
   has the fleet been complaining about", "any new fleet snags", or after
   a stretch of autonomous fleet activity when the human wants to absorb
-  the backlog. Do NOT invoke proactively — only on explicit ask.
+  the backlog. Do NOT invoke proactively — only on explicit ask, or as
+  the feedback leg of an architect-run interactive triage sweep
+  (docs/agents/triage-protocol.md "Extended sweep"), where the human's
+  sweep cue carries the ask.
 ---
 
 # review-fleet-feedback

--- a/docs/agents/skills/assess-coding-improvement.md
+++ b/docs/agents/skills/assess-coding-improvement.md
@@ -54,7 +54,11 @@ shared fleet machinery and are used concretely below.
   (rare); the PR's code didn't change, so there is usually nothing to reflect
   on.
 - On explicit ask ("should this be a fleet rule?", "assess coding
-  improvement", "file a coding-improvement").
+  improvement", "file a coding-improvement"). Explicit-ask filings use the
+  same Step-4 body shape (Class / target artifact / proposed change /
+  occurrences) — the shape is what makes batch triage mechanical, and a
+  human-cued ticket that skips it forces the triage pass to reconstruct
+  those fields from context.
 
 Skip entirely if the only feedback was subjective preference or a pure
 one-off domain fix (Step 2 gates this).
@@ -200,6 +204,33 @@ auto-edit, so leaving it un-queued is what keeps the ticket safe: the human
 decides whether and how it gets worked.
 
 Then return to the feedback flow (there is nothing more to do on the PR).
+
+## Step 5 — Close the ticket yourself when the rule lands
+
+A filed ticket sometimes resolves before triage ever sees it: the proposed
+rule lands in the target artifact via a **merged** PR — your own AMEND, a
+sibling's, or a doc PR that wrote the rule for other reasons. A worker who
+verifies that landing may close the ticket directly (`gh issue close <M>
+--reason completed`) instead of leaving it to accrue triage budget, when
+**all three** hold:
+
+1. **The landing PR is merged** — an open PR is a plan, not a landing.
+2. **The rule lives in the ticket's named target artifact** (read the
+   file on `master` and cite the location). Landed somewhere *else* is a
+   placement question — triage's call, not yours.
+3. **The landed text covers the ticket's proposed change** — the same
+   rule, not an adjacent or narrower one. A partial landing gets a
+   comment, not a close.
+
+The closing comment cites the merged PR, the commit, and the landed
+location, so the triage pass's closed-loop check can treat it exactly
+like any other closed-as-completed ticket. When any of the three is
+arguable, comment "appears landed via #N — suggest closing" and leave the
+ticket open; triage adjudicates.
+
+(Why this exists: the first backlog drain found two of its 54 tickets
+already landed — each had a worker comment saying so, but no allowance to
+close, so both still cost sweep-and-verify budget.)
 
 ---
 

--- a/docs/agents/skills/triage-coding-improvements.md
+++ b/docs/agents/skills/triage-coding-improvements.md
@@ -46,12 +46,20 @@ channel and must agree on where rules live.
 
 - On explicit human cue only: "triage coding improvements", "absorb the
   coding-improvement backlog", "work through the coding-improvement tickets".
+  An architect-run interactive triage sweep counts as the cue
+  (`docs/agents/triage-protocol.md` §"Extended sweep") — the human who cued
+  the sweep is present for the verdict round.
 - Never proactively, never from an autonomous role loop. (A worker that
   notices a large backlog may *mention* it to the human; it must not run
   this.)
 
-A natural cue rhythm is when the open-ticket count reaches a handful, or
-before a stretch of fleet activity so the absorbed rules pay off immediately.
+Cue at **10–15 open tickets** — `fleet-decisions` flips its
+coding-improvement cue to OVERDUE at 12. The first drain ran at 54 and the
+overshoot had real costs: the batch consumed a full architect session, and
+filed rules sat unabsorbed while their mistakes kept recurring (one
+PR-body omission recurred four times with its one-line fix sitting in the
+backlog). Small batches also make the per-cluster verdict round genuinely
+answerable rather than a wholesale approve.
 
 ---
 
@@ -94,6 +102,9 @@ tickets. Before triage:
    - Closed-as-**completed** match → the rule already landed and the mistake
      **recurred anyway**. The surface didn't fire. Recommend
      **escalate placement** (see Step 3), not re-adding the same text.
+     This includes tickets the filing side self-closed under
+     `assess-coding-improvement` Step 5 (rule verifiably landed via a
+     merged PR) — they are ordinary closed-as-completed evidence here.
    - Closed-as-**not-planned** match → the human previously rejected this
      rule and it came back. Surface that history in the digest — recurrence
      of a rejected rule is evidence to reconsider, but the human decides.

--- a/docs/agents/triage-protocol.md
+++ b/docs/agents/triage-protocol.md
@@ -235,6 +235,26 @@ ready-to-run `gh issue close` line; neither `list` nor `apply` ever closes
 an issue, confirmed or not. That keeps the one irreversible action out of
 agent hands entirely.
 
+### 6. Extended sweep — backlog drains
+
+Issue triage is one of three human-gated backlogs; the other two — the
+`fleet:coding-improvement` ticket pile and the `~/.fleet/feedback/`
+channel — have their own cue-only drain skills
+(`triage-coding-improvements`, `review-fleet-feedback`) because their
+verdicts and gated self-config edits need a human. Their gauges live in
+`fleet-decisions`, whose cues flip to OVERDUE past the drain thresholds
+(12 open coding-improvement tickets; a `.last-reviewed` marker 14+ days
+old or absent).
+
+After step 5, check `fleet-decisions` and continue into each drain whose
+cue shows — `triage-coding-improvements` with the present human answering
+the verdict round, then `review-fleet-feedback`. The human's sweep cue
+carries the drain cues; both skills stay cue-only in every other context,
+and the dispatched dry-run mode never runs them — its host reaches the
+gauges through the `fleet-decisions` digest instead. Issues run first:
+the per-issue pass is cheap and bounded, and the drains benefit from the
+fresher picture.
+
 ## Graduation (not in effect)
 
 Autonomous approval is earned, not assumed. The human audits verdict

--- a/scripts/fleet/fleet-decisions
+++ b/scripts/fleet/fleet-decisions
@@ -6,7 +6,10 @@
 # (fleet:needs-human, fleet:gated, fleet:design-blocked, fleet:steward-proposal,
 # fleet:state-drift, human:review-plan holds), backlog cues
 # (fleet:coding-improvement, untriaged issues), and unread feedback-channel
-# entries. Read-only: changes no labels, writes no state.
+# entries. Backlog cues flip to OVERDUE past their drain thresholds
+# (coding-improvement count, feedback-marker age) — the informational cue
+# alone let the coding-improvement backlog reach 54 before its first drain.
+# Read-only: changes no labels, writes no state.
 #
 # Usage:
 #   fleet-decisions                  # engine + game
@@ -88,13 +91,31 @@ if [[ -d "$fb_dir" ]]; then
     done
 fi
 
+# Marker age in whole days ("none" when the channel was never reviewed).
+# The marker is a touch-file whose whole meaning is its mtime — the
+# state.json generated_at rule doesn't apply here.
+marker_age_days="none"
+if [[ -f "$marker" ]]; then
+    marker_mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null)
+    if [[ -n "$marker_mtime" ]]; then
+        marker_age_days=$(( ($(date +%s) - marker_mtime) / 86400 ))
+    fi
+fi
+
 # PYTHONIOENCODING forces UTF-8 stdout for native-Windows consoles (cp1252
 # default raises on the report's em-dash / middle-dot glyphs).
-PYTHONIOENCODING=utf-8 python3 - "$manifest" "$feedback_f" << 'PYEOF'
+PYTHONIOENCODING=utf-8 python3 - "$manifest" "$feedback_f" "$marker_age_days" << 'PYEOF'
 import json
 import sys
 
 SHORT = {"jakildev/IrredenEngine": "engine", "jakildev/irreden": "game"}
+
+# Drain thresholds: past these, a backlog cue flips to OVERDUE. Values per
+# the 2026-07-30 triage retrospective — batches past ~a dozen tickets cost
+# a full architect session, and rules sit unabsorbed while their mistakes
+# recur (the acceptance-evidence omission recurred 4x with its fix filed).
+CI_DRAIN_THRESHOLD = 12
+FEEDBACK_STALE_DAYS = 14
 
 # label -> human-readable decision tag; presence on an open PR/issue means
 # a human (or human-cued architect) action is the only way it moves again.
@@ -121,6 +142,8 @@ with open(sys.argv[1], encoding="utf-8") as manifest_file:
 
 with open(sys.argv[2], encoding="utf-8") as f:
     unread_roles = [line.strip() for line in f if line.strip()]
+
+marker_age_days = None if sys.argv[3] == "none" else int(sys.argv[3])
 
 
 def names(item):
@@ -177,7 +200,15 @@ if decisions:
         print(f"  {repo} {kind} #{item['number']}  {item['title']}  [{'; '.join(tags)}]")
 
 cues = []
-if coding_improvements:
+if coding_improvements >= CI_DRAIN_THRESHOLD:
+    cues.append(
+        f"fleet:coding-improvement: {coding_improvements} open — OVERDUE "
+        f"(drain threshold {CI_DRAIN_THRESHOLD}): triage cost grows with "
+        "batch size and filed rules sit unabsorbed while their mistakes "
+        "recur; cue `triage-coding-improvements` (or an architect extended "
+        "sweep, triage-protocol.md) now"
+    )
+elif coding_improvements:
     cues.append(
         f"fleet:coding-improvement: {coding_improvements} open — "
         "cue `triage-coding-improvements` when ready"
@@ -190,10 +221,22 @@ if untriaged:
         f"untriaged (no state labels): {len(untriaged)} awaiting triage — {newest}"
     )
 if unread_roles:
-    cues.append(
+    unread = (
         f"feedback channel: {len(unread_roles)} role file(s) unread "
-        f"({', '.join(sorted(unread_roles))}) — cue `review-fleet-feedback`"
+        f"({', '.join(sorted(unread_roles))})"
     )
+    if marker_age_days is None or marker_age_days >= FEEDBACK_STALE_DAYS:
+        age = (
+            "never reviewed"
+            if marker_age_days is None
+            else f"last reviewed {marker_age_days}d ago"
+        )
+        cues.append(
+            f"{unread} — OVERDUE ({age}, stale threshold "
+            f"{FEEDBACK_STALE_DAYS}d): cue `review-fleet-feedback`"
+        )
+    else:
+        cues.append(f"{unread} — cue `review-fleet-feedback`")
 if cues:
     print("\n## Cues")
     for cue in cues:

--- a/scripts/fleet/fleet-decisions
+++ b/scripts/fleet/fleet-decisions
@@ -96,7 +96,12 @@ fi
 # state.json generated_at rule doesn't apply here.
 marker_age_days="none"
 if [[ -f "$marker" ]]; then
-    marker_mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null)
+    # GNU-first is load-bearing, not cosmetic: GNU's `-f` is --file-system and
+    # reads its argument as a path, so `stat -f %m` prints a filesystem block
+    # to *stdout* (which 2>/dev/null cannot suppress) before failing, and the
+    # captured garbage aborts the arithmetic below under `set -e`. BSD stat
+    # rejects `-c` on stderr only, so this order is safe on both hosts.
+    marker_mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null)
     if [[ -n "$marker_mtime" ]]; then
         marker_age_days=$(( ($(date +%s) - marker_mtime) / 86400 ))
     fi

--- a/scripts/fleet/tests/test_decisions.sh
+++ b/scripts/fleet/tests/test_decisions.sh
@@ -12,6 +12,10 @@
 #   - a wip-only PR appears in no decision bucket
 #   - cues: coding-improvement count, untriaged count, unread feedback roles
 #     (file newer than .last-reviewed counts, older does not)
+#   - drain thresholds: coding-improvement cue flips to OVERDUE at >= 12
+#     open (informational below); feedback cue flips to OVERDUE when the
+#     .last-reviewed marker is >= 14 days old or absent (informational when
+#     fresh) — both arms of each threshold exercised
 #   - headline decision count = merge queue + decisions
 #   - unreachable repo is skipped with a warning, not fatal
 #   - --repo=engine equals-form works; empty --repo= rejected (dual-spelling)
@@ -80,7 +84,7 @@ for arg in "$@"; do
 done
 case "$1 $2 $repo" in
     "pr list jakildev/IrredenEngine")    cat "$fixtures/engine-prs.json" ;;
-    "issue list jakildev/IrredenEngine") cat "$fixtures/engine-issues.json" ;;
+    "issue list jakildev/IrredenEngine") cat "${GH_STUB_ENGINE_ISSUES:-$fixtures/engine-issues.json}" ;;
     "pr list jakildev/irreden")          exit 1 ;;
     "issue list jakildev/irreden")       exit 1 ;;
     *) echo "gh stub: unexpected invocation: $*" >&2; exit 99 ;;
@@ -124,12 +128,58 @@ assert_contains "$out" "engine issue #201" "plan sign-off issue in decisions"
 assert_contains "$out" "engine issue #206" "triage-recommend issue in decisions"
 assert_contains "$out" "triage verdict to review" "triage tag rendered"
 assert_absent  "$out" "#105" "wip-only PR appears in no bucket"
-assert_contains "$out" "fleet:coding-improvement: 1 open" "coding-improvement cue with count"
+assert_contains "$out" "fleet:coding-improvement: 1 open — cue" "coding-improvement cue informational below drain threshold"
+assert_absent  "$out" "fleet:coding-improvement: 1 open — OVERDUE" "1 open never reads as overdue"
+assert_contains "$out" "stale threshold 14d" "ancient .last-reviewed marker flips feedback cue to OVERDUE"
 assert_contains "$out" "untriaged (no state labels): 1" "untriaged cue counts label-less issue"
 assert_contains "$out" "engine #203" "untriaged cue names the issue"
 assert_contains "$out" "merger" "feedback role newer than marker is unread"
 assert_absent  "$out" "role-worker" "feedback role older than marker is not unread"
 assert_contains "$out" "engine: 5 open PR(s) · 1 queued · 1 needs-plan" "status footer"
+
+# --- drain thresholds: both arms of each cue --------------------------------
+
+# Fresh marker (now), one feedback file made newer a second later: unread
+# but not stale — the feedback cue must render informational, not OVERDUE.
+touch "$TMP/fleet-home/feedback/.last-reviewed"
+sleep 1
+touch "$TMP/fleet-home/feedback/merger.md"
+
+status=$(run_decisions --repo=engine)
+out=$(cat "$TMP/out.txt")
+assert_eq "$status" "0" "fresh-marker run exits 0"
+assert_contains "$out" "merger" "feedback file newer than fresh marker is still unread"
+assert_contains "$out" "cue \`review-fleet-feedback\`" "fresh-marker feedback cue still points at the skill"
+assert_absent  "$out" "stale threshold" "fresh marker keeps the feedback cue informational"
+
+# 12 open coding-improvement tickets: the cue flips to OVERDUE.
+python3 - "$TMP/engine-issues-many.json" << 'PYEOF'
+import json
+import sys
+
+issues = [
+    {
+        "number": 300 + i,
+        "title": f"improvement: rule {i}",
+        "url": "u",
+        "labels": [{"name": "fleet:coding-improvement"}],
+    }
+    for i in range(12)
+]
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(issues, f)
+PYEOF
+
+status=$(GH_STUB_ENGINE_ISSUES="$TMP/engine-issues-many.json" run_decisions --repo=engine)
+out=$(cat "$TMP/out.txt")
+assert_eq "$status" "0" "threshold run exits 0"
+assert_contains "$out" "fleet:coding-improvement: 12 open — OVERDUE" "12 open flips the cue to OVERDUE"
+assert_contains "$out" "drain threshold 12" "overdue cue names the threshold"
+
+# Restore the ancient marker layout for any later cases.
+touch -t 202401010000 "$TMP/fleet-home/feedback/role-worker.md"
+touch -t 202401020000 "$TMP/fleet-home/feedback/.last-reviewed"
+touch -t 202401030000 "$TMP/fleet-home/feedback/merger.md"
 
 # --- --repo equals-form + dual-spelling validation --------------------------
 

--- a/scripts/fleet/tests/test_decisions.sh
+++ b/scripts/fleet/tests/test_decisions.sh
@@ -181,6 +181,44 @@ touch -t 202401010000 "$TMP/fleet-home/feedback/role-worker.md"
 touch -t 202401020000 "$TMP/fleet-home/feedback/.last-reviewed"
 touch -t 202401030000 "$TMP/fleet-home/feedback/merger.md"
 
+# --- marker age under GNU stat ----------------------------------------------
+#
+# The marker-age read must try GNU's `-c %Y` before BSD's `-f %m`: GNU reads
+# `-f`'s argument as a path, so it emits a filesystem block on stdout that
+# poisons the captured mtime and aborts the digest under `set -e`. This stub
+# emulates GNU stat so a macOS host still exercises the Linux path.
+cat > "$TMP/bin/stat" << 'EOF'
+#!/usr/bin/env bash
+# Delegate to the host's real stat, trying both spellings (this stub runs on
+# macOS and Linux alike); the shim's job is only to mimic GNU's *interface*.
+real_mtime() {
+    /usr/bin/stat -c %Y "$1" 2>/dev/null || /usr/bin/stat -f %m "$1" 2>/dev/null
+}
+if [[ "$1" == "-c" && "$2" == "%Y" ]]; then
+    real_mtime "$3"
+    exit $?
+fi
+if [[ "$1" == "-f" ]]; then
+    # GNU: %m is not a format here, it's a path that does not exist.
+    echo "  File: \"$3\""
+    echo "Blocks: Total: 1  Free: 1  Available: 1"
+    echo "stat: cannot read file system information for '$2'" >&2
+    exit 1
+fi
+exit 1
+EOF
+chmod +x "$TMP/bin/stat"
+
+status=$(run_decisions --repo=engine)
+out=$(cat "$TMP/out.txt")
+assert_eq "$status" "0" "GNU-stat run exits 0"
+assert_contains "$out" "stale threshold 14d" \
+    "ancient marker still flips the feedback cue to OVERDUE under GNU stat"
+assert_absent "$out" "Blocks: Total" \
+    "GNU stat's filesystem block never leaks into the report"
+
+rm -f "$TMP/bin/stat"
+
 # --- --repo equals-form + dual-spelling validation --------------------------
 
 status=$(run_decisions --repo=engine)


### PR DESCRIPTION
## Summary

Three process refinements the human approved out of the 2026-07-30 coding-improvement batch retrospective (sibling PRs: #2678 the batch itself, #2684 the simplify check split):

- **Threshold-aware backlog cues.** `fleet-decisions`' coding-improvement and feedback cues flip to `OVERDUE` past drain thresholds (≥ 12 open tickets; `.last-reviewed` marker ≥ 14 days old or absent). The informational cue alone let the backlog reach 54 before its first drain — batches that size cost a full architect session while filed rules sit unabsorbed and their mistakes recur.
- **Extended sweep.** `triage-protocol.md` now distinguishes who is running the sweep: the autonomous/cron run stays exactly the dry-run per-issue protocol, while an architect-run interactive sweep (human present) continues into the two cue-only drains — `triage-coding-improvements` (verdict round with the present human) then `review-fleet-feedback` — when their `fleet-decisions` cues show. Both drain skills' when-to-run text records the carve-out; `triage-coding-improvements` also gets the concrete 10–15-ticket cadence.
- **Self-close allowance.** `assess-coding-improvement` Step 5: a worker may close its own ticket when the proposed rule verifiably lands in the exact target artifact via a **merged** PR — three strict conditions (merged, exact artifact, full coverage), anything arguable stays open with a comment for triage. The triage flow's closed-loop check counts such closes as ordinary landed-rule evidence. Explicit-ask filings now require the standard body shape (the one #2440-style gap in the batch).

Plus the fix that keeps the first bullet working on a BSD-stat host:

- **GNU-first marker-mtime `stat` ordering** (`fleet-decisions:94-102`). `stat -c %Y … || stat -f %m …`, not the reverse: GNU's `-f` is `--file-system` and reads its argument as a path, so `stat -f %m` prints a filesystem block to *stdout* (which `2>/dev/null` cannot suppress) before failing, and the captured garbage aborts the age arithmetic under `set -e`. BSD `stat` rejects `-c` on stderr only, so this order is safe on both hosts. Carries its own regression stub — `scripts/fleet/` is not in CI, so the stub is the only thing that makes a silent re-drop visible.

## Rebase note (2026-08-01)

This PR was stacked on #2670, which has since merged to master as `1f92f34a3` (#2511). The add/add `fleet:semantic-conflict` on `scripts/fleet/fleet-triage-sweep` + `scripts/fleet/tests/test_triage_sweep.sh` was the stale **inherited prefix**, not a competing implementation — resolved by dropping it (`git rebase --onto origin/master ca9f7131`) rather than reconciling file-by-file. Verified before the drop: `git diff ca9f7131 origin/master -- <both files>` is **empty**, so master already carries the parent's review nits byte-identically and nothing was lost; and this PR's own two commits touch neither file. The residual diff is now 6 files / +212 −11, all of it this PR's own scope.

## Test plan
- [x] `bash scripts/fleet/tests/test_decisions.sh` → **40 passed, 0 failed** (re-run on the rebased head `23b604e5`, macOS/BSD-stat host — the host that actually exercises the `stat -c` → `stat -f` fallback). Covers four threshold cases exercising **both arms of both thresholds** (1 open ticket informational and asserted not-OVERDUE, 12 OVERDUE naming the threshold; ancient marker → feedback cue OVERDUE with `stale threshold 14d`, fresh marker + newer unread file → informational, asserted no `stale threshold`) plus the three GNU-stat regression assertions from the ordering fix. The earlier `37 passed` in this body predated those three and is superseded.
- [x] `bash -n scripts/fleet/fleet-decisions` clean.
- [x] Hermetic per the fleet test rules: `gh` PATH stub fails closed (exit 99 on unexpected invocation), `FLEET_HOME` points at a temp dir; the 12-ticket fixture is served via a stub env override, no live GitHub.
- [x] Cross-references verified: the three citations of `triage-protocol.md` §"Extended sweep" (both skill docs + the OVERDUE cue text) match the heading added in this diff; the assess wrapper references only Step 3 / Step i, so the new Step 5 desyncs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
