### PR TITLE
fleet: apply the GL-host gate to feedback PRs in the dispatch election

### DIFF
--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -276,12 +276,13 @@ Specifically, **never pass these via `--label` when filing**:
   **Applied by the human/architect** as a triage signal (like the model
   labels) — the scout can't reliably infer "GL-only" from a render task, so
   it is never auto-derived. **Respected at three points:** the dispatcher's
-  claimability filter (`fleet_task_class.py`) skips the task on a macOS pane
-  (a slice whose only open task is GL-only → `defer`, no churn), a
-  `fleet-claim claim` backstop gate refuses a GL-only claim from a non-GL
-  host (covers manual / raced / `--stackable-on` claims), and the feedback
-  tier skips + `fleet-claim amending-claim` refuses a labeled PR on a
-  non-GL host (#2524). No host online to
+  claimability filter (`fleet_task_class.py`) skips the item on a macOS pane
+  — **both** dimensions, a labeled task and a labeled feedback PR (#2696) —
+  so a slice whose only claimable-shaped work is GL-only → `defer`, no
+  churn, a `fleet-claim claim` backstop gate refuses a GL-only claim from a
+  non-GL host (covers manual / raced / `--stackable-on` claims), and the
+  feedback tier skips + `fleet-claim amending-claim` refuses a labeled PR on
+  a non-GL host (#2524). No host online to
   run it just means the work waits for a Linux/Windows pane — the correct
   behavior, not a loss. Once the GL task merges on a GL host, its blocked
   dependents resolve normally.

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -109,6 +109,10 @@ FEEDBACK_BLOCKING_LABELS = {"human:needs-fix", "human:blocker", "fleet:needs-fix
 # and dispatching to it is a guaranteed no-op (#1998).
 GL_CAPABLE_HOSTS = {"linux", "windows"}
 
+# The raw label behind that scout field. PR records carry labels but no derived
+# `needs_gl_host`, so the feedback dimension of the gate matches on this.
+GL_HOST_LABEL = "fleet:needs-gl-host"
+
 
 def _current_host():
     # Canonical host key (mac | linux | windows | unknown), mirroring
@@ -132,10 +136,18 @@ def _current_host():
     return "unknown"
 
 
-def _host_incompatible(task, host):
-    # A `needs_gl_host` task on a non-GL host (macOS/Metal, or unknown) can
-    # never be built/run/verified here — terminally unclaimable, like inflight.
-    return bool(task.get("needs_gl_host")) and host not in GL_CAPABLE_HOSTS
+def _host_incompatible(item, host):
+    # A GL-only item on a non-GL host (macOS/Metal, or unknown) can never be
+    # built/run/verified here — terminally unclaimable, like inflight.
+    #
+    # Reads both record shapes the slice carries: the scout derives a
+    # `needs_gl_host` field on TASK records, while PR records
+    # (`_slice_pr_with_repo`) carry only raw `labels`, so a feedback PR is
+    # gated on the label directly. Checking both keeps one predicate for both
+    # dimensions and stays correct if the scout later stamps the field on PRs.
+    needs_gl = (bool(item.get("needs_gl_host"))
+                or GL_HOST_LABEL in (item.get("labels") or []))
+    return needs_gl and host not in GL_CAPABLE_HOSTS
 
 
 def _task_claimable(task, host):
@@ -182,9 +194,10 @@ def _terminally_unclaimable(task, host):
     )
 
 
-def _only_unclaimable_tasks(slice_data, host):
-    """True when tasks_open is non-empty and EVERY item is terminally
-    unclaimable (see `_terminally_unclaimable`).
+def _only_unclaimable_work(slice_data, host):
+    """True when the slice carries claimable-shaped work but EVERY item of it
+    is terminally unclaimable — tasks per `_terminally_unclaimable`, feedback
+    PRs per the host gate.
 
     Used to pick 'go quiet' (defer) over the lane-default dispatch fallthrough:
     in this shape a fresh worker can claim nothing, so a dispatch is a no-op.
@@ -192,9 +205,22 @@ def _only_unclaimable_tasks(slice_data, host):
     plus an owner-held or otherwise non-terminal task — on the '' fallthrough so
     reservation resumes and the like still get their dispatch. A genuinely
     stackable `blocked` task is NOT terminal (it carries `stackable_blocker_pr`)
-    and is elected as a candidate above, so it never reaches this gate."""
+    and is elected as a candidate above, so it never reaches this gate.
+
+    Feedback PRs must be folded in, or the `_candidates` host gate (#2696)
+    only relocates the churn it removes: a slice whose one item is a
+    host-locked feedback PR yields no candidate, and a tasks-only quiet check
+    then reports nothing-unclaimable and falls through to a lane-default
+    no-op — the #1726 shape again. Only `tasks_open` and `feedback_prs` are
+    consulted because reaching this point means every other source (semantic
+    conflicts, needs_plan) yielded nothing, and those two yield
+    unconditionally when non-empty."""
     tasks = slice_data.get("tasks_open") or []
-    return bool(tasks) and all(_terminally_unclaimable(t, host) for t in tasks)
+    feedback = slice_data.get("feedback_prs") or []
+    if not (tasks or feedback):
+        return False
+    return (all(_terminally_unclaimable(t, host) for t in tasks)
+            and all(_host_incompatible(pr, host) for pr in feedback))
 
 
 def feedback_pr_class(labels):
@@ -280,6 +306,17 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
         return cls, task.get("effort") or CLASS_DEFAULT_EFFORT[cls]
 
     for pr in slice_data.get("feedback_prs", []) or []:
+        # Same #1998 host gate tasks get via `_task_claimable`: a
+        # `fleet:needs-gl-host` feedback PR has GL-only work left, so
+        # role-worker step 1 skips it on a Metal-only host and
+        # `amending-claim` refuses the claim outright (#2524). Counting it
+        # would inflate the elected class's claimable count on exactly the
+        # hosts that can't serve it — and since `feedback_pr_class` routes
+        # `fleet:design-unblocked` to opus, one phantom item is enough to win
+        # the class election every tick and starve the other lanes behind the
+        # concurrency cap (#2696).
+        if _host_incompatible(pr, host):
+            continue
         cls = feedback_pr_class(pr.get("labels", []))
         yield cls, CLASS_DEFAULT_EFFORT[cls], "work"
     # Step-1c work is opus+-only, so each conflict is one opus claimable item.
@@ -386,15 +423,16 @@ def resolve(slice_data, lane_default, fable_blocked, exclude=()):
     if skipped_fable or excluded_any:
         return "defer"
     # Nothing servable AND no cap-blocked fable. If the queue's only content is
-    # tasks already implemented by an open PR (every tasks_open item carries
-    # `inflight_pr`), a lane-default dispatch is a guaranteed no-op — a fresh
-    # worker refuses every one on sight — so the lane goes quiet (defer) instead
+    # work no fresh worker can claim — tasks already implemented by an open PR
+    # (`inflight_pr`), GL-only items on a Metal-only host, or host-locked
+    # feedback PRs — a lane-default dispatch is a guaranteed no-op, since a
+    # fresh worker refuses every one on sight, so the lane goes quiet instead
     # of churning that no-op every tick (#1726). Any other shape (a claimable
     # task would have been chosen above; a plain `blocked` host-compatible task
     # may still be stackable; an owned task, an empty/missing slice) returns ''
     # so the dispatcher's lane-default fallthrough keeps covering the stackable
     # tier, reservation resumes, and missing slices.
-    if _only_unclaimable_tasks(slice_data, host):
+    if _only_unclaimable_work(slice_data, host):
         return "defer"
     return ""
 

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -28,6 +28,14 @@ that matter:
   - a GL-only task (``needs_gl_host``) is unclaimable on a Metal-only host —
     terminal like `inflight_pr`, and the lane defers when it's the only
     work (#1998, the GL-vs-Metal host-capability gate);
+  - that same host gate covers **feedback PRs** (matched on the raw
+    ``fleet:needs-gl-host`` label, since PR records carry no derived field):
+    role-worker step 1 skips them on a Metal-only host and `amending-claim`
+    refuses the claim, so counting one inflated the elected class on exactly
+    the hosts that can't serve it — and via the design-unblocked→opus route
+    that phantom item won the election every tick and starved the other lanes
+    behind the concurrency cap. The quiet path widens with it, or the gate
+    only relocates the no-op it removes (#2696);
   - per-task **Effort:** overrides beat class defaults;
   - the output carries ``count`` = claimable items of the elected class,
     which the dispatcher uses to cap its idle-pane fan-out, and ``plan`` = 1
@@ -401,6 +409,119 @@ class GlHostGate(unittest.TestCase):
         out = self._resolve_on(
             "unknown", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
         self.assertEqual(out, "defer")
+
+
+class FeedbackPrHostGate(unittest.TestCase):
+    """#2696: the #1998 host gate applies to feedback PRs too, not just tasks.
+
+    A `fleet:needs-gl-host` feedback PR has GL-only work left, so role-worker
+    step 1 skips it on a Metal-only host and `amending-claim` refuses the claim
+    (#2524). Counting it anyway inflated the elected class's claimable count on
+    exactly the hosts that can't serve it, and because `feedback_pr_class`
+    routes `fleet:design-unblocked` to opus, that phantom item won the class
+    election every tick and starved the other lanes behind the concurrency cap.
+    """
+
+    def setUp(self):
+        self._saved_host = os.environ.get("FLEET_TEST_HOST")
+
+    def tearDown(self):
+        if self._saved_host is None:
+            os.environ.pop("FLEET_TEST_HOST", None)
+        else:
+            os.environ["FLEET_TEST_HOST"] = self._saved_host
+
+    @staticmethod
+    def _fb(number, labels):
+        return {"number": number, "repo": "engine", "labels": labels}
+
+    def _resolve_on(self, host, slice_data, lane_default="opus"):
+        os.environ["FLEET_TEST_HOST"] = host
+        return resolve(slice_data, lane_default, fable_blocked=False)
+
+    # -- the gate itself -------------------------------------------------
+    def test_gl_gated_feedback_pr_not_counted_on_mac(self):
+        # The live #2475 shape: design-unblocked (opus-routed) AND GL-gated.
+        # On mac it must contribute nothing; the claimable sonnet task is what
+        # gets elected, so the count reflects only work this host can serve.
+        out = self._resolve_on("mac", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+            "tasks_open": [_task("#10", "sonnet")],
+        }, lane_default="sonnet")
+        self.assertEqual(out, "sonnet high 0 1 0")
+
+    def test_gl_gated_feedback_pr_counted_on_linux(self):
+        out = self._resolve_on("linux", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+        })
+        self.assertEqual(out, "opus xhigh 0 1 0")
+
+    def test_gl_gated_feedback_pr_counted_on_windows(self):
+        out = self._resolve_on("windows", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+        })
+        self.assertEqual(out, "opus xhigh 0 1 0")
+
+    def test_ungated_feedback_pr_unaffected_on_mac(self):
+        # Only the GL label is gated — an ordinary feedback PR still counts on
+        # every host (#2393 / game #321 shape).
+        out = self._resolve_on("mac", {
+            "feedback_prs": [self._fb(2393, ["fleet:design-unblocked",
+                                             "fleet:wip"])],
+        })
+        self.assertEqual(out, "opus xhigh 0 1 0")
+
+    def test_unknown_host_is_fail_closed(self):
+        out = self._resolve_on("unknown", {
+            "feedback_prs": [self._fb(2475, ["fleet:needs-fix",
+                                             "fleet:needs-gl-host"])],
+        })
+        self.assertEqual(out, "defer")
+
+    # -- the quiet path must follow the gate -----------------------------
+    def test_gl_gated_feedback_pr_alone_on_mac_defers(self):
+        # Gating `_candidates` alone would only relocate the churn: with no
+        # candidate yielded, a tasks-only quiet check reports
+        # nothing-unclaimable and falls through to '' -> a lane-default no-op
+        # dispatch, the same #1726 shape the gate exists to remove. The slice
+        # holds real work no host-compatible worker can claim -> defer.
+        out = self._resolve_on("mac", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+        })
+        self.assertEqual(out, "defer")
+
+    def test_gl_gated_feedback_plus_terminal_tasks_on_mac_defers(self):
+        out = self._resolve_on("mac", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+            "tasks_open": [_task("#1640", "opus", inflight_pr={"number": 1700})],
+        })
+        self.assertEqual(out, "defer")
+
+    def test_gl_gated_feedback_plus_owned_task_still_falls_through(self):
+        # An owner-held task is NOT terminal, so the '' fallthrough that covers
+        # reservation resumes survives the widened quiet check.
+        out = self._resolve_on("mac", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+            "tasks_open": [_task("#10", "opus", owner="worker-1")],
+        })
+        self.assertEqual(out, "")
+
+    def test_conflict_still_dispatches_when_feedback_host_locked(self):
+        # Step 1c is host-agnostic, so a conflict must still elect opus even
+        # when the only feedback item is GL-locked on this host.
+        out = self._resolve_on("mac", {
+            "feedback_prs": [self._fb(2475, ["fleet:design-unblocked",
+                                             "fleet:needs-gl-host"])],
+            "semantic_conflict_prs": [{"number": 2417, "repo": "engine",
+                                       "labels": ["fleet:semantic-conflict"]}],
+        })
+        self.assertEqual(out, "opus xhigh 0 1 0")
 
 
 class SemanticConflictDispatchPressure(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Apply the #1998 GL-host gate to **feedback PRs** in `_candidates`, not just tasks. A `fleet:needs-gl-host` feedback PR was counted as claimable work on a Metal-only host, while role-worker step 1 skips exactly those and `amending-claim` refuses the claim (#2524) — the dispatcher was electing an item the claim layer actively refuses (#1726 churn shape).
- Widen the quiet path with it: `_only_unclaimable_tasks` → `_only_unclaimable_work`, folding feedback PRs into the all-terminal test. Gating `_candidates` alone would only **relocate** the churn — a slice whose sole item is a host-locked feedback PR yields no candidate, reports nothing-unclaimable, and falls through to a lane-default no-op.
- `_host_incompatible` now reads both record shapes: the scout derives a `needs_gl_host` field on task records, but PR records (`_slice_pr_with_repo`) carry only raw `labels`, so the feedback dimension matches `fleet:needs-gl-host` directly.
- 9 new regression tests + the label-reference doc entry, which enumerated the gate's enforcement points and scoped the dispatcher filter to tasks only.

### Why it mattered more than a stray +1
`feedback_pr_class` routes `fleet:design-unblocked` → `opus`, so a single phantom item won the class election every tick and saturated `FLEET_CONCURRENCY_WORKER`, starving the fable lane that holds the entire needs-plan backlog (`dispatcher.log`: `dispatched class=opus; other classes still queued` → `worker at concurrency cap (4 >= 4); deferring trigger`).

## Test plan
- [x] `python3 -m unittest discover -s scripts/fleet/tests -p "test_fleet_task_class.py"` — 68 pass (59 pre-existing + 9 new)
- [x] Full fleet Python suite: `python3 -m unittest discover -s scripts/fleet/tests -p "test_*.py"` — 704 pass
- [x] `bash scripts/fleet/tests/test_dispatcher_class_dispatch.sh` — PASS 28 / FAIL 0
- [x] `ruff check scripts/` — clean (CI-gated)
- [x] **Positive control**: reverted the source fix, re-ran the 9 new tests — 6 fail, 3 pass (the 3 are the preserved-behavior regression guards, correctly host-agnostic)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. GL-gated feedback PR contributes 0 on a non-GL host | `python3 scripts/fleet/fleet_task_class.py ~/.fleet/state/projections/worker.json opus 0` on macOS, live slice containing PR #2475 | `opus xhigh 1 4 0` — was `opus xhigh 1 5 0` before the fix |
| 2. Still counts on a GL-capable host | same slice with `FLEET_TEST_HOST=linux` / `=windows`, run with and without #2475 | `…1 9 0` with vs `…1 8 0` without ⇒ the PR contributes exactly 1 on GL hosts (on mac: 4 both ways ⇒ contributes 0) |
| 3. Ungated feedback PRs unaffected on every host | `test_ungated_feedback_pr_unaffected_on_mac`; live slice retains #2393 + game #321 | `opus xhigh 0 1 0`; both still counted in the mac total |
| 4. Regression test covering (1)–(3) | `test_fleet_task_class.FeedbackPrHostGate` (9 cases) | 68/68 pass; 6 of the 9 fail against unfixed source |
| 5. `_only_unclaimable_work` / defer verified for the "only a GL-gated feedback PR" slice | `test_gl_gated_feedback_pr_alone_on_mac_defers`, `…_plus_terminal_tasks_on_mac_defers`, `…_plus_owned_task_still_falls_through` | `defer`, `defer`, `""` — quiet path fires, and the owner-held fallthrough covering reservation resumes is preserved |

## Notes for reviewer
- The semantic-conflict loop is **deliberately** still ungated — step 1c build-verifies `IRShapeDebug`, which every fleet host builds natively. `test_conflict_still_dispatches_when_feedback_host_locked` locks that in.
- `_only_unclaimable_work` consults only `tasks_open` + `feedback_prs` because reaching that point means every other source (semantic conflicts, needs_plan) yielded nothing — those two yield unconditionally when non-empty.
- Filed and fixed in the same iteration from a macOS opus pane via the agent-approved follow-up lane: the defect was verified in-session (source read at `bcde4271` + running the real resolver), and it is macOS-verifiable fleet infra.

- **Duplicate lineage:** #2695 (pool-1, 00:52:59Z) and #2696 (pool-2, 00:53:39Z) are the same defect, filed 40s apart by two panes diagnosing it independently in one dispatcher tick. #2695 was closed as the duplicate; this PR closes #2696. The double-file is itself a symptom of the priority inversion this fix targets — every idle opus pane ran the same diagnosis simultaneously.

Closes #2696

🤖 Generated with [Claude Code](https://claude.com/claude-code)

