### PR TITLE
fleet: reconcile a raced fleet:needs-plan against fleet:plan-review

### DIFF
--- a/docs/agents/TASK-FILING.md
+++ b/docs/agents/TASK-FILING.md
@@ -133,6 +133,13 @@ command, observed output, suspected window, what was ruled out), plus
    `fleet:needs-plan`). Apply the step-3 high-stakes checklist yourself:
    if any item trips, also add `human:review-plan` — that human approach
    gate is the one pre-merge human touch this lane keeps.
+   This shape is three non-atomic steps and the planning gate keys on the
+   `## Plan` **comment**, so an ingest tick landing before you post it
+   stamps `fleet:needs-plan` on top of your `fleet:plan-review`. You don't
+   need to hand-strip it — ingest reconciles the pair on its next tick
+   (#2701). `fleet:needs-plan` alongside `human:review-plan` is a
+   different, legitimate state (a reviewer bounced the plan) and is left
+   alone.
 3. **You verified the defect but not the fix** → add neither. Ingest
    bounces it to `fleet:needs-plan` and the autonomous planning lane
    takes it from there.

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -307,6 +307,7 @@ def _has_plan_comment(comments):
 
 stamped = 0
 revise_reconciled = 0
+plan_race_reconciled = 0
 skipped_already = 0
 blocked_marked = 0
 plan_bounced = 0
@@ -409,6 +410,44 @@ for issue in pending:
         labels.discard('fleet:needs-plan')
         print(f'INFO issue {repo}#{n}: opted out (human:no-plan / fleet:no-plan / [no-plan] / '
               f'spike) but still carried fleet:needs-plan — stripped it; queuing directly',
+              file=sys.stderr)
+
+    # Raced-planning-gate reconcile (#2701). TASK-FILING.md §"Agent-approved
+    # follow-up lane" plan-shape 2 files in three non-atomic steps: create with
+    # fleet:agent-approved, post the `## Plan` comment, add fleet:plan-review.
+    # The planning gate below keys on the *comment* (#1932), so a tick landing
+    # between steps 1 and 2 sees a plan-less issue and stamps fleet:needs-plan;
+    # step 3 then lands fleet:plan-review on top. The pair then persists
+    # forever — the skip guard just below returns early on either label, so no
+    # later tick re-examines the issue. Left alone, the stale needs-plan makes
+    # it a candidate for a planning dispatch that re-plans work which already
+    # has a plan awaiting review, and a reviewer clearing plan-review strands
+    # it short of fleet:queued (the #2110 shape, on the plan-present path).
+    #
+    # The predicate is the label PAIR, not plan presence: a reviewer's bounce
+    # *swaps* plan-review → needs-plan (PLANNING-PROTOCOL.md), and the
+    # human:revise-plan reconcile above removes plan-review when it adds
+    # needs-plan — so nothing in the protocol produces both on purpose.
+    # fleet:needs-plan + human:review-plan, by contrast, is legitimate (a
+    # bounced plan on a high-stakes issue keeps the human's approach gate) and
+    # must NOT be touched. Stripping only needs-plan leaves the issue held by
+    # the plan-review arm of the skip guard, which is the correct state.
+    if 'fleet:needs-plan' in labels and 'fleet:plan-review' in labels:
+        er = subprocess.run(
+            ['gh', 'issue', 'edit', str(n), '--repo', repo,
+             '--remove-label', 'fleet:needs-plan'],
+            capture_output=True, text=True, timeout=15,
+        )
+        if er.returncode != 0:
+            failed += 1
+            print(f'WARN issue {repo}#{n}: strip raced fleet:needs-plan alongside '
+                  f'fleet:plan-review failed: {er.stderr.strip()}', file=sys.stderr)
+            continue
+        labels.discard('fleet:needs-plan')
+        plan_race_reconciled += 1
+        print(f'INFO issue {repo}#{n}: carried both fleet:needs-plan and '
+              f'fleet:plan-review (planning gate raced the plan comment) — '
+              f'stripped the stale needs-plan; holding for plan review',
               file=sys.stderr)
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
@@ -577,13 +616,13 @@ for issue in data.get('unblock_issues', []):
         continue
     unblocked += 1
 
-print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still},{plan_bounced},{revise_reconciled}')
+print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still},{plan_bounced},{revise_reconciled},{plan_race_reconciled}')
 STAMP_PY
 )
 
 if [[ -n "$stamping_out" ]]; then
-    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count plan_bounced_count revise_reconciled_count <<< "$stamping_out"
-    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; bounced ${plan_bounced_count:-0} to fleet:needs-plan; re-plan requested ${revise_reconciled_count:-0} (human:revise-plan); unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
+    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count plan_bounced_count revise_reconciled_count plan_race_count <<< "$stamping_out"
+    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; bounced ${plan_bounced_count:-0} to fleet:needs-plan; re-plan requested ${revise_reconciled_count:-0} (human:revise-plan); raced needs-plan stripped ${plan_race_count:-0} (needs-plan + plan-review); unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
 fi
 
 log "ingestion iteration complete"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -432,6 +432,10 @@ for issue in pending:
     # bounced plan on a high-stakes issue keeps the human's approach gate) and
     # must NOT be touched. Stripping only needs-plan leaves the issue held by
     # the plan-review arm of the skip guard, which is the correct state.
+    # No protocol path produces all three (the bounce that adds needs-plan is
+    # the same one that removes plan-review), but the triple state is inert if
+    # it is ever reached: the strip leaves plan-review AND human:review-plan,
+    # and the skip guard below holds on either — so the issue stays held.
     if 'fleet:needs-plan' in labels and 'fleet:plan-review' in labels:
         er = subprocess.run(
             ['gh', 'issue', 'edit', str(n), '--repo', repo,

--- a/scripts/fleet/tests/test_fleet_queue_ingest_plan_race.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_plan_race.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Test the fleet-queue-ingest raced-planning-gate reconcile (#2701).
+#
+# TASK-FILING.md §"Agent-approved follow-up lane" plan-shape 2 files in three
+# non-atomic steps (create → post `## Plan` comment → add fleet:plan-review).
+# The planning gate keys on the comment (#1932), so an ingest tick landing
+# between steps 1 and 2 stamps fleet:needs-plan and step 3 lands
+# fleet:plan-review on top. The pair used to persist forever — the
+# already-labeled skip guard returns early on either label, so no later tick
+# re-examined the issue. Ingest now strips the stale needs-plan and leaves the
+# issue held by the plan-review arm of the guard.
+#
+# The discriminator is the label PAIR, not plan presence: fleet:needs-plan +
+# human:review-plan is a LEGITIMATE state (a reviewer bounced the plan on a
+# high-stakes issue; the human's approach gate persists) and must be left
+# alone — observed live on #2698.
+#
+# HOME is redirected to a temp sandbox; gh is stubbed to canned surfaces and
+# every `gh issue edit` is logged for assertions.
+
+set -euo pipefail
+
+source "$(dirname "$0")/lib_assert.sh"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+# #770 = needs-plan + plan-review (the race)     → strip needs-plan, still held
+# #771 = needs-plan + human:review-plan          → legitimate bounce, untouched
+# #772 = needs-plan alone                        → left for planning (untouched)
+# #773 = plan-review alone                       → already correct, untouched
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":770,"repo":"engine"},
+  {"number":771,"repo":"engine"},
+  {"number":772,"repo":"engine"},
+  {"number":773,"repo":"engine"}
+],"unblock_issues":[]}
+JSON
+
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+export COMMENT_LOG="$TMPROOT/comment.log"; : > "$COMMENT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                case "$3" in
+                    770) echo '{"title":"fleet: raced filing","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"fleet:agent-approved"},{"name":"fleet:needs-plan"},{"name":"fleet:plan-review"}],"comments":[{"body":"## Plan\n\nstep one"}]}' ;;
+                    771) echo '{"title":"fleet: bounced high-stakes plan","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"fleet:agent-approved"},{"name":"fleet:needs-plan"},{"name":"human:review-plan"}],"comments":[{"body":"## Plan\n\nstep one"}]}' ;;
+                    772) echo '{"title":"fleet: genuinely needs a plan","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:needs-plan"}],"comments":[]}' ;;
+                    773) echo '{"title":"fleet: plan awaiting vetting","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:plan-review"}],"comments":[{"body":"## Plan\n\nstep one"}]}' ;;
+                    *)   echo '{"title":"","body":"","labels":[],"comments":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)    printf '%s\n' "$*" >> "$EDIT_LOG"; exit 0 ;;
+            comment) printf '%s\n' "$*" >> "$COMMENT_LOG"; exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in list) echo '[]'; exit 0 ;; *) exit 0 ;; esac ;;
+    api) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+echo "=== run fleet-queue-ingest ==="
+INGEST_LOG="$TMPROOT/ingest.log"
+bash "$INGEST" > "$INGEST_LOG" 2>&1 || true
+
+edits_for() { grep -E "(^| )edit $1( |$)" "$EDIT_LOG" | tr '\n' '|'; }
+
+# --- #770: the race → stale needs-plan stripped, plan-review hold preserved ---
+assert_contains "$(edits_for 770)" "--remove-label fleet:needs-plan" \
+    "#770 stripped the raced fleet:needs-plan (needs-plan + plan-review)"
+assert_absent "$(edits_for 770)" "fleet:plan-review" \
+    "#770 left fleet:plan-review in place (reviewer still owes a vet)"
+assert_absent "$(edits_for 770)" "fleet:queued" \
+    "#770 not queued — still held by the plan-review guard"
+
+# --- #771: needs-plan + human:review-plan is legitimate → untouched -----------
+assert_absent "$(edits_for 771)" "--remove-label fleet:needs-plan" \
+    "#771 kept fleet:needs-plan (reviewer bounce on a high-stakes issue)"
+assert_absent "$(edits_for 771)" "fleet:queued" \
+    "#771 not queued (correctly skipped at the needs-plan guard)"
+
+# --- #772: plain needs-plan → untouched --------------------------------------
+assert_absent "$(edits_for 772)" "--remove-label fleet:needs-plan" \
+    "#772 kept fleet:needs-plan (no plan-review present)"
+
+# --- #773: plain plan-review → untouched -------------------------------------
+assert_absent "$(edits_for 773)" "fleet:needs-plan" \
+    "#773 untouched (plan-review alone is already the correct state)"
+assert_absent "$(edits_for 773)" "fleet:queued" \
+    "#773 not queued — held for plan review"
+
+# --- the reconcile is observable in the run summary --------------------------
+assert_contains "$(cat "$INGEST_LOG")" "raced needs-plan stripped 1" \
+    "run summary counts the reconcile (1 issue)"
+
+summarize "fleet-queue-ingest raced-planning-gate reconcile"


### PR DESCRIPTION
## Summary
- `fleet-queue-ingest` now reconciles an issue carrying **both** `fleet:needs-plan` and `fleet:plan-review` by stripping the stale `needs-plan`, leaving the issue held by the plan-review arm of the skip guard.
- The state is reachable because TASK-FILING.md's agent-approved-lane **plan-shape 2** files in three non-atomic steps (create → post `## Plan` comment → add `fleet:plan-review`) while the planning gate keys on the *comment* (#1932). A tick inside that window stamps `needs-plan`; step 3 lands `plan-review` on top.
- It persisted **forever**: the already-labeled skip guard (`fleet-queue-ingest:414`) returns early on either label, so no later tick re-examined the issue. Neither existing reconcile covered it — the late-opt-out block (#2110) requires `opted_out`, and the `human:revise-plan` block requires that human marker. `fleet-reconcile-amendments` has no rule for the pair either.
- Observed live on **#2699**, which came out of filing with `needs-plan` + `plan-review` + `agent-approved` and only left that state by hand.
- Added `tests/test_fleet_queue_ingest_plan_race.sh` (9 assertions) and a one-paragraph note on plan-shape 2 in TASK-FILING.md retiring the "hand-strip it yourself" folklore.

### The discriminator
The predicate is the **label pair**, not plan presence. A reviewer's bounce *swaps* `plan-review` → `needs-plan`, and the `human:revise-plan` reconcile in this same script already removes `plan-review` when it adds `needs-plan` (`:356`) — nothing in the protocol produces both on purpose.

`fleet:needs-plan` + `human:review-plan` is a **different, legitimate** state and is deliberately untouched. Live counter-example at authoring time: **#2698** carries `needs-plan` + `human:review-plan` + a `## Plan` comment, and its `needs-plan` is a *correct* reviewer bounce ("Plan review — not sound", 2026-07-31T01:38Z). A predicate keyed on "plan comment exists" would have wrongly un-bounced it; the test pins that case.

Plan-shape 1 (`fleet:no-plan`) was already covered — it sets `opted_out`, so the #2110 block handles it. Only plan-shape 2 was exposed.

## Test plan
- [x] New `test_fleet_queue_ingest_plan_race.sh` — 9/9 pass (4 stubbed issues: the race, the legitimate `human:review-plan` bounce, bare `needs-plan`, bare `plan-review`).
- [x] **Positive control** — reverted the script to `origin/master` and re-ran: the 2 fix-specific assertions FAIL, the 7 over-reach guards stay green. Pre-fix summary reads `skipped 4 already-labeled`, i.e. the race silently persisting.
- [x] Full ingest suite green: `blocked_by` 9, `human_owned` 3, `late_no_plan` 6, `plan_gate` 14, `plan_race` 9, `review_plan` 3, `revise_plan` 7 — **51/51**.
- [x] `ruff check scripts/` clean; `python3 scripts/fleet/lint_state_mtime.py scripts/fleet/` clean; `bash -n` clean.

## Notes for the reviewer
- **AC 5 of the issue is vacuous** — it asks that a `--dry-run` path not mutate labels; `fleet-queue-ingest` has no dry-run mode (grepped). Nothing to verify.
- The reconcile adds **zero** API calls in the common case (it reads the already-fetched label set); it issues one `gh issue edit` only when the race state actually exists.
- Tests under `scripts/fleet/tests/` are not wired into CI (`quality.yml` runs ruff + the C++ suites); the new test follows its 6 siblings' fleet-run convention. Wiring the bash suites into CI is a separate change, not folded in here.
- **Reported, not applied:** ~5 sites in this script repeat the `gh issue edit` → check rc → `failed += 1` → print WARN boilerplate. Mine mirrors the adjacent block deliberately rather than extracting a shared helper — factoring all 5 is pre-existing cleanup outside this PR's surface.

Closes #2701

🤖 Generated with [Claude Code](https://claude.com/claude-code)