### PR TITLE
fleet: class fairness floor for the worker-lane election (#2699)

### DIFF
--- a/.fleet/plans/issue-2699.md
+++ b/.fleet/plans/issue-2699.md
@@ -1,0 +1,119 @@
+## Plan
+
+- **Issue:** #2699
+- **Model:** opus — dispatcher scheduling semantics; the fix is small but the
+  policy choice (fairness floor vs. churn-signal coupling) needs judgment
+- **Date:** 2026-07-31
+
+### Verified current state
+
+Read from `scripts/fleet/fleet-dispatcher` at `origin/master` `d6a44197`, plus
+`~/.fleet/logs/dispatcher.log`, `~/.fleet/state/dispatch/*.json`, and live runs
+of `fleet_task_class.py`. All numbers in the issue body were measured, not
+inferred:
+
+- The saturation test is `claim_headroom = DISPATCH_COUNT - class_racing` at
+  **1580-1583**; the fan-out that serves another class is at **1586-1591** and
+  is reached **only** when `claim_headroom == 0`.
+- `class_racing` = `count_recent_active_for_class` (**860-878**), which counts a
+  dispatch record only while `age < CLAIM_SETTLE_SECONDS` (**481**, default 90).
+- The role concurrency cap (**1503-1508**) counts `count_active_for_role` with
+  **no age filter**. The two counters therefore measure different populations,
+  and worker iterations outlive the 90s window (measured record ages at
+  01:40Z: 92s / 214s / 303s / 482s ⇒ `class_racing = 0` with all four panes
+  occupied).
+- The settle window is deliberate and its rationale is stated at **470-481**.
+  Its explicit premise — *"the task leaves tasks_open once claimed, which is
+  the real signal"* — is what fails: a **worker-refused** item is never claimed,
+  so it never leaves the slice and its count contribution is permanent.
+- Consequence measured, not assumed: `serving next class` last fired
+  **2026-07-29T10:25:35Z**; `dispatched class=` over the last 2h is 57 opus /
+  0 sonnet / 0 fable.
+
+**Explicitly NOT verified (and a phase below measures it):** I confirmed the
+resolver *reports* 10 claimable sonnet items and 21 fable planning candidates.
+I did **not** verify those items are genuinely claimable by a fresh worker —
+they could be fictional in the same way the opus five are. Phase 1 measures
+this before any behaviour change, because it decides whether the fix yields
+real throughput or just relocates the churn.
+
+### Approach
+
+Two candidate fixes; this plan ships **A** and records **B** as the convergence
+target, deliberately *not* folding B in.
+
+**A — fairness floor in the election (shipped here).** Track consecutive ticks
+in which `dispatch_role` elected the same class while `DISPATCH_MORE=1` (i.e.
+another class *is* claimable). Once that run reaches a threshold, add the class
+to `_excluded` for one pass so the existing 1586-1591 fan-out serves the next
+class. Self-contained: no new state source, no dependency on an unlanded fix,
+and it reuses the loop's own bounded-exclusion mechanism.
+
+**B — couple to the empty-exit streak (#2698, not in scope here).** A
+per-`(role, class, host)` streak is the precise signal — it demotes a class
+because workers actually claimed nothing, rather than because it has had many
+turns. B subsumes A's intent but depends on #2698, whose plan is currently
+bounced to `fleet:needs-plan`. Shipping A first gives a floor that does not
+regress if B lands later; when B lands, A's threshold can be raised or A
+retired. **A is a floor, not a substitute for B** — this plan does not claim
+otherwise.
+
+Rejected: widening `CLAIM_SETTLE_SECONDS` or switching `class_racing` to
+occupancy. Both regress the stated 470-481 intent ("a worker busy on task A
+must not block dispatching a worker for task B"), and neither fixes the case
+where `DISPATCH_COUNT > cap`, in which headroom stays positive even at full
+occupancy.
+
+### Phases
+
+1. **Measure the downstream lanes first (no behaviour change).** For the 10
+   sonnet items and the fable plan-pick list, evaluate each against the same
+   predicates `role-worker.md` step 3 applies (claim label, `Blocked by:`,
+   open-PR cross-check, host gate). Record how many a fresh worker would
+   actually claim. If that number is 0, **stop and re-scope** — the defect is
+   then projection-side, not election-side, and A would only move the churn.
+   Post the count on the issue either way.
+2. Add the consecutive-election counter next to the existing
+   `CAP_DEFER_LOGGED` bookkeeping: reset when the elected class changes or when
+   `DISPATCH_MORE=0`; increment on each tick that elects the same class with
+   `DISPATCH_MORE=1`. Keep it in-memory (daemon-lifetime), consistent with
+   `CAP_DEFER_LOGGED`; no new state file.
+3. Wire it into the loop: when the counter is at/over threshold, seed
+   `_excluded` with the elected class before the first `resolve_worker_class`
+   pass, and log the yield with the class and run length. Threshold behind
+   `FLEET_DISPATCHER_CLASS_FAIRNESS_RUN` (default 3), validated-and-clamped the
+   same way `BOOT_FANOUT_WINDOW_SECONDS` / `CLAIM_SETTLE_SECONDS` are
+   (**442-450**, **482-486**) — a non-numeric override must not kill the daemon
+   under `set -u`.
+4. Tests in `scripts/fleet/tests/`: positive-fire (AC 1) and negative control
+   (AC 2) per the issue. Extend the existing dispatcher suite rather than
+   adding a new harness.
+
+### Affected files
+
+- `scripts/fleet/fleet-dispatcher` — config block near 442-486; counter
+  bookkeeping near 850-880; the loop at 1554-1599.
+- `scripts/fleet/tests/` — dispatcher suite (exact file confirmed at
+  implementation time; do not assume a filename from this plan).
+- `~/.fleet/fleet-up.conf` documentation block — document the new knob
+  alongside the other `FLEET_DISPATCHER_*` overrides.
+
+### Acceptance criteria
+
+Inherits AC 1-3 from the issue body. AC 1 is the positive-fire criterion: the
+test must observe a **non-elected class actually dispatched**, not merely that
+the counter incremented.
+
+### Gotchas
+
+- **Run the dispatcher test suite before editing.** It shells through `~/bin`
+  into the main clone and is not hermetic — a pre-existing red must be
+  established first or it will be misattributed to this change.
+- `dispatch_role` returns early on several paths (no trigger, role cap, defer).
+  The counter must not be incremented on paths that never reached the election,
+  or a quiet fleet will accumulate a fake run and yield spuriously.
+- The loop already exits after 3 exclusion passes; seeding `_excluded` up front
+  consumes one of those. Confirm the bound still holds for a 3-class fleet.
+- Do not touch `count_recent_active_for_class` — #2698 may key new state off
+  the same records, and two in-flight edits to that function would conflict.
+

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -496,11 +496,17 @@ fi
 # see #2699).
 #
 # So bound the monopoly by turns as well: after this many consecutive ticks
-# electing the same class while ANOTHER class is claimable, yield one pass to
-# the next class regardless of coverage. Turn count is a deliberately weaker
-# signal than "workers claimed nothing" (that needs the per-(role, class, host)
-# empty-exit streak, #2698) — this bounds how long a monopoly can last, it does
-# not detect one. 0 disables the floor, leaving coverage the only yield.
+# electing the same class while ANOTHER class is claimable, yield one pass
+# regardless of coverage. The yield goes to the LEAST RECENTLY SERVED claimable
+# class, not simply the next one in candidate order — with three classes live,
+# yielding to rank 2 every time leaves rank 3 unserved forever (rank 2 is
+# recorded as the last-elected class with a run of 1, so the monopolist
+# re-elects on the very next tick and the pair just alternates). That is the
+# same unbounded starvation this floor exists to prevent, one rank down.
+# Turn count is a deliberately weaker signal than "workers claimed nothing"
+# (that needs the per-(role, class, host) empty-exit streak, #2698) — this
+# bounds how long a monopoly can last, it does not detect one.
+# 0 disables the floor, leaving coverage the only yield.
 # Validated-and-clamped like the overrides above: a non-numeric value would
 # emit arithmetic errors every tick or kill the daemon under `set -u`.
 CLASS_FAIRNESS_RUN="${FLEET_DISPATCHER_CLASS_FAIRNESS_RUN:-3}"
@@ -516,6 +522,32 @@ fi
 # a fairness heuristic (no state file to go stale or leak).
 declare -A CLASS_ELECTION_LAST=()
 declare -A CLASS_ELECTION_RUN=()
+# Per-(role, class) recency: the value of CLASS_ELECTION_TICKS at that class's
+# last election, 0 for never-served. A single-class yield only ever reaches
+# rank 2 — the yielded-to class is recorded as LAST with RUN=1, the monopolist
+# re-elects next tick, and rank 3 is never served at all. Recency is what lets
+# the yield walk PAST an already-recently-served class to the genuinely starved
+# one (the 3-class defect found on #2705).
+declare -A CLASS_ELECTION_SERVED=()
+declare -A CLASS_ELECTION_TICKS=()
+# The worker model classes, for the recency scan. Not derived from the slice:
+# a class absent from this tick's slice must still read as starved, or it could
+# never be walked to once it reappears.
+WORKER_CLASS_NAMES=(opus fable sonnet)
+
+# Lowest CLASS_ELECTION_SERVED value across all worker classes for a role —
+# i.e. how recently the LEAST recently served class ran. A never-served class
+# pins this at 0, which is what makes it the yield walk's target.
+class_min_served() {
+    local role="$1" cls served min=""
+    for cls in "${WORKER_CLASS_NAMES[@]}"; do
+        served="${CLASS_ELECTION_SERVED["$role:$cls"]:-0}"
+        if [[ -z "$min" ]] || (( served < min )); then
+            min="$served"
+        fi
+    done
+    printf '%s\n' "${min:-0}"
+}
 
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Panes are a generic pool, so this list — not
@@ -1587,29 +1619,54 @@ dispatch_role() {
     local _excluded="" _sat_excluded="" _passes=0
     # Fairness floor (#2699): the headroom test below can never fire when the
     # elected class's claimable items are ones every worker refuses, so bound
-    # the monopoly by turns as well. `_fair_yield` is kept separate from the
-    # saturation exclusions (`_sat_excluded`) so it can be dropped on its own
-    # if the yield turns out to have nothing to yield TO.
-    local _fair_yield=""
+    # the monopoly by turns as well. `_fair_yield` is a comma list, not a single
+    # class: yielding only the monopolist reaches rank 2 and no further, so with
+    # three classes live the bottom one starves anyway. It is kept separate from
+    # the saturation exclusions (`_sat_excluded`) so it can be given back on its
+    # own — one entry at a time — when the yield has nothing left to yield TO.
+    # `_fair_min` snapshots the least-recently-served class at yield time; the
+    # walk below uses it as the target, and `_fair_walked` keeps that walk
+    # one-directional so a give-back cannot re-add what it just released.
+    local _fair_yield="" _fair_walked=0 _fair_min=0
     if (( CLASS_FAIRNESS_RUN > 0 )) \
         && [[ -n "${CLASS_ELECTION_LAST[$role]:-}" ]] \
         && (( ${CLASS_ELECTION_RUN[$role]:-0} >= CLASS_FAIRNESS_RUN )); then
         _fair_yield="${CLASS_ELECTION_LAST[$role]}"
+        _fair_min=$(class_min_served "$role")
         log "$role: class=$_fair_yield elected ${CLASS_ELECTION_RUN[$role]} consecutive ticks with other classes queued; yielding one pass (fairness floor)"
     fi
     while : ; do
         _excluded="$_sat_excluded"
         [[ -n "$_fair_yield" ]] && _excluded="$_fair_yield${_excluded:+,$_excluded}"
         resolve_worker_class "$role" "$_excluded"
-        # The yielded class was claimable when the run accumulated; by this tick
-        # the OTHER class may not be. Drop only the fairness exclusion (keeping
-        # any saturation exclusions, which are still true) and re-resolve, so the
-        # floor can never turn a servable tick into a deferred one. One-shot:
-        # clearing `_fair_yield` makes this branch unreachable on the retry.
+        # The yielded class(es) were claimable when the run accumulated; by this
+        # tick the OTHERS may not be. Give back one exclusion at a time — the
+        # most recently added first — so an overshooting walk (below) falls back
+        # to the class it just skipped rather than all the way to the
+        # monopolist. Saturation exclusions are kept throughout; they are still
+        # true. Once the fairness set empties, serve the monopolist after all,
+        # so the floor can never turn a servable tick into a deferred one.
         if [[ -n "$_fair_yield" ]] && (( DISPATCH_DEFER )); then
+            if [[ "$_fair_yield" == *,* ]]; then
+                _fair_yield="${_fair_yield%,*}"
+                _fair_walked=1   # stop walking, or we would re-add what we just gave back
+                continue
+            fi
             log "$role: fairness yield of class=$_fair_yield found no other servable class; serving it after all"
             _fair_yield=""
             CLASS_ELECTION_RUN["$role"]=0
+            continue
+        fi
+        # Walk down to the genuinely starved class. The elected one may itself
+        # have been served more recently than some other class — yielding to it
+        # would just rotate between ranks 1 and 2 forever while rank 3 starves.
+        # Bounded: each pass excludes one more of the three classes, and
+        # `_fair_walked` makes the walk one-directional.
+        if [[ -n "$_fair_yield" ]] && (( ! _fair_walked )) && [[ -n "$DISPATCH_CLASS" ]] \
+            && (( ${CLASS_ELECTION_SERVED["$role:$DISPATCH_CLASS"]:-0} > _fair_min )) \
+            && [[ ",$_fair_yield," != *",$DISPATCH_CLASS,"* ]]; then
+            _fair_yield="$_fair_yield,$DISPATCH_CLASS"
+            log "$role: class=$DISPATCH_CLASS also served recently; yielding further down the class order"
             continue
         fi
         if (( DISPATCH_DEFER )); then
@@ -1646,6 +1703,19 @@ dispatch_role() {
             log "$role: class=$DISPATCH_CLASS covered ($class_racing in-flight >= $DISPATCH_COUNT claimable); serving next class"
             continue
         fi
+        # Saturated, and the fairness yield is what steered us here: the class
+        # we yielded AWAY from may still have headroom, so serving it beats
+        # idling the lane. Symmetric with the resolver-defer give-back above,
+        # and needed for the same invariant — without it the tick dispatches
+        # nothing, and because this `return` sits above the bookkeeping,
+        # CLASS_ELECTION_RUN stays at the threshold and every following tick
+        # re-yields and re-defers until the racing records settle out.
+        if [[ -n "$_fair_yield" ]]; then
+            log "$role: fairness yield target class=$DISPATCH_CLASS is cap-saturated; dropping the yield and re-resolving rather than idling the lane"
+            _fair_yield=""
+            CLASS_ELECTION_RUN["$role"]=0
+            continue
+        fi
         # Saturated with no other claimable class — keep the trigger; a later
         # tick re-evaluates once the racing workers claim or settle out.
         if [[ -z "${CAP_DEFER_LOGGED[$role-claimcap]+x}" ]]; then
@@ -1675,6 +1745,11 @@ dispatch_role() {
             CLASS_ELECTION_RUN["$role"]=1
         fi
         CLASS_ELECTION_LAST["$role"]="$DISPATCH_CLASS"
+        # Recency stamp for the yield walk. Counts ticks that actually reached
+        # an election (same guard as the run counter above), so it advances on
+        # the same clock the fairness threshold is expressed in.
+        CLASS_ELECTION_TICKS["$role"]=$(( ${CLASS_ELECTION_TICKS[$role]:-0} + 1 ))
+        CLASS_ELECTION_SERVED["$role:$DISPATCH_CLASS"]="${CLASS_ELECTION_TICKS[$role]}"
     fi
 
     local dispatched=0

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -485,6 +485,38 @@ if ! [[ "$CLAIM_SETTLE_SECONDS" =~ ^[0-9]+$ ]]; then
     CLAIM_SETTLE_SECONDS=90
 fi
 
+# Class fairness floor. The cross-class fan-out serves another class only when
+# the elected one is fully covered (headroom 0), which inherits the settle
+# window's premise above: a claimed task leaves tasks_open, so coverage is
+# eventually reached. An item every worker REFUSES — host-gated, design-parked,
+# content-declined — breaks that: it is never claimed, so it counts toward
+# DISPATCH_COUNT forever, while the workers that walked it and declined age out
+# of CLAIM_SETTLE_SECONDS. Headroom stays permanently positive and the fan-out
+# is unreachable, letting one class hold the lane indefinitely (observed: 39h,
+# see #2699).
+#
+# So bound the monopoly by turns as well: after this many consecutive ticks
+# electing the same class while ANOTHER class is claimable, yield one pass to
+# the next class regardless of coverage. Turn count is a deliberately weaker
+# signal than "workers claimed nothing" (that needs the per-(role, class, host)
+# empty-exit streak, #2698) — this bounds how long a monopoly can last, it does
+# not detect one. 0 disables the floor, leaving coverage the only yield.
+# Validated-and-clamped like the overrides above: a non-numeric value would
+# emit arithmetic errors every tick or kill the daemon under `set -u`.
+CLASS_FAIRNESS_RUN="${FLEET_DISPATCHER_CLASS_FAIRNESS_RUN:-3}"
+if ! [[ "$CLASS_FAIRNESS_RUN" =~ ^[0-9]+$ ]]; then
+    printf '[%s dispatcher] CLASS_FAIRNESS_RUN=%q is not a non-negative integer; falling back to 3\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$CLASS_FAIRNESS_RUN" >&2
+    CLASS_FAIRNESS_RUN=3
+fi
+# Per-role bookkeeping for the floor: the class elected on the previous tick
+# that reached an election, and how many consecutive such ticks elected it with
+# another class still claimable. In-memory / daemon-lifetime, like
+# CAP_DEFER_LOGGED — a restart forgives the run, which is the right default for
+# a fairness heuristic (no state file to go stale or leak).
+declare -A CLASS_ELECTION_LAST=()
+declare -A CLASS_ELECTION_RUN=()
+
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Panes are a generic pool, so this list — not
 # pane topology — is what enables a role: the smoke-worker and
@@ -1552,9 +1584,34 @@ dispatch_role() {
     # three (opus|fable|sonnet), so the loop runs a handful of times then either
     # finds a class with headroom, hits the uncapped path, or defers.
     local claim_headroom=-1   # -1 = uncapped
-    local _excluded="" _passes=0
+    local _excluded="" _sat_excluded="" _passes=0
+    # Fairness floor (#2699): the headroom test below can never fire when the
+    # elected class's claimable items are ones every worker refuses, so bound
+    # the monopoly by turns as well. `_fair_yield` is kept separate from the
+    # saturation exclusions (`_sat_excluded`) so it can be dropped on its own
+    # if the yield turns out to have nothing to yield TO.
+    local _fair_yield=""
+    if (( CLASS_FAIRNESS_RUN > 0 )) \
+        && [[ -n "${CLASS_ELECTION_LAST[$role]:-}" ]] \
+        && (( ${CLASS_ELECTION_RUN[$role]:-0} >= CLASS_FAIRNESS_RUN )); then
+        _fair_yield="${CLASS_ELECTION_LAST[$role]}"
+        log "$role: class=$_fair_yield elected ${CLASS_ELECTION_RUN[$role]} consecutive ticks with other classes queued; yielding one pass (fairness floor)"
+    fi
     while : ; do
+        _excluded="$_sat_excluded"
+        [[ -n "$_fair_yield" ]] && _excluded="$_fair_yield${_excluded:+,$_excluded}"
         resolve_worker_class "$role" "$_excluded"
+        # The yielded class was claimable when the run accumulated; by this tick
+        # the OTHER class may not be. Drop only the fairness exclusion (keeping
+        # any saturation exclusions, which are still true) and re-resolve, so the
+        # floor can never turn a servable tick into a deferred one. One-shot:
+        # clearing `_fair_yield` makes this branch unreachable on the retry.
+        if [[ -n "$_fair_yield" ]] && (( DISPATCH_DEFER )); then
+            log "$role: fairness yield of class=$_fair_yield found no other servable class; serving it after all"
+            _fair_yield=""
+            CLASS_ELECTION_RUN["$role"]=0
+            continue
+        fi
         if (( DISPATCH_DEFER )); then
             # Nothing a fresh worker can claim right now: cap-blocked fable only,
             # the queue's only items already have open PRs (inflight_pr, #1726),
@@ -1585,7 +1642,7 @@ dispatch_role() {
         fi
         # This class is saturated. Serve another claimable class if one exists.
         if (( DISPATCH_MORE )) && (( _passes++ < 3 )); then
-            _excluded="${_excluded:+$_excluded,}$DISPATCH_CLASS"
+            _sat_excluded="${_sat_excluded:+$_sat_excluded,}$DISPATCH_CLASS"
             log "$role: class=$DISPATCH_CLASS covered ($class_racing in-flight >= $DISPATCH_COUNT claimable); serving next class"
             continue
         fi
@@ -1598,6 +1655,27 @@ dispatch_role() {
         return
     done
     unset "CAP_DEFER_LOGGED[$role-noclaim]" "CAP_DEFER_LOGGED[$role-claimcap]"
+
+    # Fairness-floor bookkeeping (#2699). Deliberately here, after the election
+    # settled and before the fan-out: every return path above (no trigger, role
+    # cap, no idle pane, defer) skips it, so a quiet or fully-busy fleet cannot
+    # accumulate a run it never actually served and then yield spuriously.
+    # `DISPATCH_CLASS` is empty on the uncapped/lane-default path and for
+    # non-worker roles, which is what keeps this worker-lane-only.
+    if [[ -n "$DISPATCH_CLASS" ]]; then
+        if (( ! DISPATCH_MORE )); then
+            # Sole servable class — there is nothing to be fair to, so serving
+            # it again is not a monopoly. Reset rather than accumulate, or a
+            # single-class stretch would bank a run and yield the moment a
+            # second class appeared.
+            CLASS_ELECTION_RUN["$role"]=0
+        elif [[ "${CLASS_ELECTION_LAST[$role]:-}" == "$DISPATCH_CLASS" ]]; then
+            CLASS_ELECTION_RUN["$role"]=$(( ${CLASS_ELECTION_RUN[$role]:-0} + 1 ))
+        else
+            CLASS_ELECTION_RUN["$role"]=1
+        fi
+        CLASS_ELECTION_LAST["$role"]="$DISPATCH_CLASS"
+    fi
 
     local dispatched=0
     local gap_blocked=""
@@ -2170,6 +2248,29 @@ case "${1:-}" in
         fi
         DISPATCH_MODE="$(read_dispatch_mode)"
         build_dispatch_command "$2" "$3"
+        exit 0
+        ;;
+    --dispatch-role)
+        # Test/debug: run <count> (default 1) consecutive dispatch_role ticks
+        # and exit, without starting the daemon loop. The ticks deliberately
+        # share one process — the class fairness floor's run counter is
+        # daemon-lifetime, so a multi-tick monopoly and the yield that ends it
+        # are only observable within a single process. Everything a tick touches
+        # is env-redirectable (FLEET_STATE_DIR, tmux/pgrep on PATH), so this
+        # stays hermetic; assert on the log lines, which go to stderr.
+        # Usage: --dispatch-role <role> [count]
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-dispatcher --dispatch-role <role> [count]" >&2
+            exit 2
+        fi
+        if [[ -n "${3:-}" ]] && ! [[ "$3" =~ ^[1-9][0-9]*$ ]]; then
+            echo "fleet-dispatcher --dispatch-role: count must be a positive integer" >&2
+            exit 2
+        fi
+        DISPATCH_MODE="$(read_dispatch_mode)"
+        for (( _tick = 0; _tick < ${3:-1}; _tick++ )); do
+            dispatch_role "$2"
+        done
         exit 0
         ;;
     --resolve-class)

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -268,6 +268,17 @@
 # lower it if you want freed slots refilled faster. Default 90.
 # FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS=90
 #
+# FLEET_DISPATCHER_CLASS_FAIRNESS_RUN bounds how long one model class can hold
+# the worker lane. The cap above yields to another class only once the elected
+# one is fully covered — which never happens when its queued items are ones
+# every worker refuses (host-gated, design-parked, content-declined): those are
+# counted forever but never claimed, so one class can hold the lane for days
+# (#2699). This is the backstop: after this many consecutive ticks electing the
+# same class while another class is claimable, the lane yields one pass to that
+# class regardless of coverage. Raise it to favor throughput on the busiest
+# class, lower it for a tighter round-robin, 0 to disable. Default 3.
+# FLEET_DISPATCHER_CLASS_FAIRNESS_RUN=3
+#
 # FLEET_DISPATCHER_RATE429_DELAY is the per-pane cooldown applied after a
 # short-window 429 *failure* (claude exhausted its internal retries). It is
 # deliberately much shorter than FLEET_DISPATCHER_LIMIT_DELAY (the usage /

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -274,9 +274,11 @@
 # every worker refuses (host-gated, design-parked, content-declined): those are
 # counted forever but never claimed, so one class can hold the lane for days
 # (#2699). This is the backstop: after this many consecutive ticks electing the
-# same class while another class is claimable, the lane yields one pass to that
-# class regardless of coverage. Raise it to favor throughput on the busiest
-# class, lower it for a tighter round-robin, 0 to disable. Default 3.
+# same class while another class is claimable, the lane yields one pass
+# regardless of coverage — to the least recently served claimable class, so a
+# third class cannot starve behind the top two trading turns. Raise it to favor
+# throughput on the busiest class, lower it for a tighter round-robin, 0 to
+# disable. Default 3.
 # FLEET_DISPATCHER_CLASS_FAIRNESS_RUN=3
 #
 # FLEET_DISPATCHER_RATE429_DELAY is the per-pane cooldown applied after a

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -16,6 +16,10 @@
 #     namespacing / dry-run+review-only gating) against a stubbed fleet-claim
 #   - FLEET_MODEL_* unset -> standalone alias-default fallback resolves each
 #     class to its fleet-common.sh default (fable[1m]/opus[1m]/sonnet)
+#   - class fairness floor (#2699, T20+): negative control, positive fire,
+#     disable/clamp of the threshold, single-class no-op, the vanished-
+#     alternative give-back, three-class rotation (rank 3 must not starve
+#     behind ranks 1-2 trading turns), and a cap-saturated yield target
 #
 # The fable in-flight count comes from dispatch records under
 # $FLEET_STATE_DIR/dispatch, same records --count-active reads.
@@ -485,6 +489,121 @@ case "$out" in
     *) PASS=$((PASS+1)); echo "  ok: no tick deferred" ;;
 esac
 unset STUB_SLICE_AFTER_3 STUB_SEND_COUNT
+
+echo "T27: three claimable classes — the lowest-ranked one is not starved"
+# T21/T25 are both TWO-class slices, and the defect they cannot see lives one
+# rank down. A single-class yield excludes only CLASS_ELECTION_LAST, so the
+# yield tick always lands on rank 2; the bookkeeping then records rank 2 as
+# LAST with RUN=1, the monopolist re-elects on the next tick, and rank 3 is
+# never reached — unbounded starvation, the same shape #2699 was filed
+# against. Measured in the wild as the fable planning lane (17/17 claimable,
+# zero dispatches) sitting behind opus+sonnet.
+#
+# The yield is therefore a SET: every class served more recently than the
+# longest-unserved one is excluded, so the resolver walks down the candidate
+# order until it reaches a class that has actually gone unserved.
+# Both T27 and T28 soak across more ticks than there are panes, so panes have
+# to free up as their iterations finish — otherwise the run dies on the role
+# concurrency cap long before the assertion window. Modelled at the list-panes
+# seam, which the dispatcher calls at tick start, BEFORE the class election
+# (the send-keys seam T25 uses is too late: write_dispatch_record runs after
+# it). `pane-seed.json` is deliberately exempt — T28 needs one dispatch to stay
+# in flight across ticks.
+cat > "$STUB_BIN/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    list-panes)
+        # The previous tick's workers finished and returned to a shell.
+        for f in "$FLEET_STATE_DIR"/dispatch/pane-*.json; do
+            if [[ -f "$f" && "$f" != *pane-seed.json ]]; then rm -f "$f"; fi
+        done
+        for i in 1 2 3 4 5; do printf '%%%s|pool|zsh\n' "$i"; done
+        exit 0
+        ;;
+    display-message)
+        pane=""; fmt=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            echo "/fake/worktrees/pool-${pane#%}"
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            echo "1"
+        fi
+        exit 0
+        ;;
+    send-keys) exit 0 ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$STUB_BIN/tmux"
+THREE_CLASS_SLICE='{"tasks_open":[
+  {"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false},
+  {"issue":"#13","model":"sonnet","effort":null,"owner":"free","blocked":false}],
+ "feedback_prs":[],
+ "needs_plan":[{"number":99,"repo":"engine","labels":[]}]}'
+rm -f "$FLEET_STATE_DIR/dispatch"/*.json
+: > "$FLEET_STATE_DIR/triggers/worker"
+write_slice worker "$THREE_CLASS_SLICE"
+out=$(STUB_GRANT='engine:99' "$DISPATCHER" --dispatch-role worker 16 2>&1 >/dev/null)
+# >=2 rather than >=1 deliberately: a single dispatch is also what a one-shot
+# walk that then re-locks onto ranks 1-2 would produce. Two proves the yield
+# target keeps rotating. The machine is fully deterministic here (settle=0
+# pins class_racing to 0 and the stub frees every pane each tick), so the
+# measured 12 opus / 2 sonnet / 2 fable is stable, not timing-dependent.
+for _cls in opus sonnet fable; do
+    _n=$(printf '%s\n' "$out" | grep -c "class=$_cls effort" || true)
+    if (( _n >= 2 )); then
+        PASS=$((PASS+1)); echo "  ok: $_cls dispatched $_n times in 16 ticks"
+    else
+        FAIL=$((FAIL+1)); echo "  FAIL: $_cls dispatched $_n times in 16 ticks (want >=2):"
+        printf '%s\n' "$out"
+    fi
+done
+
+echo "T28: a cap-saturated yield target does not idle the lane"
+# fleet-dispatcher's fairness comment claims the floor "can never turn a
+# servable tick into a deferred one". The drop-and-retry backing that claim
+# fires only on RESOLVER defer; the cap-saturation defer further down was not
+# covered. Shape: the yielded-TO class resolves fine (more=0, defer=0) but has
+# no claim headroom, so the tick returns "already covered" with the fairness
+# exclusion still applied — while the yielded class had headroom and would
+# have been served without the floor. Worse, the return is above the
+# bookkeeping, so CLASS_ELECTION_RUN stays at the threshold and EVERY
+# subsequent tick re-yields and re-defers until the records age out.
+#
+# Reproduced with the MONOPOLY_SLICE shape (opus fan-out of 1/tick, so ticks
+# stay countable) plus a live settle window and one pre-seeded in-flight sonnet
+# record, so claim_headroom(sonnet) == 0 while opus still has room.
+#
+# Reuses the pane-freeing stub installed above T27; `pane-seed.json` survives
+# its sweep, so sonnet stays saturated while opus's own records never
+# accumulate against it.
+rm -f "$FLEET_STATE_DIR/dispatch"/*.json
+: > "$FLEET_STATE_DIR/triggers/worker"
+write_slice worker "$MONOPOLY_SLICE"
+# The sonnet lane's only claimable slot, already in flight and still inside the
+# settle window — claim_headroom(sonnet) == 0 on the yield tick.
+printf '{"role":"worker","pane":"%%99","class":"sonnet","dispatched_at":"%s","dispatched_epoch":%s}\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$(date +%s)" \
+    > "$FLEET_STATE_DIR/dispatch/pane-seed.json"
+out=$(FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS=90 \
+    "$DISPATCHER" --dispatch-role worker 4 2>&1 >/dev/null)
+case "$out" in
+    *"already covered by"*"deferring trigger"*|*"no claimable work"*)
+        FAIL=$((FAIL+1)); echo "  FAIL: the yield deferred a tick the elected class could serve:"
+        printf '%s\n' "$out" ;;
+    *)  PASS=$((PASS+1)); echo "  ok: no tick deferred while opus had headroom" ;;
+esac
+assert_eq "$(printf '%s\n' "$out" | grep -c 'dispatching worker -> .*class=opus')" "4" \
+    "all four ticks served opus — the saturated yield target degraded to serving, not deferring"
+rm -f "$FLEET_STATE_DIR/dispatch/pane-seed.json"
 
 echo "T26: --dispatch-role argument validation"
 "$DISPATCHER" --dispatch-role >/dev/null 2>&1 \

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -269,6 +269,231 @@ assert_eq "$(resolve_unpinned sonnet)" \
     "class=sonnet model=sonnet effort=high more=0 defer=0 count=1 plan=0" \
     "unpinned sonnet resolves to FLEET_SONNET_CLASS_DEFAULT=sonnet"
 
+# --- T20+: class fairness floor (#2699) ---------------------------------------
+#
+# The measured defect shape: the elected class's claimable items are ones every
+# worker REFUSES, so they never leave tasks_open, while the workers that walked
+# and declined them age past CLAIM_SETTLE_SECONDS and stop counting as racing.
+# `claim_headroom = DISPATCH_COUNT - class_racing` therefore stays permanently
+# positive and the `serving next class` fan-out at the saturation branch is
+# unreachable — 57 opus / 0 sonnet / 0 fable dispatches over 2h in the wild.
+#
+# Reproduced here by pinning CLAIM_SETTLE_SECONDS=0 (nothing is ever "recent",
+# so class_racing is always 0 — the same end state as every record aging out)
+# against a slice with more opus items than the tick can cover. The assertions
+# below run whole dispatch_role ticks via --dispatch-role, not just the
+# resolver, so the positive case observes a non-elected class ACTUALLY
+# DISPATCHED rather than merely a counter incrementing.
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"; mkdir -p "$FLEET_RESERVATIONS_DIR"
+export FLEET_DISPATCH_MIN_GAP_SECONDS=0     # no stagger between the ticks
+export FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS=0
+export FLEET_CONCURRENCY_WORKER=5           # > the tick count, so the role cap never gates
+export FLEET_SESSION="fleet-test-$$"
+
+# Five idle pool panes, each on its own worktree (count_active_for_role dedupes
+# by worktree). pgrep exits 1 so no pane reads as running a wrapper.
+cat > "$STUB_BIN/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    list-panes)
+        for i in 1 2 3 4 5; do printf '%%%s|pool|zsh\n' "$i"; done
+        exit 0
+        ;;
+    display-message)
+        pane=""; fmt=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            echo "/fake/worktrees/pool-${pane#%}"
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            echo "1"
+        fi
+        exit 0
+        ;;
+    send-keys) exit 0 ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$STUB_BIN/tmux"
+cat > "$STUB_BIN/pgrep" <<'PGREPEOF'
+#!/usr/bin/env bash
+exit 1
+PGREPEOF
+chmod +x "$STUB_BIN/pgrep"
+
+# One opus task (the refused-but-permanently-counted head) + one sonnet task
+# (the starved lane). DISPATCH_COUNT=1 with class_racing pinned to 0 makes
+# claim_headroom permanently 1 — positive, so the saturation fan-out never
+# fires — while capping each tick's fan-out at a single pane, which is what
+# makes ticks countable in the assertions below.
+MONOPOLY_SLICE='{"tasks_open":[
+  {"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false},
+  {"issue":"#13","model":"sonnet","effort":null,"owner":"free","blocked":false}],
+ "feedback_prs":[],"needs_plan":[]}'
+OPUS_ONLY_SLICE='{"tasks_open":[
+  {"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false}],
+ "feedback_prs":[],"needs_plan":[]}'
+
+# Run <count> consecutive worker ticks from a clean dispatch dir + fresh
+# trigger, and print the dispatcher log (stderr) for assertion.
+run_ticks() { # $1 = tick count, rest = env assignments
+    rm -f "$FLEET_STATE_DIR/dispatch"/*.json
+    mkdir -p "$FLEET_STATE_DIR/triggers"
+    : > "$FLEET_STATE_DIR/triggers/worker"
+    write_slice worker "$MONOPOLY_SLICE"
+    local n="$1"; shift
+    env "$@" "$DISPATCHER" --dispatch-role worker "$n" 2>&1 >/dev/null
+}
+
+echo "T20: negative control — a single tick still dispatches the elected class"
+# Scoped to ONE tick deliberately: the floor yields on turn count, so a
+# multi-tick soak would (correctly) yield and read as a regression. One tick is
+# the shape that pins "the settle-window intent at fleet-dispatcher:470-481 is
+# preserved — a healthy elected class is served, not withheld".
+out=$(run_ticks 1)
+case "$out" in
+    *"dispatching worker -> %1 [class=opus"*)
+        PASS=$((PASS+1)); echo "  ok: elected opus dispatched on the first tick" ;;
+    *) FAIL=$((FAIL+1)); echo "  FAIL: first tick did not dispatch opus:"; printf '%s\n' "$out" ;;
+esac
+case "$out" in
+    *"fairness floor"*) FAIL=$((FAIL+1)); echo "  FAIL: floor fired on the first tick" ;;
+    *) PASS=$((PASS+1)); echo "  ok: no yield before the run threshold" ;;
+esac
+
+echo "T21: positive fire — the 4th tick dispatches the NON-elected class"
+out=$(run_ticks 4)
+case "$out" in
+    *"dispatching worker -> "*"[class=sonnet"*)
+        PASS=$((PASS+1)); echo "  ok: sonnet (never elected) actually dispatched" ;;
+    *) FAIL=$((FAIL+1)); echo "  FAIL: no sonnet dispatch in 4 ticks:"; printf '%s\n' "$out" ;;
+esac
+case "$out" in
+    *"class=opus elected 3 consecutive ticks with other classes queued; yielding one pass (fairness floor)"*)
+        PASS=$((PASS+1)); echo "  ok: yield logged with class and run length" ;;
+    *) FAIL=$((FAIL+1)); echo "  FAIL: fairness-yield log line missing:"; printf '%s\n' "$out" ;;
+esac
+# The headroom-based fan-out must NOT be what produced it — that branch is
+# exactly the one the defect makes unreachable in this slice shape.
+case "$out" in
+    *"serving next class"*)
+        FAIL=$((FAIL+1)); echo "  FAIL: saturation fan-out fired; the defect shape is not reproduced" ;;
+    *) PASS=$((PASS+1)); echo "  ok: sonnet came from the floor, not the (unreachable) headroom fan-out" ;;
+esac
+assert_eq "$(printf '%s\n' "$out" | grep -c 'dispatching worker -> .*class=opus')" "3" \
+    "opus served exactly its 3 turns before the yield"
+
+echo "T22: FLEET_DISPATCHER_CLASS_FAIRNESS_RUN=0 disables the floor"
+out=$(run_ticks 5 FLEET_DISPATCHER_CLASS_FAIRNESS_RUN=0)
+case "$out" in
+    *"[class=sonnet"*) FAIL=$((FAIL+1)); echo "  FAIL: floor fired while disabled" ;;
+    *) PASS=$((PASS+1)); echo "  ok: run=0 restores the pre-#2699 headroom-only behaviour" ;;
+esac
+
+echo "T23: a non-numeric threshold falls back to 3 instead of killing the daemon"
+out=$(run_ticks 4 FLEET_DISPATCHER_CLASS_FAIRNESS_RUN=banana)
+case "$out" in
+    *"CLASS_FAIRNESS_RUN=banana is not a non-negative integer; falling back to 3"*)
+        PASS=$((PASS+1)); echo "  ok: invalid override warned and clamped" ;;
+    *) FAIL=$((FAIL+1)); echo "  FAIL: no clamp warning:"; printf '%s\n' "$out" ;;
+esac
+case "$out" in
+    *"[class=sonnet"*) PASS=$((PASS+1)); echo "  ok: clamped default still yields on the 4th tick" ;;
+    *) FAIL=$((FAIL+1)); echo "  FAIL: clamped-to-3 floor did not fire" ;;
+esac
+
+echo "T24: single-class slice never accumulates a run (more=0 resets it)"
+write_slice worker "$OPUS_ONLY_SLICE"
+rm -f "$FLEET_STATE_DIR/dispatch"/*.json
+: > "$FLEET_STATE_DIR/triggers/worker"
+out=$("$DISPATCHER" --dispatch-role worker 5 2>&1 >/dev/null)
+case "$out" in
+    *"fairness floor"*) FAIL=$((FAIL+1)); echo "  FAIL: floor fired with no other class to serve" ;;
+    *) PASS=$((PASS+1)); echo "  ok: opus-only slice serves opus indefinitely — no monopoly to break" ;;
+esac
+
+echo "T25: the floor never turns a servable tick into a deferred one"
+# The class the run accrued against is gone by the time the yield fires (its
+# task got claimed between ticks — the scout rewrites the slice constantly, so
+# this is a live daemon state, not a contrived one). The yield must drop its
+# own exclusion and serve the elected class anyway rather than defer the tick.
+# Simulated at the send-keys seam: the 3rd dispatch is when "another worker
+# claimed the sonnet task", so the stub rewrites the slice to drop it.
+export STUB_SLICE_AFTER_3="$TMPROOT/slice-after-3.json"
+printf '%s\n' "$OPUS_ONLY_SLICE" > "$STUB_SLICE_AFTER_3"
+export STUB_SEND_COUNT="$TMPROOT/send-count"
+cat > "$STUB_BIN/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    list-panes)
+        for i in 1 2 3 4 5; do printf '%%%s|pool|zsh\n' "$i"; done
+        exit 0
+        ;;
+    display-message)
+        pane=""; fmt=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            echo "/fake/worktrees/pool-${pane#%}"
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            echo "1"
+        fi
+        exit 0
+        ;;
+    send-keys)
+        # Optional world-changes-under-us seam (T25): after N dispatches,
+        # swap in a slice where the other class's work is gone.
+        if [[ -n "${STUB_SLICE_AFTER_3:-}" && -n "${STUB_SEND_COUNT:-}" ]]; then
+            n=$(( $(cat "$STUB_SEND_COUNT" 2>/dev/null || echo 0) + 1 ))
+            printf '%s' "$n" > "$STUB_SEND_COUNT"
+            (( n >= 3 )) && cp "$STUB_SLICE_AFTER_3" "$FLEET_STATE_DIR/projections/worker.json"
+        fi
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$STUB_BIN/tmux"
+rm -f "$FLEET_STATE_DIR/dispatch"/*.json "$STUB_SEND_COUNT"
+: > "$FLEET_STATE_DIR/triggers/worker"
+write_slice worker "$MONOPOLY_SLICE"
+out=$("$DISPATCHER" --dispatch-role worker 4 2>&1 >/dev/null)
+case "$out" in
+    *"fairness yield of class=opus found no other servable class; serving it after all"*)
+        PASS=$((PASS+1)); echo "  ok: vanished alternative detected, exclusion dropped" ;;
+    *) FAIL=$((FAIL+1)); echo "  FAIL: no fallback log line:"; printf '%s\n' "$out" ;;
+esac
+assert_eq "$(printf '%s\n' "$out" | grep -c 'dispatching worker -> .*class=opus')" "4" \
+    "all four ticks dispatched opus — the yield degraded to serving it, not to a defer"
+case "$out" in
+    *"deferring trigger"*|*"no claimable work"*)
+        FAIL=$((FAIL+1)); echo "  FAIL: the yield deferred a servable tick" ;;
+    *) PASS=$((PASS+1)); echo "  ok: no tick deferred" ;;
+esac
+unset STUB_SLICE_AFTER_3 STUB_SEND_COUNT
+
+echo "T26: --dispatch-role argument validation"
+"$DISPATCHER" --dispatch-role >/dev/null 2>&1 \
+    && { FAIL=$((FAIL+1)); echo "  FAIL: missing role exited zero"; } \
+    || { PASS=$((PASS+1)); echo "  ok: missing role exits non-zero"; }
+"$DISPATCHER" --dispatch-role worker 0 >/dev/null 2>&1 \
+    && { FAIL=$((FAIL+1)); echo "  FAIL: count=0 exited zero"; } \
+    || { PASS=$((PASS+1)); echo "  ok: non-positive count exits non-zero"; }
+
 echo
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

The dispatcher's cross-class fan-out serves a second class only once the elected
one is **fully covered** (`claim_headroom = DISPATCH_COUNT - class_racing`
reaching 0). That test inherits the settle window's stated premise — *"the task
leaves tasks_open once claimed, which is the real signal"*. An item every worker
**refuses** breaks it: never claimed, so it counts toward `DISPATCH_COUNT`
forever, while the workers that walked it and declined age out of
`CLAIM_SETTLE_SECONDS`. Headroom stays permanently positive, `serving next class`
is unreachable, and one class holds the worker lane indefinitely.

This adds a turn-based floor: after `CLASS_FAIRNESS_RUN` (default 3) consecutive
ticks electing the same class **while another class is claimable**, seed the
existing `_excluded` mechanism with that class for one pass so the fan-out serves
the next one.

- Counter lives beside `CAP_DEFER_LOGGED` — daemon-lifetime, no new state file.
- Bumped only **after** an election that reached the fan-out, so the no-trigger /
  role-cap / no-idle-pane / defer returns can't bank a run a quiet fleet never
  served.
- A yield whose alternative has since gone away drops **its own** exclusion
  (keeping saturation exclusions, which are still true) and re-resolves — the
  floor can never turn a servable tick into a deferred one.
- `_passes` is untouched by the pre-seed (it increments only inside the
  saturation branch), so the 3-pass bound still holds. Confirmed directly, per
  the plan review's note.

`FLEET_DISPATCHER_CLASS_FAIRNESS_RUN=0` restores the coverage-only behaviour.

### Phase 1 measurement (the plan's stop-and-re-scope gate)

The plan required measuring whether the starved lanes are *genuinely* claimable
before shipping a fix that only relocates churn — stop and re-scope if the count
were 0. Measured live against each of role-worker step 3's predicates (claim
label, `Blocked by:`, open-PR cross-check, host gate):

- **sonnet: 10/10 claimable.** #2514, #2681, game #295/#300/#303/#331/#333/#336
  free and unblocked; game #287/#345 valid stackables on open PR #339. No
  `fleet:claim-*` on any, no open PR references any, none host-gated.
- **fable planning: 17/17** carry live `fleet:needs-plan`; zero leaked
  `fleet:planning-*` locks, so the pre-claim would grant.
- **opus: 0/5.** All three feedback PRs terminally refused on this host
  (#2475 `fleet:needs-gl-host` on Metal-only, #2393 and game #321 tracked
  false positives) and both tasks content-declined.

The inversion the defect predicts, exactly. Gate not met — fix ships.

## Test plan

- [x] `test_dispatcher_class_dispatch.sh` extended with T20–T26 (28 → 43 asserts)
- [x] **AC 1 positive fire** (T21): 4 ticks, sonnet — never elected — is
      **actually dispatched**, not merely a counter increment. Also asserts
      `serving next class` never appears, proving the yield came from the floor
      and not the (unreachable-in-this-shape) headroom fan-out.
- [x] **AC 2 negative control** (T20): scoped to a **single tick** per the plan
      review's note 1 — the elected class is still served, no yield.
- [x] T22 `…RUN=0` disables; T23 non-numeric clamps to 3 without killing the
      daemon; T24 single-class slice never banks a run; T25 the vanished-
      alternative fallback serves rather than defers; T26 arg validation.
- [x] **AC 3**: full dispatcher suite green — 177 asserts across 10 suites, 0
      failures. Baseline captured **before** editing (the suites shell through
      `~/bin` into the main clone and are not hermetic); it was already green, so
      nothing is misattributed.
- [x] **Real-slice replay** — 8 ticks against a copy of the live
      `projections/worker.json` in an isolated `FLEET_STATE_DIR` with stubbed
      tmux (nothing dispatched into the running fleet):
      **before → 8 opus / 0 sonnet**; **after → 6 opus / 2 sonnet**, yielding on
      every 4th tick.

## Notes

- `count_recent_active_for_class` is untouched, per the plan's gotcha about a
  two-edit conflict with #2698.
- No file overlap with open PR #2697 (#2696's fix), which touches
  `fleet_task_class.py` — and its arithmetic is unchanged by this: 5 → 4
  claimable with `class_racing` settle-decayed to 0 still leaves headroom
  positive. #2696 remains necessary and insufficient.
- #2700 (scout trigger-production suppression) is a different file and mechanism;
  glanced per the review note, no interaction.

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
