### PR TITLE
fleet: claim-base must not answer master when the claim is gone

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -951,6 +951,16 @@ determine the base branch before checking out:
   `git fetch origin <upstream-branch>`
   `git checkout -b claude/<issue-number>-<short-topic> origin/<upstream-branch>`
 
+`claim-base` answers from the local claim, so it can only speak for a claim
+that still exists. With **no active claim** for the issue (released, or
+TTL-swept mid-iteration) it prints `master` but warns `base is UNVERIFIED`
+on stderr — do not take that `master` at face value on a task you claimed
+`--stackable-on`, because the sidecar recording the real base was swept with
+the claim and opening against `master` makes the diff swallow the blocker
+branch (#2703). Confirm the fork point first
+(`git merge-base --is-ancestor origin/<blocker-branch> HEAD`), or use
+`claim-base <N> --strict` to fail closed instead of guessing.
+
 Always include `Closes #<N>` in the PR body so the issue closes
 automatically when the PR merges:
 `gh pr create --title "<issue title> (#<N>)" --body "Claiming issue. Work in progress.\n\nCloses #<N>" --label "fleet:wip"`

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -17,7 +17,7 @@
 #
 # Usage:
 #   fleet-claim claim <issue-number> <agent-name> [--stackable-on <pr-url>]
-#   fleet-claim claim-base <issue-number>
+#   fleet-claim claim-base <issue-number> [--strict]
 #   fleet-claim find-stackable-blockers <issue-number>
 #   fleet-claim release <issue-number>
 #   fleet-claim check <issue-number>
@@ -72,6 +72,10 @@ FLEET_GITHUB_REPO="${FLEET_GITHUB_REPO:-jakildev/IrredenEngine}"
 # claim-base reads it to tell commit-and-push which branch to base the
 # task's PR on; release / check-stale / cleanup all delete the sidecar
 # alongside the claim dir so it never outlives the claim.
+#
+# Because the two are deleted together, the claim dir's presence is what
+# lets claim-base tell "normal claim, master is correct" from "the claim
+# is gone, so I cannot know the base" — see cmd_claim_base (#2703).
 
 __remove_claim() {
     # Remove a claim's directory and its --stackable-on sidecar (if any).
@@ -1287,11 +1291,37 @@ cmd_claim_base() {
     # the task was claimed with --stackable-on. commit-and-push reads
     # this at PR-open time to pick `--base` for `gh pr create`.
     #
-    # Usage: fleet-claim claim-base <issue-number>
+    # A missing sidecar is ambiguous, and the two readings must not be
+    # conflated: answering "master" for a --stackable-on task whose claim was
+    # TTL-swept mid-iteration opens the PR against master, so the diff swallows
+    # every commit of the blocker branch (#2703). __remove_claim deletes the
+    # claim dir and its sidecar together, so the claim dir discriminates them:
+    #
+    #   dir + sidecar   → stackable; print the recorded base
+    #   dir, no sidecar → active normal claim; "master" is an affirmative answer
+    #   no dir          → nothing local to answer from (swept claim, or an
+    #                     ad-hoc PR that never claimed) — say so on stderr
+    #
+    # The unknown case still prints "master" so existing callers (which capture
+    # stdout without checking the exit code) keep working; --strict opts into
+    # failing closed instead, the way the sibling `stack-base` already does.
+    #
+    # Usage: fleet-claim claim-base <issue-number> [--strict]
     local issue_num
     if ! issue_num=$(require_issue_number "$1"); then
         return 2
     fi
+    local strict=0
+    case "${2:-}" in
+        --strict) strict=1 ;;
+        "")       ;;
+        *)  # Never ignore an unrecognized flag: silently dropping a typo'd
+            # --strict would restore exactly the guess-quietly behavior above.
+            echo "fleet-claim claim-base: unknown option: $2" >&2
+            echo "usage: fleet-claim claim-base <issue-number> [--strict]" >&2
+            return 2
+            ;;
+    esac
     local slug
     slug=$(slugify "$issue_num")
     local meta_file="$CLAIMS_DIR/${slug}.meta"
@@ -1302,6 +1332,19 @@ cmd_claim_base() {
         if [[ -n "$base" ]]; then
             echo "$base"
             return 0
+        fi
+    fi
+    if [[ ! -d "$CLAIMS_DIR/$slug" ]]; then
+        {
+            echo "fleet-claim claim-base: no active claim for #${issue_num} — base is UNVERIFIED."
+            echo "  If this task was claimed --stackable-on, its sidecar was swept with the"
+            echo "  claim and \"master\" is wrong: the PR would swallow the blocker branch."
+            echo "  Confirm the fork point before opening the PR (both network-free):"
+            echo "    git merge-base --is-ancestor origin/<blocker-branch> HEAD"
+            echo "    git log --oneline origin/master..HEAD"
+        } >&2
+        if [[ "$strict" -eq 1 ]]; then
+            return 1
         fi
     fi
     echo "master"
@@ -4372,10 +4415,10 @@ case "${1:-}" in
         ;;
     claim-base)
         if [[ -z "${2:-}" ]]; then
-            echo "usage: fleet-claim claim-base <issue-number>" >&2
+            echo "usage: fleet-claim claim-base <issue-number> [--strict]" >&2
             exit 2
         fi
-        cmd_claim_base "$2"
+        cmd_claim_base "$2" "${3:-}"
         ;;
     find-stackable-blockers)
         if [[ -z "${2:-}" ]]; then
@@ -4661,10 +4704,14 @@ Task identity:
 commands:
   claim <issue-number> [agent] [--stackable-on <pr-url>]
                                 claim a task (exit 0=claimed, 1=taken).
-  claim-base <issue-number>     print the base branch for this task's
+  claim-base <issue-number> [--strict]
+                                print the base branch for this task's
                                 PR — "master" for normal claims, the
                                 recorded stackable_base_branch for a
-                                --stackable-on claim.
+                                --stackable-on claim. With no active
+                                claim the base is unverifiable: warns on
+                                stderr and still prints "master", or
+                                exits 1 under --strict.
   branch-check <issue-number> [branch]
                                 validate that <branch> (default: the current
                                 git branch) encodes <issue-number> via the

--- a/scripts/fleet/tests/test_fleet_claim_claim_base_states.sh
+++ b/scripts/fleet/tests/test_fleet_claim_claim_base_states.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim claim-base's three resolution states (#2703).
+#
+# claim-base used to read only the $CLAIMS_DIR/<slug>.meta sidecar and fall
+# through to a bare `echo master` when it was absent — so a --stackable-on task
+# whose claim was TTL-swept mid-iteration silently reported "master", opening a
+# PR that swallows the whole blocker branch.
+#
+# __remove_claim deletes the claim dir and the sidecar together, so the claim
+# dir discriminates the ambiguous fallthrough:
+#
+#   dir + sidecar   → stackable base   (exit 0, no warning)
+#   dir, no sidecar → "master"         (exit 0, no warning — affirmative)
+#   no dir          → "master" + stderr warning (exit 0), or exit 1 under
+#                     --strict
+#
+# Purely local: claim-base touches no network, so this suite needs no gh stub.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+# shellcheck source=lib_assert.sh
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR"
+
+BLOCKER_BRANCH="claude/2547-depth-aware-camera-center-focus"
+
+# Capture into globals rather than packing into one string: the stderr advisory
+# is multi-line, and `cut -d<sep>` is line-oriented, so a packed form would
+# split wrongly.
+OUT=""
+ERR=""
+RC=0
+run_claim_base() {
+    set +e
+    OUT=$("$FLEET_CLAIM" claim-base "$@" 2>"$TMPROOT/stderr.txt")
+    RC=$?
+    set -e
+    ERR=$(cat "$TMPROOT/stderr.txt")
+}
+
+echo "--- state 1: claim dir + --stackable-on sidecar → recorded base ---"
+mkdir -p "$FLEET_CLAIMS_DIR/2548"
+echo "stackable_base_branch=$BLOCKER_BRANCH" > "$FLEET_CLAIMS_DIR/2548.meta"
+run_claim_base 2548
+assert_eq "$OUT" "$BLOCKER_BRANCH" "stackable claim prints the recorded base"
+assert_eq "$RC" "0" "stackable claim exits 0"
+assert_eq "$ERR" "" "stackable claim warns nothing"
+
+echo "--- state 2: claim dir, no sidecar → affirmative master, silent ---"
+mkdir -p "$FLEET_CLAIMS_DIR/2703"
+run_claim_base 2703
+assert_eq "$OUT" "master" "normal active claim prints master"
+assert_eq "$RC" "0" "normal active claim exits 0"
+assert_eq "$ERR" "" "normal active claim warns nothing (no false alarm)"
+
+echo "--- state 3: no claim dir → master on stdout, warning on stderr ---"
+run_claim_base 9999
+assert_eq "$OUT" "master" "unknown state still prints master on stdout (non-breaking)"
+assert_eq "$RC" "0" "unknown state still exits 0 without --strict"
+assert_contains "$ERR" "UNVERIFIED" "unknown state warns on stderr"
+assert_contains "$ERR" "9999" "warning names the issue"
+
+echo "--- state 3 regression: the swept --stackable-on claim (#2548 incident) ---"
+# Exactly the observed failure: a stackable claim whose dir + sidecar were
+# swept together by __remove_claim while the task was still in flight.
+rm -rf "$FLEET_CLAIMS_DIR/2548" "$FLEET_CLAIMS_DIR/2548.meta"
+run_claim_base 2548
+assert_eq "$OUT" "master" "swept stackable claim falls back to master on stdout"
+assert_contains "$ERR" "UNVERIFIED" "swept stackable claim is no longer SILENT"
+assert_contains "$ERR" "swallow the blocker branch" "warning names the concrete harm"
+
+echo "--- --strict fails closed only in the unknown state ---"
+run_claim_base 2548 --strict
+assert_eq "$RC" "1" "--strict exits 1 when the base is unverifiable"
+assert_eq "$OUT" "" "--strict prints nothing to stdout when it fails closed"
+
+mkdir -p "$FLEET_CLAIMS_DIR/2548"
+echo "stackable_base_branch=$BLOCKER_BRANCH" > "$FLEET_CLAIMS_DIR/2548.meta"
+run_claim_base 2548 --strict
+assert_eq "$OUT" "$BLOCKER_BRANCH" "--strict is transparent when the sidecar is present"
+assert_eq "$RC" "0" "--strict exits 0 when the sidecar is present"
+
+mkdir -p "$FLEET_CLAIMS_DIR/2704"
+run_claim_base 2704 --strict
+assert_eq "$OUT" "master" "--strict is transparent for an active normal claim"
+assert_eq "$RC" "0" "--strict exits 0 for an active normal claim"
+
+echo "--- an unrecognized option is rejected, not ignored ---"
+run_claim_base 2704 --stict
+assert_eq "$RC" "2" "typo'd flag exits 2 rather than silently guessing"
+assert_contains "$ERR" "unknown option" "typo'd flag names itself"
+
+echo "--- game namespace keeps its own slug ---"
+# The engine slug for 2548 exists (above); the game claim must not read it.
+rm -rf "$FLEET_CLAIMS_DIR/game-2548" "$FLEET_CLAIMS_DIR/game-2548.meta"
+set +e
+GAME_OUT=$("$FLEET_CLAIM" --repo game claim-base 2548 2>"$TMPROOT/stderr.txt")
+set -e
+assert_eq "$GAME_OUT" "master" "game #2548 does not read the engine slug's sidecar"
+assert_contains "$(cat "$TMPROOT/stderr.txt")" "UNVERIFIED" "game #2548 with no claim warns"
+
+summarize


### PR DESCRIPTION
## Summary

`fleet-claim claim-base <N>` resolved a task's PR base **solely** from the local
claim sidecar `$CLAIMS_DIR/<slug>.meta`, falling through to a bare
`echo "master"` with exit 0 when it was absent. That state is ambiguous — it
means *either* "normal claim, master is correct" *or* "the claim was TTL-swept
and the recorded base went with it" — so on a `--stackable-on` task it silently
reported the wrong base. Opening that PR against `master` makes the diff carry
every commit of the blocker branch: unreviewable, and it misattributes another
worker's commits to the author.

The sibling resolver `cmd_stack_base` already fails closed in all three of its
unknown states (`fleet-claim:3546/3562/3573`), printing `master` only when it
*affirmatively* knows the task is first in the stack. This brings `claim-base`
to the same standard.

`__remove_claim` deletes the claim dir and its sidecar **together**
(`fleet-claim:76-82`), so the claim dir discriminates the two readings with no
network call:

| claim dir | sidecar | resolution |
|---|---|---|
| present | present | stackable — print the recorded base |
| present | absent | active normal claim — `master` is affirmative |
| absent | absent | **unknown** — no basis to answer |

Only the third row was defective, and it was silently merged into the second.

**Non-breaking by construction.** stdout and exit status are unchanged for both
existing paths; the unknown state still prints `master` and still exits 0, and
warns on stderr (which does not pollute `$(...)` capture — the consumer at
`.claude/skills/commit-and-push/procedures/stackable-on.md:30` captures stdout
without checking the exit code). `--strict` opts into failing closed instead.

An unrecognized option is now rejected rather than ignored — silently dropping
a typo'd `--strict` would restore exactly the guess-quietly behavior this
removes.

## Observed occurrence

2026-07-30, issue #2548 (pool-3/opus): `claim-base 2548 pool-3` returned
`claude/2547-depth-aware-camera-center-focus` at claim time and `master` four
hours later, with PR #2585 still OPEN and nothing about the base changed. The
worker only avoided the bad PR by hand-checking the fork point.

## Test plan

- [x] New suite `scripts/fleet/tests/test_fleet_claim_claim_base_states.sh` — **23/23 pass**. Covers all three states, the `#2548` swept-stackable regression, `--strict` transparency in the two known states, option rejection, and game-namespace slug isolation.
- [x] **Positive control**: the suite run against the pre-fix `fleet-claim` (`d6a44197`) fails **9** assertions; the **14** that still pass are exactly the states-1-and-2 non-regression assertions, confirming existing behavior is untouched and the suite is not vacuous. (14 + 9 = 23, the full suite.)
- [x] Neighboring suites green: `test_fleet_claim_safety_guards` (25/25), `test_fleet_claim_agent_flag_guard` (92/92), `test_fleet_claim_stackable_live_resolve` (12/12), `test_fleet_claim_symlink_lib_dir` (4/4), `test_fleet_claim_acquire` (rc=0).
- [x] `bash -n scripts/fleet/fleet-claim` clean; `ruff check scripts/` clean; `python3 scripts/fleet/lint_state_mtime.py scripts/fleet/` clean.
- [x] Live check against this PR's own claim: `claim-base 2703 --strict` → `master`, rc=0 (active claim, no sidecar); `claim-base 9999 --strict` → empty, rc=1.

## Notes for the reviewer

- `.claude/skills/commit-and-push/procedures/stackable-on.md:32` documents the
  old two-state contract ("no `.meta` sidecar → prints `master`"). That
  statement is still **true** (stdout is unchanged) but no longer complete — it
  doesn't mention the stderr advisory. It's gated self-config, so this PR can't
  touch it; flagging for a human pass.
- `simplify` §9b surfaced a candidate `scripts/fleet/CLAUDE.md` authoring rule
  ("a resolver answering from local state must distinguish *no record* from its
  default answer"). Convention changes route through the human-cued
  coding-improvement channel, so it is deliberately not added here.

Closes #2703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

