### PR TITLE
fleet: planning-claim liveness marker + confirmed-orphan sweep

### DIFF
--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -61,8 +61,14 @@ For each `fleet:needs-plan` issue:
    The `fleet:planning-<host>-<agent>` label lock itself is unchanged — the
    dispatcher and the interactive architect still take it through
    `fleet-claim planning-claim`, and the same lex-min mutex arbitrates
-   dispatcher-vs-architect collisions (plus the 1-hour TTL reaper for
-   orphans). What #2197 retires is the *worker-side contention protocol*:
+   dispatcher-vs-architect collisions (plus the orphan sweep in
+   `fleet-claim cleanup --gh`: a same-host label whose liveness marker is
+   missing or points at another issue is a *confirmed* orphan and goes
+   after a 120s grace, while anything the sweep can't vouch for locally —
+   cross-host labels, and same-host labels with a matching marker — still
+   waits the 1-hour TTL; see
+   [`fleet-labels-reference.md § fleet:planning-*`](fleet-labels-reference.md)).
+   What #2197 retires is the *worker-side contention protocol*:
    N panes racing per tick for the same oldest issue and arbitrating after
    the fact (#1810's three duplicate plans; #1999's triple re-derive). A
    planning dispatch now exists only after a successful sole-holder claim,

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -434,9 +434,21 @@ Specifically, **never pass these via `--label` when filing**:
   on human request and calls `planning-claim` directly); the shared
   mutex arbitrates dispatcher-vs-architect collisions. Orphans (a died
   iteration, a hard-killed pane) are swept by `fleet-claim cleanup
-  --gh` on a 1-hour TTL (`FLEET_CLAIM_STALE_SECS_PLANNING`), and
-  fleet-dispatch-wrap releases the label itself when a session-resume
-  discards the fresh assignment. Don't add manually.
+  --gh`: a **same-host** label whose liveness marker
+  (`~/.fleet/claims/_prlabel-planning-<agent>`, written on claim and
+  removed on release) is missing or points at another issue is a
+  confirmed orphan and is swept after a short grace
+  (`FLEET_CLAIM_PRLABEL_ORPHAN_GRACE_SECS`, 120s); anything the sweep
+  cannot vouch for locally — cross-host labels, and same-host labels
+  with a matching marker — waits the 1-hour TTL
+  (`FLEET_CLAIM_STALE_SECS_PLANNING`). The marker matters because this
+  claim is sole-holder over a `fleet:needs-plan` issue: an unswept
+  orphan strands that issue for every planner on every host, and
+  without the marker the leak is indistinguishable from a live claim
+  (#2711 — note a planning claim writes no task-claim lock, so
+  `fleet-claim list` is empty for a *live* planner too and is NOT a
+  leak test). fleet-dispatch-wrap releases the label itself when a
+  session-resume discards the fresh assignment. Don't add manually.
 - `fleet:human-amending` / `fleet:human-deferred` — owned by the
   **author worker** (any class) when picking up
   `human:needs-fix`. The two labels express which disposition the

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1643,14 +1643,18 @@ _cmd_pr_label_claim() {
         return 1
     fi
 
-    # Same-host liveness marker for reviewing/resolving claims: lets the cleanup
-    # sweep distinguish a live claim from one orphaned by a dead/restarted
+    # Same-host liveness marker for reviewing/resolving/planning claims: lets the
+    # cleanup sweep distinguish a live claim from one orphaned by a dead/restarted
     # session (whose GitHub label outlived the fleet-down wipe of ~/.fleet/claims).
     # A file (not a dir) so it can't collide with the dir-based task-claim
-    # iteration. amending carries its own heartbeat liveness; steward/planning
-    # are out of scope.
+    # iteration. amending carries its own heartbeat liveness. planning is here
+    # because it is sole-holder over a fleet:needs-plan issue: without a marker an
+    # orphaned label strands that issue for every planner on every host, and the
+    # leak is indistinguishable from a live claim (#2711). stewarding stays out of
+    # scope — it runs one pane per host, so the label itself is the cross-host
+    # signal and there is no second local claimant to vouch against.
     case "$prefix" in
-        fleet:reviewing-|fleet:resolving-)
+        fleet:reviewing-|fleet:resolving-|fleet:planning-)
             mkdir -p "$CLAIMS_DIR"
             local _tag="${prefix#fleet:}"; _tag="${_tag%-}"
             printf '%s\n' "$pr" > "$CLAIMS_DIR/_prlabel-${_tag}-${agent}" 2>/dev/null || true
@@ -1677,7 +1681,7 @@ _cmd_pr_label_release() {
 
     # Drop the same-host liveness marker (paired with the claim-side write).
     case "$prefix" in
-        fleet:reviewing-|fleet:resolving-)
+        fleet:reviewing-|fleet:resolving-|fleet:planning-)
             local _tag="${prefix#fleet:}"; _tag="${_tag%-}"
             rm -f "$CLAIMS_DIR/_prlabel-${_tag}-${agent}" 2>/dev/null || true
             ;;
@@ -2252,11 +2256,47 @@ for issue in issues:
             [[ "$added_epoch" -eq 0 ]] && continue
 
             local age=$(( now - added_epoch ))
-            [[ $age -lt $planning_stale_secs ]] && continue
+
+            # Confirmed-orphan fast path, same shape as the reviewing/resolving
+            # sweep above (#2711). planning-claim drops
+            # $CLAIMS_DIR/_prlabel-planning-<agent> (content = the issue number)
+            # on acquire and removes it on release, so a SAME-HOST planning label
+            # with no matching marker belongs to a session that died before
+            # releasing. That distinction matters more here than for reviewing: a
+            # planning claim is sole-holder over a fleet:needs-plan issue, so an
+            # orphan strands it for every planner on every host, silently — the
+            # issue keeps all its correct labels. Cross-host labels can't be
+            # vouched for locally and stay on the full TTL.
+            local planning_orphan=0
+            local _prest="${label_name#fleet:}"      # planning-<host>-<agent>
+            local _ptag="${_prest%%-*}"              # planning
+            local _pha="${_prest#*-}"                # <host>-<agent>
+            local _phost="${_pha%%-*}"               # <host>
+            local _pagent="${_pha#*-}"               # <agent>
+            if [[ "$_phost" == "$this_host" ]]; then
+                local _pmarker="$CLAIMS_DIR/_prlabel-${_ptag}-${_pagent}"
+                if [[ ! -f "$_pmarker" || "$(cat "$_pmarker" 2>/dev/null)" != "$issue_num" ]]; then
+                    planning_orphan=1
+                fi
+            fi
+
+            # The grace spares the microsecond race between the label add and the
+            # marker write, plus pre-fix claims during the one-time transition; a
+            # planner mid-thread-read is spared instead by holding a matching
+            # marker for the whole claim.
+            local _planning_grace="${FLEET_CLAIM_PRLABEL_ORPHAN_GRACE_SECS:-120}"
+            if (( planning_orphan )); then
+                [[ $age -lt $_planning_grace ]] && continue
+            elif [[ $age -lt $planning_stale_secs ]]; then
+                continue
+            fi
+
+            local _planning_note="age: $((age / 60))m"
+            (( planning_orphan )) && _planning_note="orphaned: no local marker on $this_host, ${_planning_note}"
 
             if gh issue edit "$issue_num" --repo "$repo" \
                     --remove-label "$label_name" >/dev/null 2>&1; then
-                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (age: $((age / 60))m)"
+                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (${_planning_note})"
                 total_removed=$((total_removed + 1))
             else
                 write_orphan_sentinel "$repo" "$issue_num" "$label_name" \

--- a/scripts/fleet/tests/test_fleet_claim_planning.sh
+++ b/scripts/fleet/tests/test_fleet_claim_planning.sh
@@ -35,6 +35,11 @@ assert_exit() {
 
 TMPROOT=$(mktemp -d)
 export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+# Hermetic claims dir: the fourth pass consults $CLAIMS_DIR for the planning
+# liveness marker, so an unset FLEET_CLAIMS_DIR would read the host's real
+# ~/.fleet/claims and make the sweep asserts depend on live fleet state.
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+mkdir -p "$FLEET_CLAIMS_DIR"
 export FLEET_TEST_HOST="mac"
 export FLEET_CLAIM_NO_SLEEP=1
 export FLEET_CLAIM_ACQUIRE_RETRIES=2
@@ -116,6 +121,19 @@ cmd_planning_release 740 worker >/dev/null 2>&1 || rc=$?
 assert_exit "$rc" 0 "release exits 0"
 if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then ok "release removed $MINE"; else bad "release did not remove $MINE (log: $(cat "$REMOVE_LOG"))"; fi
 
+echo "T5b: the claim/release pair maintains the same-host liveness marker (#2711)"
+# Without this marker a leaked planning label is indistinguishable from a live
+# claim, so the sole-holder lock strands a fleet:needs-plan issue for every
+# planner on every host — and `fleet-claim list` cannot tell the two apart
+# because a planning claim writes no task-claim lock at all.
+MARKER="$FLEET_CLAIMS_DIR/_prlabel-planning-worker"
+rm -f "$MARKER"; STUB_HOLDERS=""; STUB_PLAN_COMMENTS=0
+cmd_planning_claim 741 worker >/dev/null 2>&1
+if [[ -f "$MARKER" ]]; then ok "planning-claim wrote the liveness marker"; else bad "planning-claim wrote no marker at $MARKER"; fi
+if [[ "$(cat "$MARKER" 2>/dev/null)" == "741" ]]; then ok "marker content is the claimed issue number"; else bad "marker content should be 741, got '$(cat "$MARKER" 2>/dev/null)'"; fi
+cmd_planning_release 741 worker >/dev/null 2>&1
+if [[ ! -f "$MARKER" ]]; then ok "planning-release removed the liveness marker"; else bad "marker survived release (would read as a live claim forever)"; fi
+
 echo "== --replan re-plan path (#1999): bypass dedup, gate on needs-plan present =="
 
 echo "T8: --replan with a ## Plan comment AND fleet:needs-plan present → acquires (exit 0), bypassing dedup"
@@ -145,7 +163,8 @@ NP_JSON="$TMPROOT/needsplan.json"
 cat > "$NP_JSON" <<JSON
 [
   {"number":80,"labels":[{"name":"fleet:needs-plan"},{"name":"fleet:planning-mac-worker"}]},
-  {"number":81,"labels":[{"name":"fleet:needs-plan"},{"name":"fleet:planning-linux-worker"}]}
+  {"number":81,"labels":[{"name":"fleet:needs-plan"},{"name":"fleet:planning-linux-worker"}]},
+  {"number":82,"labels":[{"name":"fleet:needs-plan"},{"name":"fleet:planning-mac-fresh"}]}
 ]
 JSON
 export NP_JSON
@@ -171,10 +190,28 @@ out=$(cmd_cleanup_gh "jakildev/IrredenEngine" 2>&1)
 if grep -q -- "--remove-label fleet:planning-mac-worker" "$REMOVE_LOG"; then ok "stale planning label on needs-plan#80 swept"; else bad "stale label not swept (log: $(cat "$REMOVE_LOG"); out: $out)"; fi
 if grep -q -- "--remove-label fleet:planning-linux-worker" "$REMOVE_LOG"; then bad "fresh planning label on #81 wrongly swept"; else ok "fresh planning label on #81 kept"; fi
 
-echo "T7: FLEET_CLAIM_STALE_SECS_PLANNING override keeps even the 2h-old label"
+echo "T7: FLEET_CLAIM_STALE_SECS_PLANNING override keeps even the 2h-old VOUCHED label"
+# Post-#2711 the TTL knob governs claims the sweep cannot confirm dead:
+# cross-host labels, and same-host labels with a matching liveness marker. Give
+# #80 its marker so it is a vouched live claim — that is the claim class the
+# override is meant to protect. (A same-host label with NO marker is a confirmed
+# orphan and deliberately bypasses the TTL; T7b pins that.)
 : > "$REMOVE_LOG"; export FLEET_CLAIM_STALE_SECS_PLANNING=999999
+printf '80\n' > "$FLEET_CLAIMS_DIR/_prlabel-planning-worker"
 cmd_cleanup_gh "jakildev/IrredenEngine" >/dev/null 2>&1
-if grep -q -- "--remove-label fleet:planning-" "$REMOVE_LOG"; then bad "label swept despite TTL override (log: $(cat "$REMOVE_LOG"))"; else ok "TTL override respected; nothing swept"; fi
+if grep -q -- "--remove-label fleet:planning-" "$REMOVE_LOG"; then bad "vouched label swept despite TTL override (log: $(cat "$REMOVE_LOG"))"; else ok "TTL override respected for a vouched claim; nothing swept"; fi
+
+echo "T7b: a same-host planning label with NO marker is a confirmed orphan — swept despite the TTL override (#2711)"
+: > "$REMOVE_LOG"; rm -f "$FLEET_CLAIMS_DIR/_prlabel-planning-worker"
+cmd_cleanup_gh "jakildev/IrredenEngine" >/dev/null 2>&1
+if grep -q -- "--remove-label fleet:planning-mac-worker" "$REMOVE_LOG"; then ok "confirmed orphan swept on the fast path, not held for the TTL"; else bad "orphaned planning label survived the TTL override (log: $(cat "$REMOVE_LOG"))"; fi
+if grep -q -- "--remove-label fleet:planning-linux-worker" "$REMOVE_LOG"; then bad "cross-host label wrongly swept (cannot be vouched for locally)"; else ok "cross-host label kept on the TTL"; fi
+
+echo "T7c: a FRESH same-host no-marker label is spared by the grace (claim/marker write race)"
+# #82's label is 10s old (< the 120s grace), so the fast path must not reap it
+# even though it has no marker — that is the window between _acquire_label_on
+# returning and the marker write landing.
+if grep -q -- "--remove-label fleet:planning-mac-fresh" "$REMOVE_LOG"; then bad "fresh no-marker label reaped inside the grace"; else ok "fresh no-marker label spared by the grace"; fi
 unset FLEET_CLAIM_STALE_SECS_PLANNING
 
 echo


### PR DESCRIPTION
## Summary
- Extend the same-host liveness marker (`~/.fleet/claims/_prlabel-<tag>-<agent>`) to `fleet:planning-*` on both the claim and release side — it previously covered `fleet:reviewing-`/`fleet:resolving-` only, leaving planning the one sole-holder claim class with no liveness signal at all.
- Give the `cleanup --gh` fourth pass the confirmed-orphan fast path the reviewing/resolving sweep already has: a **same-host** planning label whose marker is missing or points at another issue is swept after the short grace (`FLEET_CLAIM_PRLABEL_ORPHAN_GRACE_SECS`, 120s); anything unvouchable locally — cross-host labels, and same-host labels with a matching marker — still waits the 1-hour TTL.
- `fleet:stewarding-*` deliberately **not** widened: it runs one pane per host, so the label itself is the cross-host signal and there is no second local claimant to vouch against.
- Update `fleet-labels-reference.md`, whose description of the planning sweep ("swept ... on a 1-hour TTL") this change makes stale.

Why it matters beyond a slow reap: `planning-claim` is sole-holder over a `fleet:needs-plan` issue, so an orphaned label strands that issue for **every planner on every host**, silently — the issue keeps all its correct labels and still counts as healthy planning backlog. And because a planning claim writes no task-claim lock, `fleet-claim list` is empty for a *live* planner too, so the by-hand "label present + no active claim = leak" test that circulates in fleet guidance is unsound: acting on it releases an issue someone is actively planning, reintroducing the same-tick double-plan race the lock exists to close (#1810).

## Test plan
- [x] `scripts/fleet/tests/test_fleet_claim_planning.sh` — 25 PASS / 0 FAIL
- [x] Sibling suites green (no regression in the shared sweep): `prlabel_orphan_sweep` 6/0, `steward` 15/0, `orphan_sweep` 5/0, `amending_sweep` 4/0
- [x] `bash -n scripts/fleet/fleet-claim`, `ruff check scripts/` clean

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| claim writes the marker, release removes it | `test_fleet_claim_planning.sh` T5b | `ok: planning-claim wrote the liveness marker` / `ok: marker content is the claimed issue number` / `ok: planning-release removed the liveness marker` |
| same-host no-marker label = confirmed orphan, swept off the fast path | T7b | `ok: confirmed orphan swept on the fast path, not held for the TTL` |
| matching marker keeps the claim (TTL still governs it) | T7 | `ok: TTL override respected for a vouched claim; nothing swept` |
| cross-host label cannot be vouched for locally → stays on TTL | T7b | `ok: cross-host label kept on the TTL` |
| grace must not reap a live planner | T7c | `ok: fresh no-marker label spared by the grace` |
| positive control — new assertions FAIL against master | new test vs `git show origin/master:scripts/fleet/fleet-claim` | `PASS: 22  FAIL: 3` — the 3 failures are exactly the new assertions (marker ×2, orphan sweep ×1); the 22 are the non-regression set |
| stewarding out of scope | `test_fleet_claim_steward.sh` | `PASS: 15  FAIL: 0` (unchanged) |

## Notes for reviewer
- **T7 was re-pointed, not deleted.** It asserted the TTL override held a same-host aged label that is now a *confirmed orphan*. Post-change the TTL knob governs claims the sweep cannot confirm dead, so T7 now gives #80 a matching marker — the claim class the override is meant to protect — and T7b pins the new bypass. This mirrors the shipped reviewing/resolving precedent, where the orphan fast path also deliberately bypasses `stale_secs`.
- **One-time transition risk, accepted:** a claim taken by a pane running pre-merge code writes no marker and can be reaped while live. The window is one dispatch generation, and the failure it risks (a duplicate plan comment — visible, recoverable) is strictly milder than the one it fixes (a needs-plan issue stranded silently and permanently). Same bet the reviewing/resolving rollout took.
- **Follow-up not taken here (out of #2711's scope):** this fixes detection/reaping, not the *emit* side. The leak's usual source is the planner's not-plannable exit path, which keeps `fleet:needs-plan` on (protocol-correct) but can skip the paired `planning-release`. Worth a separate ticket; I did not widen scope to author new planner-exit guidance.
- Related but distinct: #2476 covers why an existing TTL sweep did not fire for `fleet:reviewing-*` on PRs. Reviewing *has* a marker and a fast path; planning had neither, so a fix there leaves this hole open.

Closes #2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)