### PR TITLE
fleet: run scripts/fleet/tests in CI — runner + fix a red suite

### DIFF
--- a/.github/workflows/fleet-tests.yml
+++ b/.github/workflows/fleet-tests.yml
@@ -1,0 +1,42 @@
+name: Fleet Tests
+
+# The fleet's own bash/python suites (scripts/fleet/tests/). They are not
+# CMake tests, so `ctest` never sees them — without this workflow nothing
+# executes them and a suite can go red silently (#2712).
+#
+# Standalone rather than a step in quality.yml: that workflow is disabled
+# at the repo level, so any step added there is inert (re-enabling it is a
+# separate call — see #2718). These suites need no compiler, no GL, and no
+# CMake, so they have no reason to ride along with a build job anyway.
+#
+# Path-filtered to the fleet tooling surface — engine, shader, and asset
+# PRs skip this entirely (same convention as perf-gate.yml).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/fleet/**'
+      - '.github/workflows/fleet-tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/fleet/**'
+      - '.github/workflows/fleet-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fleet-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The suites are hermetic by the authoring rules (no live GitHub, no
+      # live ~/.fleet), and resolve the tool under test from their own
+      # directory — so a plain checkout is the whole environment. bash, python3
+      # and gh are preinstalled on ubuntu-latest.
+      - name: Run fleet tool tests
+        run: bash scripts/fleet/tests/run_all.sh

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -82,11 +82,5 @@ jobs:
       - name: Run tests
         run: ctest --preset linux-default-tests
 
-      # The fleet's own bash/python suites (scripts/fleet/tests/). They are
-      # not CMake tests, so the ctest step above does not cover them — this
-      # is the only thing that runs them (see #2712). ~2 min serial.
-      - name: Run fleet tool tests
-        run: bash scripts/fleet/tests/run_all.sh
-
       - name: Build smoke target (IRShapeDebug)
         run: cmake --build build --target IRShapeDebug -j $(nproc)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -82,5 +82,11 @@ jobs:
       - name: Run tests
         run: ctest --preset linux-default-tests
 
+      # The fleet's own bash/python suites (scripts/fleet/tests/). They are
+      # not CMake tests, so the ctest step above does not cover them — this
+      # is the only thing that runs them (see #2712). ~2 min serial.
+      - name: Run fleet tool tests
+        run: bash scripts/fleet/tests/run_all.sh
+
       - name: Build smoke target (IRShapeDebug)
         run: cmake --build build --target IRShapeDebug -j $(nproc)

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -32,9 +32,10 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   new test"; the `simplify` pre-commit pass flags the omission. Run the whole
   set with `bash scripts/fleet/tests/run_all.sh` (`--only <substring>` while
   iterating); discovery is by glob, so a new suite needs no registration.
-  These are not CMake tests — `ctest` does not cover them, so `quality.yml`'s
-  `linux-build` job calls the runner directly. That step is the only thing
-  gating them; an unexecuted suite goes red silently (see #2712).
+  These are not CMake tests — `ctest` does not cover them, so the dedicated
+  `fleet-tests.yml` workflow calls the runner directly on every push and PR
+  that touches `scripts/fleet/**`. That workflow is the only thing gating
+  them; an unexecuted suite goes red silently (see #2712).
 - **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
   `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
   `summarize` exit idiom — don't re-copy the helpers into a new test.

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -29,7 +29,12 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   `# lint: state-mtime-ok <reason>` comment.
 - **A new executable ships with a `tests/test_<name>.{sh,py}`** in the same
   PR — the fleet-tooling form of the review checklist's "new feature with no
-  new test"; the `simplify` pre-commit pass flags the omission.
+  new test"; the `simplify` pre-commit pass flags the omission. Run the whole
+  set with `bash scripts/fleet/tests/run_all.sh` (`--only <substring>` while
+  iterating); discovery is by glob, so a new suite needs no registration.
+  These are not CMake tests — `ctest` does not cover them, so `quality.yml`'s
+  `linux-build` job calls the runner directly. That step is the only thing
+  gating them; an unexecuted suite goes red silently (see #2712).
 - **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
   `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
   `summarize` exit idiom — don't re-copy the helpers into a new test.

--- a/scripts/fleet/tests/run_all.sh
+++ b/scripts/fleet/tests/run_all.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# run_all.sh — run every fleet test suite in this directory once.
+#
+# These suites are not CMake tests, so `ctest` never sees them; this runner
+# and the `quality.yml` step that calls it are the only things that execute
+# them. Keep the CI step wired — an unexecuted suite goes red silently and
+# stays that way (see #2712).
+#
+# Discovery is by glob, so a new suite is picked up with no registration
+# step. lib_assert.sh is deliberately named outside the test_* pattern and
+# is therefore skipped (it is sourced, never executed).
+#
+# Each suite runs in its own process with the tests directory as cwd —
+# matching how the suites are run by hand — and is timeout-guarded so one
+# hung suite cannot wedge CI. Suites are hermetic by the authoring rules
+# (no live GitHub, no live ~/.fleet), so this is safe to run unattended.
+#
+# Usage:
+#   run_all.sh [--only <substring>] [--list] [--timeout <seconds>]
+#
+# Options:
+#   --only <substring>  Run only suites whose filename contains <substring>.
+#   --list              Print the discovered suite list; run nothing.
+#   --timeout <secs>    Per-suite timeout (default 120). 0 disables.
+#   -h, --help          Show this help.
+#
+# Exit status:
+#   0  every selected suite passed (or --list / --help)
+#   1  at least one suite failed, timed out, or none matched --only
+#   2  usage error
+#
+# Source of truth: scripts/fleet/tests/run_all.sh in the engine repo.
+set -uo pipefail
+
+PROG=$(basename "$0")
+TESTS_DIR=$(cd "$(dirname "$0")" && pwd)
+
+only=""
+list_only=0
+per_timeout=120
+
+die_usage() {
+    echo "$PROG: $1" >&2
+    echo "usage: $PROG [--only <substring>] [--list] [--timeout <seconds>]" >&2
+    exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --only)     [[ $# -ge 2 && -n "$2" ]] || die_usage "--only needs a value"; only="$2"; shift 2 ;;
+        --only=*)   only="${1#--only=}"; [[ -n "$only" ]] || die_usage "--only needs a value"; shift ;;
+        --timeout)  [[ $# -ge 2 && -n "$2" ]] || die_usage "--timeout needs a value"; per_timeout="$2"; shift 2 ;;
+        --timeout=*) per_timeout="${1#--timeout=}"; [[ -n "$per_timeout" ]] || die_usage "--timeout needs a value"; shift ;;
+        --list)     list_only=1; shift ;;
+        # Print the header block by *shape* (every comment line after the
+        # shebang, stopping at the first line of code) rather than a fixed
+        # line range — a range silently slices the wrong text the moment the
+        # header grows or shrinks (#2436).
+        -h|--help)  awk 'NR>1 && !/^#/{exit} NR>1{sub(/^# ?/, ""); print}' "$0"; exit 0 ;;
+        *)          die_usage "unknown argument '$1'" ;;
+    esac
+done
+
+[[ "$per_timeout" =~ ^[0-9]+$ ]] || die_usage "--timeout takes a non-negative integer"
+
+# ----------------------------------------------------------------------
+# Discover: test_*.sh run under bash, test_*.py under python3.
+# ----------------------------------------------------------------------
+suites=()
+for f in "$TESTS_DIR"/test_*.sh "$TESTS_DIR"/test_*.py; do
+    [[ -f "$f" ]] || continue                       # unmatched glob
+    [[ -n "$only" && "$(basename "$f")" != *"$only"* ]] && continue
+    suites+=("$f")
+done
+
+if [[ ${#suites[@]} -eq 0 ]]; then
+    echo "$PROG: no suites matched${only:+ --only '$only'}" >&2
+    exit 1
+fi
+
+if [[ "$list_only" -eq 1 ]]; then
+    for f in "${suites[@]}"; do basename "$f"; done
+    exit 0
+fi
+
+# `timeout` is coreutils; absent on a stock macOS host, where the guard is
+# simply skipped rather than failing the run (CI is Linux and does have it).
+timeout_cmd=""
+if [[ "$per_timeout" -gt 0 ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+        timeout_cmd="timeout $per_timeout"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        timeout_cmd="gtimeout $per_timeout"
+    fi
+fi
+
+# ----------------------------------------------------------------------
+# Run: one process per suite, cwd = tests dir (how they run by hand).
+# ----------------------------------------------------------------------
+cd "$TESTS_DIR" || exit 1
+
+passed=0
+failed_names=()
+
+for f in "${suites[@]}"; do
+    name=$(basename "$f")
+    case "$name" in
+        *.py) interp=(python3) ;;
+        *)    interp=(bash) ;;
+    esac
+
+    if out=$($timeout_cmd "${interp[@]}" "$f" 2>&1); then
+        passed=$((passed + 1))
+        printf 'PASS  %s\n' "$name"
+    else
+        rc=$?
+        failed_names+=("$name")
+        # 124 is coreutils timeout's "killed on deadline" status.
+        if [[ "$rc" -eq 124 ]]; then
+            printf 'FAIL  %s (timed out after %ss)\n' "$name" "$per_timeout"
+        else
+            printf 'FAIL  %s (exit %s)\n' "$name" "$rc"
+        fi
+        printf '%s\n' "$out" | sed 's/^/      | /'
+    fi
+done
+
+echo
+echo "$PROG: ${#suites[@]} suite(s) — $passed passed, ${#failed_names[@]} failed"
+if [[ ${#failed_names[@]} -gt 0 ]]; then
+    echo "$PROG: failed: ${failed_names[*]}" >&2
+    exit 1
+fi

--- a/scripts/fleet/tests/run_all.sh
+++ b/scripts/fleet/tests/run_all.sh
@@ -2,9 +2,9 @@
 # run_all.sh — run every fleet test suite in this directory once.
 #
 # These suites are not CMake tests, so `ctest` never sees them; this runner
-# and the `quality.yml` step that calls it are the only things that execute
-# them. Keep the CI step wired — an unexecuted suite goes red silently and
-# stays that way (see #2712).
+# and the `fleet-tests.yml` workflow that calls it are the only things that
+# execute them. Keep that workflow wired — an unexecuted suite goes red
+# silently and stays that way (see #2712).
 #
 # Discovery is by glob, so a new suite is picked up with no registration
 # step. lib_assert.sh is deliberately named outside the test_* pattern and

--- a/scripts/fleet/tests/test_fleet_amend_push_scope.sh
+++ b/scripts/fleet/tests/test_fleet_amend_push_scope.sh
@@ -18,7 +18,7 @@ source "$(dirname "$0")/lib_assert.sh"
 WRAPPER="$SCRIPT_DIR/fleet-pr-amend-push"
 [[ -x "$WRAPPER" ]] || { echo "test setup: fleet-pr-amend-push not executable at $WRAPPER" >&2; exit 1; }
 
-TMPROOT=$(mktemp -d -t fleet-amend-scope)
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fleet-amend-scope.XXXXXX")
 trap '[[ -n "${TMPROOT:-}" ]] && rm -rf "$TMPROOT"' EXIT
 
 MAIN="$TMPROOT/mainclone"

--- a/scripts/fleet/tests/test_fleet_validate_roles.py
+++ b/scripts/fleet/tests/test_fleet_validate_roles.py
@@ -9,9 +9,15 @@ All I/O is via temporary directories; no network calls.
 """
 import importlib.machinery
 import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+# exec_module doesn't inherit the CLI wrapper's sys.path; add scripts/fleet/
+# so fleet_blocked_by resolves when the fleet_validate_stack loader runs below
+# (mirrors test_fleet_validate_stack.py).
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Load the module via importlib so the test works regardless of cwd.
 _MODULE = Path(__file__).parent.parent / "fleet_validate_roles.py"

--- a/scripts/fleet/tests/test_reconcile_amendments.sh
+++ b/scripts/fleet/tests/test_reconcile_amendments.sh
@@ -172,11 +172,20 @@ cat >"$FLEET_RESERVATIONS_DIR/opus-worker-1.json" <<JSON
 JSON
 write_pr_list '[{"number":659,"headRefName":"claude/163-stateless-particles","title":"T-163 particles"}]'
 
-t1_res_mtime_before=$(stat -f '%m' "$FLEET_RESERVATIONS_DIR/opus-worker-1.json" 2>/dev/null \
-    || stat -c '%Y' "$FLEET_RESERVATIONS_DIR/opus-worker-1.json")
+# GNU spelling first, BSD second — same order as fleet-claim's sentinel read.
+# The reverse order silently breaks on GNU: there `-f` means "filesystem
+# status", so `stat -f '%m' FILE` parses the format as a second FILE operand,
+# prints a statfs blob to stdout AND exits non-zero — the `||` fallback then
+# appends the real mtime to that blob. The blob carries free-block/inode
+# counts, which drift between two calls, so the comparison fails on a file
+# nothing touched.
+res_mtime() {
+    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1"
+}
+
+t1_res_mtime_before=$(res_mtime "$FLEET_RESERVATIONS_DIR/opus-worker-1.json")
 "$RECONCILER" >"$TMPROOT/log/t1.log" 2>&1 || true
-t1_res_mtime_after=$(stat -f '%m' "$FLEET_RESERVATIONS_DIR/opus-worker-1.json" 2>/dev/null \
-    || stat -c '%Y' "$FLEET_RESERVATIONS_DIR/opus-worker-1.json")
+t1_res_mtime_after=$(res_mtime "$FLEET_RESERVATIONS_DIR/opus-worker-1.json")
 assert_eq "$t1_res_mtime_after" "$t1_res_mtime_before" "T1 reservation untouched"
 # `grep -c` exits 1 when there are no matches but still prints "0" —
 # use `|| true` to suppress the failure without appending another "0".

--- a/scripts/fleet/tests/test_run_all.sh
+++ b/scripts/fleet/tests/test_run_all.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Tests for run_all.sh (#2712) — the runner that executes every fleet test
+# suite in this directory.
+#
+# Hermetic: every case copies run_all.sh into a temp dir alongside SYNTHETIC
+# fixture suites and runs it there. The runner discovers suites relative to
+# its own dirname, so it never sees the real suites, never touches
+# ~/.fleet, and never hits the network.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+RUNNER="$SCRIPT_DIR/run_all.sh"
+source "$SCRIPT_DIR/lib_assert.sh"
+
+if [[ ! -x "$RUNNER" ]]; then
+    echo "test setup: run_all.sh not executable at $RUNNER" >&2
+    exit 1
+fi
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# Builds a sandbox dir holding a copy of the runner; caller adds fixtures.
+new_sandbox() {  # $1 = sandbox name -> echoes the dir
+    local d="$TMPROOT/$1"
+    mkdir -p "$d"
+    cp "$RUNNER" "$d/run_all.sh"
+    chmod +x "$d/run_all.sh"
+    echo "$d"
+}
+
+fixture_pass() { printf '#!/usr/bin/env bash\nexit 0\n' > "$1/test_$2.sh"; }
+fixture_fail() { printf '#!/usr/bin/env bash\necho "boom in %s"\nexit 3\n' "$2" > "$1/test_$2.sh"; }
+
+echo "T1: all-passing suites exit 0 and are counted"
+d=$(new_sandbox t1)
+fixture_pass "$d" alpha
+fixture_pass "$d" beta
+printf 'import sys\nsys.exit(0)\n' > "$d/test_gamma.py"
+out=$(bash "$d/run_all.sh" 2>&1); rc=$?
+assert_eq "$rc" "0" "T1 exit 0 when every suite passes"
+assert_contains "$out" "3 suite(s) — 3 passed, 0 failed" "T1 summary counts all three"
+assert_contains "$out" "PASS  test_alpha.sh" "T1 per-suite PASS line"
+assert_contains "$out" "PASS  test_gamma.py" "T1 .py suite ran under python3"
+
+echo "T2: one failing suite exits 1 and names the failure"
+d=$(new_sandbox t2)
+fixture_pass "$d" alpha
+fixture_fail "$d" broken
+out=$(bash "$d/run_all.sh" 2>&1); rc=$?
+assert_eq "$rc" "1" "T2 exit 1 when a suite fails"
+assert_contains "$out" "FAIL  test_broken.sh (exit 3)" "T2 FAIL line carries the exit code"
+assert_contains "$out" "boom in broken" "T2 failing suite's output is echoed for triage"
+assert_contains "$out" "1 passed, 1 failed" "T2 summary counts the failure"
+assert_contains "$out" "failed: test_broken.sh" "T2 names the failing suite"
+
+echo "T3: a failing .py suite is caught too"
+d=$(new_sandbox t3)
+printf 'raise SystemExit(1)\n' > "$d/test_pybroken.py"
+out=$(bash "$d/run_all.sh" 2>&1); rc=$?
+assert_eq "$rc" "1" "T3 exit 1 on a failing python suite"
+assert_contains "$out" "FAIL  test_pybroken.py" "T3 python failure reported"
+
+echo "T4: lib_assert.sh is never executed as a suite"
+d=$(new_sandbox t4)
+fixture_pass "$d" alpha
+printf '#!/usr/bin/env bash\nexit 9\n' > "$d/lib_assert.sh"
+out=$(bash "$d/run_all.sh" 2>&1); rc=$?
+assert_eq "$rc" "0" "T4 lib_assert.sh does not fail the run"
+assert_absent "$out" "lib_assert" "T4 lib_assert.sh is not discovered"
+
+echo "T5: --list prints suites without running them"
+d=$(new_sandbox t5)
+printf '#!/usr/bin/env bash\ntouch "%s/ran-marker"\nexit 0\n' "$d" > "$d/test_alpha.sh"
+out=$(bash "$d/run_all.sh" --list 2>&1); rc=$?
+assert_eq "$rc" "0" "T5 --list exits 0"
+assert_contains "$out" "test_alpha.sh" "T5 --list names the suite"
+assert_absent "$out" "PASS" "T5 --list does not report results"
+if [[ -e "$d/ran-marker" ]]; then bad "T5 --list must not execute suites"; else ok "T5 --list executed nothing"; fi
+
+echo "T6: --only filters, in both spellings"
+d=$(new_sandbox t6)
+fixture_pass "$d" alpha
+fixture_fail "$d" broken
+out=$(bash "$d/run_all.sh" --only alpha 2>&1); rc=$?
+assert_eq "$rc" "0" "T6 --only alpha skips the failing suite"
+assert_contains "$out" "1 suite(s) — 1 passed" "T6 --only narrows the set"
+out=$(bash "$d/run_all.sh" --only=alpha 2>&1); rc=$?
+assert_eq "$rc" "0" "T6 --only=alpha equals form behaves identically"
+
+echo "T7: --only matching nothing is an error, not a vacuous pass"
+d=$(new_sandbox t7)
+fixture_pass "$d" alpha
+out=$(bash "$d/run_all.sh" --only nosuchsuite 2>&1); rc=$?
+assert_eq "$rc" "1" "T7 no match exits 1"
+assert_contains "$out" "no suites matched" "T7 explains the empty selection"
+
+echo "T8: usage errors exit 2"
+d=$(new_sandbox t8)
+fixture_pass "$d" alpha
+out=$(bash "$d/run_all.sh" --bogus 2>&1); rc=$?
+assert_eq "$rc" "2" "T8 unknown argument exits 2"
+# Dual-spelling rule (scripts/fleet/CLAUDE.md): the equals arm must reject an
+# empty value exactly as the space arm rejects a missing one.
+out=$(bash "$d/run_all.sh" --only= 2>&1); rc=$?
+assert_eq "$rc" "2" "T8 empty --only= rejected like a missing value"
+out=$(bash "$d/run_all.sh" --only 2>&1); rc=$?
+assert_eq "$rc" "2" "T8 --only with no value rejected"
+out=$(bash "$d/run_all.sh" --timeout= 2>&1); rc=$?
+assert_eq "$rc" "2" "T8 empty --timeout= rejected"
+out=$(bash "$d/run_all.sh" --timeout abc 2>&1); rc=$?
+assert_eq "$rc" "2" "T8 non-numeric --timeout rejected"
+
+echo "T9: --help exits 0 and prints the usage block"
+d=$(new_sandbox t9)
+out=$(bash "$d/run_all.sh" --help 2>&1); rc=$?
+assert_eq "$rc" "0" "T9 --help exits 0"
+assert_contains "$out" "run_all.sh [--only <substring>]" "T9 --help prints usage"
+assert_contains "$out" "Exit status:" "T9 --help reaches the end of the header"
+# The header is sliced by shape, not a line range, so growing it can't leak
+# code into the help text or truncate the block (#2436).
+assert_absent "$out" "set -uo pipefail" "T9 --help stops before the code"
+assert_absent "$out" "#!/usr/bin/env" "T9 --help omits the shebang"
+
+echo "T10: a hung suite is killed by the per-suite timeout"
+d=$(new_sandbox t10)
+printf '#!/usr/bin/env bash\nsleep 30\n' > "$d/test_hang.sh"
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    out=$(bash "$d/run_all.sh" --timeout 1 2>&1); rc=$?
+    assert_eq "$rc" "1" "T10 a timed-out suite fails the run"
+    assert_contains "$out" "timed out after 1s" "T10 timeout is reported distinctly"
+else
+    ok "T10 skipped — no timeout(1)/gtimeout(1) on this host"
+fi
+
+echo "T11: --timeout 0 disables the guard"
+d=$(new_sandbox t11)
+fixture_pass "$d" alpha
+out=$(bash "$d/run_all.sh" --timeout 0 2>&1); rc=$?
+assert_eq "$rc" "0" "T11 --timeout 0 still runs suites"
+assert_contains "$out" "1 passed" "T11 --timeout 0 reports normally"
+
+summarize "run_all.sh tests"

--- a/scripts/fleet/tests/test_session_track.sh
+++ b/scripts/fleet/tests/test_session_track.sh
@@ -45,7 +45,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-TMPROOT=$(mktemp -d -t fleet-session-track-test)
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fleet-session-track-test.XXXXXX")
 
 payload() {
     # $1 = source, $2 = session_id, $3 = cwd (optional — where the hook

--- a/scripts/fleet/tests/test_worktree_settings_hooks.sh
+++ b/scripts/fleet/tests/test_worktree_settings_hooks.sh
@@ -62,7 +62,7 @@ assert_eq() {
     fi
 }
 
-TMPROOT=$(mktemp -d -t fleet-settings-hooks)
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fleet-settings-hooks.XXXXXX")
 
 # Regenerate <settings-file> the way fleet-up does. repo_root is inert here;
 # the worktree (argv[3], → FLEET_ASSIGNED_WORKTREE) and engine root (argv[4], →


### PR DESCRIPTION
## Summary

- `scripts/fleet/tests/` held **101 suites with no execution path**: not CMake tests (so `ctest` never saw them), no workflow referencing the directory, no runner. The authoring rules mandate a test per new fleet executable and `simplify` Check 10 enforces that they get *written* — so the convention produced tests that were written, reviewed, merged, and never run.
- Adds **`scripts/fleet/tests/run_all.sh`**: discovers suites by glob (no registration step), runs each in its own timeout-guarded process with the tests dir as cwd, prints per-suite PASS/FAIL, exits non-zero if any fail. `--only <substring>`, `--list`, `--timeout <secs>`.
- Adds **`scripts/fleet/tests/test_run_all.sh`** (36 assertions) per the authoring rule — hermetic: the runner is copied into a temp dir alongside synthetic fixture suites, so it never sees the real suites, `~/.fleet`, or the network.
- Adds **`.github/workflows/fleet-tests.yml`**, a standalone workflow that runs the runner on every push/PR touching `scripts/fleet/**`, so a regression in any suite now fails the PR.
- Fixes **`test_fleet_validate_roles.py`**, which has been red on `master` for ~32 days.
- Fixes **4 more suites that only ever passed on BSD userland** — found by the new workflow's first run, which went red at 98/102 on `ubuntu-latest` against 102/102 on macOS. See "What CI caught immediately" below.

## Why a new workflow instead of a step in `quality.yml`

The first revision of this PR wired the runner into `quality.yml`'s `linux-build` job. **That step was inert** — `quality.yml` is disabled at the repo level:

```
$ gh api repos/jakildev/IrredenEngine/actions/workflows/235097563 --jq .state
disabled_manually        # since 2026-04-11
```

so the step could never fire and the PR did not actually close #2712. Caught in review — thanks.

Re-enabling `Quality` is not the fix available to a worker: it would also re-arm the `quality-checks` (Windows) job in the same file, which was part of the failing streak that got the workflow turned off, so flipping it on could red-gate every open PR on failures unrelated to this change. That remains a human call, tracked in **#2718**.

But these suites never needed that job. They are pure bash/python — no compiler, no GL, no CMake — so they have no reason to ride along with a build. A **separate workflow file gets its own workflow ID and is active by default**, which closes the execution gap now, touches nothing about the disabled workflow, and leaves the #2718 decision independent of this PR.

The `quality.yml` edit from the first revision is reverted — that file is now byte-identical to `master`, so this PR no longer touches the disabled workflow at all. Path-filtering follows the existing `perf-gate.yml` convention, so engine/shader/asset PRs skip this entirely.

## What CI caught immediately

The first run of the new workflow went **red: 98 passed, 4 failed** on `ubuntu-latest`, against 102/102 on macOS. All four are macOS-isms that had been latent in the suites for as long as they existed — nothing had ever run them on Linux. That is the execution gap in #2712 producing a concrete result within one run, so I fixed them here rather than merging a red gate:

| Suite | Root cause |
|---|---|
| `test_fleet_amend_push_scope.sh`, `test_session_track.sh`, `test_worktree_settings_hooks.sh` | `mktemp -d -t PREFIX`. BSD appends the random suffix itself; GNU requires the template to end in >=3 `X`s and fails `too few X's in template`. `TMPROOT` came back empty, so fixtures tried to `mkdir /mainclone` and `/eng` and died on permissions. |
| `test_reconcile_amendments.sh` | `stat -f '%m' FILE \|\| stat -c '%Y' FILE` — BSD spelling first. On GNU, `-f` means *filesystem status* and the format string is parsed as a second FILE operand, so the call prints a statfs blob to stdout **and** exits non-zero; the `\|\|` fallback then appends the real mtime to that blob. The blob carries free-block/inode counts, which drift between two calls, so T1 compared unequal on a file nothing had touched. |

Both fixes adopt patterns already present in the tree rather than inventing one:

- The portable `mktemp -d "${TMPDIR:-/tmp}/<prefix>.XXXXXX"` form is what `test_decisions.sh`, `test_digest_tick.sh` and `test_notify.sh` already use. The three suites above were the **only** call sites in the directory still using the bare `-t` form.
- GNU-first `stat` ordering is what `fleet-claim:2458` and `fleet-gh-token:61` already do. BSD `stat` has no `-c`, so the fallback still fires on macOS — verified on this host.

## The red suite

`fleet_validate_stack.py` gained `import fleet_blocked_by` in 1b4374b6 (2026-06-29, #2104). `test_fleet_validate_roles.py` `exec_module`s that file to borrow `check_checklist`/`parse_checklist`, but `exec_module` does not inherit the CLI wrapper's `sys.path`, so the transitive import can't resolve:

```
ModuleNotFoundError: No module named 'fleet_blocked_by'
```

Its sibling `test_fleet_validate_stack.py` loads the *same* module and passes (26/26) because it carries the guard, with a comment naming this exact hazard. Applied the same one-liner here. Nothing executed the suite, so nobody saw it go red — which is the point of the rest of this PR.

## Test plan

- [x] `bash scripts/fleet/tests/run_all.sh` → **102/102 passed**, rc=0, ~123s serial (macOS, re-run on this revision).
- [x] `bash scripts/fleet/tests/test_run_all.sh` → **36/36 passed**. Covers: all-pass exit 0; failing `.sh` and `.py` suites exit 1 and are named; failing suite's output echoed; `lib_assert.sh` never executed; `--list` runs nothing (marker-file assertion); `--only` in both spellings; `--only` with no match exits 1 rather than passing vacuously; usage errors exit 2 (unknown arg, empty `--only=`/`--timeout=` per the dual-spelling rule, non-numeric timeout); `--help`; timeout kill; `--timeout 0`.
- [x] **Positive control** — `git show origin/master:scripts/fleet/tests/test_fleet_validate_roles.py` still fails with the same `ModuleNotFoundError` (rc=1) while the branch copy passes 20/20, so the assertion is really exercising the fix.
- [x] `ruff check scripts/` clean; `python3 scripts/fleet/lint_state_mtime.py scripts/fleet/` rc=0.
- [x] Both workflow files parse as valid YAML; `git diff origin/master -- .github/workflows/quality.yml` is empty (revert is exact).
- [x] **Acceptance criterion 4 is met, not just prepared**: `fleet-tests.yml` ran on this PR and is **green — 102 suite(s), 102 passed, 0 failed** ([run 30603745362](https://github.com/jakildev/IrredenEngine/actions/runs/30603745362)). The prior run on the same branch ([30603384111](https://github.com/jakildev/IrredenEngine/actions/runs/30603384111)) went red at 98/102, so the gate demonstrably fails on a real regression rather than passing vacuously.

> Note on the local runs above: they were run with `env -u FLEET_ROLE_MODEL`. An ambient `FLEET_ROLE_MODEL` leaks into `test_fleet_claim_model_gate.sh` T7 — a known false-failure documented in #2712, not a suite defect. CI has no such ambient value.

## Notes for the reviewer

- The `--help` slice is shape-based (`awk`, stop at the first non-comment line) rather than a fixed `sed -n 'A,Bp'` range, per #2436 — T9 asserts the help reaches `Exit status:` and contains neither the shebang nor `set -uo pipefail`.
- The `timeout`/`gtimeout` lookup is GNU-first per #2690 and is a `command -v` guard, not a stdout-capturing fallback.
- The workflow `run:` is a single command, so the inline-bash rule in `simplify` Check 10 is satisfied by construction.
- Per-suite timeout defaults to 120s; the slowest real suite is `test_fleet_claim_blockers.sh` at 6.5s.
- `run_all.sh`'s header comment and `scripts/fleet/CLAUDE.md` both named `quality.yml` as the gate; the reviewer flagged the `CLAUDE.md` one, and the same overstatement was in the script header. Both now name `fleet-tests.yml`.

Closes #2712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
