### PR TITLE
build: scope format-changed to changed lines, not whole files

### DIFF
--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -102,8 +102,9 @@ function(irreden_add_quality_targets)
             VERBATIM
         )
 
-        # Diff-scoped formatter: only rewrites files changed on the
-        # current branch (committed vs upstream + working tree).
+        # Diff-scoped formatter: only rewrites the lines changed on the
+        # current branch (committed vs upstream + working tree), so a
+        # touched file's pre-existing drift stays out of the diff.
         # Safe to invoke mid-iteration; the bare `format` target is
         # whole-tree and should only run on intentional cleanup PRs.
         add_custom_target(format-changed

--- a/cmake/run_clang_format_changed.cmake
+++ b/cmake/run_clang_format_changed.cmake
@@ -77,6 +77,7 @@ execute_process(
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+set(_untracked "")
 if(_untracked_rc EQUAL 0 AND NOT _untracked_out STREQUAL "")
     string(REPLACE "\n" ";" _untracked "${_untracked_out}")
     list(APPEND _changed_files ${_untracked})
@@ -105,17 +106,105 @@ foreach(_rel IN LISTS _changed_files)
     endif()
 endforeach()
 
+# Absolute form of the untracked set, so the formatting loop below can
+# tell "brand-new file" (format it whole — all of it is new) from
+# "existing file with a few edited lines" (format only those lines).
+set(_untracked_abs "")
+foreach(_rel IN LISTS _untracked)
+    if(NOT _rel STREQUAL "")
+        list(APPEND _untracked_abs "${PROJECT_ROOT}/${_rel}")
+    endif()
+endforeach()
+
 if(NOT _targets)
     message(STATUS "clang-format (changed): diff vs ${_diff_base} touches no formattable sources.")
     return()
 endif()
 
+# Line ranges must be expressed in WORKING-TREE coordinates, because that
+# is the text clang-format rewrites. So the diff that produces them needs
+# the working tree as its post-image: `git diff <merge-base>` (two-dot,
+# commit vs working tree) covers committed AND uncommitted edits in one
+# pass, while still excluding commits the base gained after we branched —
+# the reason the file-list pass above uses three-dot `...HEAD`.
+execute_process(
+    COMMAND git -C "${PROJECT_ROOT}" merge-base "${_diff_base}" HEAD
+    OUTPUT_VARIABLE _range_base
+    RESULT_VARIABLE _range_base_rc
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _range_base_rc EQUAL 0 OR _range_base STREQUAL "")
+    set(_range_base "")
+    message(STATUS
+        "clang-format (changed): no merge-base vs ${_diff_base}; "
+        "falling back to whole-file formatting.")
+endif()
+
+# Changed line ranges for one file, as repeated `--lines=<start>:<end>`
+# arguments — clang-format's own scoping mechanism, and how upstream
+# git-clang-format restricts its rewrites.
+function(_collect_line_ranges file out_var)
+    set(${out_var} "" PARENT_SCOPE)
+    if(_range_base STREQUAL "")
+        return()
+    endif()
+    execute_process(
+        COMMAND git -C "${PROJECT_ROOT}" diff -U0 "${_range_base}" -- "${file}"
+        OUTPUT_VARIABLE _diff_out
+        RESULT_VARIABLE _diff_rc
+        ERROR_QUIET
+    )
+    if(NOT _diff_rc EQUAL 0 OR _diff_out STREQUAL "")
+        return()
+    endif()
+    # Every content line in a unified diff carries a '+'/'-'/' ' prefix and
+    # -U0 emits no context lines, so "@@" at column 0 is unambiguously a
+    # hunk header. Matching against the whole blob (rather than splitting
+    # it into a CMake list) keeps ';' inside source lines from corrupting
+    # the parse.
+    string(REGEX MATCHALL "(^|\n)@@ -[0-9]+(,[0-9]+)? \\+[0-9]+(,[0-9]+)? @@"
+        _hunks "${_diff_out}")
+    set(_ranges "")
+    foreach(_hunk IN LISTS _hunks)
+        string(REGEX MATCH "\\+([0-9]+)(,([0-9]+))?" _matched "${_hunk}")
+        if(NOT _matched)
+            continue()
+        endif()
+        set(_start "${CMAKE_MATCH_1}")
+        set(_len "${CMAKE_MATCH_3}")
+        if(_len STREQUAL "")
+            set(_len 1)
+        endif()
+        # '+N,0' is a pure deletion — no post-image lines to format, and
+        # clang-format rejects a zero-length range.
+        if(_len GREATER 0)
+            math(EXPR _end "${_start} + ${_len} - 1")
+            list(APPEND _ranges "--lines=${_start}:${_end}")
+        endif()
+    endforeach()
+    set(${out_var} "${_ranges}" PARENT_SCOPE)
+endfunction()
+
 set(_failed "")
 set(_count 0)
+set(_skipped 0)
 foreach(_file IN LISTS _targets)
+    set(_line_args "")
+    list(FIND _untracked_abs "${_file}" _untracked_idx)
+    if(_untracked_idx EQUAL -1 AND NOT _range_base STREQUAL "")
+        _collect_line_ranges("${_file}" _line_args)
+        if(NOT _line_args)
+            # Tracked, but no post-image line ranges: a mode-only or
+            # rename-only change. Nothing to format — and formatting it
+            # whole would drag the file's pre-existing drift into the diff.
+            math(EXPR _skipped "${_skipped} + 1")
+            continue()
+        endif()
+    endif()
     math(EXPR _count "${_count} + 1")
     execute_process(
-        COMMAND "${CLANG_FORMAT_BIN}" -i --style=file "${_file}"
+        COMMAND "${CLANG_FORMAT_BIN}" -i --style=file ${_line_args} "${_file}"
         RESULT_VARIABLE _rc
         ERROR_VARIABLE _err
     )
@@ -127,7 +216,8 @@ foreach(_file IN LISTS _targets)
     endif()
 endforeach()
 
-message(STATUS "clang-format (changed) formatted ${_count} file(s) vs ${_diff_base}.")
+message(STATUS "clang-format (changed) formatted ${_count} file(s) vs ${_diff_base}, "
+    "scoped to changed lines (${_skipped} skipped: no changed lines).")
 
 if(_failed)
     list(JOIN _failed "\n  - " _failed_joined)

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -196,10 +196,13 @@ cmake --build build --target format-check    # check only
 cmake --build build --target lint            # clang-tidy
 ```
 
-`format-changed` is what you want mid-iteration: it only touches files
-your branch has modified (committed vs `@{upstream}` plus working
-tree). The bare `format` target rewrites every formattable file in the
-repo and should only run on intentional cleanup PRs.
+`format-changed` is what you want mid-iteration: it only rewrites the
+**lines** your branch has modified (committed vs `@{upstream}` plus
+working tree), so a touched file's pre-existing clang-format drift stays
+out of your diff (#2719). Brand-new untracked files are still formatted
+in full — all of their content is new. The bare `format` target rewrites
+every formattable file in the repo and should only run on intentional
+cleanup PRs.
 
 ### Python (scripts)
 

--- a/scripts/fleet/tests/test_format_changed_line_scoping.sh
+++ b/scripts/fleet/tests/test_format_changed_line_scoping.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Tests for cmake/run_clang_format_changed.cmake line scoping (#2719).
+#
+# The script under test lives in cmake/, not scripts/fleet/ — but it is
+# reached exclusively through `fleet-build --target format-changed`, and
+# this directory holds the only shell-test harness in the repo, so its
+# regression coverage lives here.
+#
+# The defect: the target was diff-scoped at FILE granularity, running
+# `clang-format -i` over each changed file in full. ~20% of the engine's
+# quality files carry pre-existing clang-format drift, so a one-line edit
+# to any of them dragged the whole file's drift into the author's PR
+# (measured on master d6a44197: a 1-line edit to trixel_font.hpp produced
+# a 225-line diff). The fix scopes the rewrite to the changed lines via
+# repeated `--lines=<start>:<end>`.
+#
+# Each case builds a throwaway git repo with a synthetic origin/master
+# ref, so the merge-base path the real script takes is exercised rather
+# than its fallback.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
+CMAKE_SCRIPT="$SCRIPT_DIR/cmake/run_clang_format_changed.cmake"
+STYLE_FILE="$SCRIPT_DIR/.clang-format"
+
+if [[ ! -f "$CMAKE_SCRIPT" ]]; then
+    echo "SKIP: script under test not found at $CMAKE_SCRIPT" >&2
+    exit 0
+fi
+for tool in cmake clang-format git; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "SKIP: $tool not available" >&2
+        exit 0
+    fi
+done
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+# A file carrying plenty of pre-existing clang-format drift, plus a
+# comment line that is already format-clean and therefore safe to edit.
+write_drift_file() {
+    cat > "$1" <<'EOF'
+#include <vector>
+int  a( int x ){return x   +1;}
+int  b( int x ){return x   +2;}
+// MARKER
+int  c( int x ){return x   +3;}
+int  d( int x ){return x   +4;}
+EOF
+}
+
+# Fresh repo with one committed drift-carrying file and an origin/master
+# ref pointing at that commit. Echoes the repo path.
+new_repo() {
+    local repo="$TMPROOT/$1"
+    mkdir -p "$repo"
+    git -C "$repo" init -q .
+    git -C "$repo" config user.email t@example.com
+    git -C "$repo" config user.name test
+    cp "$STYLE_FILE" "$repo/.clang-format"
+    write_drift_file "$repo/drift.cpp"
+    git -C "$repo" add -A
+    git -C "$repo" commit -qm init
+    git -C "$repo" update-ref refs/remotes/origin/master HEAD
+    echo "$repo"
+}
+
+# Run the target the way ir_quality_tools.cmake does. Extra args are the
+# repo-relative paths to advertise as QUALITY_FILES.
+run_format_changed() {
+    local repo="$1"; shift
+    local list="$repo/quality_files.cmake"
+    {
+        echo "set(QUALITY_FILES"
+        for rel in "$@"; do echo "    \"$repo/$rel\""; done
+        echo ")"
+    } > "$list"
+    cmake -DCLANG_FORMAT_BIN="$(command -v clang-format)" \
+          -DQUALITY_FILE_LIST="$list" \
+          -DPROJECT_ROOT="$repo" \
+          -P "$CMAKE_SCRIPT" 2>&1
+}
+
+changed_line_count() {
+    git -C "$1" diff --numstat -- "$2" | awk '{print $1+$2}'
+}
+
+echo "T1: editing one line of a drift-carrying file formats only that line"
+REPO=$(new_repo t1)
+# Sanity: the fixture really does carry drift a whole-file run would rewrite.
+DRIFT=$(clang-format --style=file "$REPO/drift.cpp" | diff - "$REPO/drift.cpp" | grep -cE '^[<>]')
+if [[ "$DRIFT" -lt 4 ]]; then
+    bad "fixture carries pre-existing drift (got $DRIFT rewritable lines)"
+else
+    ok "fixture carries pre-existing drift ($DRIFT rewritable lines)"
+fi
+sed -i.bak 's|// MARKER|// MARKER edited|' "$REPO/drift.cpp" && rm -f "$REPO/drift.cpp.bak"
+OUT=$(run_format_changed "$REPO" drift.cpp)
+assert_eq "$(changed_line_count "$REPO" drift.cpp)" "2" \
+    "diff stays at the single edited line (1 added + 1 removed)"
+assert_contains "$OUT" "scoped to changed lines" "reports line-scoped formatting"
+DRIFT_AFTER=$(git -C "$REPO" diff -U0 -- drift.cpp | grep -cE '^[+-]int ' || true)
+assert_eq "$DRIFT_AFTER" "0" "pre-existing drift lines are left untouched"
+
+echo ""
+echo "T2: a misformatted CHANGED line still gets fixed (scoping, not disabling)"
+REPO=$(new_repo t2)
+sed -i.bak 's|// MARKER|int  e( int x ){return x   +5;}|' "$REPO/drift.cpp" && rm -f "$REPO/drift.cpp.bak"
+run_format_changed "$REPO" drift.cpp >/dev/null
+BODY=$(cat "$REPO/drift.cpp")
+# The style wraps the body, so the edited line becomes several lines —
+# assert the misformatted spelling is gone and the formatted one present.
+assert_absent "$BODY" "int  e( int x ){" "the edited line's bad spacing is gone"
+assert_contains "$BODY" "int e(int x) {" "the edited line is reformatted"
+# ...while its drifted neighbours, which this edit did not touch, survive.
+assert_contains "$BODY" "int  a( int x ){return x   +1;}" \
+    "neighbouring drift lines are still untouched"
+
+echo ""
+echo "T3: a brand-new untracked file is formatted in full"
+REPO=$(new_repo t3)
+write_drift_file "$REPO/fresh.cpp"
+OUT=$(run_format_changed "$REPO" drift.cpp fresh.cpp)
+REMAINING=$(clang-format --style=file "$REPO/fresh.cpp" | diff - "$REPO/fresh.cpp" | grep -cE '^[<>]' || true)
+assert_eq "$REMAINING" "0" "untracked file is fully formatted (all of it is new)"
+assert_eq "$(changed_line_count "$REPO" drift.cpp)" "" \
+    "the untouched tracked file is not reformatted"
+
+echo ""
+echo "T4: a pure-deletion hunk produces no zero-length range and no failure"
+REPO=$(new_repo t4)
+sed -i.bak '/\/\/ MARKER/d' "$REPO/drift.cpp" && rm -f "$REPO/drift.cpp.bak"
+OUT=$(run_format_changed "$REPO" drift.cpp)
+RC=$?
+assert_eq "$RC" "0" "deletion-only edit exits cleanly"
+assert_absent "$OUT" "CMake Error" "no CMake error on a '+N,0' hunk"
+DRIFT_AFTER=$(git -C "$REPO" diff -U0 -- drift.cpp | grep -cE '^\+int ' || true)
+assert_eq "$DRIFT_AFTER" "0" "deletion-only edit pulls in no drift"
+
+echo ""
+echo "T5: falls back to whole-file formatting when no merge-base exists"
+REPO="$TMPROOT/t5"
+mkdir -p "$REPO"
+git -C "$REPO" init -q .
+git -C "$REPO" config user.email t@example.com
+git -C "$REPO" config user.name test
+cp "$STYLE_FILE" "$REPO/.clang-format"
+write_drift_file "$REPO/drift.cpp"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm init
+# No origin/master ref at all -> merge-base lookup fails.
+sed -i.bak 's|// MARKER|// MARKER edited|' "$REPO/drift.cpp" && rm -f "$REPO/drift.cpp.bak"
+OUT=$(run_format_changed "$REPO" drift.cpp)
+assert_contains "$OUT" "falling back to whole-file formatting" \
+    "announces the whole-file fallback instead of silently skipping"
+REMAINING=$(clang-format --style=file "$REPO/drift.cpp" | diff - "$REPO/drift.cpp" | grep -cE '^[<>]' || true)
+assert_eq "$REMAINING" "0" "fallback still formats the file (old behavior preserved)"
+
+summarize "format-changed line scoping (#2719)"

--- a/scripts/fleet/tests/test_format_changed_line_scoping.sh
+++ b/scripts/fleet/tests/test_format_changed_line_scoping.sh
@@ -163,4 +163,26 @@ assert_contains "$OUT" "falling back to whole-file formatting" \
 REMAINING=$(clang-format --style=file "$REPO/drift.cpp" | diff - "$REPO/drift.cpp" | grep -cE '^[<>]' || true)
 assert_eq "$REMAINING" "0" "fallback still formats the file (old behavior preserved)"
 
+echo ""
+echo "T6: a new file COMMITTED on the branch is formatted in full"
+# T3's new file is untracked, so it takes the explicit whole-file branch.
+# `git add` + commit makes it tracked, so it goes down the line-range path
+# instead and its hunk header is `@@ -0,0 +1,N @@` — a zero-length
+# PRE-image, the mirror of T4's zero-length post-image. The range must come
+# out as 1:N (the whole file). Getting it wrong is not silent: a 0-start
+# range makes clang-format reject the argument outright, which is what the
+# error assertions below pin.
+REPO=$(new_repo t6)
+write_drift_file "$REPO/added.cpp"
+git -C "$REPO" add added.cpp
+git -C "$REPO" commit -qm "add a new source file on the branch"
+OUT=$(run_format_changed "$REPO" drift.cpp added.cpp)
+assert_absent "$OUT" "CMake Error" "no CMake error on a '-0,0' hunk"
+assert_absent "$OUT" "start line should be at least 1" \
+    "the range starts at line 1, not 0"
+REMAINING=$(clang-format --style=file "$REPO/added.cpp" | diff - "$REPO/added.cpp" | grep -cE '^[<>]' || true)
+assert_eq "$REMAINING" "0" "the whole added file is formatted (all of it is new)"
+assert_eq "$(changed_line_count "$REPO" drift.cpp)" "" \
+    "the untouched tracked file is not reformatted"
+
 summarize "format-changed line scoping (#2719)"


### PR DESCRIPTION
## Summary
- `format-changed` was diff-scoped at **file** granularity — it ran `clang-format -i` over each changed file in full, so pre-existing drift in a touched file landed in the author's diff. Scope the rewrite to the **changed lines** via repeated `--lines=<start>:<end>`.
- Line ranges come from `git diff -U0` against the **merge-base** (two-dot). That form is what puts the ranges in working-tree coordinates — the text clang-format actually rewrites. The file-list pass keeps its three-dot `...HEAD` range because it only needs names.
- Untracked files still format whole (all of their content is new). A tracked file with no post-image ranges (mode- or rename-only) is skipped rather than reformatted wholesale.
- Adds the first regression coverage for this script (it had none), plus a BUILD.md accuracy fix.

This is the unfinished half of #1138, which fixed the *tree* → *touched files* overreach. The same overreach survived one level down: *touched files* → *touched lines*. Distinct from #2675, which is about **which repo** the changed-set is computed against.

## Test plan
- [x] `bash scripts/fleet/tests/test_format_changed_line_scoping.sh` → 14 passed, 0 failed
- [x] **Positive control** — same suite against `origin/master`'s pre-fix script: **8 passed, 6 failed**, where the 6 failures are exactly the new line-scoping assertions. T3 (untracked → whole-file) passes on both, correctly: that behavior is unchanged by design.
- [x] Real `fleet-build --target format-changed` run end-to-end on this host (macOS, clang-format 22.1.3)
- [x] Dogfooded on this PR's own branch: `clang-format (changed): diff vs origin/master touches no formattable sources` — tree unchanged

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| One-line edit to a drift-carrying file yields only the intended edit | 1-line comment added to `trixel_font.hpp`, then `fleet-build --target format-changed` | `1 file changed, 1 insertion(+)` — was `225 lines (158+/67-)` pre-fix |
| Newly added untracked file still formatted in full | suite T3 | `ok: untracked file is fully formatted (all of it is new)` |
| Misformatted **changed** lines still get fixed (scoping, not disabling) | suite T2 | `ok: the edited line is reformatted` + `ok: neighbouring drift lines are still untouched` |
| Regression coverage exists | new `scripts/fleet/tests/test_format_changed_line_scoping.sh` | 14/14 green; positive-controlled to 8/6 against pre-fix master |

## Notes for reviewer

**Blast radius, measured not estimated.** Sweeping the real `QUALITY_FILES` set: **156 of 791** files (~20%) carry pre-existing clang-format drift, so touching any of them dragged that drift into the PR. Worst: `trixel_font.hpp` (224 lines), `video_recorder.cpp` (193), `music_theory.hpp` (148).

**Two edge cases worth a look in `_collect_line_ranges`:**
- Hunk headers are matched against the whole diff blob rather than splitting it into a CMake list — splitting would corrupt on a `;` inside a source line. With `-U0` there are no context lines and every content line carries a `+`/`-` prefix, so `@@` at column 0 is unambiguously a header.
- `+N,0` (pure deletion) is dropped: clang-format rejects a zero-length range. Suite T4 pins this.

**Behavior preserved on the failure path:** if the merge-base lookup fails, it announces the fallback and formats whole-file as before (suite T5) rather than silently formatting nothing.

Closes #2719

🤖 Generated with [Claude Code](https://claude.com/claude-code)
