### PR TITLE
docs/rules: re-measure the cpp-systems live-deviations register (#2733)

### DIFF
--- a/.claude/rules/cpp-systems.md
+++ b/.claude/rules/cpp-systems.md
@@ -11,7 +11,21 @@ Rule:
 
 > **Never** use function-local `static` for *mutable* or *system-owned* state inside a system tick or its `create()` function. Use the member-on-`System<N>` form (preferred) or the explicit `SystemParams` form.
 
-Allowed: `static constexpr`, `static const` for genuine compile-time constants. Those are program constants, not system state.
+Allowed:
+
+- `static constexpr` / `static const` **value** constants. Those are program
+  constants, not system state.
+- `static thread_local` **scratch buffers reset on entry** — cleared or
+  reassigned at the top of the function and never read before being written, so
+  no value survives the call. Only the heap capacity persists, which is the
+  point (no per-frame allocation in a render hot path), and `thread_local`
+  rules out the cross-instance cross-talk this ban exists to prevent. If the
+  buffer carries meaning across calls it is state, not scratch — migrate it.
+
+**Not allowed despite the spelling:** `static const T *p = nullptr;` is a
+*mutable pointer* to const data. The pointee is const; the variable is not, and
+reassigning it is exactly the hidden system state this rule bans. Three such
+caches shipped under this misreading — see Live deviations.
 
 See `engine/system/CLAUDE.md` § "Don't use function-local `static` for system state" for the full rationale.
 
@@ -79,11 +93,37 @@ See `engine/system/CLAUDE.md` § "Three valid TICK function signatures".
 
 ## Live deviations
 
-Files that still use function-local `static` for system-owned state are tracked in `.fleet/status/system-static-deviations.md` (queue-manager-owned). Don't add new violations; migrate when you're already touching one of the listed files. **Active known violations as of this rule landing:**
+The register is this list — it lives here, next to the rule it qualifies, not
+in a separate tracking file (see #2733).
 
-- `engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp:41-43` — `getInstances()` returns a function-local static `std::vector<CanvasInstance>&`.
-- `engine/prefabs/irreden/audio/systems/system_rhythmic_launch.hpp:29` — static unordered_map for platform cache.
-- `engine/prefabs/irreden/update/systems/system_gravity.hpp:17` — static singleton instance.
-- `engine/prefabs/irreden/update/systems/system_animation_color.hpp:25-26` — two static animation clip caches.
+Don't add new violations. Migrate when you're already touching one of these
+files for other reasons; don't delay other work to migrate aggressively.
 
-Each should be migrated to `SystemParams`. Refactor when touching the file for other reasons; don't delay other work to migrate aggressively.
+**Measured 2026-07-31** over the `paths:` globs above (134 tracked files) —
+16 sites in 8 files. Re-measure when you edit this list; a stamp that drifts
+from the tree is what made the previous register useless. Paths below are
+relative to `engine/prefabs/irreden/`.
+
+| Site | Shape |
+|---|---|
+| `common/systems/system_modifier_resolve_global.hpp:35,40,45` | 3 `static const T *p = nullptr;` frame caches, handed out by non-const reference so `beginTick` can reassign them. Spelled `const`, but mutable — see the Allowed clause. Keeps `MODIFIER_RESOLVE_GLOBAL` pinned `SERIAL`. |
+| `input/systems/system_entity_hover_detect.hpp:132` | `static EntityEventHandlers instance;` — tracked separately in **#2582** (migrating to a singleton component). |
+| `input/systems/system_entity_hover_detect.hpp:140` | `static IREntity::EntityId previousHoveredEntity`. |
+| `input/systems/system_entity_hover_detect.hpp:182` | `static int logCounter` — log throttle. |
+| `input/systems/system_hitbox_mouse_test.hpp:26-30` | 5 statics declared in `create()` and captured by the tick lambda (`s_mouseCanvas`, `s_cameraIso`, `s_cameraZoom`, `s_fbResHalf`, `s_cardinalIndex`). |
+| `render/systems/system_debug_overlay.hpp:87-88` | 2 static vertex vectors declared **inside the tick body**. |
+| `update/systems/system_action_animation.hpp:24` | `static std::unordered_map<...> clipCache` in `create()`. |
+| `update/systems/system_gravity.hpp:17` | `static C_Gravity3D instance{};` — keeps `GRAVITY_3D` pinned `SERIAL`; migrate with `MODIFIER_RESOLVE_GLOBAL`. |
+| `update/systems/system_rhythmic_launch.hpp:29` | `static std::unordered_map<...> platformCache`. |
+
+Each should move to the member-on-`System<N>` form (preferred) or `SystemParams`.
+
+**Not deviations** (allowed per the Allowed clause, listed so the next sweep
+doesn't re-flag them): `render/systems/system_shapes_to_trixel.hpp:446` and
+`render/systems/system_voxel_to_trixel.hpp:58` — `static thread_local` scratch
+buffers, both reset on entry.
+
+**Retired entries** — fixed, do not re-add: `system_entity_canvas_to_framebuffer.hpp`
+(migrated to an `instances_` member by #1520) and `system_animation_color.hpp:25-26`
+(the clip caches no longer exist there; the surviving one is
+`system_action_animation.hpp:24`, listed above).

--- a/.claude/rules/cpp-systems.md
+++ b/.claude/rules/cpp-systems.md
@@ -100,7 +100,7 @@ Don't add new violations. Migrate when you're already touching one of these
 files for other reasons; don't delay other work to migrate aggressively.
 
 **Measured 2026-07-31** over the `paths:` globs above (134 tracked files) —
-16 sites in 8 files. Re-measure when you edit this list; a stamp that drifts
+16 sites in 7 files. Re-measure when you edit this list; a stamp that drifts
 from the tree is what made the previous register useless. Paths below are
 relative to `engine/prefabs/irreden/`.
 


### PR DESCRIPTION
## Summary

- `.claude/rules/cpp-systems.md` §"Live deviations" pointed at
  `.fleet/status/system-static-deviations.md` as its tracking register. That file
  was **deleted 2026-05-11**; the rule was rewritten **2026-05-17** (`b9ab14c3`,
  #841) and kept the pointer. The T-223 audit had already confirmed the file
  absent and explicitly scoped removal into #841 — #841 closed without doing it.
- Replaced the dangling pointer with an **inline** register (the shape
  `cpp-globals.md` already uses), carrying a measurement stamp.
- Re-measured the deviation set over the rule's own `paths:` globs (134 tracked
  files): **16 real sites in 7 files**, 13 of them undocumented. The old list was
  **1-of-4 correct**.
- Closed a hole in the "Allowed" clause: `static const T *p = nullptr;` is a
  *mutable pointer* to const data, not a constant. Three such frame caches in
  `system_modifier_resolve_global.hpp` shipped under that reading — and
  `engine/system/CLAUDE.md:569` calls them a "known `cpp-systems.md` violation"
  while this rule never listed them. The two registers now agree.
- Ruled explicitly on `static thread_local` **scratch reset on entry** (two
  render sites) — allowed, with the boundary stated, so the next sweep doesn't
  re-flag them.

## Old list vs. reality

| Rule's entry | Verdict |
|---|---|
| `render/.../system_entity_canvas_to_framebuffer.hpp:41-43` | **stale** — migrated to an `instances_` member by #1520 |
| `audio/systems/system_rhythmic_launch.hpp:29` | **wrong path** — lives under `update/systems/` |
| `update/systems/system_gravity.hpp:17` | correct (1 of 4) |
| `update/systems/system_animation_color.hpp:25-26` | **stale** — no statics there; survivor is `system_action_animation.hpp:24` |

## Test plan

- [x] Every `file:line` cited in the new register resolves to a real
      function-local `static` in the current tree — **18/18, 0 stale**.
- [x] Both retired entries confirmed no longer statics at their cited lines.
- [x] No remaining reference to the deleted register outside the gated
      `simplify/SKILL.md` (see Notes).
- [x] Markdown-only diff — no build impact.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| No reference to the deleted register | `grep -rn "system-static-deviations" --include='*.md' .` | only the gated `simplify/SKILL.md:191` remains (see Notes) |
| Every cited line resolves to a real static | line-by-line resolve of all 18 cited sites | `resolved 18/18 cited lines; 0 bad` |
| Retired entries really are fixed | same check against the 2 retired sites | both `OK (not a static)` |
| `static thread_local` question answered | rule text | new bullet in "Allowed" + "Not deviations" list |

## Notes for reviewer

**One item is gated and is NOT in this diff.**
`.claude/skills/simplify/SKILL.md:185-191` carries a second, independently stale
copy of this register — and it is gated self-config (`.claude/skills/**/SKILL.md`),
which no worker class can commit. Per the partial-gate rule I shipped the
non-gated part and am handing this half over. It has **three** defects:

1. Two of its three listed deviations are stale (entries 1 and 4 in the table above).
2. It says they are tracked in `.fleet/status/system-static-deviations.md`
   *"(or will be once it's introduced)"* — it was introduced **and** deleted.
3. It cites a rule heading **"Canonical SystemParams pattern"** that does not
   exist in `cpp-systems.md` (headings are `Preferred: member-on-System<N> via
   registerSystem` and `Explicit: Params + setSystemParams (escape hatch)`), and
   points at the escape-hatch form as canonical rather than the preferred
   `registerSystem` member form.

Suggested replacement for the block at `SKILL.md:185-191`:

> Live deviations already on the list (don't re-flag, but note in the
> report if touched): see [`.claude/rules/cpp-systems.md`](../../rules/cpp-systems.md)
> §"Live deviations" — that section is the register. Don't add new
> violations; do migrate when touching one of the listed files for other
> reasons.

and in the suggestion text just above it, replace the `"Canonical SystemParams
pattern"` reference with §"Preferred: member-on-`System<N>` via `registerSystem`".

Pointing the skill at the rule instead of re-listing is what stops this pair
drifting apart a third time.

Closes #2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)
