### PR TITLE
fleet: release clears stale issue labels when no PR backs the claim

### DIFF
--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -207,16 +207,23 @@ Paste the PR URL.
 > **Claim-label lifecycle.** `fleet-claim release` clears the local
 > filesystem lock and the worktree reservation. The issue's
 > `fleet:claim-<host>-<agent>` and `fleet:in-progress` labels are
-> normally **left in place** — they persist through the PR's
-> review/merge lifecycle and are swept by `fleet-claim cleanup --gh`
-> only when the issue closes or the claim goes stale with no matching
-> open `claude/<N>-*` PR. Don't hand-strip them. The one exception is
-> a **design-blocked / design-unblocked** escalation: when the issue's
-> matching PR is parked, `release` clears those two labels itself so
-> the scout stops treating the issue as in-progress and any worker can
-> re-claim once the architect unblocks it (#1488). You don't do
-> anything special — the design-escalation step's existing
-> `fleet-claim release <N>` call handles it.
+> **left in place while a live PR backs the claim** — they persist
+> through that PR's review/merge lifecycle. Don't hand-strip them.
+> When no live PR backs the claim, `release` clears both labels
+> itself so the scout stops treating the issue as in-progress and any
+> worker can re-claim. Two such cases, and you do nothing special for
+> either — the `fleet-claim release <N>` you already run handles it:
+>
+> - **design-blocked / design-unblocked escalation** — the matching PR
+>   is parked, awaiting the architect (#1488).
+> - **decline after claim** — you claimed, found the task unworkable,
+>   commented why, and released without ever opening a PR (#2732).
+>   Retaining the labels here parked a still-`fleet:queued` task in
+>   the scout's `in_progress[]` bucket, invisible to every pane's
+>   queue walk, until the `cleanup --gh` TTL aged it out.
+>
+> `fleet-claim cleanup --gh` remains the TTL safety net for a claim
+> abandoned with no `release` call at all (crash, killed pane).
 
 Then run the shared shutdown ceremony — see
 [`FLEET-RUNTIME.md § Per-iteration shutdown`](FLEET-RUNTIME.md#per-iteration-shutdown--final-step).

--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -224,6 +224,14 @@ Paste the PR URL.
 >
 > `fleet-claim cleanup --gh` remains the TTL safety net for a claim
 > abandoned with no `release` call at all (crash, killed pane).
+>
+> One issue can carry claim labels from **two hosts**. Every path that
+> clears `fleet:in-progress` — `release`, the `cleanup --gh` TTL sweep,
+> and the `reset-sweep-host-claims` boot sweep — first checks whether a
+> claim it is *not* retiring is still live, and keeps the label if so.
+> Your host's claim going dead says nothing about the other host's, and
+> clearing `fleet:in-progress` under a live claim advertises an owned
+> task as free.
 
 Then run the shared shutdown ceremony — see
 [`FLEET-RUNTIME.md § Per-iteration shutdown`](FLEET-RUNTIME.md#per-iteration-shutdown--final-step).

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1528,6 +1528,57 @@ print(issue_pr_state(prs, os.environ["ISSUE_NUM"], os.environ.get("REPO", "")))
 ' 2>/dev/null || echo none
 }
 
+# _issue_has_unswept_claim <repo> <issue-num> <self-label> <scope> [stale-secs] [now]
+#   Does the issue still carry a `fleet:claim-*` label that the caller's pass
+#   is NOT going to remove? If so another agent's work is live and
+#   `fleet:in-progress` must stay: clearing it advertises an owned task as free
+#   and invites the double-claim race. Every path that clears
+#   `fleet:in-progress` alongside a claim label asks exactly this question, and
+#   they must not answer it differently — hence one predicate here rather than
+#   an inline copy per site.
+#
+#   <scope> selects what "the caller's pass sweeps" means:
+#     - "host" — the pass removes only `fleet:claim-<this-host>-*`
+#       (`cmd_release`, `cmd_reset_sweep_host_claims`), so ANY other host's
+#       claim is live by construction and same-host labels never count.
+#     - "ttl"  — the pass removes any host's claim once it ages past
+#       <stale-secs> (`cmd_cleanup_gh`), so another claim is live while it is
+#       younger than that. Same-host claims with no local lock are confirmed
+#       orphans that this pass sweeps on their own row, so they don't count.
+#       The PR-state gate is per-issue, shared by every label on it, so age
+#       (plus the orphan fast path) is the only per-label discriminator.
+#
+#   Fails closed: an unreadable label set or an unknown label age counts as
+#   live. Keeping `fleet:in-progress` one sweep cycle too long costs a delay;
+#   dropping it while a claim is live costs a duplicate PR.
+_issue_has_unswept_claim() {
+    local repo="$1" issue_num="$2" self_label="$3" scope="$4"
+    local stale_secs="${5:-0}" now="${6:-0}"
+    local this_host issue_labels lbl lbl_host added
+    this_host=$(derive_host)
+    issue_labels=$(gh issue view "$issue_num" --repo "$repo" \
+        --json labels --jq '.labels[].name' 2>/dev/null) || return 0
+    while IFS= read -r lbl; do
+        [[ -z "$lbl" || "$lbl" == "$self_label" ]] && continue
+        [[ "$lbl" == fleet:claim-* ]] || continue
+        lbl_host="${lbl#fleet:claim-}"
+        lbl_host="${lbl_host%%-*}"
+        if [[ "$scope" == "host" ]]; then
+            [[ "$lbl_host" == "$this_host" ]] && continue
+            return 0
+        fi
+        if [[ "$lbl_host" == "$this_host" \
+              && ! -d "$CLAIMS_DIR/$(slugify "$issue_num")" ]]; then
+            continue
+        fi
+        added=$(label_added_epoch "$repo" "$issue_num" "$lbl")
+        if [[ "$added" -eq 0 ]] || (( now - added < stale_secs )); then
+            return 0
+        fi
+    done <<< "$issue_labels"
+    return 1
+}
+
 # _release_inactive_issue_labels <issue-num>
 #   Clear this host's `fleet:claim-<host>-*` and `fleet:in-progress` labels off
 #   the issue whenever the claim is NOT backed by live work, so the scout stops
@@ -1569,17 +1620,15 @@ _release_inactive_issue_labels() {
 
     # Remove this host's claim label(s) + fleet:in-progress (mirrors the
     # cleanup --gh open-issue sweep).
-    local issue_labels lbl foreign_claim=0
+    local issue_labels lbl
     issue_labels=$(gh issue view "$issue_num" --repo "$repo" \
         --json labels --jq '.labels[].name' 2>/dev/null || echo "")
     while IFS= read -r lbl; do
         if [[ "$lbl" == fleet:claim-${host}-* ]]; then
             gh_release_label "$repo" "$issue_num" "$lbl" || true
-        elif [[ "$lbl" == fleet:claim-* ]]; then
-            foreign_claim=1
         fi
     done <<< "$issue_labels"
-    if [[ "$foreign_claim" -eq 0 ]]; then
+    if ! _issue_has_unswept_claim "$repo" "$issue_num" "" "host"; then
         gh_release_label "$repo" "$issue_num" "fleet:in-progress" || true
     fi
     return 0
@@ -2176,8 +2225,16 @@ for issue in issues:
                     --remove-label "$label_name" >/dev/null 2>&1; then
                 echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (age: $((age / 60))m, ${sweep_reason})"
                 total_removed=$((total_removed + 1))
-                gh issue edit "$issue_num" --repo "$repo" \
-                    --remove-label "fleet:in-progress" >/dev/null 2>&1 || true
+                # Two hosts can hold claims on one issue and age past the TTL
+                # at different times; only the row that retires the LAST live
+                # claim may clear fleet:in-progress.
+                if _issue_has_unswept_claim "$repo" "$issue_num" "$label_name" \
+                        "ttl" "$claim_issue_stale_secs" "$now"; then
+                    echo "cleanup --gh: keeping 'fleet:in-progress' on $repo issue#$issue_num — another claim is still live"
+                else
+                    gh issue edit "$issue_num" --repo "$repo" \
+                        --remove-label "fleet:in-progress" >/dev/null 2>&1 || true
+                fi
             else
                 write_orphan_sentinel "$repo" "$issue_num" "$label_name" \
                     "cleanup --gh: open-issue claim remove-label failed"
@@ -2412,8 +2469,15 @@ print(0)
                     --remove-label "$label_name" >/dev/null 2>&1; then
                 echo "reset-sweep-host-claims: removed '$label_name' on $repo issue#$issue_num (no open PR)"
                 total_removed=$((total_removed + 1))
-                gh issue edit "$issue_num" --repo "$repo" \
-                    --remove-label "fleet:in-progress" >/dev/null 2>&1 || true
+                # This pass only ever removes THIS host's claim labels, so a
+                # foreign claim here is live by construction — our boot
+                # sequence says nothing about another host's work.
+                if _issue_has_unswept_claim "$repo" "$issue_num" "$label_name" "host"; then
+                    echo "reset-sweep-host-claims: keeping 'fleet:in-progress' on $repo issue#$issue_num — another host's claim is still live"
+                else
+                    gh issue edit "$issue_num" --repo "$repo" \
+                        --remove-label "fleet:in-progress" >/dev/null 2>&1 || true
+                fi
             fi
         done <<< "$open_claim_plan"
     done

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1528,17 +1528,32 @@ print(issue_pr_state(prs, os.environ["ISSUE_NUM"], os.environ.get("REPO", "")))
 ' 2>/dev/null || echo none
 }
 
-# _release_parked_issue_labels <issue-num>
-#   When the issue's matching open PR is PARKED (fleet:design-blocked /
-#   fleet:design-unblocked), clear this host's `fleet:claim-<host>-*` and
-#   `fleet:in-progress` labels off the issue so the scout stops seeing it as
-#   in-progress and any worker can re-claim after the architect unblocks it
-#   (#1488 Fix A). Returns 0 only when a parked PR was detected and the sweep
-#   ran; returns 1 otherwise (gh missing, no GH repo for the namespace, or the
-#   matching PR is active — the normal PR-open release keeps its labels through
-#   the merge lifecycle, per AUTHOR-PIPELINE.md "Claim-label lifecycle").
-#   Multi-host safe: only this host's `fleet:claim-<host>-*` labels are touched.
-_release_parked_issue_labels() {
+# _release_inactive_issue_labels <issue-num>
+#   Clear this host's `fleet:claim-<host>-*` and `fleet:in-progress` labels off
+#   the issue whenever the claim is NOT backed by live work, so the scout stops
+#   seeing it as in-progress and any worker can re-claim. Two such cases, both
+#   of which `issue_pr_state` reports as not-"active":
+#     - "parked" — the matching PR is design-blocked/-unblocked; the worker
+#       released precisely so anyone can resume once the architect answers
+#       (#1488 Fix A).
+#     - "none"   — no matching PR at all: the decline-after-claim path, where a
+#       worker claims, finds the task unworkable, comments, and releases
+#       without opening a PR (#2732). Retaining the labels there leaves a
+#       still-`fleet:queued` task in the scout's in_progress[] bucket,
+#       invisible to every pane's queue walk, until `cleanup --gh`'s
+#       open-issue sweep ages it out at FLEET_CLAIM_STALE_SECS_ISSUES (2h);
+#       that sweep classifies "none" and "parked" identically, as here.
+#   `issue_pr_state`'s own contract states that callers which only distinguish
+#   keep-the-claim from release-the-claim treat "parked" and "none" identically
+#   — this is such a caller, so it gates on != "active" rather than == "parked".
+#   Returns 0 only when the sweep ran; returns 1 otherwise (gh missing, no GH
+#   repo for the namespace, or the matching PR is active — the normal PR-open
+#   release keeps its labels through the merge lifecycle, per
+#   AUTHOR-PIPELINE.md "Claim-label lifecycle").
+#   Multi-host safe: only this host's `fleet:claim-<host>-*` labels are touched,
+#   and `fleet:in-progress` is left alone while ANOTHER host's claim label
+#   survives — that host's work is still live even though ours isn't.
+_release_inactive_issue_labels() {
     local issue_num="$1"
     command -v gh >/dev/null 2>&1 || return 1
     local repo host
@@ -1550,18 +1565,23 @@ _release_parked_issue_labels() {
     prs_json=$(gh pr list --repo "$repo" --state open \
         --json number,headRefName,labels,body --limit 300 2>/dev/null || echo "[]")
 
-    [[ "$(_issue_pr_state_from "$prs_json" "$issue_num" "$repo")" == "parked" ]] || return 1
+    [[ "$(_issue_pr_state_from "$prs_json" "$issue_num" "$repo")" != "active" ]] || return 1
 
     # Remove this host's claim label(s) + fleet:in-progress (mirrors the
     # cleanup --gh open-issue sweep).
-    local issue_labels lbl
+    local issue_labels lbl foreign_claim=0
     issue_labels=$(gh issue view "$issue_num" --repo "$repo" \
         --json labels --jq '.labels[].name' 2>/dev/null || echo "")
     while IFS= read -r lbl; do
-        [[ "$lbl" == fleet:claim-${host}-* ]] || continue
-        gh_release_label "$repo" "$issue_num" "$lbl" || true
+        if [[ "$lbl" == fleet:claim-${host}-* ]]; then
+            gh_release_label "$repo" "$issue_num" "$lbl" || true
+        elif [[ "$lbl" == fleet:claim-* ]]; then
+            foreign_claim=1
+        fi
     done <<< "$issue_labels"
-    gh_release_label "$repo" "$issue_num" "fleet:in-progress" || true
+    if [[ "$foreign_claim" -eq 0 ]]; then
+        gh_release_label "$repo" "$issue_num" "fleet:in-progress" || true
+    fi
     return 0
 }
 
@@ -1590,20 +1610,18 @@ cmd_release() {
                 cmd_release_worktree "$owner" >/dev/null 2>&1 || true
             fi
         fi
-        # Issue-side `fleet:claim-*` + `fleet:in-progress` normally persist
-        # through the PR's review/merge lifecycle (see AUTHOR-PIPELINE.md
-        # "Claim-label lifecycle"): the queue reflects "active work present"
-        # until the issue closes, and `cleanup --gh` ages out abandoned
-        # claims. The ONE exception is a design-blocked / design-unblocked
-        # escalation — the worker releases precisely so ANY worker can resume
-        # after the architect responds, but the lingering claim/in-progress
-        # labels make the scout treat the issue as in-progress and block
-        # re-claim (#1488 Fix A). The escalation step adds fleet:design-blocked
-        # to the PR before calling release, so we detect the park here and
-        # clear both sides. (cleanup --gh's parked-PR carve-out is the TTL
-        # safety net if the label landed late or release was skipped.)
-        if _release_parked_issue_labels "$issue_num"; then
-            echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation + parked issue labels cleared)"
+        # Issue-side `fleet:claim-*` + `fleet:in-progress` persist through the
+        # PR's review/merge lifecycle (see AUTHOR-PIPELINE.md "Claim-label
+        # lifecycle"): the queue reflects "active work present" until the issue
+        # closes. That holds only while a live PR backs the claim — when none
+        # does (design-blocked/-unblocked park, #1488 Fix A; or no PR at all,
+        # the decline-after-claim path, #2732), the lingering labels make the
+        # scout treat the issue as in-progress and block re-claim, so we clear
+        # both sides here. (cleanup --gh's open-issue sweep, which classifies
+        # the same two cases identically, stays the TTL safety net for a claim
+        # abandoned without any release at all.)
+        if _release_inactive_issue_labels "$issue_num"; then
+            echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation + stale issue labels cleared)"
         else
             echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation cleared; issue labels retained)"
         fi

--- a/scripts/fleet/tests/test_fleet_claim_parked_release.sh
+++ b/scripts/fleet/tests/test_fleet_claim_parked_release.sh
@@ -15,6 +15,13 @@
 #           PR is design-blocked/-unblocked is swept (claim label +
 #           fleet:in-progress), while an active matching PR keeps the claim.
 #
+#   Fix C — every path that clears `fleet:in-progress` alongside a claim label
+#           (`release`, the `cleanup --gh` TTL sweep, the
+#           `reset-sweep-host-claims` boot sweep) keeps it while a claim the
+#           pass is NOT retiring is still live. Two hosts can claim one issue
+#           and go stale at different times; clearing the label under the
+#           survivor advertises an owned task as free.
+#
 # `gh` is stubbed so the label/PR surfaces are canned JSON. Host is pinned to
 # `mac` via FLEET_TEST_HOST so claim-label construction is deterministic.
 
@@ -120,8 +127,19 @@ else:
         ;;
     api)
         # events endpoint — report every claim label as added long ago so the
-        # TTL gate in the open-issue sweep always clears.
-        printf '%s ' "$@" | grep -q 'events' && echo "2020-01-01T00:00:00Z"
+        # TTL gate in the open-issue sweep always clears, EXCEPT the labels
+        # named in $FRESH_LABELS (space-separated), which report a far-future
+        # timestamp. Future rather than `date +%s` because the tests pin
+        # FLEET_CLAIM_STALE_SECS_ISSUES=1: a "now" stamp goes stale the moment
+        # the clock ticks past the next second, which would flake.
+        if printf '%s ' "$@" | grep -q 'events'; then
+            argline=$(printf '%s ' "$@")
+            stamp="2020-01-01T00:00:00Z"
+            for fresh in ${FRESH_LABELS:-}; do
+                case "$argline" in *"$fresh"*) stamp="2099-01-01T00:00:00Z"; break ;; esac
+            done
+            echo "$stamp"
+        fi
         exit 0
         ;;
     *) exit 0 ;;
@@ -234,6 +252,65 @@ assert_removed_absent  $'711\tfleet:claim-mac-opus-worker-2' "active-PR claim #7
 assert_removed_absent  $'711\tfleet:in-progress' "active-PR #711 fleet:in-progress retained"
 assert_removed_contains $'712\tfleet:claim-mac-opus-worker-1' "no-PR sweep removed #712 claim label (unchanged)"
 assert_removed_contains $'712\tfleet:in-progress' "no-PR sweep removed #712 fleet:in-progress (unchanged)"
+
+# =========================================================================
+echo "=== Phase 2b: cleanup --gh keeps fleet:in-progress while a 2nd claim is live ==="
+# =========================================================================
+: > "$REMOVED_FILE"
+# Two hosts can claim one issue and cross the TTL at different times, because
+# the age gate is evaluated per label row. Only the row retiring the LAST live
+# claim may clear fleet:in-progress — otherwise the sweep advertises a task
+# another host is actively working as free, which is the double-claim race the
+# release-side guard (the #703 case) closes.
+#
+# #720 stale mac claim + FRESH linux claim -> mac swept, in-progress STAYS.
+# #721 two stale claims                    -> both swept, in-progress cleared.
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":720,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:claim-linux-pool-2"},{"name":"fleet:in-progress"}]},
+  {"number":721,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:claim-linux-pool-3"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[]
+JSON
+export FRESH_LABELS="fleet:claim-linux-pool-2"
+CLEAN_OUT_2B=$("$FLEET_CLAIM" cleanup --gh --repo jakildev/IrredenEngine 2>&1)
+echo "$CLEAN_OUT_2B" | sed 's/^/    /'
+export FRESH_LABELS=""
+
+assert_removed_contains $'720\tfleet:claim-mac-opus-worker-1' "2-claim sweep removed #720 stale mac claim"
+assert_removed_absent  $'720\tfleet:claim-linux-pool-2' "2-claim sweep left #720 fresh foreign claim"
+assert_removed_absent  $'720\tfleet:in-progress' "2-claim sweep KEPT #720 fleet:in-progress (foreign claim live)"
+assert_removed_contains $'721\tfleet:claim-mac-opus-worker-1' "all-stale sweep removed #721 mac claim"
+assert_removed_contains $'721\tfleet:claim-linux-pool-3' "all-stale sweep removed #721 foreign claim"
+assert_removed_contains $'721\tfleet:in-progress' "all-stale sweep cleared #721 fleet:in-progress (no claim left)"
+
+# =========================================================================
+echo "=== Phase 2c: reset-sweep-host-claims keeps fleet:in-progress for a foreign claim ==="
+# =========================================================================
+: > "$REMOVED_FILE"
+# This pass removes only fleet:claim-<this-host>-*, so any other host's claim
+# is live by construction — a local boot says nothing about remote work.
+#
+# #730 mac claim + foreign linux claim -> mac swept, in-progress STAYS.
+# #731 mac claim only                  -> mac swept, in-progress cleared.
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":730,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:claim-linux-pool-2"},{"name":"fleet:in-progress"}]},
+  {"number":731,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[]
+JSON
+SWEEP_OUT=$("$FLEET_CLAIM" reset-sweep-host-claims 2>&1); echo "$SWEEP_OUT" | sed 's/^/    /'
+
+assert_removed_contains $'730\tfleet:claim-mac-opus-worker-1' "host sweep removed #730 own-host claim"
+assert_removed_absent  $'730\tfleet:claim-linux-pool-2' "host sweep left #730 foreign-host claim"
+assert_removed_absent  $'730\tfleet:in-progress' "host sweep KEPT #730 fleet:in-progress (foreign claim live)"
+assert_removed_contains $'731\tfleet:claim-mac-opus-worker-1' "host sweep removed #731 own-host claim"
+assert_removed_contains $'731\tfleet:in-progress' "host sweep cleared #731 fleet:in-progress (no claim left)"
 
 echo
 echo "================================"

--- a/scripts/fleet/tests/test_fleet_claim_parked_release.sh
+++ b/scripts/fleet/tests/test_fleet_claim_parked_release.sh
@@ -2,10 +2,13 @@
 # Tests for the #1488 claim-lifecycle hardening in fleet-claim:
 #
 #   Fix A — `fleet-claim release` clears this host's `fleet:claim-<host>-*`
-#           + `fleet:in-progress` labels off the issue ONLY when the issue's
-#           matching open PR is parked (fleet:design-blocked/-unblocked). A
-#           normal PR-open release (active matching PR) keeps the labels, per
-#           AUTHOR-PIPELINE.md "Claim-label lifecycle".
+#           + `fleet:in-progress` labels off the issue whenever no LIVE PR
+#           backs the claim: the matching open PR is parked
+#           (fleet:design-blocked/-unblocked), or there is no matching PR at
+#           all (the decline-after-claim path, #2732). A normal PR-open
+#           release (active matching PR) keeps the labels, per
+#           AUTHOR-PIPELINE.md "Claim-label lifecycle". `fleet:in-progress`
+#           survives while ANOTHER host's claim label does (#2732).
 #
 #   Fix B — `fleet-claim cleanup --gh` open-issue claim sweep treats a parked
 #           matching PR like a no-PR abandon: a stale claim whose only matching
@@ -164,6 +167,42 @@ REL701=$("$FLEET_CLAIM" release 701 2>&1); echo "$REL701" | sed 's/^/    /'
 assert_dir_absent "$FLEET_CLAIMS_DIR/701" "release dropped FS claim #701"
 assert_removed_absent $'701\tfleet:claim-mac-opus-worker-1' "active release KEPT #701 claim label"
 assert_removed_absent $'701\tfleet:in-progress' "active release KEPT #701 fleet:in-progress"
+
+# =========================================================================
+echo "=== Phase 1b: release with NO matching PR clears labels too (#2732) ==="
+# =========================================================================
+# The decline-after-claim path: a worker claims, finds the task unworkable,
+# comments, and releases without ever opening a PR. `issue_pr_state` returns
+# "none", which its own docstring says keep-vs-release callers must treat like
+# "parked" — otherwise the issue sits in the scout's in_progress[] bucket
+# (invisible to every pane's queue walk) until the 2h cleanup --gh TTL.
+#
+# #702 no PR                     -> release clears claim + in-progress.
+# #703 no PR, foreign-host claim -> our claim label goes, in-progress STAYS.
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":702,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":703,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:claim-linux-pool-2"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":802,"headRefName":"claude/999-unrelated","labels":[{"name":"fleet:wip"}]}
+]
+JSON
+mk_claim 702 opus-worker-1
+mk_claim 703 opus-worker-1
+
+REL702=$("$FLEET_CLAIM" release 702 2>&1); echo "$REL702" | sed 's/^/    /'
+assert_dir_absent "$FLEET_CLAIMS_DIR/702" "release dropped FS claim #702"
+assert_removed_contains $'702\tfleet:claim-mac-opus-worker-1' "no-PR release cleared #702 claim label"
+assert_removed_contains $'702\tfleet:in-progress' "no-PR release cleared #702 fleet:in-progress"
+
+REL703=$("$FLEET_CLAIM" release 703 2>&1); echo "$REL703" | sed 's/^/    /'
+assert_dir_absent "$FLEET_CLAIMS_DIR/703" "release dropped FS claim #703"
+assert_removed_contains $'703\tfleet:claim-mac-opus-worker-1' "no-PR release cleared #703 own-host claim label"
+assert_removed_absent  $'703\tfleet:claim-linux-pool-2' "no-PR release left #703 foreign-host claim label"
+assert_removed_absent  $'703\tfleet:in-progress' "no-PR release KEPT #703 fleet:in-progress (foreign claim live)"
 
 # =========================================================================
 echo "=== Phase 2: cleanup --gh sweeps a PARKED claim like a no-PR abandon (Fix B) ==="


### PR DESCRIPTION
## Summary
- `fleet-claim release` cleared the issue's `fleet:claim-<host>-*` + `fleet:in-progress` labels **only** when the matching PR was parked. It now clears them whenever no *live* PR backs the claim, by gating on `!= "active"` rather than `== "parked"`.
- The uncovered arm is `issue_pr_state` → `"none"`: the **decline-after-claim** path, where a worker claims a task, finds it unworkable, comments why, and releases without ever opening a PR. The retained labels parked a still-`fleet:queued` task in the scout's `in_progress[]` bucket — invisible to every pane's step-3 queue walk — until `cleanup --gh`'s open-issue sweep aged it out at the 2h TTL (`FLEET_CLAIM_STALE_SECS_ISSUES`).
- `issue_pr_state`'s own docstring already specified this: *"Callers that only distinguish 'keep the claim' from 'release the claim' treat 'parked' and 'none' identically."* `_release_parked_issue_labels` was exactly such a caller and didn't. Renamed to `_release_inactive_issue_labels` to match what it now decides.
- `cleanup --gh`'s open-issue sweep **already** classified `none` and `parked` identically (see the pre-existing `#712` case in the test) — `release` was the asymmetric side, so this makes the two agree.
- Added guard: `fleet:in-progress` is left alone while **another host's** `fleet:claim-*` label survives on the issue. Our claim being dead doesn't make theirs dead.

Live instance that prompted this: **#2728** was claimed at `04:37:04Z`, declined-and-released at `04:38:16Z`, and its `fleet:claim-mac-pool-4` + `fleet:in-progress` labels had no `unlabeled` event afterward while `fleet-claim list` reported no active claims.

## Test plan
- [x] Positive control: added the Phase 1b cases **before** the fix — 3 assertions failed (`PASS: 16  FAIL: 3`), exactly the ones the fix targets.
- [x] After the fix: `PASS: 19  FAIL: 0`.
- [x] Existing Phase 1 (`active` retains / `parked` clears) and Phase 2 (`cleanup --gh` sweep) assertions unchanged and still green.
- [x] All 21 `test_fleet_claim*.sh` suites pass.
- [x] Full fleet shell suite: 71 passed, 0 failed. Python suites: 29 passed, 1 failed — `test_fleet_validate_roles.py`, **pre-existing and unrelated** (it `SourceFileLoader`s `fleet_validate_stack.py` without putting `scripts/fleet/` on `sys.path`, so its bare `import fleet_blocked_by` fails identically from any cwd; this PR touches only a bash script and a shell test).
- [x] `bash -n` clean on both changed shell files.

Closes #2732

🤖 Generated with [Claude Code](https://claude.com/claude-code)