### PR TITLE
rules/math: replace cpp-math's dead register, migrate 73 IRMath violations

### DIFF
--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -91,15 +91,35 @@ fleet-rules-sweep \
   --pattern '^(?!\s*(//|\*)).*(\bglm::\w+|\bstd::(sin|cos|tan|sqrt|abs|min|max|clamp|floor|ceil|round|pow|log2|atan2|asin|acos|cbrt|fmod)\b)'
 ```
 
-Without the wrapper, glob from the repo top — never a path rooted at
-`creations/` — and cross-check coverage before believing a zero:
+**There is no correct `rg` spelling for this scope** — the wrapper is not a
+convenience here. `rg` honours `.gitignore`; `git ls-files` does not apply it to
+*tracked* files. Three tracked files under `creations/` sit in re-ignored
+directories (`.gitignore:40` `creations/*` with no re-inclusion for
+`bazel_test`, and `.gitignore:45` re-ignoring `creations/editors/font_maker`),
+so ripgrep cannot see them at any search root or glob spelling:
+
+```
+creations/bazel_test/main.cpp
+creations/editors/font_maker/main.cpp
+creations/editors/font_maker/systems/system_font_maker.hpp
+```
+
+Measured on this scope: the repo-top glob form covers **769** files, the sweep
+**772**. That is a second false-clean class stacked on #2739's — the walker
+one is fixed by rooting the glob at the repo top, this one is not fixable in
+`rg` at all (short of `--no-ignore`, which then pulls in the gitignored private
+`creations/game` clone and violates cross-repo isolation).
+
+If you must hand-roll it anyway, glob from the repo top — never a path rooted
+at `creations/` — and treat any count below the expected coverage as a failed
+sweep, not a clean one:
 
 ```
 rg -n -g 'engine/**/*.{hpp,cpp,h,cc}' -g 'creations/**/*.{hpp,cpp,h,cc}' '<pattern>' .
 git ls-files engine creations | grep -cE '\.(hpp|cpp|h|cc)$'   # 795 minus 23 skipped = 772
 ```
 
-Compare against the extension-filtered count, not `wc -l` over every tracked
+Compare against that extension-filtered count, not `wc -l` over every tracked
 file — `git ls-files engine creations | wc -l` is 1231, and measuring 772
 against *that* reads like a walker failure when it is the correct coverage.
 

--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -28,6 +28,8 @@ The wrapper layer in [`engine/math/include/irreden/`](../../engine/math/include/
 | `std::min(a, b)` / `std::max(a, b)` / `std::clamp(...)` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
 | `std::sin(x)` / `std::cos(x)` / `std::abs(x)` | `IRMath::sin(x)` / `IRMath::cos(x)` / `IRMath::abs(x)` |
 | `std::cbrt(x)` | `IRMath::cbrt(x)` |
+| `std::pow(b, e)` / `std::log2(x)` | `IRMath::pow(b, e)` / `IRMath::log2(x)` |
+| `std::pow(2.0f, std::round(std::log2(x)))` | `IRMath::snapToPowerOfTwo(x)` |
 | `std::fmod(x, p)` + `if (v < 0) v += p`, or `while` ±2π wrap loops | `IRMath::wrapToRange(x, p)` / `IRMath::wrapAngleTwoPi(a)` / `IRMath::wrapAnglePi(a)` |
 
 ## Iso projection: never inline the equations
@@ -48,7 +50,9 @@ If the helper you need doesn't exist yet:
 
 ## When the wrapper doesn't exist yet
 
-If you need a primitive `IRMath` doesn't expose, **add the wrapper to `engine/math/` first**, then call it. Don't reach for `glm::` "just for now" — that's the path that produced the 164 violations this rule exists to clean up.
+If you need a primitive `IRMath` doesn't expose, **add the wrapper to `engine/math/` first**, then call it. Don't reach for `glm::` "just for now" — that's the path that produced the backlog this rule exists to clean up.
+
+Known ergonomic gap: `IRMath::clamp` / `IRMath::max` / `IRMath::min` take **one** type parameter, so the mixed vector/scalar form `clamp(vec3, 0.0f, 1.0f)` that `glm::` accepts does not compile. Spell the bounds as vectors (`clamp(v, vec3(0.0f), vec3(1.0f))`) rather than reaching back for `glm::`.
 
 The math library may itself wrap `glm::*` / `std::*` internally — that is the **only** place those names should appear.
 
@@ -58,7 +62,42 @@ The math library may itself wrap `glm::*` / `std::*` internally — that is the 
 - The graphics-backend interop layer at `engine/render/include/irreden/render/backend/**` — when wiring an actual `glm` value into a `glDrawElements`-shaped API, raw glm types are the surface.
 - Shader source: `*.glsl`, `*.metal`. These have their own native math; the rule is about C++ files.
 - Standalone tools under `tools/**` that do not link the engine library (`jitter_probe`, `img_diff`): IRMath lives in `engine/math/` and is genuinely unavailable there, so `std::`/`<cmath>` math is correct. (Also outside this rule's `paths:` scope — don't raise the nit from prose alone.)
+- `engine/profile/**`. Profile is one of the three lowest modules (`common/`, `math/`, `profile/`) and does not link `IrredenEngineMath` — its only uses are index clamping (`values[std::min(n * 95 / 100, n - 1)]`), so adding a link edge from the logging module to math buys nothing. If `engine/profile` ever gains a math dependency for other reasons, drop this carve-out and migrate the sites.
 
-## Live deviations (queue-manager-owned)
+## Detection
 
-The current list of files still calling `glm::*` outside the allowlist lives in `.fleet/status/glm-deviations.md` (or will, once it's introduced — track via a follow-up task). Don't add new violations; do migrate when you're already touching one of the deviation files.
+Grep the rule's `paths:` scope minus the allowlist above, skipping `//`-comment lines:
+
+```
+pattern: '\bglm::\w+|\bstd::(sin|cos|tan|sqrt|abs|min|max|clamp|floor|ceil|round|pow|log2|atan2|asin|acos|cbrt|fmod)\b'
+glob:    'engine/**/*.{hpp,cpp,h,cc}', 'creations/**/*.{hpp,cpp,h,cc}'
+skip:    engine/math/**, engine/profile/**,
+         engine/render/include/irreden/render/backend/**, tools/**
+```
+
+Unlike the `simplify` math check and review-pr, which read a **diff**, this
+form measures the standing population. Run it tree-wide — the diff-scoped
+checks are structurally blind to violations that were already in the tree
+when they landed, which is how the count below went unmeasured for months
+(#2735).
+
+## Live deviations
+
+**Zero.** Swept tree-wide 2026-07-31 (#2735): 73 sites across 18 files
+migrated (11 `glm::`, 62 `std::`), the Detection sweep above now returns
+empty, and this register is the whole answer — there is no external status
+file. The sweep is one command; re-run it rather than trusting this line.
+
+Two rules for whoever adds the next entry:
+
+- **Keep the register inline and dated.** If it delegates to an external
+  status file, that file's existence must be verified against the tree —
+  this section spent months pointing at a `.fleet/status/` path that was
+  never created, and the sibling registers failed the same way (#2726,
+  #2733).
+- **A `round` on a position is `roundHalfUp`, not `round`.** `glm::round` /
+  `IRMath::round` are round-half-away-from-zero and disagree with the GPU
+  mirror at negative half-integers, which is the CPU↔GPU divergence §2
+  exists to prevent. Use `IRMath::roundHalfUp` / `roundVec3HalfUp` for any
+  position→cell assignment (see #2735 for a latent instance that sat in the
+  render-verify reference demo).

--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -75,6 +75,34 @@ skip:    engine/math/**, engine/profile/**,
          engine/render/include/irreden/render/backend/**, tools/**
 ```
 
+Tree-wide, run it through `fleet-rules-sweep` — this rule's `paths:` names
+`creations/**`, and an `rg`/`Grep` rooted **at** `creations/` walks 2 of its
+273 files and reports a false clean (#2739). The skip-list goes in as negation
+globs and the `//`-comment skip goes in the pattern, so the exit code is the
+whole result: **1** = real clean pass, **0** = violations, **2** = the scope
+resolved to zero files — the guard that stops a mis-scoped sweep from
+masquerading as success.
+
+```
+fleet-rules-sweep \
+  --glob 'engine/**/*.{hpp,cpp,h,cc}' --glob 'creations/**/*.{hpp,cpp,h,cc}' \
+  --glob '!engine/math/**' --glob '!engine/profile/**' \
+  --glob '!engine/render/include/irreden/render/backend/**' --glob '!tools/**' \
+  --pattern '^(?!\s*(//|\*)).*(\bglm::\w+|\bstd::(sin|cos|tan|sqrt|abs|min|max|clamp|floor|ceil|round|pow|log2|atan2|asin|acos|cbrt|fmod)\b)'
+```
+
+Without the wrapper, glob from the repo top — never a path rooted at
+`creations/` — and cross-check coverage before believing a zero:
+
+```
+rg -n -g 'engine/**/*.{hpp,cpp,h,cc}' -g 'creations/**/*.{hpp,cpp,h,cc}' '<pattern>' .
+git ls-files engine creations | grep -cE '\.(hpp|cpp|h|cc)$'   # 795 minus 23 skipped = 772
+```
+
+Compare against the extension-filtered count, not `wc -l` over every tracked
+file — `git ls-files engine creations | wc -l` is 1231, and measuring 772
+against *that* reads like a walker failure when it is the correct coverage.
+
 Unlike the `simplify` math check and review-pr, which read a **diff**, this
 form measures the standing population. Run it tree-wide — the diff-scoped
 checks are structurally blind to violations that were already in the tree
@@ -84,9 +112,11 @@ when they landed, which is how the count below went unmeasured for months
 ## Live deviations
 
 **Zero.** Swept tree-wide 2026-07-31 (#2735): 73 sites across 18 files
-migrated (11 `glm::`, 62 `std::`), the Detection sweep above now returns
-empty, and this register is the whole answer — there is no external status
-file. The sweep is one command; re-run it rather than trusting this line.
+migrated (11 `glm::`, 62 `std::`), and this register is the whole answer —
+there is no external status file. The Detection sweep above exits **1**
+(`swept 772 file(s)`) — a clean pass that covered something, not a walker
+that scoped itself into the hole. The sweep is one command; re-run it rather
+than trusting this line.
 
 Two rules for whoever adds the next entry:
 

--- a/.claude/skills/optimize/reference/common_bottlenecks.md
+++ b/.claude/skills/optimize/reference/common_bottlenecks.md
@@ -211,11 +211,11 @@ session uncovers lands here in the same PR as the fix.
 
 - **Pattern**: `glm::sin(x)`, `std::max(a, b)`, etc. in C++ code
   outside `engine/math/`.
-- **Where**: tracked in `<engine-root>/.fleet/status/glm-deviations.md`
-  (queue-manager-owned, committed; not `~/.fleet/`) — or will be, once
-  the file is introduced. Until then, discover violations with
-  `rg 'glm::|std::(sin|cos|sqrt|abs|min|max|clamp)' --type cpp engine/
-  -g '!engine/math/**'`.
+- **Where**: tracked inline in [`.claude/rules/cpp-math.md`](../../../rules/cpp-math.md)
+  §"Live deviations" (zero as of the #2735 sweep). That section's
+  §"Detection" carries the sweep command and the current allowlist — run
+  it rather than re-deriving a grep; the earlier pointer here named
+  `.fleet/status/glm-deviations.md`, a file that was never created.
 - **Symptom**: Not a runtime hotspot, but blocks the
   IRMath-implementation-swap path and breaks CPU↔GPU consistency
   (e.g. `glm::round` vs `IRMath::roundHalfUp`).

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -10,6 +10,7 @@
 // hand-written `system_periodic_idle.tick()` body for the parity gate.
 
 #include <irreden/ir_engine.hpp>
+#include <irreden/ir_math.hpp>
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_script.hpp>
@@ -203,9 +204,9 @@ void applyArgs() {
 }
 
 void validateSettings() {
-    g_settings.gridSize_ = std::max(1, g_settings.gridSize_);
-    g_settings.spacing_ = std::max(0.25f, g_settings.spacing_);
-    g_settings.wavePeriodSeconds_ = std::max(0.1f, g_settings.wavePeriodSeconds_);
+    g_settings.gridSize_ = IRMath::max(1, g_settings.gridSize_);
+    g_settings.spacing_ = IRMath::max(0.25f, g_settings.spacing_);
+    g_settings.wavePeriodSeconds_ = IRMath::max(0.1f, g_settings.wavePeriodSeconds_);
     const int poolEdge = IRRender::VoxelPoolConfig::getEdge();
     if (g_settings.gridSize_ > poolEdge) {
         IR_LOG_WARN(
@@ -219,7 +220,7 @@ void validateSettings() {
 }
 
 Color colorForCell(int x, int y, int z, int gridSize) {
-    const float denom = static_cast<float>(std::max(gridSize - 1, 1));
+    const float denom = static_cast<float>(IRMath::max(gridSize - 1, 1));
     return Color{
         static_cast<std::uint8_t>(80 + 120.0f * (static_cast<float>(x) / denom)),
         static_cast<std::uint8_t>(120 + 100.0f * (static_cast<float>(y) / denom)),
@@ -240,7 +241,7 @@ C_LuaWaveState makeWaveState(int x, int y, int z) {
     // angleIncrementPerTick = 2*pi / period / kFPS.
     const float tau = 2.0f * std::numbers::pi_v<float>;
     const float pi = std::numbers::pi_v<float>;
-    const float wavelength = std::max(8.0f, static_cast<float>(g_settings.gridSize_) * 0.5f);
+    const float wavelength = IRMath::max(8.0f, static_cast<float>(g_settings.gridSize_) * 0.5f);
     const float phase = tau * static_cast<float>(x + y + z) / wavelength;
     const float period = g_settings.wavePeriodSeconds_;
     const float angleInc = tau / period / static_cast<float>(IRConstants::kFPS);

--- a/creations/demos/modifier_demo/main.cpp
+++ b/creations/demos/modifier_demo/main.cpp
@@ -1,4 +1,5 @@
 #include <irreden/ir_engine.hpp>
+#include <irreden/ir_math.hpp>
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_input.hpp>
@@ -267,7 +268,7 @@ void initSystems() {
                         IRModifierDemo::g_speedField,
                         [](float v) -> float {
                             float phase = static_cast<float>(IRModifierDemo::g_tick) * 0.05f;
-                            return v * (1.0f + std::sin(phase));
+                            return v * (1.0f + IRMath::sin(phase));
                         },
                         IRModifierDemo::g_cubes[6],
                         -1
@@ -337,7 +338,7 @@ void initSystems() {
                 // constant under the (+x,-y) animation. The row mapping is
                 // `rowIsoY(i) = (i - (N+1)/2) * kRowIsoSpacing`.
                 const float isoY = -(pos.translation_.x + pos.translation_.y);
-                const int rowIdx = static_cast<int>(std::round(
+                const int rowIdx = static_cast<int>(IRMath::round(
                     isoY / IRModifierDemo::kRowIsoSpacing + (IRModifierDemo::kNumCubes + 1) * 0.5f
                 ));
                 Color baseColor = (rowIdx >= 1 && rowIdx <= IRModifierDemo::kNumCubes)

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -1026,7 +1026,7 @@ void applyCheckerboard(C_VoxelSetNew &voxelSet, Color baseColor) {
     for (int i = 0; i < voxelSet.numVoxels_; ++i) {
         if (voxelSet.voxels_[i].color_.alpha_ == 0)
             continue;
-        ivec3 cellPos = ivec3(glm::round(voxelSet.positions_[i].pos_));
+        ivec3 cellPos = IRMath::roundVec3HalfUp(voxelSet.positions_[i].pos_);
         Color c = baseColor;
         if (((cellPos.x + cellPos.y + cellPos.z) & 1) != 0) {
             c.red_ = static_cast<std::uint8_t>(c.red_ * 0.55f);
@@ -1043,8 +1043,8 @@ void applyCheckerboard(C_VoxelSetNew &voxelSet, Color baseColor) {
 // Classic HSV->RGB (h,s,v in [0,1]) matching the shader's hsvToRgb helper.
 vec3 hsvToRgbCpu(vec3 c) {
     const vec4 K(1.0f, 2.0f / 3.0f, 1.0f / 3.0f, 3.0f);
-    vec3 p = glm::abs(glm::fract(vec3(c.x) + vec3(K)) * 6.0f - vec3(K.w));
-    return c.z * glm::mix(vec3(K.x), glm::clamp(p - vec3(K.x), 0.0f, 1.0f), c.y);
+    vec3 p = IRMath::abs(IRMath::fract(vec3(c.x) + vec3(K)) * 6.0f - vec3(K.w));
+    return c.z * IRMath::mix(vec3(K.x), IRMath::clamp(p - vec3(K.x), vec3(0.0f), vec3(1.0f)), c.y);
 }
 
 // Color each active voxel by its LOCAL iso-depth (x+y+z), normalized to
@@ -1062,14 +1062,14 @@ void applyDepthColor(C_VoxelSetNew &voxelSet, IRRender::ShapeType type, vec4 sdf
     for (int i = 0; i < voxelSet.numVoxels_; ++i) {
         if (voxelSet.voxels_[i].color_.alpha_ == 0)
             continue;
-        ivec3 cellPos = ivec3(glm::round(voxelSet.positions_[i].pos_));
+        ivec3 cellPos = IRMath::roundVec3HalfUp(voxelSet.positions_[i].pos_);
         float d = static_cast<float>(cellPos.x + cellPos.y + cellPos.z);
-        float t = glm::clamp((d + dColor) / denom, 0.0f, 1.0f);
+        float t = IRMath::clamp((d + dColor) / denom, 0.0f, 1.0f);
         vec3 rgb = hsvToRgbCpu(vec3(0.66f * t, 1.0f, 1.0f));
         Color c{
-            static_cast<std::uint8_t>(glm::clamp(rgb.x, 0.0f, 1.0f) * 255.0f),
-            static_cast<std::uint8_t>(glm::clamp(rgb.y, 0.0f, 1.0f) * 255.0f),
-            static_cast<std::uint8_t>(glm::clamp(rgb.z, 0.0f, 1.0f) * 255.0f),
+            static_cast<std::uint8_t>(IRMath::clamp(rgb.x, 0.0f, 1.0f) * 255.0f),
+            static_cast<std::uint8_t>(IRMath::clamp(rgb.y, 0.0f, 1.0f) * 255.0f),
+            static_cast<std::uint8_t>(IRMath::clamp(rgb.z, 0.0f, 1.0f) * 255.0f),
             255
         };
         voxelSet.voxels_[i].color_ = c;

--- a/engine/audio/src/audio.cpp
+++ b/engine/audio/src/audio.cpp
@@ -1,5 +1,7 @@
 #include <irreden/audio/audio.hpp>
 
+#include <irreden/ir_math.hpp>
+
 #include <algorithm>
 #include <sstream>
 #include <utility>
@@ -47,7 +49,7 @@ bool Audio::openStreamIn(
 
     RtAudio::DeviceInfo deviceInfo = m_rtAudio.getDeviceInfo(deviceId);
     const unsigned int requestedChannels =
-        static_cast<unsigned int>(std::clamp(channels, 1, 2));
+        static_cast<unsigned int>(IRMath::clamp(channels, 1, 2));
     const unsigned int availableInputChannels = static_cast<unsigned int>(deviceInfo.inputChannels);
     if (availableInputChannels < requestedChannels) {
         IRE_LOG_ERROR(
@@ -64,7 +66,8 @@ bool Audio::openStreamIn(
     parameters.nChannels = requestedChannels;
     parameters.firstChannel = 0;
 
-    const unsigned int requestedSampleRate = static_cast<unsigned int>(std::max(sampleRate, 8'000));
+    const unsigned int requestedSampleRate =
+        static_cast<unsigned int>(IRMath::max(sampleRate, 8'000));
     unsigned int bufferFrames = kAudioInputDefaultBufferFrames;
 
     try {

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -405,6 +405,26 @@ constexpr float sqrt(float value) {
     return glm::sqrt(value);
 }
 
+/// @p base raised to @p exponent. Wraps std::pow.
+inline float pow(float base, float exponent) noexcept {
+    return std::pow(base, exponent);
+}
+
+/// Base-2 logarithm of @p value. Wraps std::log2. Caller guarantees value > 0.
+inline float log2(float value) noexcept {
+    return std::log2(value);
+}
+
+/// Snaps @p value to the nearest power of two (in log space, so the tie goes
+/// to the geometrically nearer neighbour, not the arithmetically nearer one).
+/// Caller guarantees value > 0.
+///
+/// Named so the tie-breaking rule lives in one place instead of being
+/// re-derived as `pow(2, round(log2(x)))` at each mip/zoom-quantization site.
+inline float snapToPowerOfTwo(float value) noexcept {
+    return pow(2.0f, static_cast<float>(std::round(log2(value))));
+}
+
 /// Cube root of @p value (float). Wraps std::cbrt.
 inline float cbrt(float value) noexcept {
     return std::cbrt(value);

--- a/engine/prefabs/irreden/audio/systems/system_contact_midi_trigger.hpp
+++ b/engine/prefabs/irreden/audio/systems/system_contact_midi_trigger.hpp
@@ -5,6 +5,7 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_audio.hpp>
 #include <irreden/ir_constants.hpp>
+#include <irreden/ir_math.hpp>
 
 #include <irreden/update/components/component_contact_event.hpp>
 #include <irreden/audio/components/component_midi_note.hpp>
@@ -38,7 +39,7 @@ template <> struct System<CONTACT_MIDI_TRIGGER> {
                 );
 
                 int holdFrames = static_cast<int>(midiNote.holdSeconds_ * IRConstants::kFPS);
-                holdFrames = std::max(holdFrames, 1);
+                holdFrames = IRMath::max(holdFrames, 1);
                 IREntity::createEntity(
                     C_MidiMessage{
                         buildMidiStatus(kMidiStatus_NOTE_OFF, channel),

--- a/engine/prefabs/irreden/audio/systems/system_periodic_idle_midi_trigger.hpp
+++ b/engine/prefabs/irreden/audio/systems/system_periodic_idle_midi_trigger.hpp
@@ -5,6 +5,7 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_audio.hpp>
 #include <irreden/ir_constants.hpp>
+#include <irreden/ir_math.hpp>
 
 #include <irreden/update/components/component_periodic_idle.hpp>
 #include <irreden/audio/components/component_midi_note.hpp>
@@ -39,7 +40,7 @@ template <> struct System<PERIODIC_IDLE_MIDI_TRIGGER> {
                 );
                 // NOTE_OFF: delayed by hold duration
                 int holdFrames = static_cast<int>(midiNote.holdSeconds_ * IRConstants::kFPS);
-                holdFrames = std::max(holdFrames, 1);
+                holdFrames = IRMath::max(holdFrames, 1);
                 IREntity::createEntity(
                     C_MidiMessage{
                         buildMidiStatus(kMidiStatus_NOTE_OFF, channel),

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_background.hpp
@@ -400,9 +400,7 @@ struct C_TriangleCanvasBackground {
     }
 
     float quantizePowerOfTwo(float value) const {
-        const float clamped = IRMath::max(0.01f, value);
-        const float exponent = std::round(std::log2(clamped));
-        return std::pow(2.0f, exponent);
+        return IRMath::snapToPowerOfTwo(IRMath::max(0.01f, value));
     }
 
     vec2 normalizeDirectionOrFallback(float x, float y, const vec2 &fallback) const {

--- a/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
@@ -2,6 +2,7 @@
 #define GPU_STAGE_TIMING_OBSERVER_H
 
 #include <irreden/ir_system.hpp>
+#include <irreden/ir_math.hpp>
 #include <irreden/ir_profile.hpp>
 #include <irreden/render/render_device.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
@@ -49,8 +50,9 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
         state.registryIndex_ = static_cast<int>(&info - gpuStageRegistry().data());
         state.device_ = IRRender::device();
         if (state.device_ != nullptr && state.device_->supportsGpuTimestampPairs()) {
-            const int pairsInFlight =
-                std::clamp(state.device_->recommendedTimestampPairsInFlight(), 1, kSamplesInFlight);
+            const int pairsInFlight = IRMath::clamp(
+                state.device_->recommendedTimestampPairsInFlight(), 1, kSamplesInFlight
+            );
             for (int i = 0; i < pairsInFlight; ++i) {
                 state.handles_[i] = state.device_->createTimestampPair();
             }

--- a/engine/prefabs/irreden/render/iso_spatial_hash.hpp
+++ b/engine/prefabs/irreden/render/iso_spatial_hash.hpp
@@ -37,10 +37,10 @@ class IsoSpatialHash {
     }
 
     void insert(IREntity::EntityId entity, vec2 isoMin, vec2 isoMax) {
-        int x0 = static_cast<int>(std::floor(isoMin.x / m_cellSize));
-        int y0 = static_cast<int>(std::floor(isoMin.y / m_cellSize));
-        int x1 = static_cast<int>(std::floor(isoMax.x / m_cellSize));
-        int y1 = static_cast<int>(std::floor(isoMax.y / m_cellSize));
+        int x0 = static_cast<int>(IRMath::floor(isoMin.x / m_cellSize));
+        int y0 = static_cast<int>(IRMath::floor(isoMin.y / m_cellSize));
+        int x1 = static_cast<int>(IRMath::floor(isoMax.x / m_cellSize));
+        int y1 = static_cast<int>(IRMath::floor(isoMax.y / m_cellSize));
         for (int y = y0; y <= y1; ++y) {
             for (int x = x0; x <= x1; ++x) {
                 m_cells[cellKey(x, y)].insert(entity);
@@ -50,10 +50,10 @@ class IsoSpatialHash {
 
     std::vector<IREntity::EntityId> query(vec2 viewMin, vec2 viewMax) const {
         std::unordered_set<IREntity::EntityId> result;
-        int x0 = static_cast<int>(std::floor(viewMin.x / m_cellSize));
-        int y0 = static_cast<int>(std::floor(viewMin.y / m_cellSize));
-        int x1 = static_cast<int>(std::floor(viewMax.x / m_cellSize));
-        int y1 = static_cast<int>(std::floor(viewMax.y / m_cellSize));
+        int x0 = static_cast<int>(IRMath::floor(viewMin.x / m_cellSize));
+        int y0 = static_cast<int>(IRMath::floor(viewMin.y / m_cellSize));
+        int x1 = static_cast<int>(IRMath::floor(viewMax.x / m_cellSize));
+        int y1 = static_cast<int>(IRMath::floor(viewMax.y / m_cellSize));
         for (int y = y0; y <= y1; ++y) {
             for (int x = x0; x <= x1; ++x) {
                 auto it = m_cells.find(cellKey(x, y));

--- a/engine/prefabs/irreden/update/components/component_periodic_idle.hpp
+++ b/engine/prefabs/irreden/update/components/component_periodic_idle.hpp
@@ -269,10 +269,10 @@ struct C_PeriodicIdle {
     }
 
     float mapAngleToStageTValue(float angle, const PeriodStage &stage) const {
-        float clampedAngle = std::max(stage.startAngle_, std::min(stage.endAngle_, angle));
+        float clampedAngle = IRMath::max(stage.startAngle_, IRMath::min(stage.endAngle_, angle));
         float relativePosition =
             (angle - stage.startAngle_) / (stage.endAngle_ - stage.startAngle_);
-        relativePosition = std::max(0.0f, std::min(1.0f, relativePosition));
+        relativePosition = IRMath::max(0.0f, IRMath::min(1.0f, relativePosition));
         if (stage.isReversed_) {
             relativePosition = 1.0f - relativePosition;
         }

--- a/engine/prefabs/irreden/update/systems/system_spring_color.hpp
+++ b/engine/prefabs/irreden/update/systems/system_spring_color.hpp
@@ -59,8 +59,8 @@ template <> struct System<SPRING_COLOR> {
                 if (spring.colorMinValue_ > 0.0f
                     || spring.colorMinSaturation_ > 0.0f) {
                     ColorHSV hsv = IRMath::colorToColorHSV(shifted);
-                    hsv.value_ = std::max(hsv.value_, spring.colorMinValue_);
-                    hsv.saturation_ = std::max(
+                    hsv.value_ = IRMath::max(hsv.value_, spring.colorMinValue_);
+                    hsv.saturation_ = IRMath::max(
                         hsv.saturation_, spring.colorMinSaturation_);
                     shifted = IRMath::colorHSVToColor(hsv);
                 }

--- a/engine/prefabs/irreden/update/systems/system_spring_platform.hpp
+++ b/engine/prefabs/irreden/update/systems/system_spring_platform.hpp
@@ -51,7 +51,7 @@ template <> struct System<SPRING_PLATFORM> {
                             IREntity::getComponentOptional<C_Velocity3D>(contact.otherEntity_);
                         if (velOpt.has_value()) {
                             vec3 bv = velOpt.value()->velocity_;
-                            impactSpeed = std::abs(IRMath::dot(bv, spring.direction_));
+                            impactSpeed = IRMath::abs(IRMath::dot(bv, spring.direction_));
                         }
                     }
                     spring.springVelocity_ = spring.absorptionRatio_ * impactSpeed;
@@ -91,7 +91,7 @@ template <> struct System<SPRING_PLATFORM> {
                             localXform.translation_ =
                                 spring.origin_ + spring.direction_ * spring.displacement_;
 
-                            if (std::abs(spring.displacement_ - lockPoint) < 0.01f) {
+                            if (IRMath::abs(spring.displacement_ - lockPoint) < 0.01f) {
                                 spring.displacement_ = lockPoint;
                                 spring.state_ = SPRING_LOCKED;
                                 localXform.translation_ =
@@ -104,8 +104,8 @@ template <> struct System<SPRING_PLATFORM> {
                                 IRMath::max(0.0f, 1.0f - spring.damping_ * dt);
 
                             if (spring.maxCatchOscillations_ <= 0 &&
-                                std::abs(spring.springVelocity_) <= spring.settleSpeed_ &&
-                                std::abs(offset) < 0.5f) {
+                                IRMath::abs(spring.springVelocity_) <= spring.settleSpeed_ &&
+                                IRMath::abs(offset) < 0.5f) {
                                 spring.displacement_ = lockPoint;
                                 spring.springVelocity_ = 0.0f;
                                 spring.state_ = SPRING_LOCKED;
@@ -148,7 +148,7 @@ template <> struct System<SPRING_PLATFORM> {
                 // ── Launch ──
                 if (spring.launchRequested_) {
                     float launchSpeed =
-                        std::sqrt(spring.stiffness_ * spring.length_ * spring.length_);
+                        IRMath::sqrt(spring.stiffness_ * spring.length_ * spring.length_);
                     spring.springVelocity_ = -launchSpeed;
                     spring.state_ = SPRING_LAUNCHING;
                     spring.launchRequested_ = false;
@@ -181,8 +181,8 @@ template <> struct System<SPRING_PLATFORM> {
                     spring.springVelocity_ *= IRMath::max(0.0f, 1.0f - spring.damping_ * dt);
 
                     if (spring.state_ == SPRING_REBOUNDING && spring.maxLaunchOscillations_ <= 0 &&
-                        std::abs(spring.springVelocity_) <= spring.settleSpeed_ &&
-                        std::abs(spring.displacement_) < 0.5f) {
+                        IRMath::abs(spring.springVelocity_) <= spring.settleSpeed_ &&
+                        IRMath::abs(spring.displacement_) < 0.5f) {
                         spring.displacement_ = 0.0f;
                         spring.springVelocity_ = 0.0f;
                         spring.state_ = SPRING_IDLE;
@@ -208,7 +208,7 @@ template <> struct System<SPRING_PLATFORM> {
                     localXform.translation_ =
                         spring.origin_ + spring.direction_ * spring.displacement_;
 
-                    if (std::abs(spring.displacement_) < 0.01f) {
+                    if (IRMath::abs(spring.displacement_) < 0.01f) {
                         spring.displacement_ = 0.0f;
                         spring.state_ = SPRING_IDLE;
                         spring.oscillationCount_ = 0;

--- a/engine/prefabs/irreden/voxel/systems/system_voxel_squash_stretch.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_voxel_squash_stretch.hpp
@@ -131,13 +131,13 @@ template <> struct System<VOXEL_SQUASH_STRETCH> {
                     deformAxis = useVelDir;
                     primaryScale = 1.0f + squashStretch.stretchStrength_ * blend;
                     perpScale = squashStretch.volumePreserve_
-                                    ? 1.0f / std::sqrt(primaryScale)
+                                    ? 1.0f / IRMath::sqrt(primaryScale)
                                     : 1.0f - squashStretch.squashStrength_ * blend;
                 } else if (blend < -0.0001f) {
                     deformAxis = accelDir;
                     primaryScale = 1.0f - squashStretch.squashStrength_ * (-blend);
                     perpScale = squashStretch.volumePreserve_
-                                    ? 1.0f / std::sqrt(IRMath::max(primaryScale, 0.01f))
+                                    ? 1.0f / IRMath::sqrt(IRMath::max(primaryScale, 0.01f))
                                     : 1.0f;
                 } else {
                     primaryScale = 1.0f;

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -306,7 +306,7 @@ void RenderManager::setCameraZoom(float zoom) {
         IRConstants::kTrixelCanvasZoomMin.x,
         IRConstants::kTrixelCanvasZoomMax.x
     );
-    float snapped = std::pow(2.0f, std::round(std::log2(clamped)));
+    float snapped = IRMath::snapToPowerOfTwo(clamped);
     IREntity::setComponent(m_camera, C_ZoomLevel{snapped});
 }
 
@@ -539,7 +539,7 @@ void RenderManager::resizeGuiCanvas(ivec2 newSize) {
 }
 
 void RenderManager::setGuiScale(int scale) {
-    scale = std::clamp(scale, 1, 8);
+    scale = IRMath::clamp(scale, 1, 8);
     if (scale == m_guiScale)
         return;
     if (m_guiFullResolution)
@@ -574,7 +574,7 @@ bool RenderManager::isHoveredTrixelVisible() const {
 }
 
 void RenderManager::setSunDirection(vec3 dir) {
-    const float len = glm::length(dir);
+    const float len = IRMath::length(dir);
     m_sunDirection = len > 0.0f ? dir / len : vec3(-0.3f, -0.2f, -0.93f);
 }
 

--- a/engine/video/src/video_manager.cpp
+++ b/engine/video/src/video_manager.cpp
@@ -1,6 +1,7 @@
 #include <irreden/video/video_manager.hpp>
 
 #include <irreden/ir_constants.hpp>
+#include <irreden/ir_math.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_audio.hpp>
 #include <irreden/audio/audio_capture_source.hpp>
@@ -47,13 +48,13 @@ void VideoManager::configureCapture(
     IRAudio::IAudioCaptureSource *audioCaptureSource
 ) {
     m_outputFilePath = outputFilePath;
-    m_targetFps = std::max(targetFps, 1);
-    m_videoBitrate = std::max(videoBitrate, 250000);
+    m_targetFps = IRMath::max(targetFps, 1);
+    m_videoBitrate = IRMath::max(videoBitrate, 250000);
     m_captureAudioInput = captureAudioInput;
     m_audioInputDeviceName = audioInputDeviceName;
-    m_audioSampleRate = std::max(audioSampleRate, 8'000);
-    m_audioChannels = std::clamp(audioChannels, 1, 2);
-    m_audioBitrate = std::max(audioBitrate, 64'000);
+    m_audioSampleRate = IRMath::max(audioSampleRate, 8'000);
+    m_audioChannels = IRMath::clamp(audioChannels, 1, 2);
+    m_audioBitrate = IRMath::max(audioBitrate, 64'000);
     m_audioMuxEnabled = audioMuxEnabled;
     m_audioWavEnabled = audioWavEnabled;
     m_audioSyncOffsetMs = audioSyncOffsetMs;
@@ -152,7 +153,7 @@ void VideoManager::render() {
     ++m_totalCapturedFrames;
 
     static constexpr int kMaxCatchupFrames = 4;
-    const int duplicates = std::min(framesToCapture - 1, kMaxCatchupFrames);
+    const int duplicates = IRMath::min(framesToCapture - 1, kMaxCatchupFrames);
     if (duplicates > 0) {
         IRE_LOG_WARN(
             "Video capture: {} frames due, submitting {} duplicate(s) for catchup",
@@ -383,10 +384,10 @@ void VideoManager::writePendingRoiCrops(
         IRUtility::formatNumberedFilename("screenshot_", shotIndex, 6, "");
     const std::filesystem::path outputDir(m_screenshotOutputDirPath);
     for (const PendingCrop &crop : m_pendingScreenshotCrops) {
-        const int x0 = std::max(0, crop.x_);
-        const int y0 = std::max(0, crop.y_);
-        const int x1 = std::min(frameWidth, crop.x_ + crop.w_);
-        const int y1 = std::min(frameHeight, crop.y_ + crop.h_);
+        const int x0 = IRMath::max(0, crop.x_);
+        const int y0 = IRMath::max(0, crop.y_);
+        const int x1 = IRMath::min(frameWidth, crop.x_ + crop.w_);
+        const int y1 = IRMath::min(frameHeight, crop.y_ + crop.h_);
         const int outW = x1 - x0;
         const int outH = y1 - y0;
         if (outW <= 0 || outH <= 0) {

--- a/engine/video/src/video_recorder.cpp
+++ b/engine/video/src/video_recorder.cpp
@@ -1,5 +1,6 @@
 #include <irreden/video/video_recorder.hpp>
 
+#include <irreden/ir_math.hpp>
 #include <irreden/ir_profile.hpp>
 #include <irreden/ir_utility.hpp>
 
@@ -219,8 +220,8 @@ bool VideoRecorder::start(const VideoRecorderConfig &config) {
 #else
     std::unique_ptr<FFmpegState> state = std::make_unique<FFmpegState>();
     state->audioCaptureRequested = config.capture_audio_input_;
-    state->audioSampleRate = std::max(config.audio_sample_rate_, 8'000);
-    state->audioChannels = std::clamp(config.audio_channels_, 1, 2);
+    state->audioSampleRate = IRMath::max(config.audio_sample_rate_, 8'000);
+    state->audioChannels = IRMath::clamp(config.audio_channels_, 1, 2);
     state->wavWriteEnabled = config.audio_wav_enabled_;
     if (state->audioCaptureRequested) {
         state->fallbackAudioPath = makeFallbackAudioPath(config.output_file_path_);
@@ -274,7 +275,7 @@ bool VideoRecorder::start(const VideoRecorderConfig &config) {
     state->videoCodecContext->height = config.height_;
     state->videoCodecContext->time_base = AVRational{1, config.target_fps_};
     state->videoCodecContext->framerate = AVRational{config.target_fps_, 1};
-    state->videoCodecContext->bit_rate = std::max(config.video_bitrate_, 250000);
+    state->videoCodecContext->bit_rate = IRMath::max(config.video_bitrate_, 250000);
     state->videoCodecContext->gop_size = config.target_fps_ * 2;
     state->videoCodecContext->max_b_frames = 0;
     state->videoCodecContext->thread_count = 0;
@@ -334,7 +335,7 @@ bool VideoRecorder::start(const VideoRecorderConfig &config) {
                     state->audioCodecContext->time_base = AVRational{1, state->audioSampleRate};
                     if (!config.audio_lossless_) {
                         state->audioCodecContext->bit_rate =
-                            std::max(config.audio_bitrate_, 64'000);
+                            IRMath::max(config.audio_bitrate_, 64'000);
                         state->audioCodecContext->profile = AV_PROFILE_AAC_LOW;
                     }
                     if ((state->formatContext->oformat->flags & AVFMT_GLOBALHEADER) != 0) {
@@ -555,7 +556,8 @@ bool VideoRecorder::start(const VideoRecorderConfig &config) {
                         break;
                     }
 
-                    const int chunkFrames = std::min(frameBlockSize, audioChunk.frameCount - consumedFrames);
+                    const int chunkFrames =
+                        IRMath::min(frameBlockSize, audioChunk.frameCount - consumedFrames);
                     state->audioFrame->pts = audioChunk.pts + consumedFrames;
                     const AVSampleFormat sampleFormat = state->audioCodecContext->sample_fmt;
                     const int channels = state->audioChannels;
@@ -589,8 +591,9 @@ bool VideoRecorder::start(const VideoRecorderConfig &config) {
                                 const std::size_t srcIndex = srcBaseIndex +
                                     static_cast<std::size_t>(i) * static_cast<std::size_t>(channels) +
                                     static_cast<std::size_t>(channel);
-                                const float clamped =
-                                    std::clamp(audioChunk.interleavedSamples[srcIndex], -1.0f, 1.0f);
+                                const float clamped = IRMath::clamp(
+                                    audioChunk.interleavedSamples[srcIndex], -1.0f, 1.0f
+                                );
                                 dst[i] = static_cast<std::int16_t>(std::lrint(clamped * 32767.0f));
                             }
                             for (int i = chunkFrames; i < frameBlockSize; ++i) {
@@ -602,8 +605,9 @@ bool VideoRecorder::start(const VideoRecorderConfig &config) {
                         std::fill(dst, dst + frameBlockSize * channels, 0);
                         const int totalSamples = chunkFrames * channels;
                         for (int i = 0; i < totalSamples; ++i) {
-                            const float clamped =
-                                std::clamp(audioChunk.interleavedSamples[srcBaseIndex + i], -1.0f, 1.0f);
+                            const float clamped = IRMath::clamp(
+                                audioChunk.interleavedSamples[srcBaseIndex + i], -1.0f, 1.0f
+                            );
                             dst[i] = static_cast<std::int16_t>(std::lrint(clamped * 32767.0f));
                         }
                     } else {
@@ -1005,11 +1009,11 @@ bool VideoRecorder::submitAudioInputSamples(
     if (state->firstAudioStreamTimeSeconds < 0.0) {
         state->firstAudioStreamTimeSeconds = streamTime;
     }
-    const double relativeTime = std::max(0.0, streamTime - state->firstAudioStreamTimeSeconds);
+    const double relativeTime = IRMath::max(0.0, streamTime - state->firstAudioStreamTimeSeconds);
     int64_t chunkPts =
         static_cast<int64_t>(std::llround(relativeTime * static_cast<double>(state->audioSampleRate)));
     chunkPts += state->audioSyncOffsetSamples;
-    chunkPts = std::max(chunkPts, state->nextAudioPts);
+    chunkPts = IRMath::max(chunkPts, state->nextAudioPts);
     state->nextAudioPts = chunkPts + frameCount;
 
     FFmpegState::AudioChunk chunk;


### PR DESCRIPTION
## Summary

- `.claude/rules/cpp-math.md` §"Live deviations" delegated the violation list to `.fleet/status/glm-deviations.md`, a file `git log --all` shows was **never created**. Replaced with an inline, dated register plus a `## Detection` section carrying the sweep command — the shape the sibling `cpp-globals` register landed on.
- Tree-wide sweep (rule's own `paths:` minus its allowlist) found **73 live violations in 18 files** (11 `glm::`, 62 `std::`). All migrated; the sweep now returns **zero**.
- Added the three wrappers the residual needed and the rule's "add the wrapper first" escape never got: `IRMath::pow`, `IRMath::log2`, and `IRMath::snapToPowerOfTwo` — the last replacing a `pow(2, round(log2(x)))` idiom open-coded identically in `render_manager.cpp:309` and `component_triangle_canvas_background.hpp:404`.
- Allowlist corrected: `engine/profile/**` carved out with the reason (it is one of the three lowest modules and does not link `IrredenEngineMath`; its only uses are index clamping, so a link edge from the logging module to math buys nothing).

### The one behavior change

`shape_debug`'s `applyCheckerboard` / `applyDepthColor` assigned voxels to cells with `glm::round`, while their GPU mirror uses `roundHalfUp` at every position→cell handshake (`c_shapes_to_trixel.glsl:694,795,860,945,1035`) — and `applyDepthColor`'s doc comment claims it "Matches the GPU depth-color path … **exactly**". `glm::round` is round-half-away-from-zero; the two disagree at negative half-integers, which is the CPU↔GPU divergence §2 of the rule exists to prevent, sitting in the `render-verify` reference demo.

**Latent, not live:** `createVoxelPoolShape` allocates an integer-halfExtent centered box, so positions are integral today and both roundings agree. Now `IRMath::roundVec3HalfUp`.

## Notes for the reviewer

- **`render_manager.cpp:577`'s `glm::length`** is named in **#1923** (`human:owned`). Migrating it was one line and leaving it would have made the register carry a special case that rots the same way, so it is included here. #1923's substantive scope — the shader `round()` → `roundHalfUp()` consolidation and the inlined `pos3DtoDistance` sites — is untouched; its `ir_render.cpp` `glm::floor` bullet is already gone from the tree independently.
- **Two more copies of the dead pointer are out of reach of this PR** (the #2688 shape). `.claude/skills/simplify/SKILL.md:130-137` is gated self-config — its Check 1 is tree-wide-globbed but its allowlist omits `engine/profile/**` and its pattern omits `log2`/`cbrt`/`fmod`. `.fleet/plans/issue-1923.md:27,32` belongs to #1923 and workers don't edit plan files during execution. `.claude/skills/optimize/reference/common_bottlenecks.md` (not gated) **is** fixed here.
- **No screenshots attached deliberately.** The diff touches render paths, so `attach-screenshots` ran — but the useful artifact is the measurement, not the images: **28/28 captured shots are byte-identical** to the same capture built from `origin/master` (sha256, both directions, no unmatched names). Committing 56 no-op PNGs would add repo weight and no reviewer signal. Happy to attach them if you'd rather have them inline.
- **`format-changed` reformatted whole files** (the #2719 behavior; PR #2721 is the pending fix), which pulled ~340 lines of pre-existing drift into `audio.cpp`, `video_manager.cpp`, `video_recorder.cpp`, `system_spring_color.hpp`, and `gpu_stage_timing_observer.hpp`. Those files were reverted and the substitutions re-applied by hand, so the diff carries only this change; the five added lines that crossed 100 columns were wrapped manually.

## Test plan

- [x] `IRShapeDebug`, `IRModifierDemo`, `IRLuaPerfGrid` all build clean
- [x] `IRShapeDebug --auto-screenshot 10` → `ir-run: RESULT=CLEAN exe=IRShapeDebug exit=0`
- [x] 28/28 shots byte-identical vs `origin/master` build
- [x] Detection sweep re-run post-change → 0 violations
- [ ] Reviewer: confirm the `engine/profile` allowlist carve-out is the right call vs adding the math link edge

Closes #2735

🤖 Generated with [Claude Code](https://claude.com/claude-code)