### PR TITLE
docs/rules: cpp-lua-enums — scope the audit hook + deviations register (#2745)

### DIFF
--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -2,6 +2,7 @@
 paths:
   - "engine/script/**"
   - "engine/**/*_lua.hpp"
+  - "engine/**/lua_*_bindings.hpp"
   - "creations/**/*.{hpp,cpp,h,cc}"
 ---
 
@@ -174,6 +175,37 @@ detector's blind spot shut. `cpp-systems.md` can mirror its own detector scope
 because `system_<name>.hpp` is a mandated filename (`engine/prefabs/CLAUDE.md`
 §"File pattern"); the creation-side binding surface has no such spelling to
 lean on.
+
+**The invariant that argument implies: `paths:` must cover every file the hook
+sweeps.** Wherever detection reaches a file injection doesn't, the rule is
+enforced on an author it was never shown to — and the escape hatch above,
+which is the whole reason the wide creations scope is justified, cannot fire.
+That held on the creations side and *not* on the engine side: `**/lua_*_bindings.hpp`
+sweeps a binding header anywhere in the tree, while `engine/script/**` +
+`engine/**/*_lua.hpp` only inject under `engine/script/`. A file one directory
+over — `engine/prefabs/irreden/render/lua_ctrl_bindings.hpp` — was swept and
+never injected. `engine/**/lua_*_bindings.hpp` in the frontmatter closes it;
+with that entry the swept set is a subset of the injected set with nothing left
+over. Not widened to `engine/**/*.{hpp,cpp,h,cc}` (the sibling shape): that
+would inject a Lua-binding rule into every engine translation unit to reach a
+surface with a consistent, greppable spelling. The creations side needs the
+blunt glob because creation binding files have no mandated name; the engine
+side does not.
+
+Check the invariant, don't assume it — the two glob sets are edited
+independently:
+
+```
+# swept by the hook
+fleet-rules-sweep --files-only --pattern '.' --glob 'engine/script/**' \
+  --glob '**/*_lua.hpp' --glob '**/lua_*_bindings.hpp' \
+  --glob 'creations/**/lua_*.{hpp,cpp}' | sort > /tmp/detected
+# injected by paths:
+fleet-rules-sweep --files-only --pattern '.' --glob 'engine/script/**' \
+  --glob 'engine/**/*_lua.hpp' --glob 'engine/**/lua_*_bindings.hpp' \
+  --glob 'creations/**/*.{hpp,cpp,h,cc}' | sort > /tmp/injected
+comm -23 /tmp/detected /tmp/injected      # must be empty (81 vs 141 today)
+```
 
 A creation's `main*.cpp` is deliberately **not** in scope, `main_lua.cpp`
 included — its string compares are CLI-argv parses (three in

--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -146,13 +146,14 @@ parses, plus a handful of asset-format tags and one UI-label compare. None are
 reachable from Lua, and none are this rule's to fix (#2745).
 
 Don't pin an exact census here. The wholesale count tracks unrelated creation
-churn, so it re-stales without this file being touched: it moved **30 → 36
-across a single base advance** while this rule sat unchanged (an unrelated
-`shape_debug/main.cpp` growth). Snapshot for scale only — 36 hits in 6 files
-as of `5824f71b`, of which 31 are CLI-argv, 4 asset-format tags, 1 UI label.
-The globs above are the surface this rule's prose actually names: 81 files,
-reporting **12 hits in 2 files**, every one of them classified below — and
-unlike the wholesale figure, those held steady across the same base advance.
+churn, so it re-stales without this file being touched: it moved **30 → 36 → 38
+across two base advances** while this rule sat unchanged — first an unrelated
+`shape_debug/main.cpp` growth, then an unrelated `perf_grid/main.cpp` one.
+Snapshot for scale only — 38 hits in 6 files as of `6e804773e`, of which 33 are
+CLI-argv, 4 asset-format tags, 1 UI label. The globs above are the surface this
+rule's prose actually names: 81 files, reporting **12 hits in 2 files**, every
+one of them classified below — and unlike the wholesale figure, those held
+steady across both base advances.
 
 The `creations/**/lua_*.{hpp,cpp}` glob is load-bearing. It covers the six real
 creation-side binding files — `lua_bindings.{hpp,cpp}` + `lua_component_pack.hpp`
@@ -235,14 +236,17 @@ re-deriving it.
 Cite these by **symbol**, not by line — `lua_script.cpp` grew ~70 lines in a
 single base advance under this PR, silently moving one of the ranges below off
 its target. Line numbers are an "as of" convenience; the symbol is the anchor.
+Anchor the "as of" to a **`master`** commit, never to one of the working
+branch's own shas: a rebase rewrites branch shas, orphaning the anchor and
+leaving a figure the reader cannot reproduce.
 
 - `engine/script/src/lua_script.cpp`, `parseExplicitTypeTag` (`:93-115` as of
-  `5824f71b`) — maps the Lua component schema's `type = "int"` / `"float"` /
+  `6e804773e`) — maps the Lua component schema's `type = "int"` / `"float"` /
   `"vec3"` / `"quat"` … tags onto `LuaFieldType` (`lua_component_data.hpp`,
   `enum class LuaFieldType`, 9 enumerators). **Genuine deviation, deferred.**
   No `IRComponent.FieldType` table is exposed.
 - `engine/script/src/lua_script.cpp`, the `mode` dispatch in
-  `IRSystem.registerSystem` (`:950-961` as of `5824f71b`) —
+  `IRSystem.registerSystem` (`:950-961` as of `6e804773e`) —
   `mode = "codegen"` / `"eval"` maps onto `EcsMode` (`ir_script_types.hpp`,
   `enum class EcsMode`). **Genuine deviation, deferred.** No Lua table is
   exposed.

--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -140,11 +140,19 @@ fleet-rules-sweep --glob 'engine/script/**' --glob '**/*_lua.hpp' \
 **Scope the globs at the binding surface, not at the tree.** The pattern is a
 bare string-compare match — it cannot tell a Lua-sourced value from any other
 `std::string`, so the glob is doing all the discrimination. Sweeping
-`creations` wholesale instead returns 41 hits in 7 files of which **30 are
-allowlisted classes above** (25 CLI-argv parses, 4 asset-format tags, 1 UI
-label) — none of them reachable from Lua, and none of them this rule's to fix
-(#2745). The globs above are the surface this rule's prose actually names: 81
-files, reporting **12 hits in 2 files**, every one of them classified below.
+`creations` wholesale instead returns several times the hits, and **every one
+of them lands in an allowlisted class above** — overwhelmingly CLI-argv
+parses, plus a handful of asset-format tags and one UI-label compare. None are
+reachable from Lua, and none are this rule's to fix (#2745).
+
+Don't pin an exact census here. The wholesale count tracks unrelated creation
+churn, so it re-stales without this file being touched: it moved **30 → 36
+across a single base advance** while this rule sat unchanged (an unrelated
+`shape_debug/main.cpp` growth). Snapshot for scale only — 36 hits in 6 files
+as of `5824f71b`, of which 31 are CLI-argv, 4 asset-format tags, 1 UI label.
+The globs above are the surface this rule's prose actually names: 81 files,
+reporting **12 hits in 2 files**, every one of them classified below — and
+unlike the wholesale figure, those held steady across the same base advance.
 
 The `creations/**/lua_*.{hpp,cpp}` glob is load-bearing. It covers the six real
 creation-side binding files — `lua_bindings.{hpp,cpp}` + `lua_component_pack.hpp`
@@ -224,13 +232,19 @@ The hook's 12 surviving hits, classified. Two are genuine deviations; one is a
 known-allowlisted shape kept here so a clean run is interpretable without
 re-deriving it.
 
-- `engine/script/src/lua_script.cpp:93-115` — `parseExplicitTypeTag` maps the
-  Lua component schema's `type = "int"` / `"float"` / `"vec3"` / `"quat"` … tags
-  onto `LuaFieldType` (`lua_component_data.hpp:37`, 9 enumerators). **Genuine
-  deviation, deferred.** No `IRComponent.FieldType` table is exposed.
-- `engine/script/src/lua_script.cpp:880-891` — `IRSystem.registerSystem`'s
-  `mode = "codegen"` / `"eval"` maps onto `EcsMode`
-  (`ir_script_types.hpp:42`). **Genuine deviation, deferred.** No Lua table is
+Cite these by **symbol**, not by line — `lua_script.cpp` grew ~70 lines in a
+single base advance under this PR, silently moving one of the ranges below off
+its target. Line numbers are an "as of" convenience; the symbol is the anchor.
+
+- `engine/script/src/lua_script.cpp`, `parseExplicitTypeTag` (`:93-115` as of
+  `5824f71b`) — maps the Lua component schema's `type = "int"` / `"float"` /
+  `"vec3"` / `"quat"` … tags onto `LuaFieldType` (`lua_component_data.hpp`,
+  `enum class LuaFieldType`, 9 enumerators). **Genuine deviation, deferred.**
+  No `IRComponent.FieldType` table is exposed.
+- `engine/script/src/lua_script.cpp`, the `mode` dispatch in
+  `IRSystem.registerSystem` (`:950-961` as of `5824f71b`) —
+  `mode = "codegen"` / `"eval"` maps onto `EcsMode` (`ir_script_types.hpp`,
+  `enum class EcsMode`). **Genuine deviation, deferred.** No Lua table is
   exposed.
 - `engine/script/include/irreden/script/lua_enum_def.hpp:67` — `enumName ==
   "register"` reserved-name guard. **Not a violation** — a single sentinel

--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -180,13 +180,15 @@ lean on.
 sweeps.** Wherever detection reaches a file injection doesn't, the rule is
 enforced on an author it was never shown to — and the escape hatch above,
 which is the whole reason the wide creations scope is justified, cannot fire.
-That held on the creations side and *not* on the engine side: `**/lua_*_bindings.hpp`
-sweeps a binding header anywhere in the tree, while `engine/script/**` +
-`engine/**/*_lua.hpp` only inject under `engine/script/`. A file one directory
-over — `engine/prefabs/irreden/render/lua_ctrl_bindings.hpp` — was swept and
-never injected. `engine/**/lua_*_bindings.hpp` in the frontmatter closes it;
-with that entry the swept set is a subset of the injected set with nothing left
-over. Not widened to `engine/**/*.{hpp,cpp,h,cc}` (the sibling shape): that
+**It holds today** — the swept set is a strict subset of the injected set
+(81 ⊆ 141), because every binding header currently lives under
+`engine/script/include/irreden/script/`, which `engine/script/**` already
+injects. The frontmatter's `engine/**/lua_*_bindings.hpp` is **forward-looking,
+not remedial**: the hook's `**/lua_*_bindings.hpp` glob matches a binding header
+*anywhere* in the tree, so the first one placed outside `engine/script/` would
+be swept while `engine/script/**` + `engine/**/*_lua.hpp` failed to inject it.
+The entry closes that hole before it opens; it changes no counts today. Not
+widened to `engine/**/*.{hpp,cpp,h,cc}` (the sibling shape): that
 would inject a Lua-binding rule into every engine translation unit to reach a
 surface with a consistent, greppable spelling. The creations side needs the
 blunt glob because creation binding files have no mandated name; the engine

--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -97,22 +97,96 @@ Why:
   any registry-backed string id (component name → component id,
   prefab name → path).
 - **User-facing string content.** Log messages, error diagnostics,
-  prefab `id` strings, and prefab-file paths are strings by design.
-  The rule is only about *enumerated values that have a C++ enum
-  equivalent*.
+  prefab `id` strings, prefab-file paths, and UI label text are strings
+  by design. The rule is only about *enumerated values that have a C++
+  enum equivalent*.
+- **CLI argument values.** `--subdivision-mode full` reaches C++ as a
+  string from `argv`, never from Lua, so this rule does not reach it —
+  even when the value maps onto a C++ enum. That surface has its own
+  rule: route it through `IRArgs`' `.enumValue` declaration rather than
+  a hand-rolled compare chain (see `engine/CLAUDE.md` §"CLI args go
+  through `IRArgs`").
+- **Binary / asset-format field tags.** A value read out of a `.vxs`
+  sidecar, `.irkv` store, or other on-disk format is part of that
+  format's schema. The format owns its spelling and its compatibility
+  contract; the Lua enum table is not in the loop.
+- **A single reserved-name or sentinel guard.** `if (name ==
+  "register")` rejecting one reserved key is a validation check, not a
+  value-set dispatch. The rule targets *chains* that enumerate a closed
+  set — one comparison against one literal has no enum to mirror.
 
 ## Audit hooks
 
 Open-coded `if (s == "FOO") ... else if (s == "BAR") ...` chains in
-`engine/script/src/**`, `engine/**/*_lua.hpp`, or creation Lua-binding
+`engine/script/**`, `engine/**/*_lua.hpp`, or creation Lua-binding
 code are a smell. Replace them with the binding-table + enum-cast
-pattern above when you touch the surrounding code.
+pattern above when you touch the surrounding code. (`engine/script/**`,
+not just its `src/`: one of the deviations below lives under
+`engine/script/include/`.)
 
 Run the hook through `fleet-rules-sweep`, never `rg creations` — this is the
 detector whose false clean surfaced #2739 (0 hits reported on a tree with 4
 matching files):
 
 ```
-fleet-rules-sweep --glob '*.{hpp,cpp,h,cc}' --pattern '== *"' \
-  engine/script/src creations
+fleet-rules-sweep --glob 'engine/script/**' --glob '**/*_lua.hpp' \
+  --glob '**/*_lua_bindings.hpp' --glob 'creations/**/lua_*.{hpp,cpp}' \
+  --pattern '== *"'
 ```
+
+**Scope the globs at the binding surface, not at the tree.** The pattern is a
+bare string-compare match — it cannot tell a Lua-sourced value from any other
+`std::string`, so the glob is doing all the discrimination. Sweeping
+`creations` wholesale instead returns 41 hits in 7 files of which **30 are
+allowlisted classes above** (25 CLI-argv parses, 4 asset-format tags, 1 UI
+label) — none of them reachable from Lua, and none of them this rule's to fix
+(#2745). The globs above are the surface this rule's prose actually names: 81
+files, reporting **12 hits in 2 files**, every one of them classified below.
+
+The `creations/**/lua_*.{hpp,cpp}` glob is load-bearing. It covers the six real
+creation-side binding files — `lua_bindings.{hpp,cpp}` + `lua_component_pack.hpp`
+under `demos/default` and `demos/sprite_demo` — which are clean today. Drop it
+and the detector narrows until it structurally cannot see creation binding code:
+the same false-clean shape as #2739, spelled with a glob instead of a walker. A
+creation whose binding file is named something else adds its own `--glob`.
+
+A creation's `main*.cpp` is deliberately **not** in scope, `main_lua.cpp`
+included — its string compares are CLI-argv parses (three in
+`lua_perf_grid/main_lua.cpp`), allowlisted above and owned by the `IRArgs` rule.
+Re-add it only together with a pattern that can tell argv from a Lua value.
+
+Classify every surviving hit against the Allowlist before treating it as a
+violation. A run that reports only the sites in §"Live deviations" is a clean
+pass.
+
+## Live deviations
+
+The hook's 12 surviving hits, classified. Two are genuine deviations; one is a
+known-allowlisted shape kept here so a clean run is interpretable without
+re-deriving it.
+
+- `engine/script/src/lua_script.cpp:93-115` — `parseExplicitTypeTag` maps the
+  Lua component schema's `type = "int"` / `"float"` / `"vec3"` / `"quat"` … tags
+  onto `LuaFieldType` (`lua_component_data.hpp:37`, 9 enumerators). **Genuine
+  deviation, deferred.** No `IRComponent.FieldType` table is exposed.
+- `engine/script/src/lua_script.cpp:880-891` — `IRSystem.registerSystem`'s
+  `mode = "codegen"` / `"eval"` maps onto `EcsMode`
+  (`ir_script_types.hpp:42`). **Genuine deviation, deferred.** No Lua table is
+  exposed.
+- `engine/script/include/irreden/script/lua_enum_def.hpp:67` — `enumName ==
+  "register"` reserved-name guard. **Not a violation** — a single sentinel
+  check per the Allowlist, documented in `engine/script/CLAUDE.md`
+  §"Lua-defined enums".
+
+**Why the two deviations are deferred rather than tracked as migrations.**
+Both tags are documented public schema (`engine/script/CLAUDE.md` §"Lua-defined
+components", §"Per-system mode override") and both are read by the *build-time*
+codegen tool (`cmake/lua_codegen/`) out of the same `.lua` files as the runtime.
+Swapping either for an integer table is a schema-breaking change across every
+creation `.lua` **and** the codegen tool — a design call with a compatibility
+story, not the mechanical binding-table fix §"What to do instead" describes. No
+tracking issue exists yet because filing design-direction work is the human's
+call, not a worker's; this register is the record until they make it.
+
+New code on this surface still follows the rule — these two are grandfathered,
+not a precedent. Don't migrate them in an unrelated PR.

--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -8,6 +8,8 @@ paths:
 > **Sweeping for violations?** `paths:` is an injection scope, not a search
 > root. `rg`/`Grep` rooted at `creations/` reads a **false clean** (#2739) —
 > run detectors through `fleet-rules-sweep`. See [`README.md`](README.md).
+> The `creations/**` injection scope is deliberately wider than the audit
+> hook's globs; §"Audit hooks" says why.
 
 # Lua surface: enums and constants, never string-name lookups
 
@@ -130,7 +132,7 @@ matching files):
 
 ```
 fleet-rules-sweep --glob 'engine/script/**' --glob '**/*_lua.hpp' \
-  --glob '**/*_lua_bindings.hpp' --glob 'creations/**/lua_*.{hpp,cpp}' \
+  --glob '**/lua_*_bindings.hpp' --glob 'creations/**/lua_*.{hpp,cpp}' \
   --pattern '== *"'
 ```
 
@@ -149,6 +151,29 @@ under `demos/default` and `demos/sprite_demo` — which are clean today. Drop it
 and the detector narrows until it structurally cannot see creation binding code:
 the same false-clean shape as #2739, spelled with a glob instead of a walker. A
 creation whose binding file is named something else adds its own `--glob`.
+
+`**/lua_*_bindings.hpp` is the **prefix** spelling the binding headers actually
+use (`engine/script/include/irreden/script/lua_*_bindings.hpp`, as §"What to do
+instead" names them). The suffix form `**/*_lua_bindings.hpp` matches nothing in
+the tree — `fleet-rules-sweep` reports `swept 0 file(s)` for it alone. The
+correction is coverage-neutral (those headers already sit inside
+`engine/script/**`, so the totals stay 81/12/2); it exists so a binding header
+added *outside* `engine/script/` is swept instead of silently skipped.
+
+**`paths:` stays wider than these globs — deliberately.** The frontmatter keeps
+`creations/**/*.{hpp,cpp,h,cc}` (the shape `cpp-ecs.md`, `cpp-ecs-smells.md`,
+and `cpp-math.md` share) rather than tracking
+`creations/**/lua_*.{hpp,cpp}`. Injection and detection answer different
+questions: the glob narrows because a bare `== "` pattern cannot tell a
+Lua-sourced value from any other string compare — a constraint an author
+*reading* the rule does not share. And the escape hatch above (a
+differently-named binding file adds its own `--glob`) only fires if the rule
+reached that author in the first place. Narrowing injection to `lua_*` would
+hide it from exactly the person who needs to widen the glob, sealing the
+detector's blind spot shut. `cpp-systems.md` can mirror its own detector scope
+because `system_<name>.hpp` is a mandated filename (`engine/prefabs/CLAUDE.md`
+§"File pattern"); the creation-side binding surface has no such spelling to
+lean on.
 
 A creation's `main*.cpp` is deliberately **not** in scope, `main_lua.cpp`
 included — its string compares are CLI-argv parses (three in


### PR DESCRIPTION
## Summary
- Narrows `cpp-lua-enums.md` §"Audit hooks" from `engine/script/src` + all of `creations/**` to the Lua **binding surface** (`engine/script/**`, `**/*_lua.hpp`, `**/lua_*_bindings.hpp`, `creations/**/lua_*.{hpp,cpp}`). The hook's pattern is a bare `== "` compare and cannot tell a Lua-sourced value from any other `std::string`, so the glob has to do all the discrimination.
- Adds the three Allowlist classes the out-of-scope hits fall into: CLI argv values (pointing at the `IRArgs` `.enumValue` rule that owns them), binary/asset-format field tags, and a single reserved-name sentinel.
- Adds the missing `## Live deviations` register — the last detector-carrying rule without one — classifying all 12 surviving hits.

## Base: master, 1-file diff (was a #2744 stack child)

**This note replaces the previous "Base is #2744, not master" paragraph, which the rebase inverted.** #2744 merged to `master` as `7e0b44c8a`, so the inherited prefix was dropped with `git rebase --onto origin/master 4e2607b9c`. The branch now carries only its own 5 commits + this reconciliation, and the diff is **one file**, `.claude/rules/cpp-lua-enums.md`.

The prefix drop was proven safe before it ran: the inherited commit's patch and master's merged squash differ in exactly **4 content lines**, all in one `install.sh` hunk, where master's copy additionally carries `$FLEET_POSITIVE_CONTROL_SRC` (landed by #2848 before #2744 merged). Master strictly supersedes — and keeping the child's copy would have silently reverted that chmod-loop entry. That was the semantic conflict the merger flagged.

## Test plan (re-measured on `6e804773e`, not inherited)
- [x] **Tightened hook** — `swept 81 file(s) (3936 walked in scope), 12 match(es) in 2 file(s)`. Unchanged across every base advance this PR has seen.
- [x] **`comm -23` invariant** (detected ⊆ injected) — `detected=81`, `injected=141`, diff **empty**. Holds.
- [x] **Symbol citations resolve exactly** — `parseExplicitTypeTag` at `lua_script.cpp:93-115` (opens 93, closes 115); the `IRSystem.registerSystem` mode dispatch at `:950-961` (`modeOpt` fetch 950, throw block ends 961); `enumName == "register"` at `lua_enum_def.hpp:67`; `enum class LuaFieldType` at `lua_component_data.hpp:37`; `enum class EcsMode` at `ir_script_types.hpp:42`.
- [x] **Wholesale sweep** — `creations/**` now reports **38 hits in 6 files** (was 36). The delta is `perf_grid/main.cpp` 11 → 13: an unrelated second subdivision-mode argv parse. Classification re-derived per hit: **33 CLI-argv** (perf_grid 13, shape_debug 13, lua_perf_grid 3, sessions.hpp 4) + **4 asset-format** (scene_io.hpp) + **1 UI label** (voxel_editor/main.cpp) = 38. **Zero violations** — no new class appeared.
- [x] **Stale-figure sweep** — `fleet-rules-sweep --pattern '5824f71b|36 hits in 6|31 are CLI-argv' --glob '*.md'`: 428 files swept, **0 matches**. Guarded clean pass (non-zero coverage).
- [x] Docs-only diff, one file — no build surface.

## What the reconciliation commit changed

The rebase orphaned this file's `5824f71b` "as of" anchor — it was a **branch-local** sha, so every rebase invalidates it, leaving figures a reader cannot reproduce (the exact defect class this PR was bounced for three times). Re-anchored to `6e804773e` (master) and added the general rule to §"Live deviations": *anchor "as of" to a `master` commit, never to the working branch's own*.

The census paragraph also updated 36 → 38. That second re-stale — a different file, a different base advance, this rule untouched — is now the section's own second data point for why it says not to pin an exact census.

## Notes for reviewer

**The `creations/**/lua_*.{hpp,cpp}` glob is load-bearing.** Positive-controlled two-sided: inject `if (s == "GRID")` into `creations/demos/default/lua_bindings.cpp` and **with** the glob the sweep catches it (13 hits / 3 files); **without** it the same violation reads a false clean (12 / 2). It covers the six real creation-side binding files (`lua_bindings.{hpp,cpp}` + `lua_component_pack.hpp` under `demos/default` and `demos/sprite_demo`), clean today. Omitting it would reproduce #2739's false-clean shape with a glob instead of a walker.

**`**/lua_*_bindings.hpp` is the prefix spelling, corrected mid-PR.** The suffix form `**/*_lua_bindings.hpp` matches nothing in the tree (`swept 0 file(s)`). The correction is coverage-neutral today — those headers already sit under `engine/script/**` — and exists so a binding header added *outside* `engine/script/` is swept rather than silently skipped.

**Out of scope, flagged per the issue:** the matching `simplify` / review-agent enforcement surface (`.claude/agents/simplify-check-*`, `.claude/skills/**/SKILL.md`) is commit-gated and no worker class can push it. `.claude/rules/` itself is not gated. Needs a human if that enforcement half should track this rule.

**Provenance:** a pool-2 iteration died mid-work; another agent rescued its uncommitted draft into a local commit and deeded it to pool-1 (see the issue thread). This PR is that draft re-verified end-to-end, corrected, and extended.

Closes #2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
