### PR TITLE
fleet: T7 model-gate test must unset FLEET_ROLE_MODEL, not inherit it

### DIFF
--- a/scripts/fleet/tests/test_fleet_claim_model_gate.sh
+++ b/scripts/fleet/tests/test_fleet_claim_model_gate.sh
@@ -174,7 +174,7 @@ assert_exit "$actual" 1 "body **Model:** sonnet (annotated), opus role → exit 
 
 # --- T7: FLEET_ROLE_MODEL unset passes any task -----------------------------
 echo "T7: FLEET_ROLE_MODEL unset passes fleet:opus issue"
-actual=0; "$FLEET_CLAIM" claim 1001 test-agent 2>/dev/null || actual=$?
+actual=0; env -u FLEET_ROLE_MODEL "$FLEET_CLAIM" claim 1001 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 0 "unset FLEET_ROLE_MODEL bypasses gate → exit 0"
 release_quiet 1001
 


### PR DESCRIPTION
## Summary
- T7 in `test_fleet_claim_model_gate.sh` asserted the unset-`FLEET_ROLE_MODEL` bypass path but never actually unset the variable, unlike every neighboring case (T5/T6/T8). Since `fleet-dispatch-wrap` exports `FLEET_ROLE_MODEL` in every dispatched pane, the suite's verdict silently depended on the class of the pane running it: false FAIL on sonnet/fable, vacuous PASS on opus (satisfied by a class match, not the unset-bypass path the case exists to cover).
- Fix: prefix the claim call with `env -u FLEET_ROLE_MODEL`, matching the explicit-control pattern the other cases already use.

## Test plan
- [x] `FLEET_ROLE_MODEL=sonnet bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` → 11/11
- [x] `FLEET_ROLE_MODEL=fable bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` → 11/11
- [x] `FLEET_ROLE_MODEL=opus bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` → 11/11
- [x] `env -u FLEET_ROLE_MODEL bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` → 11/11

Closes #2729

🤖 Generated with [Claude Code](https://claude.com/claude-code)