### PR TITLE
render: pivot-focus cap-entry bias is inherent, gate to the measurement

### DIFF
--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -400,16 +400,23 @@ ivec3 pivotVerifyProbeHalfExtent() {
     return g_pivotVerifyBlock == "background-center" ? kPivotVerifyBackgroundProbeHalfExtent
                                                      : kPivotVerifyProbeHalfExtent;
 }
-// `[pivot-focus-assert]` tolerance, in world units: ONE iso-depth unit of
-// composite quantization, which is `1/3` per axis, i.e. `sqrt(3)/3 ~= 0.577`.
+// `[pivot-focus-assert]` tolerance, in world units, set to the residual the
+// derive inherently carries: ONE iso-depth unit, `1/3` per axis, i.e.
+// `sqrt(3)/3 ~= 0.5774`. It sits just above the measured max rather than at a
+// round 0.6 so the admitted band is the measurement, not a guess.
 //
-// The composite stores depth per TRIXEL at sub-voxel resolution and the derive
-// reads back a single framebuffer texel, which can resolve to the neighbouring
-// triangle of the view-center iso cell — so where the center ray grazes a
-// silhouette or cap edge, "the surface under the crosshair" is genuinely
-// ambiguous by one iso unit. Measured on macOS/Metal at zoom 4: background-center
-// 0.00 (exact fallback), center-depth 0.29, center-column 0.58 (its ray enters
-// through the probe's bottom cap, the ambiguous case).
+// That residual exists because `emitDeformedFace` stamps the emitting
+// (sub-)voxel's own anchor depth across every trixel its face paints: the
+// composite is a per-face SORT KEY, not the metric depth at this trixel, so the
+// reconstruction is off by however far the center ray crosses the face from its
+// anchor. Measured on macOS/Metal, identical at zoom 4 and 8: background-center
+// 0.00 (exact — it takes the d=0 fallback and reads no depth), center-depth
+// 0.289 (off-centre lateral crossing), center-column and center-axis 0.577
+// (both cross a camera-facing cap dead-centre, half the face's 2-unit depth
+// spread). Derivation + the ruled-out alternatives (notably that this is NOT a
+// neighbouring-triangle sampling ambiguity — that would be a fixed pixel
+// offset, and the bias is instead constant in WORLD units across zooms):
+// docs/design/camera-yaw-pivot.md §"Known deviations" 2, see #2641.
 //
 // The gate stays sharp — every failure this assert exists to catch is an order
 // of magnitude outside it: a regression to the pre-#2547 iso-depth-0 focus is
@@ -418,7 +425,7 @@ ivec3 pivotVerifyProbeHalfExtent() {
 //
 // Deliberately NOT measured in iso-depth units: `pos3DtoDistance` rounds to an
 // integer, which would hide exactly the sub-voxel disagreement being bounded.
-constexpr float kPivotFocusAssertToleranceWorld = 0.6f;
+constexpr float kPivotFocusAssertToleranceWorld = 0.58f;
 // cursor-latch's own tolerance: ONE world unit, i.e. one voxel.
 //
 // This block's focus is a `castVoxelRay` SURFACE hit — the marched point where

--- a/docs/design/camera-yaw-pivot.md
+++ b/docs/design/camera-yaw-pivot.md
@@ -222,15 +222,16 @@ closes:
    - `cursor-latch` — `center-axis` geometry, but the focus comes from
      `IRPrefab::CursorPivot::resolveFocusWorld` (the real `castVoxelRay` path)
      with a synthetic cursor parked on the viewport-center anchor's screen
-     pixel, latched once and held for the sweep. Same routing as `center-axis`
-     — pinned-point oracle, silhouette reported not gated (16 px at zoom 4, the
+     pixel, latched once and held for the sweep. Pinned-point oracle like
+     `center-axis` (which is itself centroid-gated at a zoom-scaled bound);
+     cursor-latch's silhouette is reported, not gated (16 px at zoom 4, the
      same residual model plus the half-voxel offset below). It runs on the
      GUI-test cycler rather than the plain auto-screenshot one, because it needs
      scripted cursor input and a per-frame hook: the shot cycler clears the
      pivot focus at every shot boundary and the latched point is only known at
      runtime, so it cannot ride the shot table.
 
-     Its tolerance is a whole world unit rather than 0.6, and the reason is
+     Its tolerance is a whole world unit rather than 0.58, and the reason is
      geometric, not slack: the cursor latch reports a `castVoxelRay` SURFACE hit
      — the marched point where the ray first lands inside the winning voxel's
      unit cube — while the analytic oracle predicts that voxel's CENTER. The L2
@@ -241,28 +242,71 @@ closes:
      exists to catch (a revert to the pre-#2548 iso-depth-0 latch lands ~8.5
      world units off on this geometry).
 
-   **Residual: composite-depth quantization (accepted, measured).** The derive
-   consumes what the composite reports, which is quantized per trixel at
-   sub-voxel resolution. Against the probe's voxel lattice the readback lands
-   within one iso-depth unit — measured on macOS/Metal at zoom 4:
-   `background-center` 0.00 (exact), `center-depth` +0.5 iso (lateral-surface
-   entry), `center-column` and `center-axis` +1.0 iso (both enter through a
-   camera-facing cap). A 1-iso-unit bias displaces `F` by (1/3, 1/3, 1/3) world
-   units, whose xy part leaves a residual orbit: `center-axis` measures 12 px at
-   zoom 4 and 22 px at zoom 8, which is that model to within the read. This is
-   ~12x better than the pre-#2547 focus in the same configuration (150 px at
-   zoom 4) but is not exact; whether the cap-entry case can report the geometric
-   surface rather than a neighbouring trixel's depth is **#2641**, and
-   `--pivot-verify center-axis` is its repro. That issue also carries the
-   cross-backend risk: the trixel→framebuffer parity shift applies to the depth
-   read on GL but not on Metal, so the bias may differ per host (measured on
-   macOS/Metal only).
+   **Residual: the composite is a per-face SORT KEY, not a metric surface depth
+   — INHERENT (#2641, root-caused).** The derive consumes what the composite
+   reports. Measured on macOS/Metal: `background-center` 0.00 (exact — no depth
+   read at all), `center-depth` +0.5 iso (lateral-surface entry),
+   `center-column` and `center-axis` +1.0 iso (both enter through a
+   camera-facing cap), identical at zoom 4 and zoom 8. A 1-iso-unit bias
+   displaces `F` by (1/3, 1/3, 1/3) world units, whose xy part leaves a residual
+   orbit: `center-axis` measures 12 px at zoom 4 and 22 px at zoom 8 — ~12x
+   better than the pre-#2547 focus (150 px at zoom 4), but not exact.
 
-   The `[pivot-focus-assert]` tolerance (0.6 world units) is set to admit
-   exactly that one-iso-unit quantization and nothing more: a regression to the
-   pre-#2547 iso-depth-0 focus is 3.46 world units off on `center-column` and
-   12.1 on `center-depth`, and electing the far surface instead of the near one
-   is 10.0 off on `center-depth`.
+   The cause is **not** a sampling / ray-pairing error. `emitDeformedFace`
+   (`c_voxel_to_trixel_stage_1_body.glsl`) stamps ONE `encodeDepthWithFace`
+   value — the emitting (sub-)voxel's own `pos3DtoDistance` anchor — across
+   every trixel that face paints. So the value a trixel carries is the depth of
+   its face's ANCHOR, while the metric depth of the surface *at that trixel*
+   varies across the face's footprint (spread: 2 iso units for a unit voxel
+   face). `isoPixelToPos3D(viewCenterIso, storedDepth)` pairs the center's exact
+   2D coordinate with that anchor depth, so the reconstruction is off by however
+   far the center ray crosses the face from its anchor. That predicts exactly
+   what the blocks measure: both cap-entry blocks are constructed so the ray
+   hits the cap dead-centre and both read exactly +1.0 (half the 2-unit spread),
+   while `center-depth`'s off-centre lateral crossing reads +0.5.
+
+   Three measurements rule out the alternatives (macOS/Metal, `--pivot-verify`
+   + a per-row composite-depth scan around the center texel):
+
+   - **Not the trixel→framebuffer parity shift / a neighbouring-ray read.** That
+     is a fixed *pixel* offset, so its world error would halve from zoom 4 to
+     zoom 8. The measured bias is a constant 1.0 world iso unit at both, i.e.
+     4 framebuffer rows at `effSub` 4 and 8 rows at `effSub` 8.
+   - **Not a fixed sampling offset in any direction.** The analytic depth sits
+     4 rows ABOVE the sampled center row on the cap blocks and 4 rows BELOW it
+     on `center-depth` — opposite signs, because the two surfaces' depth-vs-row
+     slopes have opposite signs. No single corrected sample row fixes both.
+   - **Not a constant per-face encode offset** correctable from the decoded
+     `face_` bits: the offset is where the ray crosses the face, which is
+     content geometry, not a property of the face type.
+
+   Recovering the metric depth would need the winning face's anchor cell — which
+   the composite does not carry (only depth / face / flip) — i.e. a CPU inverse
+   of `emitDeformedFace`'s footprint, including the residual-yaw deform and
+   riser flip. The forward option instead of that inverse is to stop consuming
+   the sort key for this purpose and cast a CPU ray
+   (`IRPrefab::Picking::castVoxelRay`, exact surface hit, no GPU flush) — the
+   same primitive #2548 latches the cursor pivot with. That is a design change
+   to the derive's source of truth, not a residual fix, so it is out of #2641's
+   scope; #2548's landing is the natural point to weigh it.
+
+   The `[pivot-focus-assert]` tolerance is therefore set to the residual that
+   remains (0.58 world units, just over the measured max `sqrt(3)/3` = 0.5774)
+   rather than to a round 0.6, and `center-axis` is centroid-gated at a
+   zoom-scaled bound (`scripts/pivot-verify.py`) so the inherent orbit is
+   admitted but any growth in it fails. The gate still separates every failure
+   it exists to catch by an order of magnitude: a regression to the pre-#2547
+   iso-depth-0 focus is 3.46 world units off on `center-column` and 12.1 on
+   `center-depth`, and electing the far surface instead of the near one is 10.0
+   off on `center-depth`.
+
+   **Cross-backend: unverified.** All of the above is macOS/Metal. The emit is
+   twinned in GLSL and Metal, so the mechanism should be identical, but
+   `readbackCompositeDepth` applies a GL-only row flip (`resolution.y - 1 - y`)
+   which lands GL on a different center row than Metal for an even-height
+   framebuffer — a fixed one-row (sub-voxel) difference, not the 1.0-unit
+   effect above. A GL host must re-run `--pivot-verify` to confirm the same
+   per-block biases.
 3. **Per-axis registration offset — FIXED (#2546).** With (1) compensated,
    every residual-yaw frame rendered the voxel scene a constant ≈1 iso px
    (per axis, zoom-scaled) off the cardinal frames. Root cause: the

--- a/scripts/pivot-verify.py
+++ b/scripts/pivot-verify.py
@@ -44,8 +44,11 @@ Two oracles, applied per block:
   gated only for the blocks in ``CENTROID_GATED_BLOCKS``: those rotate their
   probe about a point on the probe's own axis, so a correct pivot maps the
   silhouette onto itself. Every other block's deviation is measured and
-  reported but not gated. The SDF twin is exempt even on a gated block
-  (``SDF_GATED``, #2645) — no lattice, so no pin to hold.
+  reported but not gated. ``center-axis`` is gated at its own zoom-scaled
+  bound (``CENTROID_THRESHOLD_PX_PER_ZOOM``) rather than ``--max-deviation``,
+  because it consumes the derived focus and so carries the inherent #2641
+  residual — see that constant for the measurement. The SDF twin is exempt
+  even on a gated block (``SDF_GATED``, #2645) — no lattice, so no pin to hold.
 
 Why a block falls in one bucket or the other — and what the reported-but-not-
 gated deviations mean — is ``docs/design/camera-yaw-pivot.md`` §"Known
@@ -86,7 +89,8 @@ FOCUS_ASSERT_BLOCKS = DEFAULT_PIVOT_BLOCKS | {"cursor-latch"}
 # its probe about a point on the probe's own axis, so a correct pivot maps the
 # silhouette onto itself. For every other block the deviation is reported but
 # not gated — see the module docstring.
-CENTROID_GATED_BLOCKS = {"focus-ctr", "focus-off", "background-center"}
+CENTROID_GATED_BLOCKS = {"focus-ctr", "focus-off", "background-center",
+                         "center-axis"}
 # The SDF twin is a continuous-geometry A/B control, NOT a pin gate (#2645).
 # Its analytic silhouette has no voxel lattice to snap to, so its centroid is
 # quantized only by the destination pixel grid: dev_x measures exactly 2.00px
@@ -100,6 +104,21 @@ CENTROID_GATED_BLOCKS = {"focus-ctr", "focus-off", "background-center"}
 # keeps `focus-ctr` gated for its voxel pass while its SDF twin only reports,
 # even though the block itself is in CENTROID_GATED_BLOCKS.
 SDF_GATED = False
+# Blocks whose centroid gate is NOT `--max-deviation` but a measurement-derived
+# bound, in px per unit of camera zoom.
+#
+# `center-axis` rotates about a point on its probe's own axis, so it is a valid
+# centroid pin — but it consumes the derived focus, which carries the inherent
+# #2641 residual: the composite is a per-face sort key stamped at the face's
+# anchor, so the derive lands up to one iso-depth unit off the metric surface
+# (docs/design/camera-yaw-pivot.md §"Known deviations" 2). A fixed world-space
+# focus error produces a screen orbit that scales with zoom, so the bound scales
+# too. Measured on macOS/Metal: 12.00 px at zoom 4 (3.00 px/zoom) and 22.00 px
+# at zoom 8 (2.75 px/zoom). 3.25 clears the worse of the two (zoom 4) by ~8%
+# instead of landing exactly on it, and still fails any growth in the residual:
+# a regression to the pre-#2547 iso-depth-0 focus is 150 px at zoom 8, ~6x this
+# bound.
+CENTROID_THRESHOLD_PX_PER_ZOOM = {"center-axis": 3.25}
 # Frame indices of the cardinal yaws (0, pi/2, pi, 3pi/2) within the demo's
 # 9-yaw sweep table (`yaws[]` in creations/demos/shape_debug/main.cpp).
 CARDINAL_FRAME_INDICES = (0, 3, 5, 7)
@@ -249,10 +268,14 @@ def main(argv: list[str] | None = None) -> int:
                       file=sys.stderr)
 
         # Whole-silhouette oracle. Always measured; gated only where it is a
-        # valid pin (CENTROID_GATED_BLOCKS), and never for the SDF twin, whose
-        # continuous silhouette rides a destination-grid floor (SDF_GATED).
+        # valid pin (CENTROID_GATED_BLOCKS), at that block's own bound, and
+        # never for the SDF twin, whose continuous silhouette rides a
+        # destination-grid floor (SDF_GATED).
+        per_zoom = CENTROID_THRESHOLD_PX_PER_ZOOM.get(block)
+        max_deviation = (max(args.max_deviation, per_zoom * zoom)
+                         if per_zoom is not None else args.max_deviation)
         centroid, dev_x, dev_y, _ = _score_pass(probe_exe, frames,
-                                                args.max_deviation)
+                                                max_deviation)
         centroid_gated = (block in CENTROID_GATED_BLOCKS
                           and (SDF_GATED if sdf else True))
         if centroid_gated:
@@ -278,8 +301,9 @@ def main(argv: list[str] | None = None) -> int:
             failed += 1
     print()
     print("verdicts: PINNED = silhouette held (threshold "
-          f"{args.max_deviation}px) · FOCUS-OK = derived focus matched the "
-          "analytic pin; the silhouette deviation is reported, not gated "
+          f"{args.max_deviation}px, or a block's own zoom-scaled bound from "
+          "CENTROID_THRESHOLD_PX_PER_ZOOM) · FOCUS-OK = derived focus matched "
+          "the analytic pin; the silhouette deviation is reported, not gated "
           "· REPORT = SDF twin, measured but ungated (see the module "
           "docstring)")
     if failed:


### PR DESCRIPTION
## Summary

- **Root-caused** the +1 iso-depth pivot-focus bias and ruled it **inherent** to
  the derive's source of truth. `emitDeformedFace` stamps the emitting
  (sub-)voxel's own anchor depth across *every* trixel its face paints, so the
  composite is a per-face **sort key**, not the metric depth at the sampled
  trixel. `isoPixelToPos3D(viewCenterIso, storedDepth)` pairs the center's exact
  2D coordinate with that anchor depth, so the reconstruction is off by however
  far the center ray crosses the face from its anchor.
- That single mechanism predicts all four blocks: **+1.0 iso** (half the face's
  2-unit depth spread) for `center-column` / `center-axis`, both built so the ray
  crosses a cap **dead-centre**; **+0.5** for `center-depth`'s off-centre lateral
  crossing; **0.00** for `background-center`, which takes the `d=0` fallback and
  reads no depth at all.
- **The issue's leading hypothesis is measured-refuted.** A trixel→framebuffer
  parity-shift / neighbouring-ray mispairing is a fixed *pixel* offset, so its
  world error would halve from zoom 4 to zoom 8. The measured bias is a constant
  **1.0 world iso unit at both** — 4 framebuffer rows at `effSub` 4, 8 rows at
  `effSub` 8. A fixed sampling offset in *either* direction is refuted too: the
  analytic depth sits 4 rows **above** the sampled row on the cap blocks and 4
  rows **below** it on `center-depth`, because those surfaces' depth-vs-row
  slopes have opposite signs. No single corrected sample row fixes both.
- Gates therefore move to the measurement: `kPivotFocusAssertToleranceWorld`
  0.6 → **0.58** (just over the measured `sqrt(3)/3` max), and `center-axis`
  joins `CENTROID_GATED_BLOCKS` at a **zoom-scaled** bound (3.25 px/zoom) instead
  of staying ungated — the inherent orbit is admitted, any growth in it fails.

Recovering the metric depth would need the winning face's anchor cell, which the
composite does not carry (depth / face / flip only) — i.e. a CPU inverse of
`emitDeformedFace`'s footprint including residual-yaw deform and riser flip. The
forward option is to stop consuming the sort key and cast a CPU ray
(`IRPrefab::Picking::castVoxelRay`, exact hit, no GPU flush) — the same primitive
#2548 latches the cursor pivot with. That is a change of *source of truth*, not a
residual fix, so it is documented as the forward path rather than done here;
#2548's landing is the natural point to weigh it.

## Test plan

- [x] `python3 scripts/pivot-verify.py --zoom 4 --zoom 8` — **14/14 passes
      green** post-rebase. `focus-ctr-sdf` scores REPORT 2.00px at both zooms —
      measured but ungated since #2648 merged `SDF_GATED = False` (closing
      #2645); the numbers themselves are unchanged from the design doc. Both SDF
      twins take an explicit `setRotationPivotFocus`, so the derive this PR
      touches never runs for them.
- [x] All four `[pivot-focus-assert]` blocks still PASS at the tightened 0.58
      tolerance, at zoom 4 and zoom 8.
- [x] `center-axis` now scores **PINNED** (was ungated FOCUS-OK) at both zooms.
- [x] Re-verified after `origin/master` advanced 22 commits mid-iteration —
      rebased onto `a86f908f9` and re-ran; every measurement identical.
- [x] Re-verified after the merger flagged a semantic conflict with #2648 in
      `scripts/pivot-verify.py`: rebased onto `34c7f7f46`, keeping #2648's
      report-don't-gate SDF semantics alongside this PR's `center-axis`
      zoom-scaled gate. `fleet-build --target IRShapeDebug` clean; full harness
      re-run 14/14 (`center-axis` PINNED 12.00px@z4 / 22.00px@z8, unchanged).
- [x] `fleet-build --target IRShapeDebug` clean; `ruff check scripts/` clean.
- [x] Re-verified after the merger flagged semantic conflicts with the #2548
      cursor-latch landing (`main.cpp` tolerance-constant region,
      `camera-yaw-pivot.md` residual section): rebased onto `6e804773e`,
      keeping #2548's `kCursorLatchFocusToleranceWorld` block and cursor-latch
      doc section alongside this PR's 0.58 tightening and root-caused residual
      rewrite (the superseded "accepted, measured" paragraph dropped; two stale
      cross-references in the kept #2548 prose corrected to the new
      gating/tolerance). `fleet-build --target IRShapeDebug` clean;
      `ruff check scripts/` clean; full harness re-run now **16/16** (the
      roster gained master's two cursor-latch passes: FOCUS-OK 16.00px@z4 /
      32.00px@z8 at their own 1.0-world-unit gate; this PR's blocks unchanged —
      `center-axis` PINNED 12.00px@z4 / 22.00px@z8).
- No screenshots: the only `creations/` change is an assert-tolerance constant and
  comments, so rendered output is byte-identical by construction.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Root-cause the +1 iso bias; correct the pairing **or** document why the residual is inherent | per-row composite-depth scan around the center texel at `effSub` 4 and 8, all four blocks | Ruled **inherent** + mechanism identified. Bias constant at **1.0 world iso unit** across zooms (4 rows @ effSub 4, 8 rows @ effSub 8) ⇒ not a pixel-domain mispairing; analytic depth 4 rows **above** center on cap blocks vs 4 **below** on `center-depth` ⇒ not a fixed sampling offset. Documented in `docs/design/camera-yaw-pivot.md` §"Known deviations" 2. |
| `center-axis` PINNED if corrected; **else** move into `CENTROID_GATED_BLOCKS` with a threshold justified by the measurement | `python3 scripts/pivot-verify.py --blocks center-axis --zoom 4 --zoom 8` | Inherent ⇒ took the else-branch. `center-axis@z4 PINNED 12.00px` (bound 13.0), `center-axis@z8 PINNED 22.00px` (bound 26.0). Bound is 3.25 px/zoom: measured 12.00px@z4 = 3.00 px/zoom and 22.00px@z8 = 2.75 px/zoom, so it clears the worse of the two by ~8% and still fails at ~6x below the pre-#2547 regression (150px @ z8). |
| Tighten `kPivotFocusAssertToleranceWorld` to the residual that remains | `--pivot-verify` all four default-pivot blocks, zoom 4 + 8 | 0.6 → **0.58**. Measured residuals: `background-center` 0.000, `center-depth` 0.289, `center-column` 0.577, `center-axis` 0.577 (max = `sqrt(3)/3` = 0.5774). All PASS at 0.58; byte-stable across all 9 shots of every sweep. |
| Confirm the derived focus agrees between OpenGL and Metal for the same block | **not run — macOS host** | **Owed.** Every measurement here is macOS/Metal. The emit is twinned GLSL/Metal so the mechanism should be identical, but `readbackCompositeDepth` applies a GL-only row flip (`resolution.y - 1 - y`) that lands GL on a different center row than Metal for an even-height framebuffer — a fixed one-row (sub-voxel) difference, not the 1.0-unit effect above. Labelled `fleet:needs-gl-host`; a GL host re-running `pivot-verify` closes it. Note the criterion's stated rationale ("the parity shift is the leading hypothesis") is itself refuted above, but the cross-backend confirmation still stands. |

Closes #2641

🤖 Generated with [Claude Code](https://claude.com/claude-code)


