### PR TITLE
fleet: resolve a `Blocked by: #<PR>` ref on the stacking surfaces (#2523)

### DIFF
--- a/.fleet/plans/issue-2523.md
+++ b/.fleet/plans/issue-2523.md
@@ -1,0 +1,148 @@
+# Plan: a `Blocked by: #<PR>` ref is invisible to the stacking surfaces
+
+- **Issue:** #2523
+- **Model:** opus — bounded script change, but the fail-closed semantics and the
+  #1751 offer/accept-agreement invariant need judgment beyond mechanical execution
+- **Date:** 2026-07-23 (planned), amended 2026-08-01 at implementation
+
+## Scope
+
+Direction **(a)** from the issue body: make a `Blocked by: #<PR>` ref (a PR
+number with no backing issue) first-class on the stacking surfaces — the scout's
+offer (`enrich_stackable_blocker_prs`) and the live finder
+(`cmd_find_stackable_blockers`) — so a task is stackable on its blocker PR while
+that PR is open. Direction (b) (reject the form at filing time) is rejected: it
+re-creates the #1749 unparsed-prose failure mode and leaves the genuine "wait for
+this approved-but-unmerged PR" dependency inexpressible. (a) preserves the
+queue-all + stacking model (#1527).
+
+## Amendment A1 (2026-08-01) — Surface 2 was retired before implementation
+
+The plan as approved covered **three** surfaces. Surface 2 (the claim's
+`--stackable-on` ancestry gate) no longer exists: PR #2656
+(`fleet: retire self-built stack mechanics + labels`) **merged**, deleting
+`missing_ancestor_reason()` from `fleet_stack_base.py` along with the
+`base issue unresolvable` refusal string this issue named. Re-verified against
+`origin/master` at implementation time:
+
+```
+'base issue unresolvable' in scripts/fleet/fleet-claim   → 0 occurrences
+missing_ancestor_reason  in fleet_stack_base.py          → 1 (a header comment
+                                                            recording the retirement)
+```
+
+Consequences, each traced to the acceptance criterion it moves:
+
+- **Original AC 1** (`--stackable-on 2508` must fail for a reason other than
+  `base issue unresolvable`) is **delivered by #2656 for free** — the code path
+  that emits that reason is gone. Implementing Step 2 would be a no-op and
+  asserting it would be a vacuous test, so Step 2 is dropped.
+- **Original AC 2** ("`test_stack_base_guard.py` gains a case exercising *both*
+  surfaces") is unsatisfiable as written — Surface 2 has no code left to
+  exercise. The cases land in the two suites that own the surviving surfaces
+  instead (`test_enrich_stackable_blocker_prs.py` for the offer,
+  `test_fleet_claim_stackable_live_resolve.sh` for the finder); the pure-lib
+  walk in `test_stack_base_guard.py` needs no change.
+- **Original AC 3** (log the silent non-offer) is unaffected and still the point.
+- **Original AC 4** ("existing tests stay green") now means green against the
+  post-#2656 tree.
+
+The **original repro pair is also gone** — PR #2508 merged 2026-07-23 and issue
+#2513 is closed — so AC 1 was unrunnable on two independent grounds. Per the
+plan's own contingency ("if #2508 has merged by then, the stubbed tests are the
+acceptance basis — do NOT hold the PR waiting for a live strand"), acceptance is
+the stubbed suites. The nearest live specimen, game #349 → PR #348, is a
+**partial** repro only: #349 carries two `Blocked by:` refs, so the #1531
+multi-blocker limitation declines it regardless of the PR-ref question.
+
+Surviving scope: Steps 1, 3, 4, 5 below. Phase 0's premise probe is dropped with
+Step 2 — it existed only to validate the ancestry walk's `gh issue view <PR#>`
+root, and there is no longer an ancestry walk.
+
+## Verified current state
+
+- **Surface 1 (offer)** — `fleet-state-scout` `enrich_stackable_blocker_prs`,
+  the `matches = [...]` comprehension: arms are
+  `branch_matches_issue(headRefName, N)` OR `N in closes_issues`. Both are False
+  for a ref naming the PR itself (an issue-less PR has no `claude/<N>-*` branch
+  and no `Closes #N`), so `len(matches) != 1` → **silent** `continue`.
+- **Surface 3 (finder)** — `cmd_find_stackable_blockers`' open-PR match uses the
+  same `branch_matches_issue OR body_closes_issue` union: same gap. Its
+  blocker-*resolution* half (`is_satisfied`) needs **no** change:
+  `gh issue view <N> --json state` resolves PR numbers, so an open blocker PR
+  reads `OPEN` (unresolved, correctly retained) and a merged one reads `MERGED`.
+- **The strand is bounded to the pre-merge window.** `check_blockers` and the
+  scout's `_resolve_ref_satisfied` both collapse a ref via that same state
+  fallback, so once the blocker PR merges the task unblocks normally. Only the
+  stacking surfaces were blind.
+- **No ambiguity is possible** — GitHub issues and PRs share one number
+  namespace, so a ref equal to an open PR's number cannot also be a live issue.
+
+## Approach
+
+**Step 1 — scout offer** (`scripts/fleet/fleet-state-scout`):
+1. Add a third arm, textually last, to the match comprehension:
+   `or pr.get("number") == issue_num_int`.
+2. Log the previously silent non-offer path (#2442's never-silent lesson):
+   0 matches and >1 matches each emit one line naming the repo, task, and
+   blocker ref (the >1 case additionally names the candidate PRs).
+
+**Step 2 — claim accept.** *Dropped — see Amendment A1.*
+
+**Step 3 — live finder agreement** (`cmd_find_stackable_blockers`): add the same
+arm (`or str(pr.get("number", "")) == blocker`) so the finder prints exactly the
+base the offer advertises (#1751 agreement).
+
+**Step 4 — tests** (stubbed, no live gh):
+1. `test_enrich_stackable_blocker_prs.py` — the offer surface: a number-matched
+   base is offered; a non-matching number is not (negative control); filter (b)
+   still suppresses a number-matched base; the arm survives the #2442
+   body-stripped 304-reuse shape; the game repo is covered. Plus the logging
+   pair: 0-match logs, multi-match logs and names candidates, a *successful*
+   offer logs nothing (positive control), and a filter-(b) rejection is not
+   misattributed to the match path.
+2. `test_fleet_claim_stackable_live_resolve.sh` — the finder surface: T9 a
+   PR-number ref returns that PR, T10 an unmatched PR-number ref returns empty
+   (the arm is not a wildcard), T11 a `fleet:wip` number-matched base returns
+   empty (offer/accept agree).
+3. Full existing suite green (`bash scripts/fleet/tests/run_all.sh`).
+
+**Step 5 — docs (same PR):** a subsection in
+`docs/design/fleet-queue-stacking.md` defining the form and its resolution
+semantics, and a corrected bullet in `docs/agents/TASK-FILING.md` (the existing
+one says PR numbers are unreliable and to withhold `human:approved` instead —
+now stale).
+
+## Affected files
+
+- `scripts/fleet/fleet-state-scout` — number arm + non-offer logging
+- `scripts/fleet/fleet-claim` — number arm in `cmd_find_stackable_blockers`
+- `scripts/fleet/tests/test_enrich_stackable_blocker_prs.py` — offer cases
+- `scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh` — finder cases
+- `docs/design/fleet-queue-stacking.md`, `docs/agents/TASK-FILING.md`
+- **No change:** `scripts/fleet/fleet_stack_base.py` (Surface 2 already retired)
+
+## Acceptance criteria
+
+Positive-fire (feature ON, observable deltas), all stubbed:
+
+- The enrichment suite asserts `stackable_blocker_pr.number == N` is *attached*
+  for a number-matched base (count > 0, not merely "no crash"), and the finder
+  suite asserts the PR line is *printed*.
+- Each new assertion is shown to fail against `origin/master` — a positive
+  control run, not an assumption.
+- The suppression path logs, and a successful offer does **not** (both asserted,
+  so the log can't degrade to firing unconditionally).
+- Base safety is unchanged: a `NOT_STACKABLE_BASE_LABELS` base and an
+  area-overlapping base are still suppressed on the number arm.
+- All existing fleet suites stay green.
+
+## Gotchas
+
+- Keep the number arm LAST in both match unions — minimal diff, existing paths
+  stay textually first.
+- Multi-blocker tasks stay out of scope (`_single_blocker_issue`'s single-ref
+  contract, the v1 Q3 decision).
+- The scout enrichment covers both repos already; nothing game-specific needed.
+- The number arm must read `pr["number"]`, never `pr["body"]` — bodies are
+  stripped on 304 reuse ticks (#2442).

--- a/docs/agents/TASK-FILING.md
+++ b/docs/agents/TASK-FILING.md
@@ -229,11 +229,15 @@ Rules that make the stack actually stack:
   satisfied ref. (Live multi-blocker resolution is planned but not
   landed — track via the open scout/fleet-claim blocker-resolution
   issue.)
-- **Use issue numbers as blockers; PR numbers are unreliable.**
-  `fleet-claim` treats a `#N` ref as gate-blocked until CLOSED (issues
-  close when their PR merges), whereas a PR number left as blocker adds
-  ambiguity. To gate on a docs PR that has no backing issue, withhold
-  `human:approved` on the dependent task instead.
+- **Prefer issue numbers as blockers; a PR number is resolvable but
+  reserved for the issue-less case.** `fleet-claim` treats a `#N` ref as
+  gate-blocked until CLOSED (issues close when their PR merges), so an
+  issue ref stays the clearer form and is what `file-epic` emits. A ref
+  naming a **PR** now resolves too — both stacking surfaces match a PR by
+  its own number, and the merged-state fallback collapses the ref once it
+  lands (#2523) — but use it only when the blocker genuinely has no
+  backing issue (an audit- or review-driven PR filed directly). Filing a
+  PR ref where an issue exists just hides the dependency from the reader.
 
 Once filed correctly, the cascade is automatic: T1 claims plain and
 opens `claude/<T1>-*`; the scout enriches T2 with `stackable_blocker_pr`

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -107,6 +107,35 @@ both the engine pass and the game pass. A `repo == game` stackable task is
 claimed with `--repo game`. Multi-blocker tasks are not eligible for stacking in
 v1 (`_single_blocker_issue` returns nothing for them).
 
+### The `Blocked by: #<PR>` form (#2523)
+
+A blocker ref matches an open PR by any of three arms: its head branch is
+`claude/<N>-*`, its body `Closes/Fixes/Resolves #N`, **or `N` is that PR's own
+number**. The third arm exists because a blocker PR can have no backing issue at
+all — an audit- or review-driven PR filed directly — in which case the first two
+arms are False by construction and there is no issue number to name instead.
+Before it, such a task was unpickable for the blocker's entire pre-merge window:
+the normal tier skipped it (`fleet:blocked`) and the stackable tier never offered
+a base, so it sat queued and approved until a human merged the blocker.
+
+The form is unambiguous: GitHub issues and PRs share one number namespace, so a
+ref equal to an open PR's number cannot also name a live issue. Resolution
+semantics follow the ref's state, and only the *open* window needed fixing —
+once the blocker PR merges, `gh issue view <N> --json state` reports `MERGED`
+and the existing satisfied-ref fallback in `check_blockers` /
+`_resolve_ref_satisfied` collapses the ref, unblocking the task normally.
+
+Both stacking surfaces carry the arm — the scout's offer
+(`enrich_stackable_blocker_prs`) and the live finder
+(`fleet-claim find-stackable-blockers`) — so the offer and the accept cannot
+disagree (#1751). The base-safety filters are unchanged: a number-matched base is
+still rejected when it carries a `NOT_STACKABLE_BASE_LABELS` label or overlaps
+the downstream task's file area. The arm widens *matching*, not the safety bar.
+
+The scout also logs every non-offer on this path (zero matches, or more than one)
+rather than skipping silently — the silence is what made #2523 take a source read
+to diagnose rather than a log line to spot (#2442's never-silent lesson).
+
 ## Why reconcile leaves these alone
 
 A `fleet:queued` + `fleet:blocked` task with no claim and no PR matches **no**

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1275,8 +1275,9 @@ sys.exit(1)
 
 cmd_find_stackable_blockers() {
     # If the task's **Blocked by:** field resolves to exactly one unresolved
-    # blocker with exactly one matching open PR (head-branch `claude/<N>-*`
-    # or body `Closes #N`), print one tab-separated line:
+    # blocker with exactly one matching open PR (head-branch `claude/<N>-*`,
+    # body `Closes #N`, or the ref being that PR's own number — #2523),
+    # print one tab-separated line:
     #   <pr-url><TAB><headRefName><TAB><author-login><TAB><number>
     # Otherwise print nothing (and exit 0).
     #
@@ -1375,9 +1376,13 @@ PYEOF
 )
     [[ -z "$blocker" ]] && return 0
 
-    # Find an open PR whose head-branch starts with claude/<N>- OR whose
-    # body contains "Closes #N" (case-insensitive). Exactly one match
-    # qualifies; zero or multiple → empty output.
+    # Find an open PR whose head-branch starts with claude/<N>-, OR whose
+    # body contains "Closes #N" (case-insensitive), OR whose own number IS N
+    # (a `Blocked by: #<PR>` ref naming an issue-less blocker PR — #2523). The
+    # three arms are the same union the scout's enrich_stackable_blocker_prs
+    # offers, so the finder can't advertise a base the offer withholds, or vice
+    # versa (#1751). Exactly one match qualifies; zero or multiple → empty
+    # output.
 
     BLOCKER="$blocker" REPO="$repo" python3 <<'PYEOF'
 import json, os, subprocess, sys
@@ -1410,7 +1415,11 @@ matches = []
 for pr in prs:
     head = pr.get("headRefName", "") or ""
     body = pr.get("body", "") or ""
-    if branch_matches_issue(head, blocker, repo) or body_closes_issue(body, blocker):
+    if (
+        branch_matches_issue(head, blocker, repo)
+        or body_closes_issue(body, blocker)
+        or str(pr.get("number", "")) == blocker
+    ):
         matches.append(pr)
 if len(matches) != 1:
     sys.exit(0)

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -4558,8 +4558,9 @@ commands:
   find-stackable-blockers <issue-number>
                                 if exactly one #N blocker has exactly
                                 one open PR (matched via head-branch
-                                `claude/<N>-*` or a body `Closes #N`
-                                reference), print one tab-separated
+                                `claude/<N>-*`, a body `Closes #N`
+                                reference, or the ref being that PR's
+                                own number), print one tab-separated
                                 line:
                                 <url><TAB><headRefName><TAB><author><TAB><number>.
                                 Empty stdout means no eligible blocker.

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1578,13 +1578,21 @@ def enrich_stackable_blocker_prs(state):
     # whose other blockers have all closed is already collapsed to a single
     # `#NNN` by resolve_blocked_by() (runs first), so it reaches here eligible.
     #
-    # A PR "matches" the blocker when its head branch is `claude/<NNN>-…` OR its
+    # A PR "matches" the blocker when its head branch is `claude/<NNN>-…`, OR its
     # derived closes_issues (Closes/Fixes/Resolves #NNN, parsed at fetch time —
-    # see body_closed_issue_numbers) contains NNN — the same union fleet-claim's
-    # find-stackable-blockers uses, so the scout offers every base the live
-    # finder would (the Closes-#N form catches blocker PRs on non-standard /
-    # human branches). The Closes half reads the derived field, not pr["body"],
-    # which is body-stripped on 304 reuse ticks (#2442).
+    # see body_closed_issue_numbers) contains NNN, OR NNN IS that PR's own number
+    # — the same union fleet-claim's find-stackable-blockers uses, so the scout
+    # offers every base the live finder would (the Closes-#N form catches blocker
+    # PRs on non-standard / human branches). The Closes half reads the derived
+    # field, not pr["body"], which is body-stripped on 304 reuse ticks (#2442).
+    #
+    # The third arm covers a `Blocked by: #<PR>` ref — a blocker PR with no
+    # backing issue, which neither the branch nor the Closes arm can resolve.
+    # Without it such a task has no offerable base for its blocker's whole
+    # pre-merge window, and the normal tier skips it too (`fleet:blocked`), so
+    # nothing can pick it up. GitHub issues and PRs share one number namespace,
+    # so a ref equal to an open PR's number cannot also name a live issue — the
+    # match is unambiguous (#2523).
     #
     # The field is always omitted when:
     #   - blocked_by doesn't reference exactly one issue (multi-blocker,
@@ -1622,8 +1630,21 @@ def enrich_stackable_blocker_prs(state):
                 pr for pr in prs
                 if branch_matches_issue(pr.get("headRefName", ""), issue_num, repo_key)
                 or issue_num_int in (pr.get("closes_issues") or [])
+                or pr.get("number") == issue_num_int
             ]
             if len(matches) != 1:
+                # A suppressed offer states its reason (#2442) — otherwise the
+                # only way to learn why a queued task is unpickable is to read
+                # this function's source.
+                task_id = task.get("id") or "?"
+                if not matches:
+                    log(f"stackable: {repo_key} {task_id} blocked by "
+                        f"#{issue_num} — no open PR matches, no base to offer")
+                else:
+                    nums = ", ".join(f"#{m.get('number')}" for m in matches)
+                    log(f"stackable: {repo_key} {task_id} blocked by "
+                        f"#{issue_num} — {len(matches)} open PRs match "
+                        f"({nums}), can't pick a base safely")
                 continue
             pr = matches[0]
 

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -409,6 +409,149 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         task = state["repos"]["engine"]["tasks"]["open"][0]
         self.assertIn("stackable_blocker_pr", task)
         self.assertEqual(task["stackable_blocker_pr"]["number"], 540)
+    # -----------------------------------------------------------------
+    # #2523 — `Blocked by: #<PR>`: the blocker ref names an issue-less open
+    # PR by its own number. Neither the branch arm nor the Closes arm can
+    # ever resolve that (the PR has no backing issue), so before the number
+    # arm the task was unpickable for its blocker's whole pre-merge window.
+    # -----------------------------------------------------------------
+
+    def test_pr_number_blocker_ref_offered(self):
+        """The blocker ref IS the open PR's own number: non-matching branch,
+        no Closes ref, no backing issue → still offered as a stackable base.
+        This is the #2523 specimen shape (#2513 → PR #2508). Fails before the
+        number arm, where both other arms are False and the offer is skipped."""
+        tasks = [_task("#2513", "#2508")]
+        prs = [_pr(2508, "claude/render-stage-select-dedup", author="jakildev")]
+        self._write_pr_cache("engine", 2508, ["engine/render/x.cpp"])
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 2508)
+        self.assertEqual(task["stackable_blocker_pr"]["headRefName"],
+                         "claude/render-stage-select-dedup")
+        self.assertEqual(task["stackable_blocker_pr"]["author"], "jakildev")
+
+    def test_pr_number_blocker_ref_wrong_number_not_matched(self):
+        """Negative control for the number arm: an open PR whose number is NOT
+        the blocker ref is not matched. Without this the arm could be passing
+        for a reason other than the number comparison."""
+        tasks = [_task("#2513", "#2508")]
+        prs = [_pr(2509, "claude/render-other-dedup")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_pr_number_blocker_ref_respects_unsafe_base_labels(self):
+        """Filter (b) still applies to a number-matched base: a blocker PR
+        carrying a NOT_STACKABLE_BASE_LABELS label is not offered, exactly as
+        for a branch- or Closes-matched one. The new arm widens *matching*, not
+        the base-safety bar."""
+        for label in ("fleet:wip", "fleet:semantic-conflict"):
+            with self.subTest(label=label):
+                tasks = [_task("#2513", "#2508")]
+                prs = [_pr(2508, "claude/render-stage-select-dedup",
+                           labels=[label])]
+                state = _state(engine_tasks=tasks, engine_prs=prs)
+                enrich_stackable_blocker_prs(state)
+                self.assertNotIn("stackable_blocker_pr",
+                                 state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_pr_number_blocker_ref_survives_304_reuse(self):
+        """The number arm reads `number`, never `body`, so a body-stripped
+        304-reuse record (#2442) offers identically. Guards against a future
+        refactor routing the arm through the body."""
+        tasks = [_task("#2513", "#2508")]
+        prs = _strip_bodies([_pr(2508, "claude/render-stage-select-dedup")])
+        self.assertNotIn("body", prs[0])
+        self.assertEqual(prs[0]["closes_issues"], [])
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertEqual(
+            state["repos"]["engine"]["tasks"]["open"][0]
+            ["stackable_blocker_pr"]["number"], 2508)
+
+    def test_pr_number_blocker_ref_offered_game_side(self):
+        """The form is not engine-specific — game #349 → PR #348 is the live
+        specimen. Enrichment covers both repos, so the game arm is exercised."""
+        tasks = [_task("#349", "#348")]
+        prs = [_pr(348, "claude/game-docs-cast-timeline")]
+        state = _state(game_tasks=tasks, game_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertEqual(
+            state["repos"]["game"]["tasks"]["open"][0]
+            ["stackable_blocker_pr"]["number"], 348)
+
+    # -----------------------------------------------------------------
+    # #2523 AC 3 — the non-offer path must not be silent (#2442's lesson).
+    # -----------------------------------------------------------------
+
+    def _capture_log(self):
+        """Swap _mod.log for a collector; restored via addCleanup."""
+        lines = []
+        orig = _mod.log
+        _mod.log = lines.append
+        self.addCleanup(lambda: setattr(_mod, "log", orig))
+        return lines
+
+    def test_zero_match_suppression_logs(self):
+        """0 open PRs match the blocker → the skip is logged with the task and
+        the blocker ref. This silent `continue` is what made #2523 need a
+        source read to diagnose."""
+        lines = self._capture_log()
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(999, "claude/2000-unrelated")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+        self.assertEqual(len(lines), 1, lines)
+        self.assertIn("#1112", lines[0])
+        self.assertIn("#1111", lines[0])
+        self.assertIn("engine", lines[0])
+
+    def test_multi_match_suppression_logs_candidates(self):
+        """>1 match → the skip is logged AND names the candidate PRs, so the
+        ambiguity is diagnosable from the log alone."""
+        lines = self._capture_log()
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(536, "claude/1111-a"), _pr(537, "claude/1111-b")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+        self.assertEqual(len(lines), 1, lines)
+        self.assertIn("#536", lines[0])
+        self.assertIn("#537", lines[0])
+
+    def test_successful_offer_does_not_log(self):
+        """Positive control for the logging pair: the log fires on suppression
+        only. Without this, a log() on every task would pass both tests above
+        while making the signal useless."""
+        lines = self._capture_log()
+        tasks = [_task("#2513", "#2508")]
+        prs = [_pr(2508, "claude/render-stage-select-dedup")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertIn("stackable_blocker_pr",
+                      state["repos"]["engine"]["tasks"]["open"][0])
+        self.assertEqual(lines, [])
+
+    def test_filter_b_suppression_is_not_logged_by_the_match_path(self):
+        """Scope guard on the new logging: a base rejected by filter (b) is a
+        *different* suppression than 'no match', and the match-path log must
+        not claim it. Filter (b)'s own reporting is out of this issue's scope —
+        this pins that the new line doesn't misattribute it."""
+        lines = self._capture_log()
+        tasks = [_task("#2513", "#2508")]
+        prs = [_pr(2508, "claude/render-stage-select-dedup", labels=["fleet:wip"])]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+        self.assertEqual(lines, [])
 
 
 class TestFetchPrs304Reuse(unittest.TestCase):

--- a/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
@@ -150,6 +150,22 @@ case "$1 $2" in
                 # #101 OPEN with a PR → stacks on the remaining #101.
                 printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #100\n**Blocked by:** #101\n"}'
                 ;;
+            3006)
+                # #2523: the blocker ref names an issue-less open PR by its OWN
+                # number (#540). Neither the branch arm nor the Closes arm can
+                # resolve it — only the number arm can.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #540\n"}'
+                ;;
+            3007)
+                # #2523 negative control: a PR-shaped ref with no open PR of
+                # that number → still empty, the arm is not a wildcard.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #777\n"}'
+                ;;
+            3008)
+                # #2523: number-matched base is still subject to filter (b) —
+                # PR #541 carries fleet:wip.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #541\n"}'
+                ;;
             *)
                 printf '%s' '{"state":"OPEN","labels":[],"body":""}'
                 ;;
@@ -162,8 +178,13 @@ case "$1 $2" in
             exit 0
         fi
         if [[ "$pr_state" == "open" ]]; then
-            # Return one open PR for issue #101.
-            printf '%s\n' '[{"url":"https://github.com/jakildev/IrredenEngine/pull/536","headRefName":"claude/101-work-branch","author":{"login":"bot"},"number":536,"body":"Closes #101"}]'
+            # #536 is issue #101's PR (branch + Closes arms).
+            # #540 / #541 are ISSUE-LESS PRs (#2523): non-claude branch, no
+            # Closes ref — reachable only by the number arm. #541 is fleet:wip
+            # so filter (b) can be exercised on a number-matched base. Neither
+            # matches #101 (number, branch, and body all disagree), so the
+            # single-match contract of T1/T5 is unaffected.
+            printf '%s\n' '[{"url":"https://github.com/jakildev/IrredenEngine/pull/536","headRefName":"claude/101-work-branch","author":{"login":"bot"},"number":536,"body":"Closes #101"},{"url":"https://github.com/jakildev/IrredenEngine/pull/540","headRefName":"audit/stage-select-dedup","author":{"login":"jakildev"},"number":540,"body":"Audit-driven, no backing issue."},{"url":"https://github.com/jakildev/IrredenEngine/pull/541","headRefName":"audit/wip-thing","author":{"login":"jakildev"},"number":541,"body":"No backing issue.","labels":[{"name":"fleet:wip"}]}]'
             exit 0
         fi
         echo "[]"
@@ -254,6 +275,31 @@ else
     FAIL=$((FAIL + 1))
     echo "  FAIL: multi-line result does not include claude/101-work-branch"
 fi
+
+# --- #2523: `Blocked by: #<PR>` — the ref names an issue-less open PR --------
+# The blocker PR has no backing issue, so branch_matches_issue and
+# body_closes_issue are both False for it by construction; only the number arm
+# can resolve the ref. Before that arm the finder printed nothing and the task
+# was unpickable for the blocker's whole pre-merge window.
+echo "T9: blocker ref IS an issue-less open PR's own number (#540) → returns PR 540"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3006 2>/dev/null || true)
+assert_nonempty "$result" "PR-number blocker ref returns a PR line"
+echo "  result: $result"
+if echo "$result" | grep -q "audit/stage-select-dedup"; then
+    PASS=$((PASS + 1))
+    echo "  ok: result includes audit/stage-select-dedup (PR #540)"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: result does not include audit/stage-select-dedup"
+fi
+
+echo "T10: PR-number blocker ref with no open PR of that number (#777) → empty"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3007 2>/dev/null || true)
+assert_output "$result" "" "unmatched PR-number ref → empty (arm is not a wildcard)"
+
+echo "T11: number-matched base still honors filter (b) — #541 is fleet:wip → empty"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3008 2>/dev/null || true)
+assert_output "$result" "" "wip number-matched base → empty (offer/accept agree, #1751)"
 
 # --- #1751: claim --stackable-on rejects an OPEN-but-unsafe base -------------
 # The base re-verify runs before any blocker/model/reservation gate, so an


### PR DESCRIPTION
## Summary

- A `Blocked by:` ref can name a **PR with no backing issue** (an audit- or review-driven PR filed directly). Both stacking surfaces matched a blocker only by head branch (`claude/<N>-*`) or body `Closes #N` — an issue-less PR satisfies neither *by construction*, so the ref resolved to nothing and a queued, approved task was unpickable for its blocker's entire pre-merge window (normal tier skips it as `fleet:blocked`; stackable tier never offered a base).
- Adds the **number arm** — the ref IS that PR's own number — to the scout's offer (`enrich_stackable_blocker_prs`) and the live finder (`cmd_find_stackable_blockers`), textually last in both unions so existing paths stay first. Both move together, preserving #1751: the finder can't advertise a base the offer withholds.
- Unambiguous by construction: GitHub issues and PRs share one number namespace, so a ref equal to an open PR's number cannot also name a live issue.
- Only the **open** window needed fixing. Once the blocker PR merges, `gh issue view <N> --json state` reports `MERGED` and the existing satisfied-ref fallback in `check_blockers` / `_resolve_ref_satisfied` collapses the ref — that half already worked.
- Base safety is untouched: a number-matched base is still rejected on a `NOT_STACKABLE_BASE_LABELS` label or a file-area overlap. The arm widens *matching*, not the safety bar.
- Also makes the scout's previously silent non-offer state its reason (#2442's never-silent lesson) — the suppression is what made this defect need a source read to diagnose.

### Re-scope: the planned third surface was retired before implementation

The approved plan covered **three** surfaces. Surface 2 (the `--stackable-on` ancestry gate) no longer exists — merged PR #2656 deleted `missing_ancestor_reason()` and took the `base issue unresolvable` refusal string with it:

```
'base issue unresolvable' in scripts/fleet/fleet-claim   → 0 occurrences on master
```

So the original AC 1 is **satisfied outright by #2656**; implementing for it would be a no-op and asserting it would be a vacuous test. The original repro pair is gone too (PR #2508 merged, issue #2513 closed), so per the plan's own contingency the stubbed suites are the acceptance basis rather than a live strand. Amendment A1 in `.fleet/plans/issue-2523.md` records all of this. Three prior worker iterations correctly declined this issue while #2656 was unmerged; that gate is now clear.

## Test plan

- [x] `python3 -m unittest discover -s scripts/fleet/tests -p test_enrich_stackable_blocker_prs.py` — **38/38 OK** (9 new cases)
- [x] `bash scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh` — **PASS: 14  FAIL: 0** (3 new cases, T9–T11)
- [x] `bash scripts/fleet/tests/run_all.sh` — **105 suites, 105 passed, 0 failed**
- [x] `ruff check scripts/` — All checks passed
- [x] **Positive control** — new assertions re-run against `origin/master`'s copy of each script: 6 of 9 enrichment cases fail, and finder T9 fails. The 3 enrichment cases that pass on master are the negative/scope controls, which are *supposed* to be non-discriminating.
- [x] **Live end-to-end** — ran the patched `enrich_stackable_blocker_prs` against the real `~/.fleet/state/state.json` and diffed the offer set against master's version on identical data: **identical** (no live PR-ref specimen exists today, so the arm is correctly inert), with the only delta being the 2 new suppression log lines.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Offer surface attaches a base for a number-matched blocker (count > 0, not "no crash") | `test_pr_number_blocker_ref_offered` | `stackable_blocker_pr.number == 2508`, headRefName + author asserted |
| Finder surface prints the same base (#1751 agreement) | `test_…live_resolve.sh` T9 | `…/pull/540	audit/stage-select-dedup	jakildev	540` |
| Both assertions genuinely discriminate | same two, run against `origin/master`'s scripts | enrichment `FAILED (failures=4, errors=2)`; T9 `FAIL … got nothing` |
| Arm is not a wildcard (negative control) | `test_pr_number_blocker_ref_wrong_number_not_matched`, T10 | no field attached / empty output |
| Base safety unchanged on a number-matched base | `test_pr_number_blocker_ref_respects_unsafe_base_labels` (`fleet:wip`, `fleet:semantic-conflict`), T11 | suppressed in all three |
| Suppression path logs its reason (AC 3) | `test_zero_match_suppression_logs`, `test_multi_match_suppression_logs_candidates` | 1 line each; multi-match names `#536, #537` |
| …and does **not** fire on success | `test_successful_offer_does_not_log`, `test_filter_b_suppression_is_not_logged_by_the_match_path` | `lines == []` — the log can't degrade to unconditional |
| Arm survives the #2442 body-stripped 304-reuse shape | `test_pr_number_blocker_ref_survives_304_reuse` | offered with `body` absent, `closes_issues == []` |
| Both repos covered | `test_pr_number_blocker_ref_offered_game_side` | game task offered PR 348 |
| Original AC 1 (Surface 2) | `grep -c 'base issue unresolvable' scripts/fleet/fleet-claim` | `0` — delivered by merged #2656, see Amendment A1 |
| Existing suites stay green against the post-#2656 tree | `run_all.sh` | 105/105 |

## Notes for the reviewer

- **No live specimen exists to demo against.** The nearest, game #349 → PR #348, is a *partial* repro only: #349 carries two `Blocked by:` refs, so #1531's multi-blocker limitation declines it regardless of the PR-ref question. Called out rather than glossed — the stubbed suites are the acceptance basis by the plan's own contingency.
- `docs/agents/TASK-FILING.md`'s existing bullet said PR numbers are unreliable and to withhold `human:approved` instead; that guidance is now stale and is corrected in place. I swept the tree for surviving copies of it — there are none, TASK-FILING.md was its only home.
- **One finding deliberately left out of scope:** this PR establishes an authoring rule `scripts/fleet/CLAUDE.md` doesn't carry ("a suppression path in an enrichment/filter pass states its reason"). The approved plan scopes docs to two files, so I did not widen it unilaterally; routing via the coding-improvement channel instead.
- Fleet-tooling only — no engine code, so no build/render verification applies. `fleet-tests.yml` is the gating workflow for these suites.

Closes #2523

🤖 Generated with [Claude Code](https://claude.com/claude-code)