### PR TITLE
fleet: a discharged stack-park label no longer strands an approved PR

### DIFF
--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -24,6 +24,12 @@
 #   - Conflicting PRs on master: attempt the rebase anyway — it's free;
 #     an actual conflict aborts cleanly and goes to the LLM pass.
 #
+# Stale-label cleanup — two label shapes that no longer describe the PR they
+# sit on, and that would otherwise park it outside every automated lane
+# forever. Rationale for each lives on its cleanup_* function:
+#   - fleet:semantic-conflict on a MERGEABLE PR (#1654).
+#   - fleet:awaiting-base / fleet:needs-base-update on a base==master PR (#2764).
+#
 # Auto-merge lane (plan-file PRs only): an approved, MERGEABLE, master-based
 # PR whose diff touches ONLY .fleet/plans/** (steward rollups, close-outs,
 # umbrella plan filings) is squash-merged here — zero build/runtime surface,
@@ -312,6 +318,57 @@ cleanup_stale_conflict() {
     log "$repo_key#$pr: removed stale fleet:semantic-conflict (fail-then-succeed race, #1654)"
 }
 
+# Remove a retired stack-park label (fleet:awaiting-base /
+# fleet:needs-base-update) from a PR whose base IS master. The park is
+# provably discharged there — a PR cannot be waiting on a base branch that
+# is master — and nothing else will ever remove it. The sole remover is
+# merger step 2.5, whose candidate filter is `baseRefName != "master"`;
+# GitHub retargets a native-stack child to master synchronously with its
+# parent's merge, so the child leaves 2.5's candidate set at the very
+# moment 2.5 would have cleared the label. The slice triage and merger
+# step 3 then both hard-skip it, stranding an approved PR from every
+# automated lane (#2764). Live-reverified before touching: confirms OPEN,
+# base still master, and the label still present, so a PR retargeted back
+# off master between the scout tick and now is never cleared.
+cleanup_stale_base_park() {
+    local repo_key="$1" pr="$2"
+    local repo_slug
+    repo_slug=$(repo_slug_for "$repo_key")
+    if (( DRY_RUN )); then
+        log "$repo_key#$pr: retired stack-park label on a base=master PR — would remove (dry-run)"
+        return 0
+    fi
+    local tsv state base labels
+    tsv=$(gh pr view "$pr" --repo "$repo_slug" \
+        --json state,baseRefName,labels \
+        --jq '[.state, .baseRefName, ([.labels[].name] | join(","))] | @tsv' \
+        2>/dev/null) || {
+        log "$repo_key#$pr: preflight for stack-park cleanup failed; skipping"
+        return 0
+    }
+    IFS=$'\t' read -r state base labels <<< "$tsv"
+    if [[ "$state" != "OPEN" ]]; then
+        log "$repo_key#$pr: no longer open; skipping stack-park cleanup"
+        return 0
+    fi
+    if [[ "$base" != "master" ]]; then
+        log "$repo_key#$pr: base is now '$base'; skipping stack-park cleanup"
+        return 0
+    fi
+    local removed="" label
+    for label in "fleet:awaiting-base" "fleet:needs-base-update"; do
+        if printf '%s' "$labels" | grep -q "$label"; then
+            gh pr edit "$pr" --repo "$repo_slug" --remove-label "$label" >/dev/null 2>&1 || true
+            removed="${removed:+$removed }$label"
+        fi
+    done
+    if [[ -z "$removed" ]]; then
+        log "$repo_key#$pr: retired stack-park label already cleared; skipping"
+        return 0
+    fi
+    log "$repo_key#$pr: removed retired stack-park label(s) [$removed] — base is master, park discharged (#2764)"
+}
+
 # Auto-merge one plan-file PR. Returns 0 = merged (or would merge, dry-run),
 # 1 = not merged (stays on the human's click; counted like llm-other so the
 # re-arm behavior for approved+MERGEABLE PRs is unchanged from before this
@@ -530,12 +587,17 @@ fi
 
 # Triage the slice. One line per PR:
 #   <repo> <number> <head> <base> <verdict>
-# verdict: attempt | merge-candidate | skip-labels | llm-other
+# verdict: attempt | merge-candidate | stale-conflict | stale-base-park
+#          | skip-labels | llm-other
 # - attempt: approved, no skip labels, and either stacked (base!=master)
 #   or not cleanly MERGEABLE — tier-0 tries the rebase.
 # - merge-candidate: approved, MERGEABLE, base==master, and every label
 #   inside the auto-merge allowlist — attempt_merge live-verifies (including
 #   the pure-.fleet/plans diff check the slice can't answer) and merges.
+# - stale-conflict: fleet:semantic-conflict on a MERGEABLE PR — label
+#   cleanup only, no branch work (#1654).
+# - stale-base-park: a retired stack-park label on a base==master PR —
+#   label cleanup only, no branch work (#2764).
 # - skip-labels: parked with another agent/human; neither tier touches it.
 # - llm-other: any other merger-actionable state this script doesn't
 #   handle (merge-ready label upkeep, stack-coordination transients,
@@ -586,14 +648,28 @@ for pr in data.get("prs", []):
         and mergeable == "MERGEABLE"
         and not any(skip_re.search(l) for l in labels if l != "fleet:semantic-conflict")
     )
+    # Retired stack-park labels, still minted by the merger role doc.
+    # base == master proves the park is discharged — a PR cannot be waiting
+    # on a base branch that is master — so route it to cleanup rather than
+    # parking it (why nothing else ever clears it: cleanup_stale_base_park,
+    # #2764). Same guards as the stale-conflict case: approved, and no other
+    # skip label claiming the branch.
+    stack_park = {"fleet:needs-base-update", "fleet:awaiting-base"} & set(labels)
+    has_stale_base_park = (
+        stack_park
+        and base == "master"
+        and approved
+        and not any(skip_re.search(l) for l in labels if l not in stack_park)
+    )
     if has_stale_conflict:
         verdict = "stale-conflict"
+    elif has_stale_base_park:
+        verdict = "stale-base-park"
     elif any(skip_re.search(l) for l in labels):
         verdict = "skip-labels"
-    elif {"fleet:needs-base-update", "fleet:awaiting-base"} & set(labels):
-        # Retired legacy stack-coordination labels — nothing sets them since
-        # the native-stacked-PRs migration, but a straggler PR still carrying
-        # one is mid-legacy-sequence; route it to the LLM pass, never tier-0.
+    elif stack_park:
+        # base != master (or not approved): a straggler still anchored to a
+        # real base, mid-legacy-sequence. The LLM pass owns it, never tier-0.
         verdict = "llm-other"
     elif approved and (base != "master" or mergeable not in ("MERGEABLE", "UNKNOWN", "", None)):
         verdict = "attempt"
@@ -639,6 +715,11 @@ for line in "${PR_LINES[@]:-}"; do
             # re-enters the normal merge-ready flow without routing a worker
             # step-1c onto an already-clean branch.
             cleanup_stale_conflict "$repo_key" "$pr"
+            ;;
+        stale-base-park)
+            # Clear the discharged park label so the PR re-enters the normal
+            # verdict path on the next tick (#2764).
+            cleanup_stale_base_park "$repo_key" "$pr"
             ;;
         skip-labels)
             # Parked with another agent/human — neither tier-0 nor the

--- a/scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Tests for fleet-rebase's retired stack-park label cleanup (issue #2764).
+#
+# Reproduces the native-stack strand: the merger labels a stacked child
+# fleet:awaiting-base while its parent is open (role-merger.md step 5a.5 i).
+# The parent merges; GitHub retargets the child to master server-side. That
+# retarget is precisely what drops the child out of merger step 2.5's
+# candidate set (it collects `baseRefName != "master"`), and 2.5 is the only
+# thing that removes the label. Meanwhile fleet-rebase's triage routed any PR
+# carrying the label to llm-other, and merger step 3 skips it on the — now
+# false — inference that the base must still be open. An approved PR is
+# stranded from every automated lane, permanently.
+#
+# The fix: base == master proves the park is discharged (a PR cannot be
+# waiting on a base branch that IS master), so triage emits a
+# "stale-base-park" verdict routing to cleanup_stale_base_park() instead of
+# llm-other. A straggler still anchored to a real base (base != master) keeps
+# the old llm-other routing.
+#
+#   T1: fleet:awaiting-base + base=master + approved -> cleanup fires
+#       (dry-run: logs "would remove").
+#   T2: fleet:needs-base-update + base=master + approved -> cleanup fires
+#       (the twin retired label takes the same path).
+#   T3: fleet:awaiting-base + base != master -> llm-other, NOT cleaned
+#       (genuine mid-sequence straggler; the LLM pass owns it).
+#   T4: fleet:awaiting-base + base=master + fleet:wip -> skip-labels, not
+#       cleaned (the WIP guard outranks the cleanup, as for stale-conflict).
+#   T5: fleet:awaiting-base + base=master but NOT approved -> llm-other,
+#       not cleaned (tier-0 never acts on an unapproved branch).
+#   T6: CONFLICTING + base=master + no park label -> the normal attempt
+#       path is untouched by this change.
+#
+# All run --auto --dry-run: cleanup_stale_base_park logs its intent and
+# returns before calling gh (which is gated behind DRY_RUN=0).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REBASE="$SCRIPT_DIR/fleet-rebase"
+
+if [[ ! -x "$REBASE" ]]; then
+    echo "test setup: fleet-rebase not executable at $REBASE" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+
+cleanup() {
+    if [[ -n "$TMPROOT" && -d "$TMPROOT" ]]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+# --- Sandbox ------------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT"
+export FLEET_STATE_DIR="$TMPROOT/.fleet/state"
+export FLEET_REBASE_SCRATCH="$TMPROOT/.fleet/rebase-scratch"
+mkdir -p "$FLEET_STATE_DIR/projections" "$TMPROOT/bin" "$TMPROOT/log"
+
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+REMOTE="$TMPROOT/remote.git"
+ENGINE="$TMPROOT/src/IrredenEngine"
+
+git init --bare -b master "$REMOTE" >/dev/null 2>&1
+
+AUTH="$TMPROOT/auth"
+git clone "$REMOTE" "$AUTH" -q
+git -C "$AUTH" config commit.gpgsign false
+echo init > "$AUTH/readme.txt"
+git -C "$AUTH" add readme.txt
+git -C "$AUTH" commit -q -m "init"
+git -C "$AUTH" push origin master -q
+
+# feat-retargeted: the shape under test — a child whose parent merged, so
+# GitHub moved its base to master while the awaiting-base label stayed on.
+git -C "$AUTH" checkout -b feat-retargeted master -q
+echo "child work" > "$AUTH/child.txt"
+git -C "$AUTH" add child.txt
+git -C "$AUTH" commit -q -m "child commit"
+git -C "$AUTH" push origin feat-retargeted -q
+
+git clone "$REMOTE" "$ENGINE" -q
+git -C "$ENGINE" config commit.gpgsign false
+
+# Minimal stub gh: silent success on everything (preflight calls in
+# attempt_pr are DRY_RUN-gated; cleanup_stale_base_park logs and returns
+# in dry-run mode before calling gh).
+cat > "$TMPROOT/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+chmod +x "$TMPROOT/bin/gh"
+export PATH="$TMPROOT/bin:$PATH"
+
+write_slice() {
+    printf '{"prs": %s}\n' "$1" > "$FLEET_STATE_DIR/projections/merger.json"
+}
+
+run_rebase() {
+    "$REBASE" --auto --dry-run 2>&1 || true
+}
+
+# === T1: fleet:awaiting-base + base=master -> cleanup logs "would remove" =====
+echo "T1: fleet:awaiting-base + base=master -> stack-park cleanup fires in dry-run"
+write_slice '[{
+  "repo":"engine","number":400,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved","fleet:awaiting-base","fleet:authored-on-macos"]
+}]'
+T1=$(run_rebase)
+assert_contains "$T1" "retired stack-park label on a base=master PR — would remove" \
+    "T1 cleanup logs 'would remove' for a retargeted child"
+assert_absent   "$T1" "llm_remaining=1" \
+    "T1 stack-park cleanup does not count toward LLM_REMAINING"
+assert_absent   "$T1" "clean rebase onto" \
+    "T1 cleanup does no branch work"
+
+# === T2: fleet:needs-base-update takes the same path =========================
+echo "T2: fleet:needs-base-update + base=master -> stack-park cleanup fires"
+write_slice '[{
+  "repo":"engine","number":401,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved","fleet:needs-base-update"]
+}]'
+T2=$(run_rebase)
+assert_contains "$T2" "retired stack-park label on a base=master PR — would remove" \
+    "T2 the twin retired label takes the same cleanup path"
+
+# === T3: base != master -> genuine straggler, still llm-other ================
+echo "T3: fleet:awaiting-base + base != master -> llm-other (straggler preserved)"
+write_slice '[{
+  "repo":"engine","number":402,
+  "headRefName":"feat-retargeted","baseRefName":"feat-parent",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved","fleet:awaiting-base"]
+}]'
+T3=$(run_rebase)
+assert_absent   "$T3" "would remove" \
+    "T3 a child still anchored to a real base is not cleaned"
+assert_contains "$T3" "llm_remaining=1" \
+    "T3 straggler still routes to the LLM pass"
+
+# === T4: fleet:wip guard outranks the cleanup ================================
+echo "T4: fleet:wip + fleet:awaiting-base + base=master -> skip-labels (WIP wins)"
+write_slice '[{
+  "repo":"engine","number":403,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved","fleet:awaiting-base","fleet:wip"]
+}]'
+T4=$(run_rebase)
+assert_absent "$T4" "would remove" \
+    "T4 fleet:wip + stack-park not cleaned (WIP guard wins)"
+assert_absent "$T4" "llm_remaining=1" \
+    "T4 WIP goes to skip-labels, not the LLM pass"
+
+# === T5: unapproved PR is never touched by tier-0 ============================
+echo "T5: fleet:awaiting-base + base=master but not approved -> llm-other"
+write_slice '[{
+  "repo":"engine","number":404,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:awaiting-base"]
+}]'
+T5=$(run_rebase)
+assert_absent   "$T5" "would remove" \
+    "T5 unapproved PR is not cleaned (tier-0 stays conservative)"
+assert_contains "$T5" "llm_remaining=1" \
+    "T5 unapproved straggler still routes to the LLM pass"
+
+# === T6: no park label -> the normal attempt path is unchanged ===============
+echo "T6: no park label + CONFLICTING + base=master -> normal attempt path"
+write_slice '[{
+  "repo":"engine","number":405,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved"]
+}]'
+T6=$(run_rebase)
+assert_absent   "$T6" "would remove" \
+    "T6 no park label -> no cleanup"
+assert_contains "$T6" "attempted=1" \
+    "T6 the ordinary rebase path is untouched by this change"
+
+# --- Summary ------------------------------------------------------------------
+summarize "fleet-rebase stale stack-park cleanup tests"


### PR DESCRIPTION
## Summary
- `fleet-rebase`'s triage routed every PR carrying `fleet:awaiting-base` / `fleet:needs-base-update` to `llm-other`, on an in-code claim that "nothing sets them since the native-stacked-PRs migration". `role-merger.md:447` still mints them — twice in the last 36 hours.
- Their only remover is merger step 2.5, whose candidate filter is `baseRefName != "master"` (`role-merger.md:168-172`). GitHub retargets a native-stack child to `master` synchronously with its parent's merge, so the child leaves 2.5's candidate set at the exact moment 2.5 would have cleared the label. Step 3 then skips it on the now-false inference "label survived ⇒ base still OPEN" (`role-merger.md:354`).
- `base == master` is proof the park is discharged — a PR cannot be waiting on a base branch that *is* master. Triage now emits a `stale-base-park` verdict for that case, mirroring the `stale-conflict` lane one arm above: same approved / no-other-skip-label guards, same live re-verification, same label-cleanup-only contract (no branch work).
- A straggler still anchored to a real base (`base != master`) keeps the old `llm-other` routing, unchanged.
- The merger-side half (stop minting the retired label) is gated self-config, so it is out of reach for every worker class — and PR #2657, which *is* that fix, was itself one of the two PRs this bug stranded. The un-gated reader side is what breaks the cycle.

## Test plan
- [x] New suite `scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh` — 6 cases, 12 assertions, `12 passed, 0 failed`.
- [x] **Positive control**: the new suite run against `origin/master`'s `fleet-rebase` (full-tree staging of `scripts/fleet` via `git archive`, only the suite swapped in) → `9 passed, 3 failed`, exit **1** (captured unpiped). The 3 failures are exactly the new-behaviour assertions; the 9 passes are the preservation cases (T3–T6), which must hold on both sides.
- [x] `bash scripts/fleet/tests/run_all.sh` → **106 suites, 106 passed, 0 failed**.
- [x] `bash -n scripts/fleet/fleet-rebase` clean; `ruff check scripts/` → `All checks passed!`.
- [x] Sibling suite `test_fleet_rebase_stale_conflict_cleanup.sh` still green — the shared `skip_re` precedence was not disturbed.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `awaiting-base` + `base==master` classifies as stale-label cleanup, not `llm-other` | T1, on the real #2657 record | `retired stack-park label on a base=master PR — would remove (dry-run)`; `llm_remaining=1` absent |
| …and re-classifies to `attempt` after the clear | classifier run on the same record minus the label | `engine 2657 claude/native-stacks-roledocs-retire master attempt` (was `llm-other`) |
| `awaiting-base` + `base != master` still `llm-other` | T3 | no cleanup line; `llm_remaining=1` present |
| `--dry-run` logs the would-remove without editing the PR | T1/T2 (stub `gh` exits 0 on everything; the DRY_RUN guard returns before any `gh` call) | `would remove (dry-run)`, no `gh pr edit` reached |
| New suite modelled on the stale-conflict sibling, with a positive control that FAILS on master | see Test plan | `9 passed, 3 failed`, exit 1 |
| `run_all.sh` green | `bash scripts/fleet/tests/run_all.sh` | `106 suite(s) — 106 passed, 0 failed` |
| Stale label cleared off #2657 and #2684 so both re-enter tier-0 | `gh pr edit --remove-label` + evidence comment on each | both now `fleet:approved, fleet:authored-on-macos`; base `master` |

Two extra guards the criteria did not ask for, both mirroring the sibling lane: an **unapproved** PR is never cleaned (T5 — tier-0 stays conservative), and `fleet:wip` outranks the cleanup (T4).

## Notes for reviewer
The two live instances (#2657, #2684) were cleared by hand in this pass rather than left to wait for this PR to merge; each carries a comment with the same evidence. Nothing else on those PRs was touched.

`fleet-rebase`'s header block previously documented neither stale-label lane; it now indexes both and points at the `cleanup_*` functions for the rationale, per `scripts/fleet/CLAUDE.md`'s "`--help` and docstrings must not drift" rule.

Closes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
