### PR TITLE
fleet: witness reports ROSTER EMPTY instead of all-healthy at tracked=0 (#2770)

### DIFF
--- a/scripts/fleet/tests/test_witness_roster.sh
+++ b/scripts/fleet/tests/test_witness_roster.sh
@@ -9,8 +9,15 @@
 # roster with zero tracked heartbeats gets a distinct ROSTER EMPTY warning
 # and a `witness-roster.stuck` alert file instead of "all healthy".
 #
-# Hermetic: HOME points at a temp dir per case, so no live
-# ~/.fleet/heartbeats or ~/.fleet/alerts is ever touched.
+# The roster-empty condition holds until a human acts, so the warning must
+# escalate-then-quiet rather than re-emit every 60 s forever (see
+# scripts/fleet/CLAUDE.md §"An every-tick guard that warns must
+# escalate-then-quiet"). Case (d) pins that rate-limiting.
+#
+# Hermetic: HOME points at a temp dir per case, and the FLEET_* overrides
+# witness honours are scrubbed from the caller's environment, so no live
+# ~/.fleet/{heartbeats,alerts,state} is ever touched even when the suite runs
+# from a fleet pane that exports them.
 #
 # Covers:
 #   (a) empty roster (heartbeats dir exists, no rostered file in it) =>
@@ -19,11 +26,18 @@
 #       tracked)", no witness-roster.stuck
 #   (c) a rostered agent with a stale heartbeat => STALE: line +
 #       <agent>.stuck, no witness-roster.stuck (tracked > 0)
+#   (d) a persistent empty roster => loud up to the Nth pass, silent after,
+#       witness.log stops growing, witness-roster.stuck keeps refreshing its
+#       count past N, and a rostered heartbeat clears counter + alert so the
+#       next outage escalates from scratch
 
 set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
-WITNESS="$SCRIPT_DIR/witness"
+# Overridable so the positive control stays reproducible after merge: point
+# WITNESS at an older revision (e.g. `git show <sha>:scripts/fleet/witness`
+# saved to a temp file) and the roster cases must go red.
+WITNESS="${WITNESS:-$SCRIPT_DIR/witness}"
 source "$(dirname "$0")/lib_assert.sh"
 
 if [[ ! -x "$WITNESS" ]]; then
@@ -34,10 +48,21 @@ fi
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/test-witness-roster.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
+# run_witness <fake_home> [escalate_n]
+# One `--once` pass with the caller's FLEET_* overrides scrubbed. Cases that
+# exercise the escalation threshold pass their own N so the test doesn't have
+# to run witness's ~10-minute production default that many times.
 run_witness() {
-    local fake_home="$1"
+    local fake_home="$1" escalate_n="${2:-}"
     mkdir -p "$fake_home/.fleet/heartbeats"
-    HOME="$fake_home" "$WITNESS" --once > "$fake_home/out.txt" 2>&1
+    local -a env_args=(
+        -u FLEET_ALERTS_DIR -u FLEET_STATE_DIR -u FLEET_WITNESS_ROSTER_ESCALATE_N
+        "HOME=$fake_home"
+    )
+    if [[ -n "$escalate_n" ]]; then
+        env_args+=("FLEET_WITNESS_ROSTER_ESCALATE_N=$escalate_n")
+    fi
+    env "${env_args[@]}" "$WITNESS" --once > "$fake_home/out.txt" 2>&1
 }
 
 # --- (a) empty roster: no rostered heartbeat file at all --------------------
@@ -87,5 +112,76 @@ assert_absent "$out_c" "ROSTER EMPTY" "stale heartbeat: no roster-empty warning 
 [[ -f "$home_c/.fleet/alerts/witness-roster.stuck" ]] \
     && bad "stale heartbeat: witness-roster.stuck NOT written" \
     || ok "stale heartbeat: witness-roster.stuck NOT written"
+
+# --- (d) persistent empty roster: escalate, then quiet ----------------------
+# N=3 keeps the case fast; the production default is 10 (~10 min of passes).
+
+home_d="$TMP/home-escalate"
+esc_n=3
+counter_d="$home_d/.fleet/state/.witness-roster-skip"
+alert_d="$home_d/.fleet/alerts/witness-roster.stuck"
+log_d="$home_d/.fleet/logs/witness.log"
+
+# Passes 1..N-1: the ordinary loud warn, not yet escalated.
+run_witness "$home_d" "$esc_n"
+out_d1=$(cat "$home_d/out.txt")
+assert_contains "$out_d1" "ROSTER EMPTY" "pass 1 (< N): still warns loudly"
+assert_absent   "$out_d1" "ESCALATION"   "pass 1 (< N): has not escalated yet"
+assert_contains "$(cat "$alert_d" 2>/dev/null || true)" "count=1" \
+    "pass 1 (< N): alert records count=1"
+[[ -f "$counter_d" ]] \
+    && ok "pass 1 (< N): consecutive-skip counter written" \
+    || bad "pass 1 (< N): consecutive-skip counter written"
+
+run_witness "$home_d" "$esc_n"
+out_d2=$(cat "$home_d/out.txt")
+assert_contains "$out_d2" "ROSTER EMPTY" "pass 2 (< N): still warns loudly"
+assert_absent   "$out_d2" "ESCALATION"   "pass 2 (< N): has not escalated yet"
+
+# Pass N: the single loud escalation line.
+run_witness "$home_d" "$esc_n"
+out_d3=$(cat "$home_d/out.txt")
+assert_contains "$out_d3" "ROSTER EMPTY ESCALATION" "pass N: escalates once"
+assert_contains "$out_d3" "3 consecutive passes"    "pass N: names the streak length"
+assert_contains "$(cat "$alert_d" 2>/dev/null || true)" "count=3" \
+    "pass N: alert records count=3"
+log_lines_at_n=$(wc -l < "$log_d" 2>/dev/null || echo 0)
+
+# Past N: silent on stdout and in the log, but the alert keeps refreshing —
+# it is the only standing signal once the loud channel goes quiet.
+run_witness "$home_d" "$esc_n"
+out_d4=$(cat "$home_d/out.txt")
+assert_absent "$out_d4" "ROSTER EMPTY" "pass N+1: quiet on stdout"
+assert_absent "$out_d4" "all healthy"  "pass N+1: quiet does not become a health claim"
+assert_contains "$(cat "$alert_d" 2>/dev/null || true)" "count=4" \
+    "pass N+1: alert still refreshed past N"
+
+run_witness "$home_d" "$esc_n"
+assert_contains "$(cat "$alert_d" 2>/dev/null || true)" "count=5" \
+    "pass N+2: alert count keeps advancing (not frozen at N)"
+log_lines_after=$(wc -l < "$log_d" 2>/dev/null || echo 0)
+assert_eq "$log_lines_after" "$log_lines_at_n" \
+    "past N: witness.log stops growing (no unbounded append)"
+
+# A healthy pass clears both, so the next outage escalates from scratch.
+touch "$home_d/.fleet/heartbeats/opus-architect"
+run_witness "$home_d" "$esc_n"
+out_d_ok=$(cat "$home_d/out.txt")
+assert_contains "$out_d_ok" "all healthy (1 agent(s) tracked)" \
+    "healthy pass: reports health again"
+[[ -f "$alert_d" ]] \
+    && bad "healthy pass: alert cleared" \
+    || ok "healthy pass: alert cleared"
+[[ -f "$counter_d" ]] \
+    && bad "healthy pass: counter cleared" \
+    || ok "healthy pass: counter cleared"
+
+rm -f "$home_d/.fleet/heartbeats/opus-architect"
+run_witness "$home_d" "$esc_n"
+out_d_again=$(cat "$home_d/out.txt")
+assert_contains "$out_d_again" "ROSTER EMPTY" "after clear: warns loudly again"
+assert_absent   "$out_d_again" "ESCALATION"   "after clear: streak restarted, not resumed"
+assert_contains "$(cat "$alert_d" 2>/dev/null || true)" "count=1" \
+    "after clear: count restarts at 1"
 
 summarize "witness roster tests"

--- a/scripts/fleet/tests/test_witness_roster.sh
+++ b/scripts/fleet/tests/test_witness_roster.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tests for witness's roster-empty detection (#2770).
+#
+# witness's per-role staleness thresholds only monitor a fixed roster
+# (opus-architect, game-architect). If no rostered agent has ever written a
+# heartbeat, `tracked` stays 0 forever and the old code unconditionally
+# printed "all healthy" — the dangerous failure mode for a monitor: it does
+# not error, it reports health. These tests pin the fixed behavior: a
+# roster with zero tracked heartbeats gets a distinct ROSTER EMPTY warning
+# and a `witness-roster.stuck` alert file instead of "all healthy".
+#
+# Hermetic: HOME points at a temp dir per case, so no live
+# ~/.fleet/heartbeats or ~/.fleet/alerts is ever touched.
+#
+# Covers:
+#   (a) empty roster (heartbeats dir exists, no rostered file in it) =>
+#       ROSTER EMPTY warning, no "all healthy", witness-roster.stuck written
+#   (b) a rostered agent with a fresh heartbeat => "all healthy (1 agent(s)
+#       tracked)", no witness-roster.stuck
+#   (c) a rostered agent with a stale heartbeat => STALE: line +
+#       <agent>.stuck, no witness-roster.stuck (tracked > 0)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+WITNESS="$SCRIPT_DIR/witness"
+source "$(dirname "$0")/lib_assert.sh"
+
+if [[ ! -x "$WITNESS" ]]; then
+    echo "test setup: witness not found (or not executable) at $WITNESS" >&2
+    exit 1
+fi
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/test-witness-roster.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+run_witness() {
+    local fake_home="$1"
+    mkdir -p "$fake_home/.fleet/heartbeats"
+    HOME="$fake_home" "$WITNESS" --once > "$fake_home/out.txt" 2>&1
+}
+
+# --- (a) empty roster: no rostered heartbeat file at all --------------------
+
+home_a="$TMP/home-empty"
+run_witness "$home_a"
+out_a=$(cat "$home_a/out.txt")
+
+assert_contains "$out_a" "ROSTER EMPTY" "empty roster: distinct warning emitted"
+assert_absent   "$out_a" "all healthy"  "empty roster: does not report all healthy"
+assert_contains "$out_a" "opus-architect" "empty roster: warning names a rostered agent"
+assert_contains "$out_a" "game-architect" "empty roster: warning names the other rostered agent"
+[[ -f "$home_a/.fleet/alerts/witness-roster.stuck" ]] \
+    && ok "empty roster: witness-roster.stuck written" \
+    || bad "empty roster: witness-roster.stuck written"
+assert_contains "$(cat "$home_a/.fleet/logs/witness.log" 2>/dev/null || true)" \
+    "ROSTER EMPTY" "empty roster: warning also logged to witness.log"
+
+# --- (b) rostered agent, fresh heartbeat ------------------------------------
+
+home_b="$TMP/home-fresh"
+mkdir -p "$home_b/.fleet/heartbeats"
+touch "$home_b/.fleet/heartbeats/opus-architect"
+run_witness "$home_b"
+out_b=$(cat "$home_b/out.txt")
+
+assert_contains "$out_b" "all healthy (1 agent(s) tracked)" \
+    "fresh heartbeat: reports all healthy with tracked=1"
+assert_absent "$out_b" "ROSTER EMPTY" "fresh heartbeat: no roster-empty warning"
+[[ -f "$home_b/.fleet/alerts/witness-roster.stuck" ]] \
+    && bad "fresh heartbeat: witness-roster.stuck NOT written" \
+    || ok "fresh heartbeat: witness-roster.stuck NOT written"
+
+# --- (c) rostered agent, stale heartbeat ------------------------------------
+
+home_c="$TMP/home-stale"
+mkdir -p "$home_c/.fleet/heartbeats"
+touch -t 202401010000 "$home_c/.fleet/heartbeats/game-architect"
+run_witness "$home_c"
+out_c=$(cat "$home_c/out.txt")
+
+assert_contains "$out_c" "STALE: game-architect" "stale heartbeat: STALE line emitted"
+assert_absent "$out_c" "ROSTER EMPTY" "stale heartbeat: no roster-empty warning (tracked>0)"
+[[ -f "$home_c/.fleet/alerts/game-architect.stuck" ]] \
+    && ok "stale heartbeat: game-architect.stuck written" \
+    || bad "stale heartbeat: game-architect.stuck written"
+[[ -f "$home_c/.fleet/alerts/witness-roster.stuck" ]] \
+    && bad "stale heartbeat: witness-roster.stuck NOT written" \
+    || ok "stale heartbeat: witness-roster.stuck NOT written"
+
+summarize "witness roster tests"

--- a/scripts/fleet/witness
+++ b/scripts/fleet/witness
@@ -14,7 +14,10 @@
 # If NO rostered agent has ever written a heartbeat (roster misconfigured,
 # or every rostered role retired), witness does not report "all healthy" —
 # tracking zero agents is not health. It logs a ROSTER EMPTY warning and
-# writes ~/.fleet/alerts/witness-roster.stuck instead.
+# writes ~/.fleet/alerts/witness-roster.stuck instead. That condition holds
+# until a human acts, so the warning escalates-then-quiets: loud for the
+# first N consecutive passes, then silent while the alert file keeps being
+# refreshed every pass. A rostered heartbeat clears counter and alert.
 #
 # Usage:
 #   witness          run continuously (normal fleet pane mode)
@@ -26,7 +29,8 @@
 set -euo pipefail
 
 HEARTBEAT_DIR="$HOME/.fleet/heartbeats"
-ALERT_DIR="$HOME/.fleet/alerts"
+ALERT_DIR="${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}"
+STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
 LOG_DIR="$HOME/.fleet/logs"
 LOG="$LOG_DIR/witness.log"
 
@@ -68,6 +72,110 @@ threshold_for_agent() {
 # Portable file mtime in Unix seconds (macOS + Linux).
 file_mtime() {
     python3 -c "import os, sys; print(int(os.path.getmtime(sys.argv[1])))" "$1"
+}
+
+# --- roster-empty escalation --------------------------------------------------
+# run_one_pass runs unattended every 60 s and the roster-empty condition stays
+# true until a human acts (it means no rostered agent writes a heartbeat at
+# all), so a plain per-pass warn re-emits identically forever — spam that buries
+# the outage instead of reporting it, and grows witness.log without bound. Count
+# consecutive zero-tracked passes; emit the loud line up to the Nth, then go
+# quiet. See scripts/fleet/CLAUDE.md §"An every-tick guard that warns must
+# escalate-then-quiet" (#2363); fleet-clone-freshness.sh's _freshness_warn is
+# the reference shape.
+#
+# Counter: $STATE_DIR/.witness-roster-skip
+#          one line, "<count> <first_seen_epoch> <reason>|<roster>"
+# Alert:   $ALERT_DIR/witness-roster.stuck
+#
+# Deliberate deviation from _freshness_warn: the alert is written from the FIRST
+# pass, not only from the Nth. witness has always written it on every pass and
+# it is not the noisy channel — one file, overwritten, never appended — so
+# gating it behind N would remove a durable signal rather than reduce noise.
+# Only the stdout/log line is rate-limited. It keeps being rewritten past N per
+# the sub-rule: once the loud channel is quiet the file is the only standing
+# signal, so a write-once alert would freeze its count/age at the escalation
+# instant and let a human clearing the alerts inbox silence a still-live
+# condition forever.
+#
+# Every counter/alert write is best-effort: a read-only $HOME must not break
+# the health pass this guards.
+ROSTER_COUNTER="$STATE_DIR/.witness-roster-skip"
+ROSTER_ALERT="$ALERT_DIR/witness-roster.stuck"
+
+# Consecutive zero-tracked passes before escalating. Passes run ~1/min, so 10 is
+# ~10 min — long enough to ride out the boot-time gap before a freshly launched
+# architect pane writes its first heartbeat, and an order of magnitude inside
+# the 2 h staleness threshold above. Roster-empty is strictly worse than a stale
+# heartbeat (nothing is being watched at all), so it must not alert later than
+# staleness would.
+_roster_escalate_n() {
+    local n="${FLEET_WITNESS_ROSTER_ESCALATE_N:-10}"
+    if [[ ! "$n" =~ ^[0-9]+$ ]] || (( n < 1 )); then
+        n=10
+    fi
+    echo "$n"
+}
+
+# _roster_iso8601 <epoch>
+# BSD (macOS) spells it `date -r`, GNU spells it `date -d @…`; -r on GNU tries
+# to stat a file and fails, so the chain lands on the right one either way.
+_roster_iso8601() {
+    date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || echo "$1"
+}
+
+# _roster_warn <now_str> <msg>
+# Emit the roster-empty warning, escalating-then-quieting on repetition.
+_roster_warn() {
+    local now_str="$1" msg="$2"
+    local key n now count first prev_key since
+    key="roster-empty|${ROSTER[*]}"
+    n="$(_roster_escalate_n)"
+    now="$(date +%s)"
+
+    count=0
+    first="$now"
+    prev_key=""
+    if [[ -f "$ROSTER_COUNTER" ]]; then
+        read -r count first prev_key < "$ROSTER_COUNTER" 2>/dev/null || true
+    fi
+    [[ "${count:-}" =~ ^[0-9]+$ ]] || count=0
+    [[ "${first:-}" =~ ^[0-9]+$ ]] || first="$now"
+    # A changed roster is news again — restart rather than inherit a tally
+    # raised against a different set of agents.
+    if [[ "${prev_key:-}" != "$key" ]]; then
+        count=0
+        first="$now"
+    fi
+    count=$(( count + 1 ))
+
+    mkdir -p "$(dirname "$ROSTER_COUNTER")" 2>/dev/null || true
+    printf '%s %s %s\n' "$count" "$first" "$key" > "$ROSTER_COUNTER" 2>/dev/null || true
+
+    since="$(_roster_iso8601 "$first")"
+
+    if (( count < n )); then
+        echo "[$now_str witness] $msg" | tee -a "$LOG"
+    elif (( count == n )); then
+        echo "[$now_str witness] $msg" | tee -a "$LOG"
+        echo "[$now_str witness] ROSTER EMPTY ESCALATION: $count consecutive passes tracking zero agents since $since. Wrote $ROSTER_ALERT. Remedy: give each rostered agent (${ROSTER[*]}) a fleet-heartbeat call at its role step 0, or correct the roster. Suppressing further identical warns until a rostered heartbeat appears." | tee -a "$LOG"
+    fi
+
+    mkdir -p "$(dirname "$ROSTER_ALERT")" 2>/dev/null || true
+    printf '%s roster=%s count=%s since=%s\n' \
+        "$now_str" "${ROSTER[*]}" "$count" "$since" \
+        > "$ROSTER_ALERT" 2>/dev/null || true
+    return 0
+}
+
+# _roster_all_clear
+# A rostered heartbeat appeared: drop the counter and the alert so the next
+# persistent roster-empty escalates from scratch.
+_roster_all_clear() {
+    rm -f "$ROSTER_COUNTER" "$ROSTER_ALERT" 2>/dev/null || true
+    return 0
 }
 
 run_one_pass() {
@@ -121,10 +229,9 @@ run_one_pass() {
 
     if [[ "$tracked" -eq 0 ]]; then
         local msg="ROSTER EMPTY: no heartbeat file for any monitored agent (${ROSTER[*]}) — witness is not tracking anyone, this is not health"
-        echo "[$now_str witness] $msg" | tee -a "$LOG"
-        echo "$now_str roster=${ROSTER[*]}" > "$ALERT_DIR/witness-roster.stuck"
+        _roster_warn "$now_str" "$msg"
     else
-        rm -f "$ALERT_DIR/witness-roster.stuck"
+        _roster_all_clear
         if [[ "$stale_count" -eq 0 ]]; then
             echo "[$now_str witness] all healthy ($tracked agent(s) tracked)"
         fi

--- a/scripts/fleet/witness
+++ b/scripts/fleet/witness
@@ -11,6 +11,11 @@
 # ~/.fleet/alerts/<agent>.stuck. Healthy agents have their alert files
 # cleared automatically.
 #
+# If NO rostered agent has ever written a heartbeat (roster misconfigured,
+# or every rostered role retired), witness does not report "all healthy" —
+# tracking zero agents is not health. It logs a ROSTER EMPTY warning and
+# writes ~/.fleet/alerts/witness-roster.stuck instead.
+#
 # Usage:
 #   witness          run continuously (normal fleet pane mode)
 #   witness --once   run one pass and exit (for testing/CI)
@@ -31,7 +36,7 @@ ONCE=0
 for arg in "$@"; do
     case "$arg" in
         --once)      ONCE=1 ;;
-        -h|--help)   sed -n '2,20p' "$0"; exit 0 ;;
+        -h|--help)   awk 'NR==1{next} /^#/{print; next} {exit}' "$0"; exit 0 ;;
         *) echo "witness: unknown argument '$arg'" >&2; exit 2 ;;
     esac
 done
@@ -46,6 +51,13 @@ done
 # Architects use --resume sessions, may sit at "standing by" between
 # human prompts. The 2 h threshold is generous enough for typical
 # desk-time gaps without missing a genuine wedge.
+#
+# ROSTER names the same agents as the case arms below — kept in sync by
+# hand since bash has no clean way to introspect a case statement. Used
+# to detect the roster-empty condition (no rostered agent has ever
+# written a heartbeat) so that case reports as broken, not healthy.
+readonly ROSTER=(opus-architect game-architect)
+
 threshold_for_agent() {
     case "$1" in
         opus-architect|game-architect)  echo 7200 ;;  # 2 h
@@ -107,8 +119,15 @@ run_one_pass() {
         fi
     fi
 
-    if [[ "$stale_count" -eq 0 ]]; then
-        echo "[$now_str witness] all healthy ($tracked agent(s) tracked)"
+    if [[ "$tracked" -eq 0 ]]; then
+        local msg="ROSTER EMPTY: no heartbeat file for any monitored agent (${ROSTER[*]}) — witness is not tracking anyone, this is not health"
+        echo "[$now_str witness] $msg" | tee -a "$LOG"
+        echo "$now_str roster=${ROSTER[*]}" > "$ALERT_DIR/witness-roster.stuck"
+    else
+        rm -f "$ALERT_DIR/witness-roster.stuck"
+        if [[ "$stale_count" -eq 0 ]]; then
+            echo "[$now_str witness] all healthy ($tracked agent(s) tracked)"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- `witness --once` no longer reports "all healthy" when `tracked == 0` — it logs a distinct `ROSTER EMPTY` warning to `~/.fleet/logs/witness.log` and writes `~/.fleet/alerts/witness-roster.stuck` naming the rostered agents (`opus-architect`, `game-architect`) that have no heartbeat file.
- That warning **escalates-then-quiets** (added in `7bdc45e8b`, addressing review): the roster-empty condition stays true until a human acts, so a plain per-tick warn inside witness's `while true; sleep 60` loop would spam stdout and grow `witness.log` without bound. Consecutive zero-tracked passes are counted, the loud line is emitted up to the Nth pass, then witness goes silent — while `witness-roster.stuck` keeps being refreshed every pass. A rostered heartbeat clears counter and alert so the next outage escalates from scratch.
- Added `readonly ROSTER=(opus-architect game-architect)` beside `threshold_for_agent` so the empty-roster message doesn't drift from the case arms it mirrors.
- Swapped the `--help` slice from a hardcoded `sed -n '2,20p'` line range (which the header-comment growth in this same PR would have silently broken) to an awk pass that stops at the first non-comment line.
- New `scripts/fleet/tests/test_witness_roster.sh` covers empty roster, fresh heartbeat, stale heartbeat, and the escalate-then-quiet transition.

## Escalation threshold

`N` defaults to **10** (~10 min at one pass/min), overridable via `FLEET_WITNESS_ROSTER_ESCALATE_N`. Sized against the outage rather than rounded: long enough to ride out the gap before a freshly launched architect pane writes its first heartbeat, and an order of magnitude inside the 2 h architect staleness threshold — roster-empty is strictly worse than a stale heartbeat (nothing is being watched at all), so it must not alert later than staleness would.

Shape follows `fleet-clone-freshness.sh`'s `_freshness_warn` per `scripts/fleet/CLAUDE.md` §"An every-tick guard that warns must escalate-then-quiet" (#2363). The helper itself is **not** reusable as-is — its counter path, alert name, message and remedy are all clone-specific, and generalising it would mean refactoring a guard `fleet-claim` sources. Same call `fleet-rebase`'s `escalate_if_hung_lock` made. Three sites now hand-roll the shape; that is a reasonable DRY candidate for a separate pass, flagged here rather than expanded into this PR.

**Deliberate deviation from `_freshness_warn`:** `witness-roster.stuck` is still written from the **first** pass, not gated behind N. witness has always written it every pass and it is not the noisy channel (one file, overwritten, never appended), so gating it would remove a durable signal rather than reduce noise. It keeps being rewritten past N per that section's sub-rule — once stdout goes quiet the file is the only standing signal, so a write-once alert would freeze its `count=`/age at the escalation instant and let a human clearing the alerts inbox silence a still-live condition permanently.

`ALERT_DIR` / `STATE_DIR` now honour `FLEET_ALERTS_DIR` / `FLEET_STATE_DIR`, the env overrides the convention specifies; unset, they resolve to the same paths as before.

## Test plan
- [x] `bash scripts/fleet/tests/test_witness_roster.sh` — **33 passed, 0 failed**
- [x] `bash scripts/fleet/tests/run_all.sh` — **106 suite(s), 106 passed, 0 failed** (includes the new suite)
- [x] Manual `HOME=<isolated tmpdir> scripts/fleet/witness --once` against all three states (empty heartbeats dir, fresh `opus-architect` heartbeat, stale `game-architect` heartbeat) — output and alert files matched expectations in each case
- [x] Positive control against this PR's **pre-amend** head `9bed3814e` — 23 passed, **10 failed**; every case-(d) discriminator red
- [x] Positive control against `origin/master` — 15 passed, **18 failed**
- [x] `witness --help` still prints the header only (no code leak) and picks up the new paragraph

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `witness --once` does not report all healthy at `tracked==0`; emits distinct warning + alert | `HOME=<tmp> scripts/fleet/witness --once` (empty heartbeats dir) | `[...] ROSTER EMPTY: no heartbeat file for any monitored agent (opus-architect game-architect) — witness is not tracking anyone, this is not health`; `~/.fleet/alerts/witness-roster.stuck` written |
| Loud below N, one escalation line at N, silent past N | case (d), `FLEET_WITNESS_ROSTER_ESCALATE_N=3` | passes 1–2 warn with no `ESCALATION`; pass 3 emits `ROSTER EMPTY ESCALATION: 3 consecutive passes tracking zero agents since …`; pass 4 emits neither `ROSTER EMPTY` nor `all healthy` |
| `witness.log` stops growing past N (no unbounded append) | line count at pass N vs pass N+2 | `3` → `3` (fixed); pre-amend `9bed3814e` gives `3` → `5` |
| Alert keeps refreshing past N, count not frozen at N | `cat witness-roster.stuck` after passes N+1, N+2 | `count=4`, then `count=5` |
| A healthy pass clears counter **and** alert; next outage restarts at 1 | touch `opus-architect` heartbeat → pass; then remove it → pass | `all healthy (1 agent(s) tracked)`, both files gone; next pass warns loudly again with `count=1` and no `ESCALATION` |
| New suite auto-discovered by `run_all.sh`, covers (a)/(b)/(c)/(d) | `scripts/fleet/tests/run_all.sh` | `106 suite(s) — 106 passed, 0 failed` |
| Case (a)/(d) confirmed RED against the unpatched witness (positive control) | `WITNESS=<older rev> bash tests/test_witness_roster.sh` | pre-amend `9bed3814e`: `23 passed, 10 failed`; `origin/master`: `15 passed, 18 failed` |
| Architect-only roster kept as-is; no pool panes added | `git diff scripts/fleet/witness` | `ROSTER=(opus-architect game-architect)` — same two names as the pre-existing `case` arms, nothing else added |

Hermeticity note: `run_witness` now scrubs `FLEET_ALERTS_DIR` / `FLEET_STATE_DIR` / `FLEET_WITNESS_ROSTER_ESCALATE_N` from the caller's environment, so the suite cannot be redirected at the live `~/.fleet` when run from a fleet pane that exports them. `WITNESS` is overridable so the positive control above stays reproducible after merge.

## Notes for reviewer
The issue's "gated half" (architect panes should actually call `fleet-heartbeat` at their step 0, editing `.claude/commands/role-opus-architect.md`) is deliberately out of scope here — that's gated self-config no worker class can push — and stays flagged on #2770 for a human/architect to pick up separately. The escalate-then-quiet guard above is precisely what keeps that gap from turning into per-minute log spam in the meantime.

Closes #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
