### PR TITLE
fleet: docs — retire step g's dead rebase-downstream command

### DIFF
--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -528,27 +528,22 @@ path was `fleet:has-nits`. (The AMEND path already cleared
 approval is still valid; human tweaks and nit cleanups don't
 invalidate it.
 
-### Step g — propagate the upstream fix downstream
+### Step g — downstream propagation is automatic now
 
-Always run, after every feedback fix:
+No fleet-side action needed here. The `fleet-claim` downstream-rebase
+molecule subcommand was retired with the native-stacked-PRs migration (see
+[`docs/design/native-stacked-prs-migration.md`](../design/native-stacked-prs-migration.md)) —
+GitHub's native Stacked PRs now own cascading a fix to downstream branches:
+once the upstream PR merges, every remaining PR in the stack is retargeted
+and rebased onto trunk server-side, synchronously with the merge. There is
+nothing to run at this step.
 
-```
-fleet-claim molecule rebase-downstream <your-worktree-basename>
-```
-
-The subcommand auto-detects the upstream issue number from the current
-branch (`claude/<issue#>-…`) and is a graceful no-op if there's no
-active molecule, the current branch isn't in one, or the upstream
-is already the tail of the chain — so it is safe to invoke
-unconditionally.
-
-When it does apply: it fetches the new tip, rebases each downstream
-branch in molecule order, force-pushes with `--force-with-lease`,
-and comments on each downstream PR. A rebase conflict pauses the
-chain at that task: the affected PR gets `fleet:blocker` + a
-comment, remaining downstreams stay on the prior base, and the
-subcommand exits non-zero — surface the failure to the human and
-move on.
+If you want downstream branches to pick up this fix's commits immediately,
+*before* the upstream PR merges, use GitHub's own tooling rather than a
+fleet wrapper: the PR's "Rebase stack" button, or `gh stack sync` / `gh
+stack rebase` from the CLI. This is optional — correctness doesn't depend
+on it, since coupled merges + automatic retargeting guarantee downstream
+branches are consistent with trunk once the stack actually merges.
 
 ### Step h — release the amendment reservation
 


### PR DESCRIPTION
## Summary
- `FLEET-FEEDBACK-HANDLING.md` step g told every feedback AMEND to run `fleet-claim molecule rebase-downstream`, a subcommand retired with the native-stacked-PRs migration — it exits 2, and the step's prose falsely described it as a graceful auto-rebasing no-op.
- Rewrote step g to describe the actual mechanism: GitHub's native Stacked PRs cascade-rebase downstream branches server-side on merge; `gh stack sync` / the "Rebase stack" button is the optional way to pull the fix in early.
- Kept the step's letter (`g`) so h/i and their external references (line 167 in this file, `assess-coding-improvement.md`, `.claude/skills/assess-coding-improvement/SKILL.md`) stay valid without a renumbering cascade.

## Test plan
- [x] `grep -rn "molecule rebase-downstream" docs/ .claude/` — zero hits (verified after rewording to avoid the exact substring in the explanatory prose too).
- [x] Confirmed on `origin/master`: `fleet-claim` has no `cmd_molecule_rebase_downstream` function (only a comment noting its retirement) and the `molecule` case dispatcher has no `rebase-downstream` arm — matches the issue's repro.
- [x] `fleet-claim molecule rebase-downstream pool-2` still exits 2 with `unknown molecule subcommand` — confirms the doc now matches live behavior.
- [x] Verified the relative link to `docs/design/native-stacked-prs-migration.md` resolves and its content (§"Server-side cascade rebase") backs the replacement described.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `grep -rn "molecule rebase-downstream" docs/ .claude/` returns no hits | ran the exact command post-edit | zero hits |
| Step g states the native replacement or is removed outright | rewrote step g in place (kept letter `g`) | now describes GitHub native cascade rebase + `gh stack sync`/"Rebase stack" button |
| No surviving prose claims fleet auto-rebases downstream molecule members on a feedback fix | reread the rewritten step g | prose now attributes the cascade to GitHub, not the fleet, and states "no fleet-side action needed" |
| Steps renumbered/cross-checked if g is deleted | avoided deletion — kept step g's letter, so h/i and all external `Step i` references stay valid unchanged | confirmed no other file references "Step g" by content, only by letter for h/i which are untouched |

Closes #2755

🤖 Generated with [Claude Code](https://claude.com/claude-code)