### PR TITLE
fleet: fix stale v1-gating claim in scout's stackable-offer docstring

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1599,9 +1599,10 @@ def enrich_stackable_blocker_prs(state):
     #     bases ARE accepted; see fleet_stack_base)
     #   - downstream task's area files appear in the blocker PR diff (filter a)
     #
-    # Engine and game tasks are both enriched; worker pickup only honors
-    # the field for engine in v1 (the merger's cascade-rebase doesn't
-    # process game PRs yet) — that gating lives in the role doc.
+    # Engine and game tasks are both enriched, and worker pickup honors the
+    # field for both repos — role-worker.md step 3's stackable-fallback tier
+    # covers engine and game identically; native stacks maintain the chain
+    # server-side either way.
     #
     # (The former filter (c) — the #2447 base-ancestry containment walk — was
     # retired with the native-stacked-PRs migration: a native stack self-heals


### PR DESCRIPTION
## Summary
- `enrich_stackable_blocker_prs`'s docstring in `scripts/fleet/fleet-state-scout` said worker pickup only honors the `stackable_blocker_pr` field for engine "in v1" (citing a merger cascade-rebase rationale the native-stacked-PRs migration retired). `role-worker.md` step 3's stackable-fallback tier already covers engine and game identically, and the enrichment loop was already repo-agnostic — only the prose was stale.
- Comment-only fix: drop the stale "engine in v1" claim and its retired rationale, state that both repos' offers are honored by worker pickup, referencing the native-stacks migration that made the chain server-side.

## Test plan
- [x] `ruff check scripts/` — clean
- [x] `python3 -c "import ast; ast.parse(...)"` — file still parses
- [x] `bash scripts/fleet/tests/run_all.sh --only stackable` — `test_enrich_stackable_blocker_prs.py` and `test_fleet_claim_stackable_live_resolve.sh` both pass (no behavior change, comment-only)

Closes #2763

🤖 Generated with [Claude Code](https://claude.com/claude-code)