### PR TITLE
fleet/scout: skip fleet:gated issues from the task queue (#2762)

### DIFF
--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -464,15 +464,22 @@ Specifically, **never pass these via `--label` when filing**:
   merger (when a conflict's whole surface is gated self-config — it labels
   `fleet:gated` instead of `fleet:semantic-conflict`), or a worker (a
   semantic-conflict whose conflicted files are all gated, role-worker.md step
-  1c d''; or a `fleet:needs-fix` PR whose entire fix surface is gated,
-  FLEET-FEEDBACK-HANDLING.md DEFER path). Means **the PR is blocked on an edit
-  to a gated self-config file** (`.claude/commands/role-*.md`,
-  `.claude/agents/*`, `.claude/skills/**/SKILL.md`) that the auto-mode
-  self-modification gate physically prevents any agent class from pushing.
+  1c d''; a `fleet:needs-fix` PR whose entire fix surface is gated,
+  FLEET-FEEDBACK-HANDLING.md DEFER path; or an **issue** whose task itself
+  turns out to require a gated edit, per an approved plan). Means **the PR (or
+  issue) is blocked on an edit to a gated self-config file**
+  (`.claude/commands/role-*.md`, `.claude/agents/*`,
+  `.claude/skills/**/SKILL.md`) that the auto-mode self-modification gate
+  physically prevents any agent class from pushing.
   **It is a hard, human-only stop:** it is in *every* picker's skip set —
-  the merger sweep, all worker-class dispatch, and reviewer pickup (see
-  fleet-state-scout `_merger_action_signal`, `project_worker`/`slice_worker`,
-  and `REVIEW_SKIP_LABELS`). Nothing automated touches it until a human (or
+  on **PRs**: the merger sweep, all worker-class dispatch, and reviewer
+  pickup (see fleet-state-scout `_merger_action_signal`,
+  `project_worker`/`slice_worker`, and `REVIEW_SKIP_LABELS`); on **issues**:
+  `fetch_task_queue`'s per-issue skip (so a gated issue never lands in
+  `tasks.open[]` as free-and-pickable) and `fleet-queue-ingest`'s hold set
+  (so ingest never re-stamps `fleet:queued` onto it — the issue keeps
+  `human:approved` and survives re-ingest, same shape as `fleet:needs-human`;
+  #2762). Nothing automated touches it until a human (or
   the architect, who can push gated edits with a human in the loop) resolves
   the gated edit and drops the label.
   **Why it exists, distinct from `fleet:human-deferred`:** human-deferred

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -476,10 +476,14 @@ Specifically, **never pass these via `--label` when filing**:
   pickup (see fleet-state-scout `_merger_action_signal`,
   `project_worker`/`slice_worker`, and `REVIEW_SKIP_LABELS`); on **issues**:
   `fetch_task_queue`'s per-issue skip (so a gated issue never lands in
-  `tasks.open[]` as free-and-pickable) and `fleet-queue-ingest`'s hold set
+  `tasks.open[]` as free-and-pickable), `fleet-queue-ingest`'s hold set
   (so ingest never re-stamps `fleet:queued` onto it — the issue keeps
-  `human:approved` and survives re-ingest, same shape as `fleet:needs-human`;
-  #2762). Nothing automated touches it until a human (or
+  `human:approved` and survives re-ingest, same shape as `fleet:needs-human`),
+  and both projection-side sets `_ALREADY_QUEUED_LABELS` /
+  `_INGEST_SKIP_LABELS` (so a park that keeps `human:approved` also *leaves*
+  `human_approved` and the ingest hash input, instead of being re-fetched and
+  re-submitted every tick for as long as it stays parked; #2762). Nothing
+  automated touches it until a human (or
   the architect, who can push gated edits with a human in the loop) resolves
   the gated edit and drops the label.
   **Why it exists, distinct from `fleet:human-deferred`:** human-deferred

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -268,9 +268,9 @@
     },
     {
       "name": "fleet:gated",
-      "scope": "pr",
+      "scope": "issue+pr",
       "color": "b60205",
-      "description": "Conflict/fix surface is gated self-config; human-only; merger + all workers + reviewers skip"
+      "description": "Conflict/fix surface is gated self-config; human-only; on PRs merger + all workers + reviewers skip, on issues the scout's task-queue fetch + ingest's requeue hold skip"
     },
     {
       "name": "fleet:human-amending",

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -456,7 +456,8 @@ for issue in pending:
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
             or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels
-            or 'fleet:plan-review' in labels or 'human:review-plan' in labels):
+            or 'fleet:plan-review' in labels or 'human:review-plan' in labels
+            or 'fleet:gated' in labels):
         # fleet:plan-review (#1932): the plan is posted but a reviewer hasn't
         # vetted it yet — ingest holds off until the reviewer clears the label
         # (sound → removed; not sound → swapped to fleet:needs-plan).
@@ -466,6 +467,10 @@ for issue in pending:
         # stays in the pending set and survives re-ingest, like fleet:needs-human)
         # but ingest must NOT stamp fleet:queued while present — the human clears
         # the label to release it. See PLANNING-PROTOCOL.md §"High-stakes".
+        # fleet:gated (#2762): a worker parked the issue because the fix
+        # surface is gated self-config no class can push. Keeps
+        # human:approved (survives re-ingest) but must never get
+        # fleet:queued re-stamped — same shape as fleet:needs-human.
         skipped_already += 1
         continue
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -766,6 +766,15 @@ def fetch_task_queue(repo_slug):
         if "fleet:plan-review" in labels:
             continue
 
+        # fleet:gated marks issues a worker parked because the fix surface
+        # is gated self-config no class can push (#2066). Skip for the same
+        # reason as fleet:needs-human above: without this, ingest re-stamps
+        # fleet:queued and every matching dispatch re-claims, re-hits the
+        # ungateable surface, and releases — an unbounded pane-burn loop
+        # (#2762).
+        if "fleet:gated" in labels:
+            continue
+
         in_progress = "fleet:in-progress" in labels or owner != "free"
         status = "~" if in_progress else " "
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -378,9 +378,16 @@ def sample_github_rate_limit():
             log(f"github rate-limit latch failed for {pool}: {e}")
 
 
-_ALREADY_QUEUED_LABELS = frozenset({"fleet:queued", "fleet:scope-shipped", "fleet:needs-human"})
-# fleet:needs-human included: parked issues must not re-enter the queue even if the
-# two-step add+remove call creates a TOCTOU window where fleet:queued is transiently absent.
+_ALREADY_QUEUED_LABELS = frozenset({
+    "fleet:queued",
+    "fleet:scope-shipped",
+    "fleet:needs-human",
+    "fleet:gated",
+})
+# fleet:needs-human / fleet:gated included: parked issues must not re-enter the queue
+# even if the two-step add+remove call creates a TOCTOU window where fleet:queued is
+# transiently absent. Both parks keep human:approved, so without this exclusion
+# fetch_human_approved returns them on every tick, forever (#2762).
 
 # Labels that mark issues the queue-manager role doc explicitly skips at
 # Step 5 — filter these out of the ingest projector/slicer so epics and
@@ -402,6 +409,11 @@ _INGEST_SKIP_LABELS = frozenset({
     "fleet:scope-shipped", # scope landed under a different issue; human should close
     "fleet:needs-human",   # parked: fleet can't do it autonomously, human must act;
                            # keeps human:approved but must NOT be re-queued
+    "fleet:gated",         # #2762: parked because the fix surface is gated self-config
+                           # no worker class can push. Same shape as fleet:needs-human —
+                           # keeps human:approved but must NOT be re-queued, so it must
+                           # also drop out of the ingest set or it holds the projection
+                           # hash non-zero and costs a live `gh issue view` every tick.
     "human:review-plan",   # #2011: worker-planned high-stakes issue holding for the
                            # human's approach sign-off; keeps human:approved but must
                            # NOT queue until the human clears it (surfaced separately

--- a/scripts/fleet/tests/test_fleet_queue_ingest_gated.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_gated.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Test that fleet-queue-ingest skips fleet:gated issues (#2762).
+#
+# A worker parks an issue fleet:gated when the fix surface is gated
+# self-config no class can push (.claude/commands/role-*.md, .claude/agents/*,
+# .claude/skills/**/SKILL.md). Because it keeps human:approved, it stays in
+# the ingest pending set — so ingest must explicitly NOT re-stamp
+# fleet:queued onto it, or the issue re-enters autonomous pickup and every
+# matching dispatch re-claims, re-hits the ungateable surface, and releases
+# (an unbounded pane-burn loop). A normal human:approved issue in the same
+# batch must still be stamped, which proves the harness can stamp and the
+# skip is meaningful (same shape as the human:owned / human:review-plan
+# regression tests).
+#
+# HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
+# paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":830,"repo":"engine"},
+  {"number":831,"repo":"engine"}
+]}
+JSON
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                # #830 carries fleet:gated (parked, gated fix surface);
+                # #831 is a normal approved issue.
+                case "$3" in
+                    830) echo '{"body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:gated"}],"comments":[{"body":"## Plan\nstep 1"}]}' ;;
+                    831) echo '{"body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}],"comments":[{"body":"## Plan\nstep 1"}]}' ;;
+                    *)   echo '{"body":"","labels":[],"comments":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)
+                printf '%s\n' "$*" >> "$EDIT_LOG"
+                exit 0 ;;
+            comment) exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in
+            list) echo '[]'; exit 0 ;;   # scope-shipped: no merged coverage
+            *) exit 0 ;;
+        esac ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+echo "=== run fleet-queue-ingest over a batch with one fleet:gated issue ==="
+bash "$INGEST" >/dev/null 2>&1 || true
+
+# #831 (normal approved) must be stamped fleet:queued.
+if grep -qE '(^| )831( |$)' "$EDIT_LOG"; then
+    ok "normal approved #831 was stamped (harness can stamp)"
+else
+    bad "normal approved #831 was NOT stamped — harness broken, skip test would be vacuous"
+fi
+if grep -q 'fleet:queued' "$EDIT_LOG" && grep -qE '(^| )831( |$)' "$EDIT_LOG"; then
+    ok "#831 stamp carried fleet:queued"
+else
+    bad "#831 stamp missing fleet:queued"
+fi
+
+# #830 (fleet:gated) must NOT be touched at all.
+if grep -qE '(^| )830( |$)' "$EDIT_LOG"; then
+    bad "fleet:gated #830 was edited (should have been skipped): $(grep 830 "$EDIT_LOG")"
+else
+    ok "fleet:gated #830 was skipped — never re-stamped fleet:queued"
+fi
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -257,6 +257,28 @@ class FetchTaskQueueDispatch(unittest.TestCase):
         self.assertEqual(out["in_progress"], [])
         self.assertEqual(out["done"], [])
 
+    def test_gated_issue_absent_from_all_sections(self):
+        # #2762: fleet:gated parks an issue whose fix surface no class can
+        # push. Without this skip it stays in tasks.open as free-and-pickable
+        # and ingest re-stamps fleet:queued, recycling panes indefinitely.
+        out = self._run([{
+            "number": 100, "title": "gated task",
+            "labels": [{"name": "fleet:queued"}, {"name": "fleet:gated"}],
+            "body": "",
+        }])
+        all_ids = [t["id"] for t in out["open"] + out["in_progress"] + out["done"]]
+        self.assertNotIn("#100", all_ids)
+
+    def test_gated_issue_positive_control_present_without_label(self):
+        # Same issue minus fleet:gated must still surface — proves the skip
+        # above is keyed on the label, not some other property of the fixture.
+        out = self._run([{
+            "number": 101, "title": "ungated task",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "",
+        }])
+        self.assertEqual(out["open"][0]["id"], "#101")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -210,6 +210,33 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
         self.assertEqual(out["pending_issues"], [],
                          "needs-human issue must be absent from pending_issues slice")
 
+    def test_gated_excluded_from_pending(self):
+        # fleet:gated parks an approved issue whose fix surface is gated
+        # self-config no worker class can push. Like fleet:needs-human it KEEPS
+        # human:approved, so without the skip the issue holds the projection hash
+        # non-zero forever and costs fleet-queue-ingest one live `gh issue view`
+        # every tick for as long as it stays parked (#2762). fleet-queue-ingest's
+        # own per-issue loop already refuses to stamp fleet:queued, so this is
+        # the projection-side half of that parity.
+        parked = [{"number": 2762, "title": "gated self-config edit",
+                   "labels": ["human:approved", "fleet:gated"]}]
+        h = stable_hash(project_queue_manager_ingest(_state(engine_human_approved=parked)))
+        self.assertEqual(h, stable_hash(project_queue_manager_ingest(_state())),
+                         "gated issue must not contribute to the ingest hash")
+        out = slice_queue_manager_ingest(_state(engine_human_approved=parked))
+        self.assertEqual(out["pending_issues"], [],
+                         "gated issue must be absent from pending_issues slice")
+
+    def test_gated_positive_control_present_without_label(self):
+        # Positive control for test_gated_excluded_from_pending: the same issue
+        # with fleet:gated removed MUST reach pending_issues, proving the
+        # exclusion is the label's doing and not an inert fixture.
+        live = [{"number": 2762, "title": "gated self-config edit",
+                 "labels": ["human:approved"]}]
+        out = slice_queue_manager_ingest(_state(engine_human_approved=live))
+        self.assertEqual([i["number"] for i in out["pending_issues"]], [2762],
+                         "issue must reach pending_issues once fleet:gated is gone")
+
     def test_revise_plan_overrides_skip_into_pending(self):
         # human:revise-plan is the human-added "change the posted plan" gate. It
         # lands on an issue mid-review (fleet:plan-review / human:review-plan,

--- a/scripts/fleet/tests/test_scout_agent_approved_fetch.py
+++ b/scripts/fleet/tests/test_scout_agent_approved_fetch.py
@@ -76,6 +76,28 @@ class TestAgentApprovedFetchUnion(unittest.TestCase):
         with patch.object(_mod, "fetch_issues_by_label", side_effect=stub):
             self.assertEqual(fetch_human_approved(_REPO), [])
 
+    def test_parked_labels_excluded_from_both_fetches(self):
+        # Both fetches must carry the parked-label exclusions, or a park that
+        # KEEPS human:approved (fleet:needs-human, fleet:gated) is re-fetched on
+        # every tick and never leaves repo_state["human_approved"] (#2762).
+        # fleet:needs-human is the positive control: it has been excluded since
+        # #1312, so a run where only it is asserted would pass even if
+        # fleet:gated were missing.
+        seen = {}
+
+        def _capture(repo, filter_label, exclude_labels=None, with_body=False,
+                     per_page=100):
+            seen[filter_label] = set(exclude_labels or ())
+            return []
+
+        with patch.object(_mod, "fetch_issues_by_label", side_effect=_capture):
+            fetch_human_approved(_REPO)
+        self.assertEqual(set(seen), {"human:approved", "fleet:agent-approved"})
+        for filter_label, excluded in seen.items():
+            for parked in ("fleet:needs-human", "fleet:gated"):
+                self.assertIn(parked, excluded,
+                              f"{filter_label} fetch must exclude {parked}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `fleet-state-scout`'s `fetch_task_queue` now skips issues labeled `fleet:gated`, alongside the existing `fleet:needs-human` / `fleet:plan-review` skips, so a gated issue never lands in `tasks.open[]` as free-and-pickable.
- `fleet-queue-ingest`'s requeue hold set now includes `fleet:gated`, so ingest never re-stamps `fleet:queued` onto a gated issue (it keeps `human:approved` and survives re-ingest — same shape as `fleet:needs-human`).
- Updated `docs/agents/fleet-labels-reference.md` and `docs/agents/fleet-state-machine.json`'s `fleet:gated` entries to cover the issue-side skip too (previously PR-only; JSON `scope` is now `issue+pr`, matching the existing `fleet:needs-gl-host` convention).

## Test plan
- [x] `python3 scripts/fleet/tests/test_issue_queue_parser.py -v` — 35/35 pass, including the two new cases.
- [x] `bash scripts/fleet/tests/test_fleet_queue_ingest_gated.sh` — 3/3 pass.
- [x] `bash scripts/fleet/tests/run_all.sh` — 106/106 suites pass.
- [x] `ruff check scripts/fleet/` — clean.
- [x] `./scripts/fleet/fleet-labels --check` — catalog and JSON node set agree (55 labels, all descriptions ≤100 chars).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `fetch_task_queue` skips issues labeled `fleet:gated` | `python3 scripts/fleet/tests/test_issue_queue_parser.py -v` | `test_gated_issue_absent_from_all_sections ... ok` |
| `fleet-queue-ingest`'s hold set includes `fleet:gated`, keeps `human:approved`, never re-stamps `fleet:queued` | `bash scripts/fleet/tests/test_fleet_queue_ingest_gated.sh` | `ok: fleet:gated #830 was skipped — never re-stamped fleet:queued` (positive control `#831` still stamped, proving the harness can stamp) |
| New regression test for the scout skip (positive + negative control) | `python3 scripts/fleet/tests/test_issue_queue_parser.py -v` | `test_gated_issue_absent_from_all_sections ... ok` / `test_gated_issue_positive_control_present_without_label ... ok` |
| New regression test for the ingest hold | `bash scripts/fleet/tests/test_fleet_queue_ingest_gated.sh` | `PASS: 3    FAIL: 0` |
| `fleet-labels-reference.md`'s `fleet:gated` entry cites the issue-side skips | manual read | entry now names `fetch_task_queue`'s per-issue skip and `fleet-queue-ingest`'s hold set explicitly, with both PR-side and issue-side pickers listed |
| Existing suites stay green | `bash scripts/fleet/tests/run_all.sh` | `run_all.sh: 106 suite(s) — 106 passed, 0 failed` |
| Projection sets carry `fleet:gated` too (review nit, `79cd4efde`) | `python3 scripts/fleet/tests/test_queue_manager_projection.py` | `test_gated_excluded_from_pending ... ok` / `test_gated_positive_control_present_without_label ... ok` (34/34) |
| `fetch_human_approved` excludes both parked labels (review nit, `79cd4efde`) | `python3 scripts/fleet/tests/test_scout_agent_approved_fetch.py` | `test_parked_labels_excluded_from_both_fetches ... ok` (5/5); asserts `fleet:needs-human` as its in-test positive control |
| Both new tests invert against the pre-fix scout | reverted `fleet-state-scout` to `580700381`, re-ran | both FAIL; the positive control still passes, so the failure keys on the label, not an inert fixture |

## Review-nit addendum (`79cd4efde`)

`_ALREADY_QUEUED_LABELS` and `_INGEST_SKIP_LABELS` in `fleet-state-scout` also
needed `fleet:gated`, for full parity with `fleet:needs-human`. Without it a
`human:approved` + `fleet:gated` issue never left `repo_state["human_approved"]`
(nor the ingest projection hash / `pending_issues`), so it was re-fetched and
re-submitted to a live `gh issue view` every ingest tick for as long as it
stayed parked. Not a correctness bug — `fleet-queue-ingest`'s per-issue loop
still refused to stamp `fleet:queued` — but a permanent projection entry and a
standing API cost. `fleet-labels-reference.md`'s issue-side picker enumeration
was extended to match.

Closes #2762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
