### PR TITLE
fleet: label_added_epoch must not hand jq's --arg to gh api — every claim-label TTL sweep was inert (#2781)

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -15,6 +15,20 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   `tempfile.TemporaryDirectory()` `cache_dir` instead. When migrating a
   fetcher's transport (e.g. `run_capture(gh)` → `conditional_get`), re-point
   *every* test mock at the new seam in the same PR.
+- **A CLI stub models the tool's argument parsing, not just its endpoint.**
+  A `gh` stub that matches a substring of `"$@"` and ignores flags accepts
+  arguments the real binary rejects, so the suite certifies a call that has
+  never once succeeded in production. `label_added_epoch` passed jq's
+  `--arg` to `gh api` — rejected before the request, swallowed by
+  `2>/dev/null`, permanently returning "age unknown" and silently disabling
+  every claim-label TTL sweep — while every suite covering it stayed
+  green (#2781).
+  Validate flags against the real tool's accepted set (transcribe it from
+  `--help`) and fail the way it fails; where the stub emulates `--jq`,
+  evaluate the program against fixture JSON instead of pre-baking the
+  filter's answer, and fail closed on a program shape you don't model.
+  Pair it with a fidelity assertion (the stub still rejects the flag the
+  bug used), or the next stub rewrite silently reopens the hole.
 - **Exercise every arm — dual spellings and defaulting chains alike.**
   A wrapper that accepts `--opt val` and `--opt=val` has two independent
   case arms: reject an empty `--opt=` exactly as the space form rejects a

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -362,13 +362,20 @@ gh_release_label() {
 #   or a parse failure). Mirrors the events-API timestamp method
 #   cmd_cleanup_gh uses to age out stale labels; reconcile (R4a) uses it to
 #   keep the most-recently-applied of two contradictory labels.
+#
+#   The label reaches the filter through the environment, NOT through jq's
+#   `--arg`: `--arg` is a jq flag that `gh api` does not accept, and it exits
+#   1 on the unknown flag *before* issuing the request. Anything that makes
+#   this call fail is swallowed by the `2>/dev/null` below and reported as a
+#   permanent "age unknown", which every caller reads as "skip" — so a
+#   malformed invocation here disables the TTL sweeps fleet-wide in silence
+#   (#2781).
 label_added_epoch() {
     local repo="$1" target="$2" label="$3"
     command -v gh >/dev/null 2>&1 || { echo 0; return 0; }
     local added_at
-    added_at=$(gh api "repos/${repo}/issues/${target}/events" --paginate \
-        --arg lname "$label" \
-        --jq '.[] | select(.event=="labeled" and .label.name==$lname) | .created_at' \
+    added_at=$(FLEET_LABEL_NAME="$label" gh api "repos/${repo}/issues/${target}/events" --paginate \
+        --jq '.[] | select(.event=="labeled" and .label.name==env.FLEET_LABEL_NAME) | .created_at' \
         2>/dev/null | tail -n1 || true)
     [[ -z "$added_at" ]] && { echo 0; return 0; }
     ADDED_AT="$added_at" python3 -c '

--- a/scripts/fleet/tests/test_fleet_claim_label_added_epoch.sh
+++ b/scripts/fleet/tests/test_fleet_claim_label_added_epoch.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's label_added_epoch() — the timestamp lookup every
+# claim-label TTL sweep ages its labels against.
+#
+# Regression coverage for #2781: the lookup passed jq's `--arg lname` to
+# `gh api`, which does not accept it. Real gh exits 1 on the unknown flag
+# BEFORE issuing the request; the call site's `2>/dev/null` swallowed the
+# usage text, so the function fell through to its "unknown age" guard and
+# returned 0 on every call, on every host, always. Each caller reads 0 as
+# "can't tell how old this is" and skips, so all five cleanup --gh sweeps,
+# the acquisition force-sweep, and reconcile R4a were silently inert.
+#
+# Why the sibling claim suites could not catch it: their gh stubs match the
+# substring `events` anywhere in argv and ignore flags entirely (see
+# test_fleet_claim_prlabel_orphan_sweep.sh), so a flag rejection is
+# unrepresentable. The stub here therefore models `gh api`'s FLAG PARSING —
+# it validates against gh api's real accepted flag set and fails the way gh
+# fails — and evaluates the --jq program against real events JSON rather
+# than pretending the filter already ran. T6 is the positive control on that
+# fidelity: it asserts the stub still rejects the flag the bug used, so a
+# future stub rewrite can't quietly turn this suite into a no-op.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+[[ -x "$FLEET_CLAIM" ]] || { echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2; exit 1; }
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""; cleanup(){ [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_STATE_DIR" "$FLEET_ORPHANS_DIR"
+
+TARGET_LABEL="fleet:reviewing-mac-pool-8"
+OTHER_LABEL="fleet:approved"
+TS_FIRST="2026-07-20T01:57:21Z"
+TS_LAST="2026-07-30T17:12:40Z"
+TS_OTHER="2026-08-01T09:53:23Z"   # later than TS_LAST, but a DIFFERENT label
+
+epoch_of() { ADDED_AT="$1" python3 -c '
+import os, datetime
+dt = datetime.datetime.strptime(os.environ["ADDED_AT"], "%Y-%m-%dT%H:%M:%SZ")
+print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
+'; }
+
+export EVENTS_JSON="$TMPROOT/events.json"
+cat > "$EVENTS_JSON" <<JSON
+[
+  {"event":"labeled","label":{"name":"$TARGET_LABEL"},"created_at":"$TS_FIRST"},
+  {"event":"unlabeled","label":{"name":"$TARGET_LABEL"},"created_at":"$TS_OTHER"},
+  {"event":"labeled","label":{"name":"$TARGET_LABEL"},"created_at":"$TS_LAST"},
+  {"event":"labeled","label":{"name":"$OTHER_LABEL"},"created_at":"$TS_OTHER"}
+]
+JSON
+
+# --- gh stub: models `gh api` flag parsing + jq evaluation -----------------
+# Accepted-flag set is transcribed from `gh api --help` (gh 2.89.0), NOT from
+# what fleet-claim happens to pass — that is what keeps this a real check.
+# Anything else exits 1 with gh's own "unknown flag" shape and no stdout.
+# The --jq evaluator covers exactly the filter shapes this call site uses and
+# fails closed (exit 3, diagnostic on stderr) on anything it does not model,
+# so a rewritten filter can never silently read as a pass.
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+[[ "${1:-}" == "api" ]] || exit 0
+shift
+endpoint=""; jqprog=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --paginate|--silent|--slurp|--verbose|-i|--include) shift ;;
+        --jq|-q)   jqprog="$2"; shift 2 ;;
+        --jq=*)    jqprog="${1#--jq=}"; shift ;;
+        -q=*)      jqprog="${1#-q=}"; shift ;;
+        --method|-X|--header|-H|--field|-F|--raw-field|-f|--input|\
+        --hostname|--cache|--template|-t|--preview|-p) shift 2 ;;
+        --method=*|--header=*|--field=*|--raw-field=*|--input=*|\
+        --hostname=*|--cache=*|--template=*|--preview=*) shift ;;
+        -*)
+            printf 'unknown flag: %s\n\nUsage:  gh api <endpoint> [flags]\n' "$1" >&2
+            exit 1 ;;
+        *) endpoint="$1"; shift ;;
+    esac
+done
+[[ -n "$endpoint" ]] || { echo 'gh: no endpoint' >&2; exit 1; }
+JQPROG="$jqprog" python3 - "$EVENTS_JSON" <<'PY'
+import json, os, re, sys
+
+prog = os.environ.get("JQPROG", "")
+events = json.load(open(sys.argv[1]))
+if not prog:
+    print(json.dumps(events)); raise SystemExit(0)
+
+# Models: .[] | select(.event=="labeled" and .label.name==<EXPR>) | .created_at
+m = re.fullmatch(
+    r'\s*\.\[\]\s*\|\s*select\(\s*\.event\s*==\s*"(?P<ev>[^"]*)"\s+and\s+'
+    r'\.label\.name\s*==\s*(?P<expr>\S+?)\s*\)\s*\|\s*\.(?P<field>\w+)\s*',
+    prog)
+if not m:
+    print("stub jq: unmodelled program: %r" % prog, file=sys.stderr)
+    raise SystemExit(3)
+
+expr = m.group("expr")
+if expr.startswith('"') and expr.endswith('"'):
+    want = expr[1:-1]
+elif expr.startswith("env."):
+    want = os.environ.get(expr[4:], "")      # jq: unset env key -> null, never matches
+    if expr[4:] not in os.environ:
+        want = None
+elif expr.startswith("$ENV."):
+    want = os.environ.get(expr[5:])
+elif expr.startswith("$"):
+    # A jq variable with no --arg binding: real jq refuses to compile.
+    print("jq: error: %s is not defined" % expr, file=sys.stderr)
+    raise SystemExit(1)
+else:
+    print("stub jq: unmodelled name expression: %r" % expr, file=sys.stderr)
+    raise SystemExit(3)
+
+for e in events:
+    if e.get("event") == m.group("ev") and want is not None \
+       and e.get("label", {}).get("name") == want:
+        print(e[m.group("field")])
+PY
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# A PATH with the coreutils label_added_epoch needs but no `gh` (T5). Emptying
+# PATH outright would hide `tail`/`python3` too and test the wrong thing.
+NOGH_DIR="$TMPROOT/nogh-bin"; mkdir -p "$NOGH_DIR"
+for tool in tail python3; do ln -s "$(command -v "$tool")" "$NOGH_DIR/$tool"; done
+
+# Source fleet-claim as a library (defines helpers, skips the dispatch). Clear
+# positional args first so the script's top-level --repo parse is a no-op.
+set --
+FLEET_CLAIM_LIB=1 source "$FLEET_CLAIM"
+# fleet-claim's header sets -e; this suite deliberately runs commands that
+# exit non-zero (T5's missing gh, T6's rejected flag), so restore our own.
+set +e
+set -uo pipefail
+
+REPO="jakildev/IrredenEngine"
+
+echo "== label_added_epoch =="
+
+# T1: the regression. A label that IS present must resolve to a real epoch.
+# Pre-fix this is 0, because the stub rejects `--arg` exactly as gh does.
+echo "T1: present label -> the epoch of its most recent 'labeled' event"
+assert_eq "$(label_added_epoch "$REPO" 2393 "$TARGET_LABEL")" "$(epoch_of "$TS_LAST")" \
+    "resolves a non-zero epoch for a label that is actually present"
+
+# T2: the filter is genuinely applied — a LATER event for a different label
+# must not leak through. Catches both "filter dropped" and "env name wrong".
+echo "T2: a later event for a different label does not leak"
+assert_absent "$(label_added_epoch "$REPO" 2393 "$TARGET_LABEL")" "$(epoch_of "$TS_OTHER")" \
+    "does not return another label's (later) timestamp"
+
+# T3: only 'labeled' events count — the unlabeled event at TS_OTHER is skipped
+# above, which T1 already pins; here the second label is queried directly.
+echo "T3: a different present label resolves to its own epoch"
+assert_eq "$(label_added_epoch "$REPO" 2393 "$OTHER_LABEL")" "$(epoch_of "$TS_OTHER")" \
+    "each label ages against its own 'labeled' event"
+
+# T4: genuinely-unknown age still reports 0 (the documented contract the
+# callers' `-eq 0 && continue` guards rely on).
+echo "T4: absent label -> 0"
+assert_eq "$(label_added_epoch "$REPO" 2393 "fleet:never-applied")" "0" \
+    "a label with no 'labeled' event reports unknown age (0)"
+
+# T5: no gh on PATH -> 0.
+echo "T5: gh missing -> 0"
+assert_eq "$(PATH="$NOGH_DIR" label_added_epoch "$REPO" 2393 "$TARGET_LABEL")" "0" \
+    "no gh binary reports unknown age (0)"
+
+# T6: positive control on the stub itself. If a future edit relaxes the stub's
+# flag parsing, T1-T5 would pass no matter what fleet-claim sends — this keeps
+# the suite from decaying into the same blind spot it exists to close.
+echo "T6: stub fidelity — gh api rejects jq-only flags"
+stub_rc=0
+stub_out=$(gh api "repos/$REPO/issues/2393/events" --paginate \
+    --arg lname "$TARGET_LABEL" \
+    --jq '.[] | select(.event=="labeled" and .label.name==$lname) | .created_at' 2>&1) \
+    || stub_rc=$?
+assert_eq "$stub_rc" "1" "stub exits 1 on the unknown flag, as gh api does"
+assert_contains "$stub_out" "unknown flag: --arg" "stub reports the unknown flag"
+
+echo "T7: stub fidelity — an accepted-flag call still returns data"
+stub_ok=$(FLEET_LABEL_NAME="$TARGET_LABEL" gh api "repos/$REPO/issues/2393/events" --paginate \
+    --jq '.[] | select(.event=="labeled" and .label.name==env.FLEET_LABEL_NAME) | .created_at' 2>&1)
+assert_contains "$stub_ok" "$TS_LAST" "stub serves events when every flag is accepted"
+
+summarize "fleet-claim label_added_epoch tests"

--- a/scripts/fleet/tests/test_fleet_claim_parked_release.sh
+++ b/scripts/fleet/tests/test_fleet_claim_parked_release.sh
@@ -132,11 +132,13 @@ else:
         # timestamp. Future rather than `date +%s` because the tests pin
         # FLEET_CLAIM_STALE_SECS_ISSUES=1: a "now" stamp goes stale the moment
         # the clock ticks past the next second, which would flake.
+        # The queried label rides in $FLEET_LABEL_NAME, not argv: `gh api` has
+        # no --arg, so label_added_epoch passes it through the environment
+        # (#2781).
         if printf '%s ' "$@" | grep -q 'events'; then
-            argline=$(printf '%s ' "$@")
             stamp="2020-01-01T00:00:00Z"
             for fresh in ${FRESH_LABELS:-}; do
-                case "$argline" in *"$fresh"*) stamp="2099-01-01T00:00:00Z"; break ;; esac
+                case "${FLEET_LABEL_NAME:-}" in *"$fresh"*) stamp="2099-01-01T00:00:00Z"; break ;; esac
             done
             echo "$stamp"
         fi

--- a/scripts/fleet/tests/test_fleet_claim_reconcile.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile.sh
@@ -138,11 +138,14 @@ case "$1" in
         ;;
     api)
         # events endpoint; emulate --jq selecting created_at by label name.
-        # design-unblocked applied later than design-blocked.
-        if printf '%s ' "$@" | grep -q 'design-unblocked'; then
-            echo "2026-05-29T02:00:00Z"
-        elif printf '%s ' "$@" | grep -q 'design-blocked'; then
-            echo "2026-05-29T01:00:00Z"
+        # design-unblocked applied later than design-blocked. The label rides
+        # in $FLEET_LABEL_NAME, not argv: `gh api` has no --arg, so
+        # label_added_epoch passes it through the environment (#2781).
+        if printf '%s ' "$@" | grep -q 'events'; then
+            case "${FLEET_LABEL_NAME:-}" in
+                *design-unblocked) echo "2026-05-29T02:00:00Z" ;;
+                *design-blocked)   echo "2026-05-29T01:00:00Z" ;;
+            esac
         fi
         exit 0
         ;;


### PR DESCRIPTION
## Summary

- `label_added_epoch` passed jq's `--arg lname` to **`gh api`**, which rejects
  it (`unknown flag: --arg`, exit 1) *before* issuing the request. The call
  site's `2>/dev/null` swallowed the usage text, so the function returned its
  "age unknown" sentinel `0` on every call, on every host, always.
- Every caller reads `0` as "can't tell how old this is" and skips — so all
  five `cleanup --gh` sweeps (reviewing/resolving/amending, claim, steward,
  planning), `_sweep_stale_prefix_holders`, and reconcile's R4a design-label
  ordering were **inert**. Stale claim labels never aged out and had to be
  released by hand (observed: `fleet:reviewing-mac-sonnet-reviewer` ~16h on
  PR #2453 → #2476; `fleet:reviewing-mac-pool-8` ~18h on PR #2736).
- Fix: pass the label through the environment and read it with jq's `env`.
  Same `--paginate` / `--jq` transport, same `tail -n1` "most recent labeled
  event" semantics.
- New hermetic suite `test_fleet_claim_label_added_epoch.sh`. The sibling
  suites could not catch this: their `gh` stubs match the substring `events`
  anywhere in argv and **ignore flags entirely**, so a flag rejection is
  unrepresentable. This stub validates flags against `gh api`'s real accepted
  set (transcribed from `--help`), fails the way `gh` fails, and evaluates the
  `--jq` program against fixture JSON instead of pre-baking the filter's
  answer — with T6/T7 as a fidelity control so a later stub rewrite can't
  silently reopen the hole.
- Two existing stubs identified the queried label by grepping **argv**
  (`test_fleet_claim_reconcile.sh`, `test_fleet_claim_parked_release.sh`);
  both are re-pointed at the environment seam in this PR, per
  `scripts/fleet/CLAUDE.md` §"re-point *every* test mock at the new seam".
  They now positively depend on the fix too.
- `scripts/fleet/CLAUDE.md` gains the generalized authoring rule (a CLI stub
  models the tool's argument parsing, not just its endpoint).

## Test plan

- [x] New suite green post-fix — 8 passed, 0 failed.
- [x] **Positive fire verified by hand**: `git stash push -- scripts/fleet/fleet-claim`,
      re-run → `6 passed, 2 failed` (T1 and T3 return `0` instead of the epoch);
      `git stash pop` → green again.
- [x] `bash scripts/fleet/tests/run_all.sh --only claim` → 25/25.
- [x] `bash scripts/fleet/tests/run_all.sh` (whole set) → **106/106**.
- [x] Root cause confirmed against live GitHub with a positive control (below).
- [x] Swept `scripts/` for sibling `--arg`-to-`gh` misuse: the remaining
      `--arg` uses are on real `jq` (`fleet-transition:138,152`,
      `fleet-guard-worktree-edit:60`) and are correct.

## Acceptance evidence

| Criterion (#2781) | Check run | Observed |
|---|---|---|
| Non-zero epoch for a label that IS present; `0` only for genuinely-unknown | `bash scripts/fleet/tests/test_fleet_claim_label_added_epoch.sh` | T1 `ok: resolves a non-zero epoch for a label that is actually present`; T4 `ok: a label with no 'labeled' event reports unknown age (0)`; T5 `ok: no gh binary reports unknown age (0)` |
| No jq-only flags passed to `gh api` | `grep -rn -- "--arg" scripts/ \| grep -v tests/` | only real-`jq` call sites remain (`fleet-transition`, `fleet-guard-worktree-edit`); the `fleet-claim` hit is the explanatory comment |
| Hermetic suite whose stub rejects unknown flags as real `gh` does | same suite, T6 | `ok: stub exits 1 on the unknown flag, as gh api does` / `ok: stub reports the unknown flag`; T7 `ok: stub serves events when every flag is accepted` |
| Suite fails pre-fix, passes post-fix (positive fire by hand) | `git stash push -- scripts/fleet/fleet-claim` → run → `git stash pop` | pre-fix `fleet-claim label_added_epoch tests: 6 passed, 2 failed` (`expected: 1785431560 / actual: 0`); post-fix `8 passed, 0 failed` |
| `run_all.sh --only claim` stays green | `bash scripts/fleet/tests/run_all.sh --only claim` | `25 suite(s) — 25 passed, 0 failed` |

Live root-cause control (macOS, `gh` 2.89.0, master `6b464a555`):

```
$ gh api "repos/jakildev/IrredenEngine/issues/2393/events" --paginate \
    --arg lname "fleet:design-unblocked" --jq '...'
unknown flag: --arg
$ echo $?
1

$ FLEET_LABEL_NAME="fleet:design-unblocked" gh api ".../events" --paginate \
    --jq '.[] | select(.event=="labeled" and .label.name==env.FLEET_LABEL_NAME) | .created_at'
2026-07-20T01:57:21Z
2026-07-30T17:12:40Z
2026-08-01T09:53:23Z
```

## Notes for the reviewer

- The flag is rejected by `gh api`'s own parser, so this reproduces on every
  `gh` version — the lookup has never worked, on any host.
- Sweeps go from never-firing to firing. Expect stale `fleet:reviewing-*` /
  `fleet:planning-*` / `fleet:stewarding-*` / `fleet:claim-*` labels that have
  accumulated past their TTL to be reaped on the next `cleanup --gh`. The
  liveness guards (`_amending_heartbeat_fresh`, the same-host orphan-marker
  fast paths) are unchanged and still protect live claims.
- Not changed: the `2>/dev/null`. It legitimately absorbs network failures,
  and the "unknown age ⇒ skip" contract is what makes that safe. The function
  header now says so explicitly, since that swallow is what hid this for so
  long.

Closes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
