### PR TITLE
fleet: a prose #N no longer costs a task its stackable offer (#2783)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1647,8 +1647,15 @@ def enrich_stackable_blocker_prs(state):
             # Prefer the declared-only view when resolve_blocked_by found the
             # value's prose inflating the ref count (#2783) — eligibility asks
             # "how many blockers were declared", not "what gates the claim".
-            blocked_by = (task.get("blocked_by_declared")
-                          or task.get("blocked_by") or "").strip()
+            # The narrowing may only ever ADD an offer, never withdraw one. Once
+            # every declared ref resolves while a decorative one has not, the
+            # declared view reads "(none)" while the gate still blocks on that
+            # decorative ref (#1281) — honoring it would leave the task with no
+            # claim AND no base to stack on. Fall back to the gate's own value.
+            declared_view = (task.get("blocked_by_declared") or "").strip()
+            if declared_view.lower().startswith("(none"):
+                declared_view = ""
+            blocked_by = (declared_view or task.get("blocked_by") or "").strip()
             issue_num = _single_blocker_issue(blocked_by)
             if not issue_num:
                 continue

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -52,7 +52,11 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import fleet_poll_topology
-from fleet_blocked_by import is_no_blocker_value, parse_blocked_by
+from fleet_blocked_by import (
+    is_no_blocker_value,
+    parse_blocked_by,
+    ref_is_decorative,
+)
 from fleet_branch_match import (
     PARKED_PR_LABELS,
     body_closed_issue_numbers,
@@ -1230,8 +1234,15 @@ EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh", "max"})
 # is now CLOSED arrives here as one ref and qualifies.
 def _single_blocker_issue(blocked_by):
     """Return the sole blocker issue number (digits, no '#') when blocked_by
-    references exactly one issue, else None."""
-    refs = re.findall(r"#(\d+)", blocked_by or "")
+    references exactly one issue, else None.
+
+    Refs living in the value's prose don't count toward the total — the caller
+    (stackable eligibility, this function's only one) asks how many blockers
+    were *declared*, and `#2770 (PR #2772 — …)` declares one (#2783). Applied
+    here as well as via `blocked_by_declared` so the answer doesn't depend on
+    whether resolve_blocked_by has already normalized the value."""
+    refs = [m.group(1) for m in re.finditer(r"#(\d+)", blocked_by or "")
+            if not ref_is_decorative(blocked_by, m.start())]
     return refs[0] if len(refs) == 1 else None
 
 
@@ -1307,13 +1318,20 @@ _REPO_SLUG_MAP = {
 _REPO_NAME_TO_KEY = {"irredenengine": "engine", "irreden": "game"}
 
 
-def _parse_blocker_refs(raw, default_key):
+def _parse_blocker_refs(raw, default_key, declared_only=False):
     """(repo_key, number) for every #N in a raw **Blocked by:** value, routing
     each ref to the repo named by its optional `[owner/]Repo#N` qualifier. A
     bare ref or an unrecognized qualifier falls back to default_key — the
-    issue's own repo. (#1522)"""
+    issue's own repo. (#1522)
+
+    `declared_only` drops refs that live in the value's explanatory prose with
+    no blocker verb — the "how many blockers were declared" question stackable
+    eligibility asks (#2783). It is deliberately NOT the default: the blocking
+    gate counts every ref, matching fleet_blocked_by.blocker_refs and #1281."""
     refs = []
     for m in _BLOCKER_REF_RE.finditer(raw or ""):
+        if declared_only and ref_is_decorative(raw, m.start()):
+            continue
         name = m.group(1)
         key = _REPO_NAME_TO_KEY.get(name.lower(), default_key) if name else default_key
         refs.append((key, m.group(2)))
@@ -1379,6 +1397,13 @@ def resolve_blocked_by(state):
             refs = _parse_blocker_refs(raw, repo_key)
             if not refs:
                 continue  # free-text or PR-URL form — leave unchanged
+            # Which of those were actually *declared*, vs named only in the
+            # value's prose (#2783). Normalization discards the prose, so the
+            # distinction has to be captured while the raw value still exists —
+            # enrich_stackable_blocker_prs needs the declared count, while
+            # `blocked_by` keeps every ref for the blocking gate.
+            declared = {r for _, r in
+                        _parse_blocker_refs(raw, repo_key, declared_only=True)}
 
             unresolved = []
             for ref_key, ref in refs:
@@ -1402,6 +1427,14 @@ def resolve_blocked_by(state):
                 task["blocked_by"] = f"#{unresolved[0]}"
             else:
                 task["blocked_by"] = ", ".join(f"#{r}" for r in unresolved)
+
+            # Only when the prose inflated the count — a value whose refs were
+            # all declared needs no second field, so state.json stays as-is for
+            # the overwhelming majority of tasks (#2783).
+            declared_unresolved = [r for r in unresolved if r in declared]
+            if declared_unresolved != unresolved:
+                task["blocked_by_declared"] = (
+                    ", ".join(f"#{r}" for r in declared_unresolved) or "(none)")
 
 
 def resolve_human_approved_blockers(state):
@@ -1611,7 +1644,11 @@ def enrich_stackable_blocker_prs(state):
     for repo_key, repo_state in state["repos"].items():
         prs = repo_state.get("prs", [])
         for task in repo_state.get("tasks", {}).get("open", []):
-            blocked_by = (task.get("blocked_by") or "").strip()
+            # Prefer the declared-only view when resolve_blocked_by found the
+            # value's prose inflating the ref count (#2783) — eligibility asks
+            # "how many blockers were declared", not "what gates the claim".
+            blocked_by = (task.get("blocked_by_declared")
+                          or task.get("blocked_by") or "").strip()
             issue_num = _single_blocker_issue(blocked_by)
             if not issue_num:
                 continue

--- a/scripts/fleet/fleet_blocked_by.py
+++ b/scripts/fleet/fleet_blocked_by.py
@@ -97,6 +97,12 @@ _BLOCKER_VERB_RE = re.compile(
 )
 # Clause boundaries used to isolate the text introducing a single `#N`.
 _CLAUSE_SPLIT_RE = re.compile(r'[;,—–(]')
+# List separators between *declared* blockers (#2783). A `Blocked by:` value is
+# a list of refs — each optionally carrying its own parenthetical annotation
+# (`#100 (done), #101 (still open)`) — so the first ref of every segment is
+# declared and only later refs in the same segment are candidates for prose.
+# `and` is included because hand-written values spell the list both ways.
+_LIST_SPLIT_RE = re.compile(r',|\band\b', re.IGNORECASE)
 
 
 def _leads_with_none_sentinel(value):
@@ -124,6 +130,50 @@ def _ref_is_see_also(value, ref_start):
     if _BLOCKER_VERB_RE.search(clause):
         return False
     return bool(_SEE_ALSO_RE.search(clause))
+
+
+def ref_is_decorative(value, ref_start):
+    """True when the `#N` starting at `ref_start` sits in `value`'s explanatory
+    prose and no blocker verb introduces it — a decoration rather than a
+    dependency (#2783).
+
+    Answers "was this ref *declared*", NOT "does it gate" — the two questions
+    genuinely differ, so only ask this one where the declared count is what
+    matters (stackable eligibility). The blocking gate `blocker_refs` counts
+    every ref on purpose: a parenthetical PR ref is load-bearing there. #1281
+    taught the resolver to accept such a ref once the PR is MERGED — while it
+    is still OPEN the ref gates, which is what stops a claim on work whose
+    implementing PR hasn't landed. The common shape is the blocker's own PR —
+    `#2770 (PR #2772 — lands the shape this generalizes)` declares one blocker
+    and gates on two.
+
+    A ref is declared — never decorative — when it is the **first** in its list
+    segment, so `#100, #101` and the per-ref-annotated
+    `#100 (done), #101 (still open)` both keep every blocker. Only a *second*
+    ref inside one segment can be prose, and #1910's `_BLOCKER_VERB_RE` clause
+    scan rescues that one when the prose restates a real dependency
+    (`#100 — also blocked by #999`). The bias toward declared is deliberate:
+    dropping a genuine blocker would unblock work whose base has not merged,
+    far worse than the overcount it corrects.
+
+    Lives here rather than in the scout so the eligibility rule can't drift
+    from the gate it deliberately differs from — the #1749 reconciliation.
+    """
+    value = value or ""
+    # A leading-`none` value is #1910's territory: `is_no_blocker_value` already
+    # rules on it and deliberately keeps every unqualified ref as a blocker
+    # (the anti-evasion guard). Staying out keeps that corpus byte-identical —
+    # this fix is scoped to values that declare a real blocker list.
+    if _leads_with_none_sentinel(value):
+        return False
+    seg_start = 0
+    for sep in _LIST_SPLIT_RE.finditer(value[:ref_start]):
+        seg_start = sep.end()
+    preceding = value[seg_start:ref_start]
+    if not _REF_RE.search(preceding):
+        return False
+    clause = _CLAUSE_SPLIT_RE.split(preceding)[-1]
+    return not _BLOCKER_VERB_RE.search(clause)
 
 
 def is_no_blocker_value(value):
@@ -239,7 +289,14 @@ def blocker_refs(body, default_repo):
     """(slug, number) for every blocker `#N` declared in `body`, routing each
     cross-repo `[owner/]Repo#N` qualifier to its GitHub slug (#1522) and
     defaulting bare refs to `default_repo` (the issue's own repo). A
-    sentinel-only or unblocked body contributes nothing."""
+    sentinel-only or unblocked body contributes nothing.
+
+    Every ref counts here, prose included: this is the *blocking gate*, and a
+    parenthetical `(PR #200 must merge — …)` is load-bearing for it — #1281
+    resolves such a ref against PR state, so it stops gating only once that PR
+    is MERGED. Callers that need the narrower "how many blockers were actually
+    declared" question (stackable eligibility) filter with `ref_is_decorative`
+    instead; they must not widen this one (#2783)."""
     value = parse_blocked_by(body)
     return [(_ref_slug(m.group(1), default_repo), m.group(2))
             for m in _REF_RE.finditer(value)]

--- a/scripts/fleet/tests/test_blocked_by.py
+++ b/scripts/fleet/tests/test_blocked_by.py
@@ -218,6 +218,119 @@ class BlockerRefs(unittest.TestCase):
         self.assertEqual(fbb.blocker_refs("**Blocked by:** (none)\n", "jakildev/IrredenEngine"), [])
 
 
+class DecorativeProseRefs(unittest.TestCase):
+    """#2783 — `ref_is_decorative` answers "was this ref *declared*", the
+    narrower question stackable eligibility asks.
+
+    The miscount it fixes is not cosmetic: `enrich_stackable_blocker_prs`
+    offers a base only for single-blocker tasks, so one phantom ref silently
+    drops the task out of the worker's stackable fallback tier for the
+    blocker's whole pre-merge window.
+
+    `blocker_refs` — the blocking gate — deliberately does NOT use this; see
+    `BlockerRefsCountsProseForTheGate` below.
+    """
+
+    def _nums(self, value):
+        # Production always hands ref_is_decorative a parsed *value*, never the
+        # whole `**Blocked by:** …` line — the leading-`none` guard keys on the
+        # value's first token, so passing the label would mask it.
+        v = fbb.parse_blocked_by(f"**Blocked by:** {value}\n") or value
+        return [m.group(2) for m in fbb._REF_RE.finditer(v)
+                if not fbb.ref_is_decorative(v, m.start())]
+
+    def test_blockers_own_pr_in_parens_is_not_a_second_blocker(self):
+        # The live #2780 shape: the parenthetical names the very PR a stacker
+        # should stack ON, and counting it withheld that offer.
+        self.assertEqual(
+            self._nums("#2770 (PR #2772 — lands the `_roster_warn` shape this generalizes)"),
+            ["2770"],
+        )
+
+    def test_blockers_own_pr_after_dash(self):
+        # Live #1938: a merged-blocker note trailing the ref.
+        self.assertEqual(
+            self._nums("#1937 — **MERGED** (PR #2013, 2026-06-25); the reference now exists."),
+            ["1937"],
+        )
+
+    def test_genuine_multi_ref_list_survives(self):
+        self.assertEqual(self._nums("#100, #101"), ["100", "101"])
+
+    def test_per_ref_annotated_list_survives(self):
+        # Each ref carries its own parenthetical — every segment's first ref is
+        # declared, so neither is mistaken for prose.
+        self.assertEqual(self._nums("#100 (done), #101 (still open)"), ["100", "101"])
+
+    def test_and_spelled_list_survives(self):
+        self.assertEqual(self._nums("#100 and #101"), ["100", "101"])
+
+    def test_cross_repo_qualifier_survives_in_list(self):
+        self.assertEqual(self._nums("#324, jakildev/IrredenEngine#2666"),
+                         ["324", "2666"])
+
+    def test_prose_ref_with_blocker_verb_still_gates(self):
+        # #1910's anti-evasion guard, now reused for enumeration: prose that
+        # restates a real dependency must not be droppable.
+        self.assertEqual(self._nums("#100 — also blocked by #999"), ["100", "999"])
+        self.assertEqual(self._nums("#100 (depends on #999 too)"), ["100", "999"])
+
+    def test_leading_prose_ref_is_declared(self):
+        # No earlier ref in the segment ⇒ declared, whatever introduces it.
+        self.assertEqual(self._nums("waiting on #500"), ["500"])
+
+    def test_duplicate_mention_collapses(self):
+        # Live irreden#72: the same blocker restated in its own prose used to
+        # read as two, which also cost the stackable offer.
+        self.assertEqual(
+            self._nums("#83 (game does not build against engine master — see #83)"),
+            ["83"],
+        )
+
+    def test_leading_none_value_keeps_every_ref(self):
+        # A `(none) — …` value is #1910's territory; #2783 stays out of it so
+        # that corpus is byte-identical. Live #1923's shape.
+        self.assertEqual(
+            self._nums("(none) — touches shaders shared with #1883/#1884; per #1881's rule"),
+            ["1883", "1884", "1881"],
+        )
+
+    def test_sentinel_rows_unchanged(self):
+        # The `(none) — #N` corpus is deliberately conservative (#1910): a ref
+        # with neither qualifier still gates. #2783 must not move it.
+        self.assertFalse(
+            fbb.is_no_blocker_value("(none) — #2278 is expected to merge independently"))
+        self.assertTrue(
+            fbb.is_no_blocker_value("(none — runs in parallel with #2497)"))
+
+
+class BlockerRefsCountsProseForTheGate(unittest.TestCase):
+    """#2783's counterpart lock: `blocker_refs` must keep counting prose refs.
+
+    A parenthetical PR ref is load-bearing for the *blocking gate*: #1281
+    resolves it against PR state, so it keeps gating until that PR is MERGED,
+    and the signal lives only in the prose. Narrowing `blocker_refs` to
+    declared refs would let a worker claim a task whose base has not merged, so
+    the two questions stay separate on purpose — `test_fleet_claim_blockers.sh`
+    T2 is the end-to-end lock.
+    """
+
+    def test_parenthetical_pr_ref_still_counted(self):
+        self.assertEqual(
+            fbb.blocker_refs("**Blocked by:** #100 (PR #201 must merge — context)\n",
+                             "jakildev/IrredenEngine"),
+            [("jakildev/IrredenEngine", "100"), ("jakildev/IrredenEngine", "201")],
+        )
+
+    def test_blockers_own_pr_still_counted(self):
+        # The very value #2783 fixes for *eligibility* is unchanged here.
+        self.assertEqual(
+            fbb.blocker_refs("**Blocked by:** #2770 (PR #2772 — lands the shape)\n",
+                             "jakildev/IrredenEngine"),
+            [("jakildev/IrredenEngine", "2770"), ("jakildev/IrredenEngine", "2772")],
+        )
+
+
 class HasBlockedByField(unittest.TestCase):
     def test_present_forms(self):
         for body in ("**Blocked by:** #5\n", "**Blocked by:** (none)\n",

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -282,6 +282,32 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         self.assertEqual(task["stackable_blocker_pr"]["headRefName"],
                          "claude/1308-per-axis-trixel-canvas-infra")
 
+    def test_single_ref_whose_prose_names_the_blockers_own_pr_enriched(self):
+        """#2783 — the prose ref is the blocker's OWN PR, i.e. the very base a
+        stacker should stack on, and counting it as a second blocker withheld
+        that offer for the blocker's whole pre-merge window.
+
+        Live shape at filing: engine #2780 blocked by "#2770 (PR #2772 — …)",
+        where PR #2772's head is claude/2770-witness-roster-empty."""
+        tasks = [_task("#2780", "#2770 (PR #2772 — lands the `_roster_warn` "
+                                "shape this generalizes; rebase on it)")]
+        prs = [_pr(2772, "claude/2770-witness-roster-empty", author="jakildev")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 2772)
+
+    def test_prose_ref_restating_a_dependency_still_blocks(self):
+        """#2783 must not become an evasion hole: prose carrying a blocker verb
+        is a real second blocker, so no offer (#1910's guard, reused)."""
+        tasks = [_task("#999", "#101 — also blocked by #102")]
+        prs = [_pr(1, "claude/101-x"), _pr(2, "claude/102-y")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
     # ---- #1751: non-stackable base-state rejection (offer side) -----------
 
     def _assert_no_offer(self, labels=None, cached_files="unset"):

--- a/scripts/fleet/tests/test_live_blocker_resolution.py
+++ b/scripts/fleet/tests/test_live_blocker_resolution.py
@@ -105,6 +105,28 @@ class TestResolveBlockedBy(unittest.TestCase):
             resolve_blocked_by(state)
         self.assertEqual(tasks[0]["blocked_by"], "#101")
 
+    def test_prose_ref_stashes_declared_only_view(self):
+        """#2783 — normalization throws the prose away, so the declared-only
+        view is captured alongside it for stackable eligibility. `blocked_by`
+        itself still carries both refs: the parenthetical PR gates the claim
+        (#1281), it just isn't a second *declared* blocker."""
+        tasks = [_task("#2780", "#2770 (PR #2772 — lands the shape this generalizes)")]
+        state = _state(engine_tasks=tasks)
+        with patch.object(_mod.subprocess, "run",
+                          _gh_state_stub({"2770": "OPEN", "2772": "OPEN"})):
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#2770, #2772")
+        self.assertEqual(tasks[0]["blocked_by_declared"], "#2770")
+
+    def test_no_declared_field_when_prose_adds_nothing(self):
+        """The field is absent for the overwhelming majority of tasks — it
+        appears only where the prose actually inflated the count."""
+        tasks = [_task("#200", "#101")]
+        state = _state(engine_tasks=tasks)
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN"})):
+            resolve_blocked_by(state)
+        self.assertNotIn("blocked_by_declared", tasks[0])
+
     def test_both_refs_closed_resolves_to_none(self):
         """Both refs closed → (none)."""
         tasks = [_task("#200", "#100, #102")]

--- a/scripts/fleet/tests/test_live_blocker_resolution.py
+++ b/scripts/fleet/tests/test_live_blocker_resolution.py
@@ -242,6 +242,31 @@ class TestResolveAndEnrichIntegration(unittest.TestCase):
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr", state["repos"]["engine"]["tasks"]["open"][0])
 
+    def test_declared_view_emptying_out_still_offers_the_gate_ref(self):
+        """#2783 — the declared-only narrowing may only ADD an offer.
+
+        The declared blocker (#100) closes while the decorative ref (#102) is
+        still open, so the declared view empties to "(none)" while the claim
+        gate still blocks on #102. Reading "(none)" in preference would leave
+        the task un-claimable AND un-stackable; enrich must fall back to
+        `blocked_by` and offer #102's PR."""
+        tasks = [_task("#300", "#100 (context: see #102)")]
+        open_prs = [_pr(536, "claude/102-decorative-work")]
+        state = _state(
+            engine_tasks=tasks,
+            engine_prs=open_prs,
+            closed=[_closed_issue(100)],
+        )
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"102": "OPEN"})):
+            resolve_blocked_by(state)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertEqual(task["blocked_by"], "#102")
+        # The diagnostic field still records that nothing *declared* remains.
+        self.assertEqual(task["blocked_by_declared"], "(none)")
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
+
 
 # ---------------------------------------------------------------------------
 # Part (c) — cross-repo blocker refs (#1522)


### PR DESCRIPTION
## Summary

- `enrich_stackable_blocker_prs` offers a stack base only for **single**-blocker
  tasks, but the count came from a bare `#N` scan over the whole `Blocked by:`
  value — prose included. A task declaring one blocker while naming another
  number in the same line's explanatory text read as multi-blocker and silently
  fell out of the worker's stackable fallback tier for its blocker's entire
  pre-merge window. Nothing logged the demotion.
- The prose ref is almost always **the blocker's own PR** — the very base a
  stacker should stack on. The sentence that tells a human "stack here" was what
  disqualified the machine from offering it.
- Splits the two conflated questions. New `ref_is_decorative` answers *"was this
  ref declared"*, keyed on list segments so `#100, #101` **and** the per-ref
  annotated `#100 (done), #101 (still open)` keep every blocker; #1910's
  blocker-verb clause scan still rescues a prose ref that restates a real
  dependency (`#100 — also blocked by #999`).
- **The blocking gate is deliberately unchanged.** A parenthetical PR ref is
  load-bearing for `blocker_refs` — #1281 resolves it against PR state, so it
  keeps gating until that PR is MERGED. Narrowing it would let a worker claim
  work whose base has not merged, strictly worse than the overcount this fixes.
  `BlockerRefsCountsProseForTheGate` locks that asymmetry from the other side.
- Scoped out of #1910's leading-`none` corpus, so the `(none) — #N` rows keep
  their current conservative verdict.

- **The narrowing may only ADD an offer, never withdraw one.** Review nit:
  `blocked_by_declared` itself resolves to `"(none)"` once every *declared* ref
  resolves while a decorative one has not, and reading that in preference
  skipped the offer — while the gate, which reads `blocked_by`, still blocked on
  the decorative ref. That left the task with no claim *and* no base: the same
  silent demotion, re-entered through the fix. `enrich` now falls back to the
  gate's own value when the declared view empties out. Measured as a regression
  against pre-narrowing behavior, not merely a missed optimization.

Naming note: the issue proposed `declared_blocker_refs`; shipped as the
predicate `ref_is_decorative` instead, so both the scout's key-routing parser
and `_single_blocker_issue` share one rule rather than duplicating a ref-list
walk.

## Test plan

- [x] `python3 -m unittest discover -s scripts/fleet/tests` — **702 passed**
- [x] `bash scripts/fleet/tests/run_all.sh` — **105 suites, 105 passed, 0 failed**
- [x] `bash scripts/fleet/tests/test_fleet_claim_blockers.sh` — **21/21**, incl.
      T2 (the #1281 case). An earlier revision of this change broke T2 by
      narrowing `blocker_refs`; that is why the gate is now locked by its own test.
- [x] `ruff check scripts/` — clean
- [x] Corpus scan over **207 open issues** (143 engine + 64 game), old parse vs new

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| 1 ref for `#2770 (PR #2772 — …)` / `#1961 (PR #2007 …)`; 2 for `#100, #101` | `DecorativeProseRefs` (11 cases) | all pass; `#100 (done), #101 (still open)` and `#100 and #101` also keep both |
| `blocker_refs` behavior byte-identical, asserted | `BlockerRefsCountsProseForTheGate` + `test_fleet_claim_blockers.sh` T1/T2 | gate still returns `['2770','2772']`; 21/21 |
| 4 `(none) — #N` sentinel rows keep their verdict | `test_leading_none_value_keeps_every_ref`, `test_sentinel_rows_unchanged` | `(none) — …#1883/#1884…#1881` → all 3 refs retained, as before |
| Scout offers `stackable_blocker_pr` for #2780 (base PR #2772) | `enrich_stackable_blocker_prs` on the live shape | `{'number': 2772, 'headRefName': 'claude/2770-witness-roster-empty'}` |
| …and for #2015 (base PR #2007) | live state check | **not applicable** — PR #2007 is MERGED, so #2015's ref already resolves as satisfied and there is no open base to offer. The *parse* fix still applies (`['1961','2007']` → `['1961']`); the offer half is moot. |
| Declared view emptying out still offers the gate's ref | `test_declared_view_emptying_out_still_offers_the_gate_ref` | offer restored; confirmed to **fail pre-fix on the offer assertion alone** (the two preceding assertions hold either way, so it keys on the fix's effect) |
| …and the shape's live frequency | old-vs-new over the 3 prose-inflated rows | **0/3 today** — each row's decorative ref is the declared blocker's own PR, so both resolve on the same merge. Needs a decorative ref independent of the blocker (e.g. an issue closed as a dup while its PR stays open) — reachable, and silent when it happens |
| Corpus re-scan: 0 rows suppressed by a prose-only ref | old-vs-new diff over 207 open issues | **4 rows change, all genuine decorations, none loses a blocker**: #2780 `['2770','2772']→['2770']`, #2015 `['1961','2007']→['1961']`, #1938 `['1937','2013']→['1937']`, irreden#72 `['83','83']→['83']` |
| `unittest discover` green | see Test plan | 701 passed |

irreden#72 is a bonus catch — the duplicate-mention variant (`#83 … see #83`),
which a dedupe would fix but this subsumes.

Closes #2783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
