### PR TITLE
fleet: suppress a stackable offer that fleet-claim can never honor (#2775)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1598,6 +1598,11 @@ def enrich_stackable_blocker_prs(state):
     #     filter (b): WIP / amending / design-unblocked / etc. (frozen-design
     #     bases ARE accepted; see fleet_stack_base)
     #   - downstream task's area files appear in the blocker PR diff (filter a)
+    #   - the task's OWN issue already has an open implementation PR
+    #     (`inflight_pr`, set by enrich_inflight_pr_tasks — which must run
+    #     first) — fleet-claim's duplicate-open-PR guard refuses every
+    #     `--stackable-on` claim such an offer would enable, so emitting it is
+    #     a dead affordance the worker pays a round-trip to discover (#2586)
     #
     # Engine and game tasks are both enriched; worker pickup only honors
     # the field for engine in v1 (the merger's cascade-rebase doesn't
@@ -1614,6 +1619,14 @@ def enrich_stackable_blocker_prs(state):
             blocked_by = (task.get("blocked_by") or "").strip()
             issue_num = _single_blocker_issue(blocked_by)
             if not issue_num:
+                continue
+            if task.get("inflight_pr"):
+                # #2586: the task's own issue already has an open PR, so
+                # fleet-claim's duplicate-open-PR guard refuses every
+                # `--stackable-on` claim this offer would enable — don't
+                # advertise a claim no worker can complete.
+                log(f"stackable offer suppressed: {repo_key} {task.get('id')} "
+                    f"already has inflight_pr #{task['inflight_pr'].get('number')}")
                 continue
             # _single_blocker_issue returns a digit string; closes_issues holds
             # ints — compare as int so "255" in [255] doesn't silently miss.
@@ -2854,6 +2867,12 @@ def tick_once():
         resolve_human_approved_blockers(state)
         resolve_needs_plan_blocked_by(state)
         resolve_epic_children(state)
+        # enrich_inflight_pr_tasks must run before enrich_stackable_blocker_prs
+        # — the stackable pass reads a task's `inflight_pr` field to suppress
+        # a doomed offer on a task whose own issue already has an open PR
+        # (#2775); neither pass reads pr["body"], so this ordering is safe
+        # relative to the body-pop below.
+        enrich_inflight_pr_tasks(state)
         enrich_stackable_blocker_prs(state)
         # Drop PR bodies so they don't bloat state.json or the per-role slices
         # — mirrors resolve_human_approved_blockers popping issue bodies. Safe
@@ -2865,7 +2884,6 @@ def tick_once():
         for _repo_state in state["repos"].values():
             for _pr in _repo_state.get("prs", []):
                 _pr.pop("body", None)
-        enrich_inflight_pr_tasks(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 
     if authoritative:

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -389,6 +389,35 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         self.assertIn("stackable_blocker_pr",
                       state["repos"]["engine"]["tasks"]["open"][0])
 
+    # ---- #2775: suppress the offer when the task's own issue has a PR -----
+
+    def test_own_inflight_pr_suppresses_offer(self):
+        """A task carrying `inflight_pr` (its own issue already has an open
+        PR) must not also get a `stackable_blocker_pr` offer — fleet-claim's
+        duplicate-open-PR guard refuses every claim such an offer would
+        enable (#2586), so emitting it advertises a claim no worker can
+        complete."""
+        task = _task("#2321", "#2385")
+        task["inflight_pr"] = {"number": 2393, "headRefName": "claude/2321-x",
+                                "parked": False}
+        prs = [_pr(2654, "claude/2385-sun-splat-coverage")]
+        state = _state(engine_tasks=[task], engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_no_inflight_pr_still_offered(self):
+        """Guard against over-suppression: a task with a stackable blocker
+        and no `inflight_pr` field still gets its offer (the game #287 /
+        #345 shape from #2775)."""
+        task = _task("#287", "#285")
+        prs = [_pr(339, "claude/285-x")]
+        state = _state(engine_tasks=[task], engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        out = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", out)
+        self.assertEqual(out["stackable_blocker_pr"]["number"], 339)
+
     def test_closes_n_offer_survives_304_reuse(self):
         """#2442: the Closes-#N offer must survive the 304-reuse path. The
         prev list fetch_prs serves on a 304 is body-stripped (exactly what


### PR DESCRIPTION
## Summary
- `enrich_stackable_blocker_prs` attached a `stackable_blocker_pr` offer to a
  task even when the task's own issue already had an open PR (`inflight_pr`).
  `fleet-claim`'s duplicate-open-PR guard refuses every `--stackable-on`
  claim such an offer enables, so the offer was a dead affordance a worker
  paid a full round-trip to discover (#2586's refusal case).
- Reorders `enrich_inflight_pr_tasks` ahead of `enrich_stackable_blocker_prs`
  in `tick_once()` so the stackable pass can read the task's `inflight_pr`
  field (computed by the inflight pass) and skip. Neither pass reads
  `pr["body"]`, so the reorder is safe relative to the body-pop step between
  them.
- The suppression is logged (`log("stackable offer suppressed: ...")`) per
  #2761 — a silent skip in this exact enrichment pass previously cost three
  worker iterations to diagnose (#2523).
- The blocking gate itself (`blocked_by` resolution, `fleet-claim`'s refusal)
  is unchanged — only the scout's *offer* is suppressed.

## Test plan
- [x] `python3 -m unittest discover -s scripts/fleet/tests` — 703 passed
      (701 pre-existing + 2 new)
- [x] `bash scripts/fleet/tests/run_all.sh` — 105 suites, 105 passed, 0 failed
- [x] `ruff check scripts/` — clean
- [x] Manually verified the new regression test fails without the fix (the
      `inflight_pr` skip is the only thing suppressing the offer; removing it
      reproduces the exact live shape from the issue — engine #2321,
      `inflight_pr` #2393, `stackable_blocker_pr` #2654)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| A task carrying both `inflight_pr` and a would-be `stackable_blocker_pr` emits no `stackable_blocker_pr`, and the suppression is logged | `test_own_inflight_pr_suppresses_offer` + inline `log()` call added at the suppression site | field absent; `log()` emits `stackable offer suppressed: <repo> <id> already has inflight_pr #<N>` |
| A task with a stackable blocker and no `inflight_pr` still gets its offer (guard against over-suppression) | `test_no_inflight_pr_still_offered` (game #287/#345 shape) | `stackable_blocker_pr` present, correct PR number |
| New hermetic test case in `scripts/fleet/tests/` covering both arms | `test_enrich_stackable_blocker_prs.py` | 2 new tests added, both pass |
| `run_all.sh` green | see Test plan | 105/105 |

Closes #2775

🤖 Generated with [Claude Code](https://claude.com/claude-code)