### PR TITLE
fleet: witness's STALE branches escalate-then-quiet like ROSTER EMPTY (#2780)

### DIFF
--- a/scripts/fleet/tests/test_witness_roster.sh
+++ b/scripts/fleet/tests/test_witness_roster.sh
@@ -9,10 +9,11 @@
 # roster with zero tracked heartbeats gets a distinct ROSTER EMPTY warning
 # and a `witness-roster.stuck` alert file instead of "all healthy".
 #
-# The roster-empty condition holds until a human acts, so the warning must
-# escalate-then-quiet rather than re-emit every 60 s forever (see
+# Every condition witness warns on holds until a human acts, so each warning
+# must escalate-then-quiet rather than re-emit every 60 s forever (see
 # scripts/fleet/CLAUDE.md §"An every-tick guard that warns must
-# escalate-then-quiet"). Case (d) pins that rate-limiting.
+# escalate-then-quiet"). Cases (d)-(g) pin that rate-limiting on all three
+# branches: roster-empty (#2770), stale agent and dead dispatcher (#2780).
 #
 # Hermetic: HOME points at a temp dir per case, and the FLEET_* overrides
 # witness honours are scrubbed from the caller's environment, so no live
@@ -30,6 +31,15 @@
 #       witness.log stops growing, witness-roster.stuck keeps refreshing its
 #       count past N, and a rostered heartbeat clears counter + alert so the
 #       next outage escalates from scratch
+#   (e) a persistently-stale agent => same escalate-then-quiet shape on its own
+#       per-agent counter, <agent>.stuck still refreshed past N, and a
+#       heartbeat refresh restarts the streak
+#   (f) two agents stale at once => independent counters; neither resets the
+#       other, both escalate at N, and one recovering leaves the other's
+#       streak intact
+#   (g) a dead dispatcher pid => same shape on .witness-stale-dispatcher-skip,
+#       a new dead pid restarts the streak (the pid is the subject), and a
+#       live pid clears counter + alert
 
 set -uo pipefail
 
@@ -56,11 +66,11 @@ run_witness() {
     local fake_home="$1" escalate_n="${2:-}"
     mkdir -p "$fake_home/.fleet/heartbeats"
     local -a env_args=(
-        -u FLEET_ALERTS_DIR -u FLEET_STATE_DIR -u FLEET_WITNESS_ROSTER_ESCALATE_N
+        -u FLEET_ALERTS_DIR -u FLEET_STATE_DIR -u FLEET_WITNESS_ESCALATE_N
         "HOME=$fake_home"
     )
     if [[ -n "$escalate_n" ]]; then
-        env_args+=("FLEET_WITNESS_ROSTER_ESCALATE_N=$escalate_n")
+        env_args+=("FLEET_WITNESS_ESCALATE_N=$escalate_n")
     fi
     env "${env_args[@]}" "$WITNESS" --once > "$fake_home/out.txt" 2>&1
 }
@@ -183,5 +193,147 @@ assert_contains "$out_d_again" "ROSTER EMPTY" "after clear: warns loudly again"
 assert_absent   "$out_d_again" "ESCALATION"   "after clear: streak restarted, not resumed"
 assert_contains "$(cat "$alert_d" 2>/dev/null || true)" "count=1" \
     "after clear: count restarts at 1"
+
+# --- (e) persistently-stale agent: escalate, then quiet ---------------------
+# Same rule as (d), on the other unbounded-append branch (#2780). The agent
+# stays stale until a human acts, so the loud line must stop while
+# <agent>.stuck keeps being refreshed every pass.
+
+home_e="$TMP/home-stale-escalate"
+mkdir -p "$home_e/.fleet/heartbeats"
+touch -t 202401010000 "$home_e/.fleet/heartbeats/opus-architect"
+counter_e="$home_e/.fleet/state/.witness-stale-opus-architect-skip"
+alert_e="$home_e/.fleet/alerts/opus-architect.stuck"
+log_e="$home_e/.fleet/logs/witness.log"
+
+run_witness "$home_e" 3
+assert_contains "$(cat "$home_e/out.txt")" "STALE: opus-architect" \
+    "stale pass 1 (< N): still warns loudly"
+assert_absent "$(cat "$home_e/out.txt")" "ESCALATION" \
+    "stale pass 1 (< N): has not escalated yet"
+[[ -f "$counter_e" ]] \
+    && ok "stale pass 1 (< N): per-agent counter written" \
+    || bad "stale pass 1 (< N): per-agent counter written"
+
+run_witness "$home_e" 3
+run_witness "$home_e" 3
+out_e3=$(cat "$home_e/out.txt")
+assert_contains "$out_e3" "STALE ESCALATION" "stale pass N: escalates once"
+assert_contains "$out_e3" "3 consecutive passes" "stale pass N: names the streak length"
+log_lines_at_n_e=$(wc -l < "$log_e" 2>/dev/null || echo 0)
+
+# Past N: silent on stdout and in the log. Delete the alert first so its
+# recreation proves witness still writes the durable signal past the
+# escalation instead of freezing it there.
+rm -f "$alert_e"
+run_witness "$home_e" 3
+out_e4=$(cat "$home_e/out.txt")
+assert_absent "$out_e4" "STALE: opus-architect" "stale pass N+1: quiet on stdout"
+assert_absent "$out_e4" "all healthy" "stale pass N+1: quiet does not become a health claim"
+[[ -f "$alert_e" ]] \
+    && ok "stale pass N+1: <agent>.stuck still refreshed past N" \
+    || bad "stale pass N+1: <agent>.stuck still refreshed past N"
+log_lines_after_e=$(wc -l < "$log_e" 2>/dev/null || echo 0)
+assert_eq "$log_lines_after_e" "$log_lines_at_n_e" \
+    "past N: witness.log stops growing on the stale branch"
+
+# A heartbeat refresh clears that subject's counter, so a later re-stale
+# escalates from scratch rather than resuming the quieted streak.
+touch "$home_e/.fleet/heartbeats/opus-architect"
+run_witness "$home_e" 3
+assert_contains "$(cat "$home_e/out.txt")" "all healthy" "stale: fresh heartbeat reports health"
+[[ -f "$counter_e" ]] \
+    && bad "stale: fresh heartbeat clears the counter" \
+    || ok "stale: fresh heartbeat clears the counter"
+
+touch -t 202401010000 "$home_e/.fleet/heartbeats/opus-architect"
+run_witness "$home_e" 3
+out_e_again=$(cat "$home_e/out.txt")
+assert_contains "$out_e_again" "STALE: opus-architect" "stale after clear: warns loudly again"
+assert_absent "$out_e_again" "ESCALATION" "stale after clear: streak restarted, not resumed"
+
+# --- (f) two agents stale at once: independent counters ---------------------
+# The discriminating case for the per-subject <tag>. On one shared counter the
+# two warns would each see the other's key, reset to 1 every pass, and never
+# reach N at all.
+
+home_f="$TMP/home-stale-two"
+mkdir -p "$home_f/.fleet/heartbeats"
+touch -t 202401010000 "$home_f/.fleet/heartbeats/opus-architect"
+touch -t 202401010000 "$home_f/.fleet/heartbeats/game-architect"
+
+run_witness "$home_f" 3
+run_witness "$home_f" 3
+run_witness "$home_f" 3
+out_f=$(cat "$home_f/out.txt")
+assert_contains "$out_f" "STALE: opus-architect" "two stale: first agent still warned at N"
+assert_contains "$out_f" "STALE: game-architect" "two stale: second agent still warned at N"
+assert_eq "$(grep -c "STALE ESCALATION" <<< "$out_f")" "2" \
+    "two stale: both escalate on the same pass (neither reset the other)"
+for a in opus-architect game-architect; do
+    c=$(awk '{print $1}' "$home_f/.fleet/state/.witness-stale-$a-skip" 2>/dev/null || echo "")
+    assert_eq "$c" "3" "two stale: $a kept its own streak"
+done
+
+# Clearing one must not touch the other's streak.
+touch "$home_f/.fleet/heartbeats/opus-architect"
+run_witness "$home_f" 3
+[[ -f "$home_f/.fleet/state/.witness-stale-opus-architect-skip" ]] \
+    && bad "two stale: recovered agent's counter cleared" \
+    || ok "two stale: recovered agent's counter cleared"
+assert_eq "$(awk '{print $1}' "$home_f/.fleet/state/.witness-stale-game-architect-skip" 2>/dev/null || echo "")" \
+    "4" "two stale: still-stale agent's streak untouched by the other's recovery"
+
+# --- (g) dead dispatcher pid: escalate, then quiet --------------------------
+# A rostered heartbeat keeps tracked>0 so this exercises the dispatcher branch
+# alone, not roster-empty.
+
+home_g="$TMP/home-dispatcher"
+mkdir -p "$home_g/.fleet/heartbeats" "$home_g/.fleet/state"
+touch "$home_g/.fleet/heartbeats/opus-architect"
+echo 999999 > "$home_g/.fleet/state/dispatcher.pid"
+counter_g="$home_g/.fleet/state/.witness-stale-dispatcher-skip"
+alert_g="$home_g/.fleet/alerts/fleet-dispatcher.stuck"
+
+run_witness "$home_g" 3
+assert_contains "$(cat "$home_g/out.txt")" "STALE: fleet-dispatcher" \
+    "dead dispatcher pass 1 (< N): still warns loudly"
+assert_absent "$(cat "$home_g/out.txt")" "all healthy" \
+    "dead dispatcher: a dead dispatcher is not health"
+
+run_witness "$home_g" 3
+run_witness "$home_g" 3
+assert_contains "$(cat "$home_g/out.txt")" "STALE ESCALATION" \
+    "dead dispatcher pass N: escalates once"
+
+rm -f "$alert_g"
+run_witness "$home_g" 3
+out_g4=$(cat "$home_g/out.txt")
+assert_absent "$out_g4" "STALE: fleet-dispatcher" "dead dispatcher pass N+1: quiet on stdout"
+assert_absent "$out_g4" "all healthy" "dead dispatcher pass N+1: quiet is not a health claim"
+[[ -f "$alert_g" ]] \
+    && ok "dead dispatcher pass N+1: fleet-dispatcher.stuck still refreshed past N" \
+    || bad "dead dispatcher pass N+1: fleet-dispatcher.stuck still refreshed past N"
+
+# A relaunched-but-also-dead dispatcher is a NEW outage: the pid is the
+# subject, so the streak restarts rather than staying quiet under the old one.
+echo 999998 > "$home_g/.fleet/state/dispatcher.pid"
+run_witness "$home_g" 3
+out_g_newpid=$(cat "$home_g/out.txt")
+assert_contains "$out_g_newpid" "STALE: fleet-dispatcher (pid 999998" \
+    "dead dispatcher: a new dead pid warns loudly again"
+assert_absent "$out_g_newpid" "ESCALATION" \
+    "dead dispatcher: new pid restarts the streak, not resumes it"
+
+# A live pid clears the counter, so a later death escalates from scratch.
+echo $$ > "$home_g/.fleet/state/dispatcher.pid"
+run_witness "$home_g" 3
+assert_contains "$(cat "$home_g/out.txt")" "all healthy" "live dispatcher: reports health"
+[[ -f "$counter_g" ]] \
+    && bad "live dispatcher: counter cleared" \
+    || ok "live dispatcher: counter cleared"
+[[ -f "$alert_g" ]] \
+    && bad "live dispatcher: alert cleared" \
+    || ok "live dispatcher: alert cleared"
 
 summarize "witness roster tests"

--- a/scripts/fleet/tests/test_witness_roster.sh
+++ b/scripts/fleet/tests/test_witness_roster.sh
@@ -336,4 +336,28 @@ assert_contains "$(cat "$home_g/out.txt")" "all healthy" "live dispatcher: repor
     && bad "live dispatcher: alert cleared" \
     || ok "live dispatcher: alert cleared"
 
+# A removed pidfile clears both artifacts too. Nothing asserts a dead
+# dispatcher without one, so a streak and a .stuck alert raised while it
+# existed must not outlive it — the alert especially, since past N it is the
+# only standing signal and no later pass could rewrite or clear it.
+echo 999997 > "$home_g/.fleet/state/dispatcher.pid"
+run_witness "$home_g" 3
+assert_contains "$(cat "$home_g/out.txt")" "STALE: fleet-dispatcher (pid 999997" \
+    "removed pidfile: precondition — a dead pid raises the streak and the alert"
+[[ -f "$counter_g" && -f "$alert_g" ]] \
+    && ok "removed pidfile: precondition — counter and alert both on disk" \
+    || bad "removed pidfile: precondition — counter and alert both on disk"
+
+rm -f "$home_g/.fleet/state/dispatcher.pid"
+run_witness "$home_g" 3
+out_g_nopid=$(cat "$home_g/out.txt")
+assert_absent "$out_g_nopid" "STALE: fleet-dispatcher" \
+    "removed pidfile: no dead-dispatcher claim without a recorded pid"
+[[ -f "$counter_g" ]] \
+    && bad "removed pidfile: counter cleared" \
+    || ok "removed pidfile: counter cleared"
+[[ -f "$alert_g" ]] \
+    && bad "removed pidfile: alert cleared" \
+    || ok "removed pidfile: alert cleared"
+
 summarize "witness roster tests"

--- a/scripts/fleet/witness
+++ b/scripts/fleet/witness
@@ -14,10 +14,14 @@
 # If NO rostered agent has ever written a heartbeat (roster misconfigured,
 # or every rostered role retired), witness does not report "all healthy" —
 # tracking zero agents is not health. It logs a ROSTER EMPTY warning and
-# writes ~/.fleet/alerts/witness-roster.stuck instead. That condition holds
-# until a human acts, so the warning escalates-then-quiets: loud for the
-# first N consecutive passes, then silent while the alert file keeps being
-# refreshed every pass. A rostered heartbeat clears counter and alert.
+# writes ~/.fleet/alerts/witness-roster.stuck instead.
+#
+# Every one of those conditions — stale agent, dead dispatcher, empty roster —
+# holds until a human acts, so each warning escalates-then-quiets on its own
+# counter: loud for the first N consecutive passes, then silent while the
+# alert file keeps being refreshed every pass. A healthy pass for that subject
+# (a fresh heartbeat, a live dispatcher pid, a rostered heartbeat) clears its
+# counter, so a later recurrence escalates from scratch.
 #
 # Usage:
 #   witness          run continuously (normal fleet pane mode)
@@ -74,107 +78,115 @@ file_mtime() {
     python3 -c "import os, sys; print(int(os.path.getmtime(sys.argv[1])))" "$1"
 }
 
-# --- roster-empty escalation --------------------------------------------------
-# run_one_pass runs unattended every 60 s and the roster-empty condition stays
-# true until a human acts (it means no rostered agent writes a heartbeat at
-# all), so a plain per-pass warn re-emits identically forever — spam that buries
-# the outage instead of reporting it, and grows witness.log without bound. Count
-# consecutive zero-tracked passes; emit the loud line up to the Nth, then go
-# quiet. See scripts/fleet/CLAUDE.md §"An every-tick guard that warns must
-# escalate-then-quiet" (#2363); fleet-clone-freshness.sh's _freshness_warn is
-# the reference shape.
+# --- escalate-then-quiet warnings ---------------------------------------------
+# run_one_pass runs unattended every 60 s and every condition it warns on — a
+# stale agent heartbeat, a dead dispatcher pid, an empty roster — stays true
+# until a human acts, so a plain per-pass warn re-emits identically forever:
+# spam that buries the outage instead of reporting it, and grows witness.log
+# without bound. Count consecutive passes per subject; emit the loud line up to
+# the Nth, then go quiet. See scripts/fleet/CLAUDE.md §"An every-tick guard that
+# warns must escalate-then-quiet" (#2363); fleet-clone-freshness.sh's
+# _freshness_warn is the reference shape.
 #
-# Counter: $STATE_DIR/.witness-roster-skip
-#          one line, "<count> <first_seen_epoch> <reason>|<roster>"
-# Alert:   $ALERT_DIR/witness-roster.stuck
+# Counter: $STATE_DIR/.witness-<tag>-skip
+#          one line, "<count> <first_seen_epoch> <reason>|<subject>"
 #
-# Deliberate deviation from _freshness_warn: the alert is written from the FIRST
-# pass, not only from the Nth. witness has always written it on every pass and
-# it is not the noisy channel — one file, overwritten, never appended — so
-# gating it behind N would remove a durable signal rather than reduce noise.
-# Only the stdout/log line is rate-limited. It keeps being rewritten past N per
-# the sub-rule: once the loud channel is quiet the file is the only standing
-# signal, so a write-once alert would freeze its count/age at the escalation
-# instant and let a human clearing the alerts inbox silence a still-live
-# condition forever.
+# The <tag> is what keeps the streaks independent: two agents stale at once
+# must not share one counter, or each one's warn would reset the other's tally
+# and neither would ever reach N. The in-file key is the second half of that —
+# a changed <subject> under the same tag (a relaunched dispatcher's new pid) is
+# news again and restarts the tally rather than inheriting one raised against
+# something else.
 #
-# Every counter/alert write is best-effort: a read-only $HOME must not break
-# the health pass this guards.
-ROSTER_COUNTER="$STATE_DIR/.witness-roster-skip"
+# Alert files are NOT written here: each caller already rewrites its own
+# `.stuck` file every pass, which is the durable signal the rule requires past
+# N. Only the stdout/log line is rate-limited — the alert is one file,
+# overwritten, never appended, so gating it behind N would remove a standing
+# signal rather than reduce noise, and freezing it at the escalation instant
+# would let a human clearing the alerts inbox silence a still-live condition
+# forever.
+#
+# Every counter write is best-effort: a read-only $HOME must not break the
+# health pass this guards.
 ROSTER_ALERT="$ALERT_DIR/witness-roster.stuck"
 
-# Consecutive zero-tracked passes before escalating. Passes run ~1/min, so 10 is
+# Consecutive matching passes before escalating. Passes run ~1/min, so 10 is
 # ~10 min — long enough to ride out the boot-time gap before a freshly launched
 # architect pane writes its first heartbeat, and an order of magnitude inside
-# the 2 h staleness threshold above. Roster-empty is strictly worse than a stale
-# heartbeat (nothing is being watched at all), so it must not alert later than
-# staleness would.
-_roster_escalate_n() {
-    local n="${FLEET_WITNESS_ROSTER_ESCALATE_N:-10}"
+# the 2 h staleness threshold above. One N covers every site: roster-empty is
+# strictly worse than a stale heartbeat (nothing is being watched at all), so it
+# must not alert later than staleness would, and a stale agent has already burned
+# its 2 h threshold before the first warn, which dwarfs the escalation delay.
+_witness_escalate_n() {
+    local n="${FLEET_WITNESS_ESCALATE_N:-10}"
     if [[ ! "$n" =~ ^[0-9]+$ ]] || (( n < 1 )); then
         n=10
     fi
     echo "$n"
 }
 
-# _roster_iso8601 <epoch>
+# _witness_iso8601 <epoch>
 # BSD (macOS) spells it `date -r`, GNU spells it `date -d @…`; -r on GNU tries
 # to stat a file and fails, so the chain lands on the right one either way.
-_roster_iso8601() {
+_witness_iso8601() {
     date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
         || date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
         || echo "$1"
 }
 
-# _roster_warn <now_str> <msg>
-# Emit the roster-empty warning, escalating-then-quieting on repetition.
-_roster_warn() {
-    local now_str="$1" msg="$2"
-    local key n now count first prev_key since
-    key="roster-empty|${ROSTER[*]}"
-    n="$(_roster_escalate_n)"
+# _witness_warn <tag> <key> <label> <now_str> <msg> <remedy>
+#   <tag>    counter discriminator — one streak per subject
+#   <key>    "<reason>|<subject>"; a changed subject restarts the tally
+#   <label>  escalation-line prefix, e.g. STALE / ROSTER EMPTY
+#   <msg>    the loud per-pass line (may carry a changing age — keep it OUT of
+#            <key>, or the streak would restart every pass and never quiet)
+#   <remedy> what a human should do, appended to the escalation line
+#
+# Emit <msg>, escalating-then-quieting on repetition. Publishes the streak as
+# _WITNESS_WARN_COUNT / _WITNESS_WARN_SINCE for callers that record it in their
+# own alert file.
+_witness_warn() {
+    local tag="$1" key="$2" label="$3" now_str="$4" msg="$5" remedy="$6"
+    local counter n now count first prev_key since
+    counter="$STATE_DIR/.witness-${tag}-skip"
+    n="$(_witness_escalate_n)"
     now="$(date +%s)"
 
     count=0
     first="$now"
     prev_key=""
-    if [[ -f "$ROSTER_COUNTER" ]]; then
-        read -r count first prev_key < "$ROSTER_COUNTER" 2>/dev/null || true
+    if [[ -f "$counter" ]]; then
+        read -r count first prev_key < "$counter" 2>/dev/null || true
     fi
     [[ "${count:-}" =~ ^[0-9]+$ ]] || count=0
     [[ "${first:-}" =~ ^[0-9]+$ ]] || first="$now"
-    # A changed roster is news again — restart rather than inherit a tally
-    # raised against a different set of agents.
     if [[ "${prev_key:-}" != "$key" ]]; then
         count=0
         first="$now"
     fi
     count=$(( count + 1 ))
 
-    mkdir -p "$(dirname "$ROSTER_COUNTER")" 2>/dev/null || true
-    printf '%s %s %s\n' "$count" "$first" "$key" > "$ROSTER_COUNTER" 2>/dev/null || true
+    mkdir -p "$(dirname "$counter")" 2>/dev/null || true
+    printf '%s %s %s\n' "$count" "$first" "$key" > "$counter" 2>/dev/null || true
 
-    since="$(_roster_iso8601 "$first")"
+    since="$(_witness_iso8601 "$first")"
+    _WITNESS_WARN_COUNT="$count"
+    _WITNESS_WARN_SINCE="$since"
 
     if (( count < n )); then
         echo "[$now_str witness] $msg" | tee -a "$LOG"
     elif (( count == n )); then
         echo "[$now_str witness] $msg" | tee -a "$LOG"
-        echo "[$now_str witness] ROSTER EMPTY ESCALATION: $count consecutive passes tracking zero agents since $since. Wrote $ROSTER_ALERT. Remedy: give each rostered agent (${ROSTER[*]}) a fleet-heartbeat call at its role step 0, or correct the roster. Suppressing further identical warns until a rostered heartbeat appears." | tee -a "$LOG"
+        echo "[$now_str witness] $label ESCALATION: $count consecutive passes since $since. $remedy Suppressing further identical warns until the condition clears." | tee -a "$LOG"
     fi
-
-    mkdir -p "$(dirname "$ROSTER_ALERT")" 2>/dev/null || true
-    printf '%s roster=%s count=%s since=%s\n' \
-        "$now_str" "${ROSTER[*]}" "$count" "$since" \
-        > "$ROSTER_ALERT" 2>/dev/null || true
     return 0
 }
 
-# _roster_all_clear
-# A rostered heartbeat appeared: drop the counter and the alert so the next
-# persistent roster-empty escalates from scratch.
-_roster_all_clear() {
-    rm -f "$ROSTER_COUNTER" "$ROSTER_ALERT" 2>/dev/null || true
+# _witness_all_clear <tag>
+# The condition resolved: drop that subject's counter so the next occurrence
+# escalates from scratch. Callers clear their own alert file alongside.
+_witness_all_clear() {
+    rm -f "$STATE_DIR/.witness-${1}-skip" 2>/dev/null || true
     return 0
 }
 
@@ -201,10 +213,16 @@ run_one_pass() {
             thr_min=$((threshold / 60))
             stale_count=$((stale_count + 1))
             msg="STALE: $agent (last hb ${age_min}m ago, threshold ${thr_min}m)"
-            echo "[$now_str witness] $msg" | tee -a "$LOG"
+            # Per-agent tag: two agents stale at once keep independent streaks.
+            # The age is deliberately absent from the key — it grows every pass,
+            # and keying on it would restart the tally forever.
+            _witness_warn "stale-$agent" "stale-heartbeat|$agent" "STALE" \
+                "$now_str" "$msg" \
+                "Wrote $ALERT_DIR/$agent.stuck, refreshed every pass. Remedy: check the $agent pane — it is alive but not looping, or it died without clearing its heartbeat."
             echo "$now_str $agent age=${age_min}m threshold=${thr_min}m" > "$ALERT_DIR/$agent.stuck"
         else
             rm -f "$ALERT_DIR/$agent.stuck"
+            _witness_all_clear "stale-$agent"
         fi
     done
 
@@ -220,18 +238,34 @@ run_one_pass() {
         if [[ -n "$dispatcher_pid" ]] && ! kill -0 "$dispatcher_pid" 2>/dev/null; then
             stale_count=$((stale_count + 1))
             local msg="STALE: fleet-dispatcher (pid $dispatcher_pid recorded but process is dead)"
-            echo "[$now_str witness] $msg" | tee -a "$LOG"
+            # Subject is the pid: a relaunch that also died is a new outage, so
+            # it escalates on its own streak rather than inheriting the old one.
+            _witness_warn "stale-dispatcher" "dispatcher-dead|$dispatcher_pid" "STALE" \
+                "$now_str" "$msg" \
+                "Wrote $ALERT_DIR/fleet-dispatcher.stuck, refreshed every pass. Remedy: rerun fleet-up to relaunch the dispatcher."
             echo "$now_str dispatcher pid=$dispatcher_pid not running" > "$ALERT_DIR/fleet-dispatcher.stuck"
         else
             rm -f "$ALERT_DIR/fleet-dispatcher.stuck"
+            _witness_all_clear "stale-dispatcher"
         fi
     fi
 
     if [[ "$tracked" -eq 0 ]]; then
         local msg="ROSTER EMPTY: no heartbeat file for any monitored agent (${ROSTER[*]}) — witness is not tracking anyone, this is not health"
-        _roster_warn "$now_str" "$msg"
+        # A changed roster is news again: it is the subject here, so a tally
+        # raised against a different set of agents is not inherited.
+        _witness_warn "roster" "roster-empty|${ROSTER[*]}" "ROSTER EMPTY" \
+            "$now_str" "$msg" \
+            "Wrote $ROSTER_ALERT, refreshed every pass. Remedy: give each rostered agent (${ROSTER[*]}) a fleet-heartbeat call at its role step 0, or correct the roster."
+        # No other site writes this alert, and it is the roster condition's
+        # only durable signal — so it is refreshed every pass, including past N.
+        mkdir -p "$(dirname "$ROSTER_ALERT")" 2>/dev/null || true
+        printf '%s roster=%s count=%s since=%s\n' \
+            "$now_str" "${ROSTER[*]}" "$_WITNESS_WARN_COUNT" "$_WITNESS_WARN_SINCE" \
+            > "$ROSTER_ALERT" 2>/dev/null || true
     else
-        _roster_all_clear
+        _witness_all_clear "roster"
+        rm -f "$ROSTER_ALERT" 2>/dev/null || true
         if [[ "$stale_count" -eq 0 ]]; then
             echo "[$now_str witness] all healthy ($tracked agent(s) tracked)"
         fi

--- a/scripts/fleet/witness
+++ b/scripts/fleet/witness
@@ -248,6 +248,14 @@ run_one_pass() {
             rm -f "$ALERT_DIR/fleet-dispatcher.stuck"
             _witness_all_clear "stale-dispatcher"
         fi
+    else
+        # No pidfile: nothing asserts a dead dispatcher, so neither artifact
+        # may outlive it. A streak raised while the pidfile existed would
+        # otherwise survive its removal, and the .stuck alert — the only
+        # standing signal once the warn goes quiet past N — would become a
+        # file no pass can ever rewrite or clear.
+        rm -f "$ALERT_DIR/fleet-dispatcher.stuck"
+        _witness_all_clear "stale-dispatcher"
     fi
 
     if [[ "$tracked" -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Generalizes PR #2772's `_roster_warn` into a keyed `_witness_warn <tag> <key> <label> <now_str> <msg> <remedy>` that the two `STALE:` branches now call, so a stale agent and a dead dispatcher escalate-then-quiet instead of appending an identical line to `witness.log` every 60 s forever.
- `<tag>` gives each subject its own counter (`$STATE_DIR/.witness-<tag>-skip`), so two agents stale at once keep independent streaks rather than resetting each other. The dispatcher's key is `dispatcher-dead|<pid>` — a relaunched-but-also-dead dispatcher is a new outage and restarts its streak.
- The age stays **out** of the key (`stale-heartbeat|<agent>`): it changes every pass, so keying on it would restart the streak forever and nothing would ever quiet.
- Every healthy arm (`rm -f "$ALERT_DIR/$agent.stuck"`, the dispatcher's live-pid `else`, and — since the nit fix — the no-pidfile `else`) clears its subject's counter and alert, so a later recurrence escalates from scratch and no artifact outlives the condition that raised it.
- `.stuck` alert files are untouched and still rewritten every pass — only the stdout/log emission is rate-limited, per the sub-rule that the file is the only standing signal once the loud channel goes quiet.
- `FLEET_WITNESS_ROSTER_ESCALATE_N` → `FLEET_WITNESS_ESCALATE_N` (one N for every site, per the issue's "do not re-pick a threshold per site"). It had no consumers outside `witness` and its own test, both of which land in this PR.

## Test plan
- [x] `bash scripts/fleet/tests/test_witness_roster.sh` → `69 passed, 0 failed` (was 30 assertions; +34 across the three new cases, +5 for the removed-pidfile sub-case added in the nit fix).
- [x] `bash scripts/fleet/tests/run_all.sh` → `119 suite(s) — 119 passed, 0 failed` (re-measured after the 2026-08-04 rebase onto master; the suite count grew from 106 as master landed new suites).
- [x] Determinism baseline: suite run twice back-to-back, `69 passed, 0 failed` both times.
- [x] `bash -n` clean on both changed files; `witness --help` emits only the header (no code leak past the comment block).
- [x] Hermeticity spot-check: `ls ~/.fleet/state/.witness-*` after the full run → the only match is `.witness-roster-skip`, and it is the **live witness daemon's** file, not test residue: its contents are a real roster key (`39 <epoch> roster-empty|opus-architect game-architect`) and a `witness` process is running on this host. None of the per-tag files this PR introduces (`.witness-stale-heartbeat-skip`, `.witness-dispatcher-dead-skip`) appear, so no test wrote into the live fleet state dir. (The original "no matches" reading was taken on a host with no live daemon — re-worded so a reviewer who sees the match doesn't read it as a leak.)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Persistently-stale agent: loud for first N passes, then nothing on stdout/`witness.log`, while `<agent>.stuck` keeps refreshing | case (e), `bash scripts/fleet/tests/test_witness_roster.sh` | `ok: stale pass N: escalates once` / `ok: stale pass N+1: quiet on stdout` / `ok: past N: witness.log stops growing on the stale branch` / `ok: stale pass N+1: <agent>.stuck still refreshed past N` (alert deleted before the pass, so its reappearance proves the write still runs past N) |
| Same for the dead-dispatcher branch and `fleet-dispatcher.stuck` | case (g), same suite | `ok: dead dispatcher pass N: escalates once` / `ok: dead dispatcher pass N+1: quiet on stdout` / `ok: dead dispatcher pass N+1: fleet-dispatcher.stuck still refreshed past N` |
| Two agents stale at once escalate on independent counters — neither resets the other | case (f), same suite | `ok: two stale: both escalate on the same pass (neither reset the other)` (exactly 2 `STALE ESCALATION` lines on pass N) / `ok: two stale: opus-architect kept its own streak` / `ok: two stale: game-architect kept its own streak` (both counters = 3) / `ok: two stale: still-stale agent's streak untouched by the other's recovery` (= 4 while the other cleared) |
| A heartbeat refresh (or live dispatcher pid) clears that subject's counter, so a later re-stale escalates from scratch | cases (e) + (g), same suite | `ok: stale: fresh heartbeat clears the counter` / `ok: stale after clear: streak restarted, not resumed` / `ok: live dispatcher: counter cleared` / `ok: live dispatcher: alert cleared` |
| Both suites green with new cases; positive control against pre-fix `witness` shows the new assertions red | `WITNESS=/tmp/w_master.sh bash scripts/fleet/tests/test_witness_roster.sh`, where `/tmp/w_master.sh` is `git show origin/master:scripts/fleet/witness` (re-anchored from `origin/claude/2770-witness-roster-empty` after the prefix drop — that branch's tip is now byte-identical to master at both changed paths, and a branch ref disappears at merge while master does not) | `witness roster tests: 52 passed, 17 failed` — red includes `stale pass 1 (< N): per-agent counter written`, `stale pass N: escalates once`, `stale pass N+1: quiet on stdout`, `past N: witness.log stops growing on the stale branch`, `two stale: both escalate on the same pass`, both `two stale: <agent> kept its own streak`, `dead dispatcher pass N: escalates once`, `dead dispatcher pass N+1: quiet on stdout`. Fixed version: 69/69 |
| Nit fix: a removed `dispatcher.pid` clears the streak AND the `.stuck` alert | case (g) removed-pidfile sub-case; positive control `WITNESS=/tmp/w_prenit.sh` = `git show 7d68df250:scripts/fleet/witness` (this PR's own first commit; the rebase rewrote it from `dd8e37d6e`) | Fixed: `69 passed, 0 failed`. Control: `67 passed, 2 failed` — red on exactly `removed pidfile: counter cleared` and `removed pidfile: alert cleared`; the three preconditions/no-claim asserts pass in both arms, so they are not keyed on the fix. |

## Notes for reviewer
- **Positive-control caveat:** 4 of the 17 control failures are the pre-existing roster case (d), not new assertions. They go red because the control binary predates the `FLEET_WITNESS_ROSTER_ESCALATE_N` → `FLEET_WITNESS_ESCALATE_N` rename, so it falls back to N=10 and never escalates within the case's 3 passes. The 13 remaining failures are the genuinely new assertions. The fixed version passes all 69. (The earlier `49 passed, 15 failed` reading in this table was measured against the 64-assertion suite as it stood *before* the nit-fix commit added the 5 removed-pidfile assertions — 49+15=64, not 69 — so it was no longer reproducible against the suite this PR actually ships. Re-run against the final 69-assertion suite: 52/17.)
- **Follow-up, deliberately not folded in:** `_witness_warn`'s counter block (read → validate → key-compare → increment → write) is a near-line-for-line twin of `fleet-clone-freshness.sh`'s `_freshness_warn`, with no shared helper; #2691 adds a third consumer of the shape. Separately — and more consequentially — `scripts/fleet/CLAUDE.md` and `_freshness_warn`'s own comment both cite `fleet-rebase`'s `escalate_if_hung_lock` as "the reference shape", but that function has no counter, no N, and never quiets (it gates on an age ceiling and re-emits on every invocation while the lock stays wedged). I read all three before writing this. Filed as #2795 rather than expanding this PR's surface.

Closes #2780

🤖 Generated with [Claude Code](https://claude.com/claude-code)


