### PR TITLE
build: run the header convention checks on an active CI workflow (#2794)

### DIFF
--- a/.claude/rules/cpp-globals.md
+++ b/.claude/rules/cpp-globals.md
@@ -64,14 +64,6 @@ cmake --build <build-dir> --target header-checks   # pure CMake, no external too
 cmake --build <build-dir> --target lint            # + clang-tidy
 ```
 
-In CI it runs as the **Header Checks** workflow
-(`.github/workflows/header-checks.yml`) on every push and PR touching the
-scanned tree, via `cmake/run_header_checks_standalone.cmake` — same collector,
-same rules, no configure step. The workflow is named here on purpose: "this
-check is executed" is only worth asserting if the reader can go confirm *what*
-executes it. Note that `lint` is not that path — it reaches CI only through
-`quality.yml`, which is disabled (#2718).
-
 It reports the offending file and declaration and fails the target. The
 matcher allows `constexpr` / `const` (including `inline static const`),
 `extern "C"` linkage blocks, and function declarations; allowlisted paths

--- a/.claude/rules/cpp-globals.md
+++ b/.claude/rules/cpp-globals.md
@@ -64,6 +64,14 @@ cmake --build <build-dir> --target header-checks   # pure CMake, no external too
 cmake --build <build-dir> --target lint            # + clang-tidy
 ```
 
+In CI it runs as the **Header Checks** workflow
+(`.github/workflows/header-checks.yml`) on every push and PR touching the
+scanned tree, via `cmake/run_header_checks_standalone.cmake` — same collector,
+same rules, no configure step. The workflow is named here on purpose: "this
+check is executed" is only worth asserting if the reader can go confirm *what*
+executes it. Note that `lint` is not that path — it reaches CI only through
+`quality.yml`, which is disabled (#2718).
+
 It reports the offending file and declaration and fails the target. The
 matcher allows `constexpr` / `const` (including `inline static const`),
 `extern "C"` linkage blocks, and function declarations; allowlisted paths

--- a/.github/workflows/header-checks.yml
+++ b/.github/workflows/header-checks.yml
@@ -1,0 +1,64 @@
+name: Header Checks
+
+# The header convention checks (header-global ban, anonymous namespaces,
+# `*Detail` namespaces) from cmake/run_header_convention_checks.cmake.
+#
+# Standalone for the same reason fleet-tests.yml is: the only other caller of
+# these checks is the `lint` CMake target, which reaches CI solely through
+# quality.yml — disabled at the repo level, so a step added there is inert until
+# it is re-enabled (#2718). See #2794.
+#
+# Runs the checks through cmake/run_header_checks_standalone.cmake, which globs
+# the source tree directly — no configure, no FetchContent, no compiler, so this
+# stays a fast job on a bare runner with cmake.
+#
+# Path-filtered to the C/C++ surface the checks scan plus the cmake files that
+# implement them (same convention as perf-gate.yml and fleet-tests.yml). The two
+# path lists are duplicated because GitHub Actions does not support YAML
+# anchors — keep them in sync.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'engine/**'
+      - 'creations/**'
+      - 'test/**'
+      - 'tools/**'
+      - 'cmake/ir_quality_tools.cmake'
+      - 'cmake/run_header_convention_checks.cmake'
+      - 'cmake/run_header_checks_standalone.cmake'
+      - 'scripts/fleet/tests/test_header_checks_standalone.sh'
+      - '.github/workflows/header-checks.yml'
+  pull_request:
+    paths:
+      - 'engine/**'
+      - 'creations/**'
+      - 'test/**'
+      - 'tools/**'
+      - 'cmake/ir_quality_tools.cmake'
+      - 'cmake/run_header_convention_checks.cmake'
+      - 'cmake/run_header_checks_standalone.cmake'
+      - 'scripts/fleet/tests/test_header_checks_standalone.sh'
+      - '.github/workflows/header-checks.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  header-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # A green check run looks identical whether it scanned everything or
+      # nothing, so prove the detector still fires before trusting it.
+      - name: Positive-control the checker
+        run: bash scripts/fleet/tests/test_header_checks_standalone.sh
+
+      # cmake is preinstalled on ubuntu-latest. Nothing else is needed: the
+      # checks only glob and read text.
+      - name: Run header convention checks
+        run: cmake -DPROJECT_ROOT="$GITHUB_WORKSPACE" -P cmake/run_header_checks_standalone.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ Thumbs.db
 .pr-body.md
 .merger-body.md
 .coding-improvement-body.md
+# run_header_checks_standalone.cmake's scratch file list; it cleans up on
+# success, but a FATAL_ERROR on a real violation leaves it behind.
+.header-checks-files.cmake
 __pycache__/
 
 # creations: keep demos, voxel editor scaffold, and top-level CLAUDE.md; ignore private tools

--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -16,10 +16,19 @@ function(irreden_collect_quality_files out_var)
         "${PROJECT_SOURCE_DIR}/tools"
     )
 
+    # CONFIGURE_DEPENDS re-runs the glob on rebuild, but CMake rejects it
+    # outside configure mode. run_header_checks_standalone.cmake calls this same
+    # function under `cmake -P` so CI can check headers with no configure, so
+    # the flag has to drop out there (#2794).
+    set(glob_mode CONFIGURE_DEPENDS)
+    if(CMAKE_SCRIPT_MODE_FILE)
+        set(glob_mode "")
+    endif()
+
     set(globbed_files "")
     foreach(root IN LISTS search_roots)
         if(EXISTS "${root}")
-            file(GLOB_RECURSE root_files CONFIGURE_DEPENDS
+            file(GLOB_RECURSE root_files ${glob_mode}
                 "${root}/*.h"
                 "${root}/*.hpp"
                 "${root}/*.c"

--- a/cmake/run_header_checks_standalone.cmake
+++ b/cmake/run_header_checks_standalone.cmake
@@ -1,0 +1,54 @@
+# Script-mode entry point for the header convention checks (#2794).
+#
+# The `header-checks` and `lint` targets only exist after a full CMake
+# *configure*, which pulls the whole FetchContent dependency graph and needs a
+# compiler. The checks themselves need neither: irreden_collect_quality_files is
+# a pure file(GLOB_RECURSE) and run_header_convention_checks.cmake only reads
+# text. This wrapper is what lets CI run them on their own:
+#
+#   cmake -DPROJECT_ROOT=<repo-root> -P cmake/run_header_checks_standalone.cmake
+#
+# Deliberately a thin shim. It reuses irreden_collect_quality_files for the file
+# set and delegates every actual rule to run_header_convention_checks.cmake, so
+# the CI path and the `header-checks` / `lint` targets cannot drift into
+# checking different things — the drift #2727 was filed about.
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED PROJECT_ROOT OR PROJECT_ROOT STREQUAL "")
+    message(FATAL_ERROR "PROJECT_ROOT is required.")
+endif()
+string(REPLACE "\"" "" PROJECT_ROOT "${PROJECT_ROOT}")
+get_filename_component(PROJECT_ROOT "${PROJECT_ROOT}" ABSOLUTE)
+
+if(NOT EXISTS "${PROJECT_ROOT}/cmake/ir_quality_tools.cmake")
+    message(FATAL_ERROR
+        "PROJECT_ROOT does not look like the engine repo root: ${PROJECT_ROOT}")
+endif()
+
+# irreden_collect_quality_files globs relative to PROJECT_SOURCE_DIR, which
+# script mode never sets for us.
+set(PROJECT_SOURCE_DIR "${PROJECT_ROOT}")
+include("${PROJECT_ROOT}/cmake/ir_quality_tools.cmake")
+
+irreden_collect_quality_files(quality_files)
+if(quality_files STREQUAL "")
+    message(FATAL_ERROR "No files found under ${PROJECT_ROOT}.")
+endif()
+
+# run_header_convention_checks.cmake consumes a file list as an includable
+# script, not as a variable — write one to a temp path and hand it over.
+set(quality_file_list "${CMAKE_CURRENT_LIST_DIR}/../.header-checks-files.cmake")
+if(DEFINED OUTPUT_FILE_LIST AND NOT OUTPUT_FILE_LIST STREQUAL "")
+    set(quality_file_list "${OUTPUT_FILE_LIST}")
+endif()
+file(WRITE "${quality_file_list}" "set(QUALITY_FILES\n")
+foreach(file_path IN LISTS quality_files)
+    file(APPEND "${quality_file_list}" "    \"${file_path}\"\n")
+endforeach()
+file(APPEND "${quality_file_list}" ")\n")
+
+set(QUALITY_FILE_LIST "${quality_file_list}")
+include("${PROJECT_ROOT}/cmake/run_header_convention_checks.cmake")
+
+file(REMOVE "${quality_file_list}")

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Positive control for cmake/run_header_checks_standalone.cmake.
+#
+# A green header-check run proves nothing on its own: the executor could be
+# scanning zero files, or matching nothing, and would look identical. These
+# tests drive it against a fixture tree that contains a known violation and
+# assert it FAILS, then assert the clean tree passes.
+#
+# Fixture-based rather than run against the real repo, so the suite stays
+# hermetic and never writes into engine/.
+#
+# Covers:
+#   - a mutable namespace-scope global in a header  → exit 1, names the file
+#   - `constexpr` / `const` constants               → exit 0 (not state)
+#   - a clean fixture tree                          → exit 0
+#   - a missing PROJECT_ROOT                        → exit 1 (usage guard)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
+CHECKER="$SCRIPT_DIR/cmake/run_header_checks_standalone.cmake"
+
+source "$(dirname "$0")/lib_assert.sh"
+
+if [[ ! -f "$CHECKER" ]]; then
+    echo "test setup: checker not found at $CHECKER" >&2
+    exit 1
+fi
+if ! command -v cmake >/dev/null 2>&1; then
+    echo "test setup: cmake not on PATH" >&2
+    exit 1
+fi
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# The checker only needs cmake/ to identify a tree as the repo root, plus one
+# of the globbed source roots to have headers in it.
+make_fixture() {
+    local root="$1"
+    mkdir -p "$root/cmake" "$root/engine/include/irreden"
+    cp "$SCRIPT_DIR/cmake/ir_quality_tools.cmake" \
+       "$SCRIPT_DIR/cmake/run_header_convention_checks.cmake" \
+       "$CHECKER" "$root/cmake/"
+    cat > "$root/engine/include/irreden/clean.hpp" <<'EOF'
+#pragma once
+namespace IRFixture {
+constexpr int kCleanConstant = 1;
+const char *const kCleanName = "clean";
+}
+EOF
+}
+
+run_checker() {
+    local root="$1"
+    cmake -DPROJECT_ROOT="$root" -P "$root/cmake/run_header_checks_standalone.cmake" 2>&1
+}
+
+# --- clean tree passes ------------------------------------------------------
+CLEAN="$TMPROOT/clean"
+make_fixture "$CLEAN"
+clean_out=$(run_checker "$CLEAN")
+clean_rc=$?
+assert_eq "0" "$clean_rc" "clean fixture exits 0"
+assert_contains "$clean_out" "Header convention checks scanned" \
+    "clean run reports what it scanned"
+
+# A run that scans nothing would also exit 0 — pin that it saw the fixture.
+assert_absent "$clean_out" "scanned 0 header file(s)" \
+    "clean run actually scanned headers"
+
+# --- a banned mutable global fails ------------------------------------------
+DIRTY="$TMPROOT/dirty"
+make_fixture "$DIRTY"
+cat > "$DIRTY/engine/include/irreden/violation.hpp" <<'EOF'
+#pragma once
+namespace IRFixture {
+inline int g_mutableGlobal = 0;
+}
+EOF
+dirty_out=$(run_checker "$DIRTY")
+dirty_rc=$?
+assert_eq "1" "$dirty_rc" "header global makes the checker exit 1"
+assert_contains "$dirty_out" "violation.hpp" "failure names the offending file"
+assert_contains "$dirty_out" "g_mutableGlobal" "failure names the declaration"
+
+# The clean fixture's constants must not be what tripped it.
+assert_absent "$dirty_out" "clean.hpp" "constexpr/const constants stay allowed"
+
+# --- usage guard ------------------------------------------------------------
+noroot_out=$(cmake -P "$CHECKER" 2>&1)
+noroot_rc=$?
+assert_eq "1" "$noroot_rc" "missing PROJECT_ROOT exits 1"
+assert_contains "$noroot_out" "PROJECT_ROOT is required" \
+    "missing PROJECT_ROOT explains itself"
+
+summarize "run_header_checks_standalone tests"


### PR DESCRIPTION
## Summary
- `#2727` added a working executor for the cpp-globals header-global ban (plus the anonymous-namespace and `*Detail`-namespace checks) but wired it only to the `header-checks` and `lint` CMake targets. `lint` reaches CI from exactly one place — `quality.yml` — which is `disabled_manually` (last three runs all `failure`, 2026-04-11). So the checks ran nowhere, while `.claude/rules/cpp-globals.md` told every agent *"**This check is executed** — don't hand-grep it."*
- Adds a standalone **Header Checks** workflow, for the same reason `fleet-tests.yml` is standalone: a step added to `quality.yml` stays inert until that workflow is re-enabled (#2718).
- New `cmake/run_header_checks_standalone.cmake` reuses `irreden_collect_quality_files` and delegates every rule to the existing executor, so the CI path and the CMake targets cannot drift into checking different things. Verified: both report the same 557 headers.
- `irreden_collect_quality_files` drops `CONFIGURE_DEPENDS` under `cmake -P` (CMake rejects it outside configure mode). No behavior change for the targets.
- Adds a hermetic positive-control suite; the workflow runs it before the real check.

Not a duplicate of #2718 (re-enable `quality.yml` wholesale, still red since April) — this is deliberately the thing you do *instead of* waiting for it, and it stays useful after #2718 lands.

## Test plan
- [x] Standalone entry point on the real tree: `cmake -DPROJECT_ROOT=$PWD -P cmake/run_header_checks_standalone.cmake` → `scanned 557 header file(s)`, rc=0
- [x] Configure-mode target unaffected by the collector edit: `cmake --build build --target header-checks` → re-configured clean, `scanned 557 header file(s)`, rc=0 (same count ⇒ the two paths agree)
- [x] New suite: `bash scripts/fleet/tests/test_header_checks_standalone.sh` → **9 passed, 0 failed**
- [x] **The suite was positive-controlled**: neutering the header-global branch to `if(header_global_failures AND FALSE)` turned it **red on exactly the 3 detection assertions** (6 passed, 3 failed); reverting restored 9/9 with an empty `git diff`
- [x] Full fleet suite unaffected on this host: `scripts/fleet/tests/run_all.sh` → **105 passed, 0 failed** (pre-change baseline, macOS)
- [x] Workflow YAML parses; `push` and `pull_request` path lists verified identical (GitHub Actions has no YAML anchors)
- [x] Test committed executable (`100755`), satisfying the #2750 exec-bit guard

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Checks run in CI on an **active** workflow, path-filtered to the scanned surface | `gh pr checks 2797` on this PR | **`header-checks` fired and passed in 11s** (run 30697545046) — live proof the workflow triggers, which is the exact property #2794 was missing. `fleet-tests` also green (2m0s), so the new suite runs there too. |
| Job runs without a full CMake configure | `cmake -DPROJECT_ROOT=… -P …` on a tree with no build dir | `-- Header convention checks scanned 557 header file(s)` — no FetchContent, no compiler |
| Positive control: a banned header global fails the job; reverting passes | added `engine/include/irreden/zz_positive_control.hpp` with `inline int g_positiveControl = 0;` | `RC=1` naming the file + declaration; after `rm`, `RC=0` at 557 headers. Now permanent as `test_header_checks_standalone.sh` |
| `cpp-globals.md`'s "this check is executed" claim becomes true **without editing that file** | the workflow above | **Met.** The claim is true because of the wiring, not because the text was softened — and the diff no longer touches `.claude/rules/cpp-globals.md`: the +8-line pointer hunk was dropped in `762247f79` per review. Re-verified after the revert: standalone entry point → `scanned 557 header file(s)`, rc=0; `test_header_checks_standalone.sh` → **9 passed, 0 failed**. |

Found on a no-pick opus iteration via the run-the-tooling intake; filed and fixed in the same iteration.

Closes #2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)


