### PR TITLE
fleet: escalate-then-quiet the hung-lock warn + re-point the rule (#2795)

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -137,8 +137,17 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   at N: once stderr goes quiet the file is the only standing signal, so a
   write-once alert freezes its `count=`/age at the escalation instant and —
   worse — lets a human triaging the alerts inbox silence a still-live
-  condition permanently (nothing would ever recreate it). `fleet-rebase`'s
-  `escalate_if_hung_lock` is the reference shape (#2363).
+  condition permanently (nothing would ever recreate it). The reference
+  implementation is `fleet-clone-freshness.sh`'s `_freshness_warn` +
+  `_freshness_all_clear` pair — it is the one that actually counts, keys,
+  escalates at N, and quiets, and `tests/test_clone_freshness.sh` T19–T22
+  is the matching test shape (every-tick loop, N sized in ticks).
+  `fleet-rebase`'s `escalate_if_hung_lock` + `hung_lock_all_clear` is the
+  same cycle for a **one-shot** tool the dispatcher re-invokes: the streak
+  counter lives on disk because there is no in-process loop to hold it, and
+  N is 1 because an age ceiling — not a tick count — does the sizing there
+  (#2363, #2795). Copy whichever matches your call cadence; don't invent a
+  third counter block by hand.
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,

--- a/scripts/fleet/fleet-clone-freshness.sh
+++ b/scripts/fleet/fleet-clone-freshness.sh
@@ -201,8 +201,10 @@ _freshness_warn() {
     # standing signal — hence rewritten every tick past N, not stamped once at
     # it. Write-once would freeze count= at the escalation instant, and would
     # let a human triaging the alerts inbox silence a still-live condition
-    # forever (warns stay suppressed, so nothing recreates the file). Same shape
-    # as fleet-rebase's escalate_if_hung_lock (#2362).
+    # forever (warns stay suppressed, so nothing recreates the file). Only the
+    # flat one-line alert artifact is shared with fleet-rebase's
+    # `fleet-rebase-hung-lock` (#2362); the counter/quiet cycle around it is
+    # this function's own (see #2795).
     if (( count == n )); then
         echo "$msg" >&2
         echo "fleet-clone-freshness: ESCALATION — $root has skipped its advance $count consecutive times (reason=$reason branch='$branch') since $since. Wrote $alert. Remedy: $remedy. Suppressing further identical warns until the condition clears." >&2

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -150,6 +150,11 @@ LOCK_DIR="$STATE_DIR/fleet-rebase.lock.d"
 # tier-0 pass is seconds; anything near 30 min is wedged, not busy.
 FLEET_REBASE_LOCK_HUNG_SECS="${FLEET_REBASE_LOCK_HUNG_SECS:-1800}"
 ALERTS_DIR="${FLEET_ALERTS_DIR:-$HOME/.fleet/alerts}"
+HUNG_LOCK_ALERT="$ALERTS_DIR/fleet-rebase-hung-lock"
+# Streak counter behind the escalate-then-quiet cycle below. Lives beside the
+# lock, not inside it — the EXIT trap rm -rf's LOCK_DIR, which would erase the
+# streak every release.
+HUNG_LOCK_COUNTER="$STATE_DIR/.fleet-rebase-hung-lock-skip"
 
 # Stamp the lock we just created with our pid and acquisition time. The
 # `started` stamp powers the hung-lock escalation below; the EXIT trap removes
@@ -177,6 +182,20 @@ acquire_lock() {
     return 1
 }
 
+# Consecutive contended invocations past the age ceiling before the loud line
+# is suppressed. Defaults to 1 — unlike a per-minute daemon guard, the ceiling
+# has already done the sizing the rule asks for (see the escalate_if_hung_lock
+# header), and fleet-rebase's dispatcher-driven cadence is not fixed, so a
+# tick-count N here would be sized against an unknown wall clock. Overridable
+# for tests and for a host that wants a couple of confirmations first.
+hung_lock_escalate_n() {
+    local n="${FLEET_REBASE_HUNG_LOCK_ESCALATE_N:-1}"
+    if [[ ! "$n" =~ ^[0-9]+$ ]] || (( n < 1 )); then
+        n=1
+    fi
+    echo "$n"
+}
+
 # Hung-lock escalation (#2362): the benign "deferring to the LLM pass" message
 # below reads as ordinary concurrency, so a holder that is alive but wedged on a
 # black-holed network call (the outage that motivated this) went unseen for
@@ -185,8 +204,19 @@ acquire_lock() {
 # alive holder — a mid-rebase kill corrupts the scratch worktree (see the
 # acquire_lock rationale). With every net op now timeout-bounded this alert
 # should be rare-to-never; it exists to make the next silent wedge visible.
+#
+# Escalate-then-quiet (#2795), per scripts/fleet/CLAUDE.md: fleet-rebase is a
+# one-shot invocation, but the dispatcher re-invokes it, and the wedged holder
+# it reports persists until a human acts — so an unguarded `log` re-emits the
+# same line on every trigger until then. Keyed streak on the holder pid: a
+# *different* wedged holder is news again and re-escalates. N is 1 because the
+# ceiling above is the rate limit — reaching this point already means half an
+# hour of wedge, with no transient phase left to wait out. Past N the loud line
+# stops but the alert keeps being rewritten, so a triaged-away inbox re-arms
+# and `count=` stays honest. `hung_lock_all_clear` (the healthy pass, i.e. we
+# got the lock) clears both.
 escalate_if_hung_lock() {
-    local started now age holder
+    local started now age holder key n count first prev_key
     started=$(cat "$LOCK_DIR/started" 2>/dev/null || true)
     # Missing/garbage stamp (a pre-fix holder still running mid-rollout) → skip
     # the age check rather than guess an age.
@@ -195,12 +225,52 @@ escalate_if_hung_lock() {
     age=$(( now - started ))
     (( age > FLEET_REBASE_LOCK_HUNG_SECS )) || return 0
     holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo unknown)
-    log "HUNG-LOCK: $LOCK_DIR held ${age}s by pid $holder (> ${FLEET_REBASE_LOCK_HUNG_SECS}s ceiling) — a wedged holder is starving tier-0 conflict rebasing; investigate (see #2362). Not auto-breaking an alive holder."
+    key="hung-lock|${holder:-unknown}"
+    n="$(hung_lock_escalate_n)"
+
+    count=0
+    first="$now"
+    prev_key=""
+    if [[ -f "$HUNG_LOCK_COUNTER" ]]; then
+        read -r count first prev_key < "$HUNG_LOCK_COUNTER" 2>/dev/null || true
+    fi
+    [[ "${count:-}" =~ ^[0-9]+$ ]] || count=0
+    [[ "${first:-}" =~ ^[0-9]+$ ]] || first="$now"
+    if [[ "${prev_key:-}" != "$key" ]]; then
+        count=0
+        first="$now"
+    fi
+    count=$(( count + 1 ))
+    # Best-effort throughout: a read-only $HOME must never break the defer path.
+    mkdir -p "$(dirname "$HUNG_LOCK_COUNTER")" 2>/dev/null || true
+    printf '%s %s %s\n' "$count" "$first" "$key" > "$HUNG_LOCK_COUNTER" 2>/dev/null || true
+
+    if (( count <= n )); then
+        log "HUNG-LOCK: $LOCK_DIR held ${age}s by pid $holder (> ${FLEET_REBASE_LOCK_HUNG_SECS}s ceiling) — a wedged holder is starving tier-0 conflict rebasing; investigate (see #2362). Not auto-breaking an alive holder."
+    fi
+    if (( count == n )); then
+        log "HUNG-LOCK: escalated after $count consecutive contended run(s) on holder pid $holder; wrote $HUNG_LOCK_ALERT and suppressing further identical lines until the lock clears (see #2795)."
+    fi
+    # count= and escalating_since_epoch= are what make a refreshed alert
+    # distinguishable from one frozen at the escalation instant; age_secs= and
+    # at= already carry the human-readable clock, so `first` ships as a raw
+    # epoch rather than pulling in a third copy of clone-freshness's BSD/GNU
+    # date shim (the two counter blocks still have no shared home — see #2795).
     mkdir -p "$ALERTS_DIR" 2>/dev/null || true
-    printf 'fleet-rebase hung lock: host=%s holder_pid=%s age_secs=%s at=%s\n' \
-        "$(hostname 2>/dev/null || echo '?')" "$holder" "$age" \
+    printf 'fleet-rebase hung lock: host=%s holder_pid=%s age_secs=%s count=%s escalating_since_epoch=%s at=%s\n' \
+        "$(hostname 2>/dev/null || echo '?')" "$holder" "$age" "$count" "$first" \
         "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-        > "$ALERTS_DIR/fleet-rebase-hung-lock" 2>/dev/null || true
+        > "$HUNG_LOCK_ALERT" 2>/dev/null || true
+    return 0
+}
+
+# The condition cleared — we hold the lock, so no holder is wedged. Drop the
+# streak counter and any standing alert so the next wedge escalates from
+# scratch. Without this the alert outlives the outage it reported and the
+# counter never re-arms the loud line.
+hung_lock_all_clear() {
+    rm -f "$HUNG_LOCK_COUNTER" "$HUNG_LOCK_ALERT" 2>/dev/null || true
+    return 0
 }
 
 if ! acquire_lock; then
@@ -214,6 +284,9 @@ if ! acquire_lock; then
     exit 0
 fi
 trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
+# We hold the lock, so nothing is wedged — retire any standing hung-lock signal.
+# After the trap, so the lock we just took is release-protected first.
+hung_lock_all_clear
 
 repo_path_for() {
     case "$1" in

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -224,8 +224,12 @@ escalate_if_hung_lock() {
     now=$(date +%s)
     age=$(( now - started ))
     (( age > FLEET_REBASE_LOCK_HUNG_SECS )) || return 0
-    holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo unknown)
-    key="hung-lock|${holder:-unknown}"
+    # Default once, at the read (acquire_lock's read has the same shape): `cat`
+    # on an *empty* stamp exits 0, so a trailing `|| echo unknown` defaults the
+    # key but leaves the log and alert lines below printing an empty holder.
+    holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+    holder="${holder:-unknown}"
+    key="hung-lock|$holder"
     n="$(hung_lock_escalate_n)"
 
     count=0

--- a/scripts/fleet/tests/test_fleet_rebase_hung_lock.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_hung_lock.sh
@@ -11,6 +11,14 @@
 #   alive holder + fresh `started`      -> benign defer only, no alert
 #   dead holder                         -> stale-break acquires (no escalation)
 #   alive holder + missing `started`    -> no escalation (skip the age check)
+#
+# Escalate-then-quiet (#2795), T5-T8: the wedged holder persists until a human
+# acts and the dispatcher keeps re-invoking this one-shot script, so the loud
+# line must stop after N while the alert keeps refreshing.
+#   N+1 contended invocations           -> loud line once, alert refreshed after
+#   a different wedged holder pid       -> key changed, escalates again
+#   healthy pass (we get the lock)      -> counter + alert cleared
+#   counter wiped every tick            -> positive control: loud line every tick
 
 set -euo pipefail
 
@@ -45,6 +53,7 @@ SDIR="$TMPROOT/state"
 ADIR="$TMPROOT/alerts"
 LOCK="$SDIR/fleet-rebase.lock.d"
 ALERT="$ADIR/fleet-rebase-hung-lock"
+COUNTER="$SDIR/.fleet-rebase-hung-lock-skip"
 mkdir -p "$SDIR"
 
 # Spawn a fresh long-lived process to stand in for an "alive holder"; sets
@@ -65,8 +74,20 @@ run_rebase() {  # runs the real script against the temp dirs; captures combined 
     "$REBASE" --auto 2>&1 || true
 }
 
+run_rebase_n() {  # as run_rebase, but with an explicit FLEET_REBASE_HUNG_LOCK_ESCALATE_N.
+    # Kept separate so run_rebase keeps exercising the *unset* defaulting arm —
+    # passing an empty override there would shadow it (scripts/fleet/CLAUDE.md
+    # "Exercise every arm").
+    FLEET_STATE_DIR="$SDIR" \
+    FLEET_ALERTS_DIR="$ADIR" \
+    FLEET_REBASE_HUNG_LOCK_ESCALATE_N="$1" \
+    "$REBASE" --auto 2>&1 || true
+}
+
 seed_lock() {   # $1 = pid, $2 = started epoch ("" = omit the started file)
-    rm -rf "$LOCK" "$ADIR"
+    # The streak counter is cleared too, so each subtest escalates from scratch;
+    # T5+ deliberately seed once and then re-invoke without re-seeding.
+    rm -rf "$LOCK" "$ADIR" "$COUNTER"
     mkdir -p "$LOCK"
     echo "$1" > "$LOCK/pid"
     [[ -n "$2" ]] && echo "$2" > "$LOCK/started"
@@ -114,6 +135,95 @@ out=$(run_rebase)
 echo "$out" | grep -q "deferring to the LLM pass" && ok "defers" || fail "did not defer: $out"
 echo "$out" | grep -q "HUNG-LOCK" && fail "escalated without a started stamp: $out" || ok "no escalation when started is absent"
 [[ -f "$ALERT" ]] && fail "wrote an alert without a started stamp" || ok "no alert without a started stamp"
+
+# --- T5: N+1 contended invocations -> loud once, alert keeps refreshing ------
+# The dispatcher re-invokes this one-shot script while the wedge persists, so an
+# unguarded `log` would repeat identically forever. Past N stderr goes quiet and
+# the alert file becomes the only standing signal — hence the delete-and-reappear
+# assertion: a human triaging ~/.fleet/alerts must not be able to silence a
+# still-live wedge permanently.
+echo "T5: N+1 contended runs -> one loud HUNG-LOCK, then quiet, alert refreshed"
+spawn_live; hp=$HOLDER_PID
+seed_lock "$hp" "$(( now - 4000 ))"
+t5a=$(run_rebase)
+alert_at_n=$(cat "$ALERT" 2>/dev/null || true)
+rm -f "$ALERT"                                    # human clears the inbox mid-wedge
+t5b=$(run_rebase)
+t5c=$(run_rebase)
+echo "$t5a" | grep -q "HUNG-LOCK" && ok "tick 1 (== N) escalates loudly" || fail "tick 1 did not escalate: $t5a"
+echo "$t5a" | grep -q "suppressing further identical lines" && ok "tick 1 announces the suppression" || fail "no suppression notice: $t5a"
+echo "$alert_at_n" | grep -q "count=1" && ok "alert at N records count=1" || fail "wrong count at N: $alert_at_n"
+echo "$t5b" | grep -q "HUNG-LOCK" && fail "tick 2 (> N) still loud: $t5b" || ok "tick 2 (> N) is quiet"
+echo "$t5c" | grep -q "HUNG-LOCK" && fail "tick 3 (> N) still loud: $t5c" || ok "tick 3 (> N) is quiet"
+echo "$t5b" | grep -q "deferring to the LLM pass" && ok "quiet ticks still defer normally" || fail "quiet tick stopped deferring: $t5b"
+[[ -f "$ALERT" ]] && ok "alert re-created past N (cleared inbox re-arms)" || fail "alert stayed gone past N — wedge permanently silent"
+grep -q "count=3" "$ALERT" 2>/dev/null && ok "refreshed alert carries the current count" || fail "stale count past N: $(cat "$ALERT" 2>/dev/null)"
+
+# --- T6: a different wedged holder is news again -----------------------------
+echo "T6: new holder pid restarts the streak and re-escalates"
+spawn_live; hp2=$HOLDER_PID
+rm -rf "$LOCK"; mkdir -p "$LOCK"                  # new holder, counter deliberately kept
+echo "$hp2" > "$LOCK/pid"
+echo "$(( now - 4000 ))" > "$LOCK/started"
+out=$(run_rebase)
+echo "$out" | grep -q "HUNG-LOCK" && ok "re-escalates for a different holder" || fail "suppressed a new wedged holder: $out"
+grep -q "holder_pid=$hp2" "$ALERT" 2>/dev/null && ok "alert names the new holder" || fail "alert kept the old holder: $(cat "$ALERT" 2>/dev/null)"
+grep -q "count=1" "$ALERT" 2>/dev/null && ok "streak restarted at 1 on the new key" || fail "count did not restart: $(cat "$ALERT" 2>/dev/null)"
+
+# --- T7: a healthy pass clears the counter and the alert ---------------------
+# Acquiring the lock means no holder is wedged. Without the all-clear the alert
+# outlives the outage it reported and the streak never re-arms the loud line.
+echo "T7: healthy pass (lock acquired) clears counter + alert"
+dead2=$(sh -c 'echo $$')
+rm -rf "$LOCK"; mkdir -p "$LOCK"
+echo "$dead2" > "$LOCK/pid"
+echo "$(( now - 4000 ))" > "$LOCK/started"
+[[ -f "$COUNTER" && -f "$ALERT" ]] && ok "fixture starts with a standing counter + alert" || fail "fixture precondition missing"
+out=$(run_rebase)
+echo "$out" | grep -q "breaking stale lock" && ok "acquires by breaking the dead holder's lock" || fail "did not acquire: $out"
+[[ ! -f "$COUNTER" ]] && ok "counter removed on the healthy pass" || fail "counter survived: $(cat "$COUNTER" 2>/dev/null)"
+[[ ! -f "$ALERT" ]] && ok "alert removed on the healthy pass" || fail "alert survived: $(cat "$ALERT" 2>/dev/null)"
+
+# --- T8: positive control -- without the counter the quiet assertions fail ----
+# Discriminates on a runtime condition, not on whether the fix is present at some
+# ref: wiping the counter between ticks reproduces exactly the pre-#2795 state
+# (no persisted streak), so it can never invert once this change is committed.
+# If T5's "tick 2 is quiet" still passed here, T5 would be proving nothing.
+echo "T8: positive control -- counter wiped each tick -> loud EVERY tick"
+spawn_live; hp3=$HOLDER_PID
+seed_lock "$hp3" "$(( now - 4000 ))"
+pc_loud=0
+for _ in 1 2 3; do
+    rm -f "$COUNTER"                              # pre-fix: nothing persists the streak
+    out=$(run_rebase)
+    if echo "$out" | grep -q "HUNG-LOCK"; then
+        pc_loud=$((pc_loud + 1))
+    fi
+done
+(( pc_loud == 3 )) && ok "pre-fix shape is loud on all 3 ticks (control is meaningful)" || fail "control only loud on $pc_loud/3 — T5 may pass vacuously"
+
+# --- T9: the N override arm (default 1 is only one of the two arms) ----------
+echo "T9: FLEET_REBASE_HUNG_LOCK_ESCALATE_N=3 -> warn, warn, escalate, quiet"
+spawn_live; hp4=$HOLDER_PID
+seed_lock "$hp4" "$(( now - 4000 ))"
+n1=$(run_rebase_n 3); n2=$(run_rebase_n 3); n3=$(run_rebase_n 3); n4=$(run_rebase_n 3)
+echo "$n1" | grep -q "HUNG-LOCK" && ! echo "$n1" | grep -q "suppressing further" && ok "tick 1 warns without escalating" || fail "tick 1 wrong: $n1"
+echo "$n2" | grep -q "HUNG-LOCK" && ! echo "$n2" | grep -q "suppressing further" && ok "tick 2 warns without escalating" || fail "tick 2 wrong: $n2"
+echo "$n3" | grep -q "suppressing further" && ok "tick 3 (== N) escalates" || fail "tick 3 did not escalate: $n3"
+echo "$n4" | grep -q "HUNG-LOCK" && fail "tick 4 (> N) still loud: $n4" || ok "tick 4 (> N) is quiet"
+grep -q "count=4" "$ALERT" 2>/dev/null && ok "alert still refreshes past a non-default N" || fail "stale count: $(cat "$ALERT" 2>/dev/null)"
+
+# --- T10: a garbage / out-of-range N falls back to 1, never to "never" -------
+# A bad override must not disable the escalation entirely — that would turn a
+# typo into a silent wedge.
+echo "T10: invalid N falls back to 1"
+for bad in "abc" "0" "-2" ""; do
+    spawn_live; hpb=$HOLDER_PID
+    seed_lock "$hpb" "$(( now - 4000 ))"
+    b1=$(run_rebase_n "$bad"); b2=$(run_rebase_n "$bad")
+    echo "$b1" | grep -q "suppressing further" && ok "N='$bad' escalates on tick 1" || fail "N='$bad' did not escalate: $b1"
+    echo "$b2" | grep -q "HUNG-LOCK" && fail "N='$bad' still loud on tick 2: $b2" || ok "N='$bad' quiets on tick 2"
+done
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- `scripts/fleet/CLAUDE.md`'s escalate-then-quiet rule cited `escalate_if_hung_lock` as its reference shape, but that function had no counter, no key, and no suppression — only an age ceiling plus an unconditional `log`. Re-pointed at `_freshness_warn` / `_freshness_all_clear` (the pair that actually implements the cycle) and narrowed `fleet-clone-freshness.sh`'s twin comment to the flat alert-file artifact it genuinely shares.
- Made `escalate_if_hung_lock` escalate-then-quiet for real. `fleet-rebase` is a one-shot the dispatcher re-invokes, so the streak counter persists on disk (`$STATE_DIR/.fleet-rebase-hung-lock-skip`) instead of living in a loop; the key is `hung-lock|<holder-pid>`, so a *different* wedged holder re-escalates. Past N the loud line stops while the alert keeps being rewritten with a live `count=`.
- **N defaults to 1** (`FLEET_REBASE_HUNG_LOCK_ESCALATE_N` overrides). The judgment call the `opus` tag asked for: the 30-min age ceiling above already does the sizing, and `fleet-rebase`'s cadence is dispatcher-driven and unfixed, so a tick-count N would be sized against an unknown wall clock. Reaching this point means half an hour of wedge — there is no transient phase left to wait out.
- Added `hung_lock_all_clear`, run on the healthy pass (we acquired the lock). **The alert file was previously never removed at all** — it outlived every outage it reported.

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_rebase_hung_lock.sh` → `PASS: 42  FAIL: 0` (was 13 assertions, now 42)
- [x] `bash scripts/fleet/tests/test_clone_freshness.sh` → `PASS: 74  FAIL: 0` (comment-only change there; ran to confirm)
- [x] `bash scripts/fleet/tests/run_all.sh` → `105 suite(s) — 105 passed, 0 failed`
- [x] **Refutation run** — swapped `origin/master`'s `fleet-rebase` in under the new suite: `PASS: 23  FAIL: 19`. The new assertions genuinely discriminate; restored and re-verified byte-identical.
- [x] `bash -n` on all three changed shell files

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `grep -rn "escalate_if_hung_lock is the reference shape" scripts/` returns nothing, and the rule cites an implementation that counts/keys/escalates/quiets | see the **AC-1 caveat** below | rc=1 (empty) — but empty on `master` too |
| …restated with a grep that actually discriminates | `grep -rnE 'escalate_if_hung_lock.{0,2} is the reference shape' scripts/` | rc=1 (empty); same grep on `origin/master` returns `scripts/fleet/CLAUDE.md:141` |
| `_freshness_warn`'s comment no longer claims to be the same shape (or is narrowed to the alert-rewrite half) | `grep -n "Same shape" scripts/fleet/fleet-clone-freshness.sh` | rc=1 (empty); on `origin/master` returns `:204`. Narrowed to *"Only the flat one-line alert artifact is shared with fleet-rebase's `fleet-rebase-hung-lock` (#2362); the counter/quiet cycle around it is this function's own"* |
| `escalate_if_hung_lock` escalates-then-quiets on a `<reason>\|<holder-pid>` streak | `test_fleet_rebase_hung_lock.sh` T5, T6 | `tick 1 (== N) escalates loudly` / `tick 2 (> N) is quiet` / `tick 3 (> N) is quiet` / `re-escalates for a different holder` / `streak restarted at 1 on the new key` |
| Hermetic case drives N+1 consecutive contended invocations; loud line stops while the alert keeps refreshing | T5 | `alert at N records count=1`; alert deleted mid-wedge → `alert re-created past N (cleared inbox re-arms)`; `refreshed alert carries the current count` (`count=3`) |
| …with a positive control against the pre-fix function | T8, plus the external refutation run | T8 `pre-fix shape is loud on all 3 ticks (control is meaningful)`; external run against `origin/master`'s script: 19/42 fail |
| `bash scripts/fleet/tests/run_all.sh` green | `bash scripts/fleet/tests/run_all.sh` | `105 suite(s) — 105 passed, 0 failed` |

### AC-1 caveat — the issue's own repro grep is a false-negative gate

`grep -rn "escalate_if_hung_lock is the reference shape" scripts/` returns **nothing on `origin/master` either**: the line reads ``  `escalate_if_hung_lock` is the reference shape (#2363).`` — with backticks — so the literal string never existed. Anyone verifying this PR with the AC as written gets a green that proves nothing. The row above restates it as `grep -rnE 'escalate_if_hung_lock.{0,2} is the reference shape'`, which returns the `master` line and is empty here. Flagging so the criterion isn't graded off the vacuous form.

## Notes for the reviewer

- **Deliberately not hoisted.** `escalate_if_hung_lock`'s counter block is a near-twin of `_freshness_warn`'s. #2795 declares the shared home an explicit non-goal until #2691 and #2792 settle and the third consumer's shape is known; both sites are annotated. `first` ships as a raw epoch in the alert specifically to avoid a third copy of clone-freshness's BSD/GNU `date` shim.
- **Alert format gained `count=` and `escalating_since_epoch=`.** Nothing parses `~/.fleet/alerts/fleet-rebase-hung-lock` (grepped `scripts/`, `docs/agents/`, `.claude/` — `witness` only owns `*.stuck`), so this is additive for human triage. `count=` is what makes a refreshed alert distinguishable from one frozen at the escalation instant.
- **`hung_lock_all_clear` is placed after the EXIT trap**, so the lock we just took is release-protected before anything else runs.
- Pre-existing gap not bundled: `fleet-rebase`'s header has no `Env:` section (`FLEET_REBASE_LOCK_HUNG_SECS` and `FLEET_REBASE_SCRATCH` are undocumented too), and `--help` hardcodes `sed -n '2,31p'`, so adding one would shift the help slice.

Closes #2795

🤖 Generated with [Claude Code](https://claude.com/claude-code)