### PR TITLE
fleet: an awaiting-base PR is a valid stack base (unblocks depth-2+)

### DIFF
--- a/scripts/fleet/fleet_stack_base.py
+++ b/scripts/fleet/fleet_stack_base.py
@@ -50,9 +50,17 @@ exactly like `fleet_branch_match.py`.
 # be gone). If the eventual design answer reworks the base, the native stack
 # cascade (`gh stack sync` / server-side rebase) propagates it — the normal
 # stacked-PR maintenance path. So the frozen-design labels are deliberately
-# NOT rejected here. (fleet:awaiting-base / fleet:fork-of-other-pr below are
-# retired legacy labels — kept in the reject set as inert safety for any
-# straggler PR still carrying them.)
+# NOT rejected here.
+#
+# `fleet:awaiting-base` is NOT rejected either, for the same reason (#2805). It
+# states that the base's OWN base has not merged yet — a fact about the base's
+# base, not about its head diff, which is typically approved and parked.
+# `role-merger.md` mints it on every stacked PR whose base is still open, i.e.
+# on this tier's whole population for its entire pre-merge life, so rejecting
+# it forbids stacking deeper than one level — silently, since neither surface
+# reports a withheld offer (the task just projects free-and-unblocked, with no
+# base). Do not re-add it on a "retired / inert legacy label" reading: the
+# minting site is live.
 NOT_STACKABLE_BASE_LABELS = frozenset({
     # Work-in-progress / mid-amend — the head diff will move under the stack.
     "fleet:wip", "human:wip", "fleet:human-amending", "fleet:merger-cooldown",
@@ -63,8 +71,13 @@ NOT_STACKABLE_BASE_LABELS = frozenset({
     # Pending merger rebase — diff against master is meaningless until resolved;
     # stacking would create a two-rebase chain when the conflict is resolved.
     "fleet:semantic-conflict",
-    # Not yet rebaseable against its own base / not its own work.
-    "fleet:awaiting-base", "fleet:awaiting-upstream-review",
+    # Reviewer is holding the child's verdict until the upstream PR is approved,
+    # so the base can still be sent back for rework by that upstream verdict.
+    "fleet:awaiting-upstream-review",
+    # Not the author's own work: the branch carries commits inherited from
+    # another open PR, so a stack on it re-parents a foreign prefix the upstream
+    # author may rewrite. `role-merger.md` mints this one live too — it stays
+    # rejected on the grounds above, not as legacy safety (#2805).
     "fleet:fork-of-other-pr",
 })
 

--- a/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
@@ -29,6 +29,11 @@ set -euo pipefail
 # does not care about clone freshness — disable the #1810 freshness gate.
 export FLEET_SKIP_CLONE_FRESHNESS=1
 
+# Every issue fixture below is fleet:sonnet, so an inherited FLEET_ROLE_MODEL
+# from the launching pane would fail T9's claim on the model-tag gate instead of
+# the base check it is grading (#2748 — a suite must not inherit its class).
+unset FLEET_ROLE_MODEL
+
 SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
 
@@ -177,6 +182,10 @@ case "$1 $2" in
             902) printf '%s' '{"state":"OPEN","headRefName":"claude/902-empty","labels":[{"name":"fleet:queued"}]}' ;;
             903) printf '%s' '{"state":"OPEN","headRefName":"claude/903-clean","labels":[{"name":"fleet:queued"}]}' ;;
             904) printf '%s' '{"state":"OPEN","headRefName":"claude/904-difffail","labels":[{"name":"fleet:queued"}]}' ;;
+            # #2805: approved base whose ONLY formerly-disqualifying label is
+            # fleet:awaiting-base — the label is deliberately still present, so
+            # the accept is graded against a live carrier, not a cleaned-up one.
+            905) printf '%s' '{"state":"OPEN","headRefName":"claude/905-awaiting-base","labels":[{"name":"fleet:approved"},{"name":"fleet:awaiting-base"}]}' ;;
             *)   printf '%s' '{"state":"OPEN","headRefName":"claude/x","labels":[]}' ;;
         esac
         exit 0
@@ -188,6 +197,7 @@ case "$1 $2" in
             902) : ;;                                  # empty diff (claim-commit only)
             903) printf '%s\n' "engine/render/x.cpp" ;;  # real non-empty diff
             904) exit 1 ;;                             # fetch failure
+            905) printf '%s\n' "scripts/fleet/witness" ;;  # real non-empty diff
             *)   printf '%s\n' "engine/x.cpp" ;;
         esac
         exit 0
@@ -284,6 +294,26 @@ assert_refused 902 "not a stackable base (empty claim-commit)" "empty-claim base
 
 echo "T8: claim --stackable-on a base whose diff fetch fails (#904) → refused"
 assert_refused 904 "refusing to stack on an unverifiable base" "unverifiable base refused"
+
+# --- #2805: an approved base carrying only fleet:awaiting-base IS stackable ---
+# The merger mints fleet:awaiting-base on every stacked PR whose base is still
+# open, so rejecting it made depth-2+ stacking impossible. Claimed against a
+# base that still carries the label (this fix removes it from no PR). Runs last
+# because it is the only case here that leaves a claim behind.
+echo "T9: claim --stackable-on an approved fleet:awaiting-base base (#905) → accepted"
+t9_err="$TMPROOT/t9.err"
+if "$FLEET_CLAIM" claim 3004 worker-test --stackable-on 905 >/dev/null 2>"$t9_err"; then
+    PASS=$((PASS + 1))
+    echo "  ok: awaiting-base base accepted"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: awaiting-base base refused:"
+    sed 's/^/        /' "$t9_err"
+fi
+# Not vacuous: prove the claim took the STACKABLE path, not a silent fallback
+# to master (claim-base reads the --stackable-on sidecar, #2703).
+t9_base=$("$FLEET_CLAIM" claim-base 3004 2>/dev/null || true)
+assert_output "$t9_base" "claude/905-awaiting-base" "claim recorded the awaiting-base PR as the stack base"
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_stack_base_guard.py
+++ b/scripts/fleet/tests/test_stack_base_guard.py
@@ -84,6 +84,64 @@ class TestUnsafeBaseReason(unittest.TestCase):
                 self.assertNotIn(label, NOT_STACKABLE_BASE_LABELS)
                 self.assertIsNone(unsafe_base_reason([label], ["engine/x.cpp"]))
 
+    def test_awaiting_base_is_a_stackable_base(self):
+        """#2805: `fleet:awaiting-base` describes the base's OWN base, not its
+        head diff, and the merger mints it on every stacked PR whose base is
+        still open — so rejecting it made depth-2+ stacking impossible. Live
+        shape when filed: PR #2792 (fleet:approved + fleet:awaiting-base) was
+        refused as a base for #2803, whose target code exists only on that
+        branch. Graded against a base that STILL carries the label — the fix
+        does not remove it from any PR."""
+        self.assertNotIn("fleet:awaiting-base", NOT_STACKABLE_BASE_LABELS)
+        self.assertIsNone(unsafe_base_reason(
+            ["fleet:approved", "fleet:awaiting-base", "fleet:authored-on-macos"],
+            ["scripts/fleet/witness"]))
+
+    def test_awaiting_base_does_not_exempt_a_co_carried_reject(self):
+        """Dropping the label must not turn its carriers into a blanket
+        exemption: a base that is awaiting-base AND genuinely in flux still
+        rejects, and reports the in-flux label by name. (Pre-fix these returned
+        "fleet:awaiting-base" — it sorts first — so this flips with the fix.)"""
+        for label in ("fleet:wip", "fleet:merger-cooldown",
+                      "fleet:semantic-conflict", "fleet:amending-mac-pool-1"):
+            with self.subTest(label=label):
+                self.assertEqual(
+                    unsafe_base_reason(["fleet:awaiting-base", label],
+                                       ["scripts/fleet/witness"]),
+                    label)
+        self.assertEqual(
+            unsafe_base_reason(["fleet:approved", "fleet:awaiting-base"], []),
+            "empty claim-commit")
+
+    def test_retained_reject_states_survive_the_awaiting_base_drop(self):
+        """The states #2805 keeps must still reject, each reported by name — a
+        bare `assertIsNone` on the safe case passes vacuously if a future edit
+        empties the set. These assertions hold in BOTH arms of the #2805
+        positive control (pre- and post-fix), so they are not keyed on the fix;
+        only the two tests above flip."""
+        for label in ("fleet:wip", "human:wip", "fleet:human-amending",
+                      "fleet:merger-cooldown", "fleet:design-unblocked",
+                      "fleet:semantic-conflict", "fleet:awaiting-upstream-review",
+                      "fleet:fork-of-other-pr"):
+            with self.subTest(label=label):
+                self.assertIn(label, NOT_STACKABLE_BASE_LABELS)
+                self.assertEqual(
+                    unsafe_base_reason([label], ["scripts/fleet/witness"]), label)
+        self.assertEqual(unsafe_base_reason(["fleet:approved"], []),
+                         "empty claim-commit")
+
+    def test_fork_of_other_pr_stays_rejected_on_its_own_grounds(self):
+        """#2805's sibling decision: `fleet:fork-of-other-pr` shares the false
+        "retired legacy label" framing but keeps rejecting — the branch carries
+        commits inherited from another open PR, so the base is not the author's
+        own work and the upstream author may rewrite the prefix under the
+        stack. Unlike awaiting-base, that is a property of the head diff."""
+        self.assertIn("fleet:fork-of-other-pr", NOT_STACKABLE_BASE_LABELS)
+        self.assertEqual(
+            unsafe_base_reason(["fleet:approved", "fleet:fork-of-other-pr"],
+                               ["engine/x.cpp"]),
+            "fleet:fork-of-other-pr")
+
     def test_semantic_conflict_rejected(self):
         """A PR awaiting merger rebase is not a safe stack base — its diff
         against master is meaningless until the conflict is resolved, and


### PR DESCRIPTION
## Summary

- Drop `fleet:awaiting-base` from `fleet_stack_base.NOT_STACKABLE_BASE_LABELS`. The predicate's own discriminator is whether the base's HEAD DIFF is moving; `awaiting-base` describes the base's *base* (an approved, parked diff), so it belongs with the frozen-design states that are already exempt.
- Correct the parenthetical that called it and `fleet:fork-of-other-pr` "retired legacy labels — kept in the reject set as inert safety for any straggler PR". Both have live minting sites in `role-merger.md`; the comment now says so and warns against re-adding on that reading.
- `fleet:fork-of-other-pr` **stays rejected**, on its own stated grounds rather than a false retirement claim: the branch carries commits inherited from another open PR, so the base is not the author's own work and the upstream author may rewrite the prefix under the stack. That *is* a property of the head diff, unlike `awaiting-base`.
- Because both stacking surfaces share the predicate, the failure was silent — the scout withheld `stackable_blocker_pr` and `fleet-claim --stackable-on` refused, leaving the task projecting free-and-unblocked with no base. `find-stackable-blockers` (the third consumer) is fixed by the same change.

The merge-side straggler in `fleet-rebase` is #2764's lane (open PR #2767, same file) and is untouched here.

## Test plan

- [x] `python3 scripts/fleet/tests/test_stack_base_guard.py` — `Ran 15 tests … OK` (11 pre-existing + 4 new).
- [x] `bash scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh` — `PASS: 12  FAIL: 0` (T1–T8 pre-existing, T9 new).
- [x] `bash scripts/fleet/tests/run_all.sh` — `105 suite(s) — 105 passed, 0 failed`.
- [x] `ruff check scripts/` — `All checks passed!`.
- [x] Positive control run against `origin/master`'s `fleet_stack_base.py` with the tests held fixed (both arms below).

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `fleet:awaiting-base` no longer causes `unsafe_base_reason` to reject | `unsafe_base_reason(['fleet:approved','fleet:awaiting-base','fleet:authored-on-macos'], ['scripts/fleet/witness'])` — live label set of PR #2792, re-derived this session | `None` (pre-fix: `'fleet:awaiting-base'`) |
| …the comment no longer calls live-minted labels inert | `git ls-files 'scripts/fleet/**' \| xargs grep -n "inert\|straggler"` | no surviving hit in `fleet_stack_base.py` asserting inertness; the two remaining lines state the minting site is live. (`fleet-rebase:595` still carries the old claim — #2764's lane, see Residual.) |
| `claim --stackable-on` accepts a base whose only disqualifying label was `fleet:awaiting-base`, **graded against a base that still carries it** | `test_fleet_claim_stackable_live_resolve.sh` T9 (stub PR #905 = `fleet:approved` + `fleet:awaiting-base`, label deliberately left on) | `ok: awaiting-base base accepted` + `ok: claim recorded the awaiting-base PR as the stack base` — `claim-base` returns `claude/905-awaiting-base`, proving the **stackable** path took rather than a silent fallback to `master` (#2703) |
| Regression case pins an approved `awaiting-base` base as safe | `test_awaiting_base_is_a_stackable_base` | ok |
| …keeps `fleet:wip` / `fleet:merger-cooldown` / `fleet:semantic-conflict` / empty-claim rejecting, **asserted by name individually** | `test_retained_reject_states_survive_the_awaiting_base_drop` — 8 labels each `assertIn(set)` + `assertEqual(reason, label)`, plus `empty claim-commit` | ok (a bare `assertIsNone` on the safe case cannot pass vacuously against this) |
| …and dropping the label is not a blanket exemption | `test_awaiting_base_does_not_exempt_a_co_carried_reject` — `awaiting-base` + each in-flux label, incl. the `fleet:amending-` prefix arm and the empty-diff arm | ok; each reports the *in-flux* label, not `awaiting-base` |
| Positive control: the new safe-base assertion goes red against the pre-fix predicate | pre-fix arm (`git show origin/master:scripts/fleet/fleet_stack_base.py`, tests unchanged) | `FAILED (failures=6)` — exactly `test_awaiting_base_is_a_stackable_base` + `test_awaiting_base_does_not_exempt_a_co_carried_reject` (1 + 4 subtests + rollup). Claim gate: `PASS: 10  FAIL: 2`, citing `905 is not a stackable base (fleet:awaiting-base)` |
| …and the retained reject assertions pass in **both** arms | same two runs, per-test verdicts | `test_retained_reject_states_…`, `test_fork_of_other_pr_…`, `test_each_reject_label`, `test_semantic_conflict_rejected`, `test_empty_claim_commit_rejected`, `test_frozen_design_states_…` → `ok` pre- **and** post-fix; claim-gate T1–T8 `ok` in both. Not keyed on the fix. |
| `fleet:fork-of-other-pr` explicitly decided + rationale recorded in the comment | `fleet_stack_base.py` reject-set entry + `test_fork_of_other_pr_stays_rejected_on_its_own_grounds` | kept in the set; comment states the grounds (inherited foreign prefix, live minter) with no retirement claim |
| `bash scripts/fleet/tests/run_all.sh` green | as above | `105 suite(s) — 105 passed, 0 failed` |

### Note on the issue body's `#2746` control

The issue cited #2746 as the sharper control (`fleet:approved` + `fleet:stacked` + `fleet:reviewing-mac-pool-5`). Re-derived live before implementing, #2746 has since moved to `fleet:needs-fix` + `fleet:amending-mac-pool-1`, so it is no longer a clean control — with the label removed it now rejects on `fleet:amending-mac-pool-1`. **#2792 is the clean live carrier** and is what the evidence above uses. The predicate-level control that replaces #2746's role is `test_awaiting_base_does_not_exempt_a_co_carried_reject`, which pins that exact interaction (`amending-` still rejects a base that also carries `awaiting-base`).

### Residual (not fixed here, not filed — already owned)

`scripts/fleet/fleet-rebase:595` still carries the same "retired … but a straggler PR still carrying" claim. That is the *merge*-side consumer, owned by #2764 with the fix in flight as open PR #2767 touching exactly that file — folding it in here would conflict. The upstream source of both, the "Retired stacking labels" bullet in `docs/agents/fleet-labels-reference.md:328`, becomes true when #2657 (`fleet:approved`, removes the merger's minting instruction) merges; no third ticket filed.

Closes #2805

🤖 Generated with [Claude Code](https://claude.com/claude-code)
