### PR TITLE
render: scrub the Metal render-target pair on texture destruction (#2808)

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -1126,3 +1126,20 @@ parity with voxel-pool primary shapes.
   (`metal_runtime.cpp`) — mirroring GL's delete-unbinds semantics. A new
   resource type that lands in any sticky table must untrack itself the same
   way.
+
+  **The render-target pair is a sticky table too, and it is the one this rule
+  keeps getting read as excluding.** `MetalRuntimeState` holds non-owning
+  `MTL::Texture *` in four places, not two: the `textures_` / `imageTextures_`
+  bind-slot arrays **plus** `colorTexture_` / `depthTexture_`, written by
+  `bindMetalFramebufferRenderTarget` and consumed by `createRenderEncoder`
+  (`metal_render_impl.cpp`), which both `setTexture:`-retains the handle and
+  dereferences it for the viewport. `untrackMetalTexture` scrubs all four
+  (#2808); a destroyed attachment falls the runtime back to the **default**
+  target rather than nulling in place, because a null colour attachment with
+  `useDefaultRenderTarget_` still false makes `createRenderEncoder` return
+  `nullptr` for every later pass — rendering nothing, silently.
+  `~MetalFramebufferImpl` performs the same scrub as an independent second
+  closing path. The invariant is executed by
+  `test/render/metal_sticky_untrack_test.cpp`, so extending
+  `MetalRuntimeState` with a fifth handle-holding field should fail a test
+  rather than a screenshot.

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -1129,17 +1129,26 @@ parity with voxel-pool primary shapes.
 
   **The render-target pair is a sticky table too, and it is the one this rule
   keeps getting read as excluding.** `MetalRuntimeState` holds non-owning
-  `MTL::Texture *` in four places, not two: the `textures_` / `imageTextures_`
-  bind-slot arrays **plus** `colorTexture_` / `depthTexture_`, written by
-  `bindMetalFramebufferRenderTarget` and consumed by `createRenderEncoder`
-  (`metal_render_impl.cpp`), which both `setTexture:`-retains the handle and
-  dereferences it for the viewport. `untrackMetalTexture` scrubs all four
+  `MTL::Texture *` in four places `untrackMetalTexture` must scrub, not two:
+  the `textures_` / `imageTextures_` bind-slot arrays **plus** `colorTexture_`
+  and `depthTexture_`, written by `bindMetalFramebufferRenderTarget` and
+  consumed by `createRenderEncoder` (`metal_render_impl.cpp`), which both
+  `setTexture:`-retains the handle and dereferences it for the viewport. `untrackMetalTexture` scrubs all four
   (#2808); a destroyed attachment falls the runtime back to the **default**
   target rather than nulling in place, because a null colour attachment with
   `useDefaultRenderTarget_` still false makes `createRenderEncoder` return
   `nullptr` for every later pass — rendering nothing, silently.
   `~MetalFramebufferImpl` performs the same scrub as an independent second
-  closing path. The invariant is executed by
-  `test/render/metal_sticky_untrack_test.cpp`, so extending
-  `MetalRuntimeState` with a fifth handle-holding field should fail a test
-  rather than a screenshot.
+  closing path.
+
+  A **fifth** holder exists and is deliberately outside that scrub:
+  `imageAtomicScratchBuffers_`'s map key, cleared at
+  `releaseImageAtomicScratchBuffer` instead, because the entry owns the mapped
+  `MTL::Buffer` and has to release it rather than just drop the reference (the
+  reason is stated at the field itself in `metal_runtime.cpp`). Five holders,
+  four scrubbed — so a newly added slot is the *sixth*, not the fifth.
+  `test/render/metal_sticky_untrack_test.cpp` regression-guards the four
+  scrubbed slots **by name**; it has no reflection over `MetalRuntimeState`, so
+  a sixth handle-holding field would fail nothing. Scrubbing it and covering it
+  stays on whoever adds it — the same "prose read as stronger than what runs"
+  gap that hid #2808 for two resource types.

--- a/engine/render/src/metal/metal_framebuffer.cpp
+++ b/engine/render/src/metal/metal_framebuffer.cpp
@@ -41,6 +41,23 @@ class MetalFramebufferImpl final : public FramebufferImpl {
               static_cast<MTL::PixelFormat>(textureDepth.getNativePixelFormat())
           ) {}
 
+    // The runtime's render-target pair is sticky and holds non-owning handles,
+    // so a framebuffer destroyed while it is the bound target would leave them
+    // dangling into createRenderEncoder's setTexture + viewport deref. The
+    // attachment textures' own destructors scrub it too (untrackMetalTexture);
+    // this is the second, independent closing path, mirroring how the texture
+    // dtor and the runtime scrub double-cover the sampler/image tables.
+    // Guarded: destroying an *unbound* framebuffer must not steal whichever
+    // target is actually bound.
+    ~MetalFramebufferImpl() override {
+        const bool isBoundTarget =
+            (m_colorTexture != nullptr && metalCurrentColorTexture() == m_colorTexture) ||
+            (m_depthTexture != nullptr && metalCurrentDepthTexture() == m_depthTexture);
+        if (isBoundTarget) {
+            bindMetalDefaultRenderTarget();
+        }
+    }
+
     void bind() const override {
         bindMetalFramebufferRenderTarget(
             m_colorTexture,

--- a/engine/render/src/metal/metal_runtime.cpp
+++ b/engine/render/src/metal/metal_runtime.cpp
@@ -40,6 +40,13 @@ struct MetalRuntimeState {
     MTL::PixelFormat colorPixelFormat_ = MTL::PixelFormatBGRA8Unorm;
     MTL::PixelFormat depthPixelFormat_ = MTL::PixelFormatInvalid;
 
+    // The one MTL::Texture * here that untrackMetalTexture does NOT scrub: the
+    // map key is cleared at its own site, releaseImageAtomicScratchBuffer,
+    // because the entry owns the mapped MTL::Buffer and has to release it
+    // rather than just drop the reference. ~MetalTexture2DImpl calls it; only
+    // 2D textures ever reach the map (ensureImageAtomicScratchBuffer's sole
+    // caller is the 2D bindAsImage path), so the 3D destructor is complete
+    // without it.
     std::unordered_map<MTL::Texture *, MTL::Buffer *> imageAtomicScratchBuffers_;
     MTL::Buffer *currentImageAtomicScratch_ = nullptr;
 
@@ -284,6 +291,15 @@ void untrackMetalTexture(MTL::Texture *texture) {
         if (runtime.imageTextures_[unit] == texture) {
             runtime.imageTextures_[unit] = nullptr;
         }
+    }
+    // The render-target pair is sticky the same way the bind slots are: only a
+    // later bind clears it, and no bind is reachable from a destructor. Fall
+    // back to the default target rather than nulling in place — a bare null
+    // leaves useDefaultRenderTarget_ false with no color attachment, and
+    // createRenderEncoder then returns nullptr for every later pass, silently
+    // rendering nothing. Same scrub MetalFramebufferImpl::unbind() performs.
+    if (runtime.colorTexture_ == texture || runtime.depthTexture_ == texture) {
+        bindMetalDefaultRenderTarget();
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(IrredenEngineTest
   render/per_axis_canvas_size_test.cpp
   render/frame_data_sun_layout_test.cpp
   render/gpu_compute_dispatch_test.cpp
+  render/metal_sticky_untrack_test.cpp
   render/opengl_shader_include_test.cpp
   render/per_canvas_light_scope_test.cpp
   render/picking_aim_iso_pixel_test.cpp

--- a/test/render/metal_sticky_untrack_test.cpp
+++ b/test/render/metal_sticky_untrack_test.cpp
@@ -1,0 +1,138 @@
+// Executes the sticky-table scrub invariant stated in engine/render/CLAUDE.md:
+//
+//   "A new resource type that lands in any sticky table must untrack itself
+//    the same way."
+//
+// The runtime's bind slots and its render-target pair both hold non-owning
+// MTL::Texture handles that only a later bind ever clears, so a texture
+// destroyed while still referenced leaves a dangling pointer that the next
+// encode retains (setTexture:) and dereferences (viewport sizing). That
+// invariant held by convention alone for two resource types, which is how the
+// render-target pair was missed (#2808).
+//
+// These cases exercise the bookkeeping only: the handles are opaque sentinel
+// pointers that are never dereferenced, and no MTL::Device is required, so the
+// suite runs headless on any macOS host.
+
+#include <gtest/gtest.h>
+
+#if defined(IR_GRAPHICS_METAL)
+
+#include <irreden/render/metal/metal_runtime.hpp>
+
+#include <cstdint>
+
+namespace {
+
+// Opaque non-null sentinels. untrackMetalTexture and the bind/query helpers
+// compare and store the pointer without ever dereferencing it.
+MTL::Texture *sentinelTexture(std::uintptr_t id) {
+    return reinterpret_cast<MTL::Texture *>(id);
+}
+
+} // namespace
+
+TEST(MetalStickyUntrack, ClearsSamplerAndImageBindSlots) {
+    auto *texture = sentinelTexture(0x1001);
+    IRRender::bindMetalTexture(3, texture);
+    IRRender::bindMetalImageTexture(5, texture);
+    ASSERT_EQ(IRRender::boundMetalTexture(3), texture);
+    ASSERT_EQ(IRRender::boundMetalImageTexture(5), texture);
+
+    IRRender::untrackMetalTexture(texture);
+
+    EXPECT_EQ(IRRender::boundMetalTexture(3), nullptr);
+    EXPECT_EQ(IRRender::boundMetalImageTexture(5), nullptr);
+}
+
+// A colour attachment surviving untrackMetalTexture is a freed handle that
+// createRenderEncoder retains via setTexture: and dereferences for the
+// viewport, so the scrub has to reach the render-target pair too (#2808).
+TEST(MetalStickyUntrack, ClearsRenderTargetColorAttachment) {
+    auto *color = sentinelTexture(0x2001);
+    auto *depth = sentinelTexture(0x2002);
+    IRRender::bindMetalFramebufferRenderTarget(
+        color,
+        depth,
+        MTL::PixelFormatRGBA8Unorm,
+        MTL::PixelFormatDepth32Float
+    );
+    ASSERT_EQ(IRRender::metalCurrentColorTexture(), color);
+    ASSERT_FALSE(IRRender::metalUsesDefaultRenderTarget());
+
+    IRRender::untrackMetalTexture(color);
+
+    EXPECT_EQ(IRRender::metalCurrentColorTexture(), nullptr);
+    EXPECT_EQ(IRRender::metalCurrentDepthTexture(), nullptr);
+    // Falling back to the default target rather than nulling in place is the
+    // point: a null colour attachment with useDefaultRenderTarget_ still false
+    // makes createRenderEncoder return nullptr for every later pass, which
+    // renders nothing with no crash and no log.
+    EXPECT_TRUE(IRRender::metalUsesDefaultRenderTarget());
+
+    IRRender::bindMetalDefaultRenderTarget();
+}
+
+// Destroying the depth attachment strands the pair just as destroying the
+// colour one does — the encode path reads both.
+TEST(MetalStickyUntrack, ClearsRenderTargetDepthAttachment) {
+    auto *color = sentinelTexture(0x3001);
+    auto *depth = sentinelTexture(0x3002);
+    IRRender::bindMetalFramebufferRenderTarget(
+        color,
+        depth,
+        MTL::PixelFormatRGBA8Unorm,
+        MTL::PixelFormatDepth32Float
+    );
+    ASSERT_EQ(IRRender::metalCurrentDepthTexture(), depth);
+
+    IRRender::untrackMetalTexture(depth);
+
+    EXPECT_EQ(IRRender::metalCurrentColorTexture(), nullptr);
+    EXPECT_EQ(IRRender::metalCurrentDepthTexture(), nullptr);
+    EXPECT_TRUE(IRRender::metalUsesDefaultRenderTarget());
+
+    IRRender::bindMetalDefaultRenderTarget();
+}
+
+// Guard against the over-correction: untracking an unrelated texture must not
+// steal the render target from whichever framebuffer is actually bound.
+TEST(MetalStickyUntrack, LeavesUnrelatedRenderTargetBound) {
+    auto *color = sentinelTexture(0x4001);
+    auto *depth = sentinelTexture(0x4002);
+    auto *unrelated = sentinelTexture(0x4003);
+    IRRender::bindMetalFramebufferRenderTarget(
+        color,
+        depth,
+        MTL::PixelFormatRGBA8Unorm,
+        MTL::PixelFormatDepth32Float
+    );
+
+    IRRender::untrackMetalTexture(unrelated);
+
+    EXPECT_EQ(IRRender::metalCurrentColorTexture(), color);
+    EXPECT_EQ(IRRender::metalCurrentDepthTexture(), depth);
+    EXPECT_FALSE(IRRender::metalUsesDefaultRenderTarget());
+
+    IRRender::bindMetalDefaultRenderTarget();
+}
+
+TEST(MetalStickyUntrack, NullTextureIsANoOp) {
+    auto *color = sentinelTexture(0x5001);
+    auto *depth = sentinelTexture(0x5002);
+    IRRender::bindMetalFramebufferRenderTarget(
+        color,
+        depth,
+        MTL::PixelFormatRGBA8Unorm,
+        MTL::PixelFormatDepth32Float
+    );
+
+    IRRender::untrackMetalTexture(nullptr);
+
+    EXPECT_EQ(IRRender::metalCurrentColorTexture(), color);
+    EXPECT_FALSE(IRRender::metalUsesDefaultRenderTarget());
+
+    IRRender::bindMetalDefaultRenderTarget();
+}
+
+#endif // IR_GRAPHICS_METAL


### PR DESCRIPTION
## Summary
- `untrackMetalTexture` scrubbed only 2 of the 4 `MTL::Texture *` slots in `MetalRuntimeState`. `colorTexture_` / `depthTexture_` are written by `bindMetalFramebufferRenderTarget` and read by `createRenderEncoder`, which `setTexture:`-retains the handle and dereferences it twice for the viewport — so a framebuffer destroyed while bound left a use-after-free behind a green build. Same class as #2412 (buffers) and #1961 (bind slots); OpenGL is structurally immune, so a Linux-only fleet never surfaces it.
- The scrub falls back to the **default** render target rather than nulling in place: a null colour attachment with `useDefaultRenderTarget_` still false makes `createRenderEncoder` return `nullptr` for every later pass, rendering nothing with no crash and no log. Failing visible beats failing silent.
- `~MetalFramebufferImpl` performs the same scrub as an independent second closing path, guarded so destroying an *unbound* framebuffer cannot steal the live target.
- The invariant is now **executed** for the four scrubbed slots rather than asserted in prose — it had held by convention for two resource types, which is exactly how the third slot was missed. The suite guards those four **by name**; it has no reflection over `MetalRuntimeState`, so a newly added handle-holding slot still fails nothing and is on its author to scrub and cover.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — `[100%] Built target IrredenEngineTest`
- [x] Full suite: `1479 tests from 255 test suites ran` → `[  PASSED  ] 1479 tests.`
- [x] `fleet-build --target IRShapeDebug` — `[100%] Built target IRShapeDebug`
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` → `ir-run: RESULT=CLEAN exe=IRShapeDebug exit=0`
- [x] `clang-format --dry-run --Werror` clean on the new test; `format-changed` reformatted 1 file (changed lines only)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. `untrackMetalTexture` leaves no `MTL::Texture *` field in `MetalRuntimeState` dangling; each is scrubbed or carries an in-file reason | read `metal_runtime.cpp:31-44` + the new function body | All 4 handle-holding slots (`textures_`, `imageTextures_`, `colorTexture_`, `depthTexture_`) scrubbed in `untrackMetalTexture`. The 5th holder — the `imageAtomicScratchBuffers_` map **key** — now carries an in-file comment at its declaration explaining it is cleared at `releaseImageAtomicScratchBuffer` instead (the entry owns its mapped `MTL::Buffer` and must release it, not just drop the reference) |
| 2. `MetalFramebufferImpl` has a destructor performing the unbind scrub | read `metal_framebuffer.cpp` | `~MetalFramebufferImpl()` added, guarded on `metalCurrentColorTexture()/DepthTexture()` matching this framebuffer's own attachments |
| 3. A `test/render/` test asserts (1) mechanically, **positive-controlled RED against `origin/master`** | `git stash push -- engine/render/src/metal/metal_runtime.cpp`, rebuild, run | `[  FAILED  ] 2 tests`: `ClearsRenderTargetColorAttachment`, `ClearsRenderTargetDepthAttachment` — depth read back as `0x3002` (survived) and `metalUsesDefaultRenderTarget()` was `false`. The other 3 cases stayed **green**, so the suite discriminates rather than uniformly failing. With the fix restored: `[  PASSED  ] 5 tests.` |
| 4. macOS/Metal build green + smoke `RESULT=CLEAN` | `fleet-build --target IRShapeDebug`; `fleet-run IRShapeDebug --auto-screenshot 10` | `[100%] Built target IRShapeDebug`; `ir-run: RESULT=CLEAN exe=IRShapeDebug exit=0` |
| 5. `engine/render/CLAUDE.md` residency paragraph names the render-target pair alongside the sampler/image tables | read the diff | New paragraph added under the residency rule, citing all four scrubbed slots, the default-target rationale, and the test that guards them by name. Also names the fifth `MTL::Texture *` holder (`imageAtomicScratchBuffers_`'s map key) and why it is outside the scrub, so the holder count reconciles with `metal_runtime.cpp` |

## Notes for reviewer
- **Severity is LATENT, stated in the issue too — no live crash.** The only `C_TrixelCanvasFramebuffer` producer is the setup-time named `"mainFramebuffer"` entity, and `system_trixel_to_framebuffer.hpp:449` / `system_entity_canvas_to_framebuffer.hpp:366` rebind every frame they run, so reaching it needs a destroy landing *after* a bind and *before* the next bind — teardown, or any future resize/recreate or per-canvas framebuffer. Filed and fixed anyway because it is precisely what the two shipped scrubbers exist to make unrepresentable, and the next author of a runtime-lifecycle framebuffer inherits it with no build or test signal.
- **No screenshots, deliberately.** The diff touches `engine/render/`, but both changed functions run only on resource destruction and are no-ops on every rendering frame, so before/after pairs would be byte-identical by construction — the #2343 trap where that reads as "no visual change". Taking `engine/render/CLAUDE.md`'s documented exception ("internal refactors with provably no runtime effect"); the `RESULT=CLEAN` smoke above is the runtime evidence instead.
- **`optimize` skipped:** neither changed function is on a per-frame path (destructor-only), so there is no hot path to profile.
- Authored on macOS/Metal — the OpenGL side is unaffected (no GL file in the diff), and the new test compiles to nothing under `IR_GRAPHICS_OPENGL`, so Linux CI builds it as an empty TU.


### Amendment (nits, 2026-08-04)
Addressed both `fleet:has-nits` nits from the Opus recheck, in `engine/render/CLAUDE.md` only — no code, test, or build-input change, so the verification above still stands as measured.

Closes #2808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

