### PR TITLE
tools/jitter_probe: --expect-frames guard + wipe step in the hand-run jitter recipes

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -469,6 +469,13 @@ Three checks, in order:
    silhouette changes under yaw and contaminates the metric).
 
    ```bash
+   # ALWAYS wipe first. The engine never clears this dir and numbers *around*
+   # leftovers (VideoManager::reserveNextScreenshotIndex), so without this the
+   # glob below scores earlier runs' frames too. End the path at .../screenshots
+   # — a find rooted at the demo dir also deletes staged data/images/ assets and
+   # the next run dies on a misleading image-load assert. Use -delete, not
+   # `rm -f <dir>/*.png`: zsh aborts the whole && chain on an unmatched glob.
+   find <save_files>/screenshots -name '*.png' -delete
    # pan jitter (voxel box, yaw 45, zoom 4):
    IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 \
        --zoom 4 --auto-screenshot 6
@@ -476,9 +483,15 @@ Three checks, in order:
    IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep \
        --zoom 4 --auto-screenshot 6
    # then score the captured sequence (in order). --reversal-eps 0.8 retires the
-   # reversal criterion on these probes (see "the reversal criterion" below):
-   build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 \
-       <save_files>/screenshots/screenshot_0*.png
+   # reversal criterion on these probes (see "the reversal criterion" below).
+   # The 6-digit glob matches full frames ONLY — ROI crops share the prefix and
+   # append _<label>__crop_<crop>.png, and a 128x128 crop has no usable
+   # foreground. --expect-frames must equal the --auto-screenshot count: it is
+   # the only thing that catches a widened glob, since scoring the wrong set
+   # still yields a confident verdict (measured during #2469 — see
+   # tools/jitter_probe/README.md §"Wipe before every capture").
+   build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 --expect-frames 6 \
+       <save_files>/screenshots/screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png
    ```
 
 3. **Read the verdict.** `jitter_probe` tracks the shape's centroid across the

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -94,9 +94,14 @@ Two things that recipe gets right and are easy to get wrong:
 - **End the path at `.../save_files/screenshots`.** A `find` rooted at the demo
   build dir also deletes the staged runtime assets under `data/images/`, and the
   next run dies on `Failed to load image file: .../irreden_engine_logo_v6_alpha.png`
-  — which reads as a crash your change caused. `fleet-build --target
-  <Demo>Assets` will *not* restore them (the copy is up to date by timestamp);
-  restage by hand with `cp -R engine/render/data/. <exedir>/data/`.
+  — which reads as a crash your change caused. Recover by rebuilding the demo's
+  asset target: `fleet-build --target <Demo>Assets` (e.g. `IRShapeDebugAssets`).
+  That restores them — the target is an `add_custom_target` with no `OUTPUT`
+  (`cmake/ir_functions.cmake`), so an explicit build always re-runs its
+  `copy_directory` commands rather than short-circuiting on timestamps. Don't
+  hand-copy a single source dir: the staged `data/` is a *merge* of
+  `engine/render/data` and `engine/data`, and the file in the assert above
+  lives in the latter.
 - **Use `-delete`, not `rm -f <dir>/*.png`.** Under zsh an unmatched glob aborts
   the entire `&&` chain, silently skipping everything after it.
 

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -27,6 +27,7 @@ jitter_probe <frame_0.png> <frame_1.png> ... <frame_N.png>   # >=3, in capture o
     [--stationary]       assert the centroid does NOT move (pivot-pin check)
     [--max-deviation PX] PINNED verdict requires deviation <= this (default 1.50)
     [--verbose]          print the per-frame centroid + residual table
+    [--expect-frames N]  fail (exit 2) unless exactly N frames were passed
 ```
 
 Exit code: `0` = SMOOTH/PINNED, `1` = JITTER/DRIFT detected, `2` = argument / IO
@@ -55,6 +56,10 @@ Use an **isolated shape on a black field** so the centroid is uncontaminated.
 stability (per-frame jitter)"):
 
 ```bash
+# Wipe first — the dir is never auto-cleared and the engine numbers around
+# leftovers, so skipping this scores earlier runs too ("Wipe before every
+# capture" below has the why, and the two ways to get this line wrong):
+find save_files/screenshots -name '*.png' -delete
 # Pan jitter — camera pans at a fixed non-cardinal yaw:
 IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 --zoom 4 \
     --auto-screenshot 6
@@ -63,9 +68,47 @@ IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 --zoom 
 IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep --zoom 4 \
     --auto-screenshot 6
 
-# Then point jitter_probe at the captured sequence (in order):
-build/tools/jitter_probe/jitter_probe save_files/screenshots/screenshot_0001*.png
+# Then point jitter_probe at the captured sequence (in order). The 6-digit glob
+# matches full frames ONLY; --expect-frames must equal the --auto-screenshot
+# count (see "Wipe before every capture" below for why both are load-bearing):
+build/tools/jitter_probe/jitter_probe --expect-frames 6 \
+    save_files/screenshots/screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png
 ```
+
+### Wipe before every capture
+
+`save_files/screenshots/` is **never** auto-cleared, and
+`VideoManager::reserveNextScreenshotIndex` deliberately numbers *around* files
+that are already there so runs don't collide. A second run therefore appends —
+it never replaces. Point a glob at that directory and you score this run's
+frames plus every earlier run's, plus any ROI crop files (crops share the
+`screenshot_<index>` prefix and append `_<label>__crop_<crop>.png`; a 128x128
+crop has no usable foreground).
+
+```bash
+find save_files/screenshots -name '*.png' -delete
+```
+
+Two things that recipe gets right and are easy to get wrong:
+
+- **End the path at `.../save_files/screenshots`.** A `find` rooted at the demo
+  build dir also deletes the staged runtime assets under `data/images/`, and the
+  next run dies on `Failed to load image file: .../irreden_engine_logo_v6_alpha.png`
+  — which reads as a crash your change caused. `fleet-build --target
+  <Demo>Assets` will *not* restore them (the copy is up to date by timestamp);
+  restage by hand with `cp -R engine/render/data/. <exedir>/data/`.
+- **Use `-delete`, not `rm -f <dir>/*.png`.** Under zsh an unmatched glob aborts
+  the entire `&&` chain, silently skipping everything after it.
+
+Scoring the wrong set does not fail — it produces a *confident* verdict.
+Measured during the #2469 investigation: a 24-frame sweep read against 52 files
+in the directory reported `max_residual=770.84px, verdict=JITTER`; the same
+sweep after wiping reported `0.57px`. `--expect-frames` exists because that
+failure is otherwise
+indistinguishable from a real regression: the scripted harnesses
+(`scripts/render-verify.py`, `cull-verify.py`, and `pivot-verify.py` via
+`verify_common.run_pass`) all `rmtree` the directory for exactly this reason,
+and a hand-run sweep gets no such protection.
 
 For a multi-shape scene with no isolation, pass `--color R,G,B,T` to lock onto
 one shape. A static-determinism check ("does it jitter after the camera stops?")

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -229,7 +229,7 @@ int main(int argc, char **argv) {
     parser.flag("--verbose", "Print the per-frame centroid + residual table");
     parser.integer(
         "--expect-frames",
-        "Fail unless exactly this many frames were passed (0 = no check)",
+        "Fail unless exactly this many frames were passed (omit to disable)",
         0
     );
     parser.variadic("frames", "Frame PNGs in capture order (>= 3)", 3);
@@ -265,7 +265,16 @@ int main(int argc, char **argv) {
     // verdict, indistinguishable from a real regression. See README.md
     // §"Wipe before every capture" for the measured case.
     if (parser.wasProvided("--expect-frames")) {
-        const size_t expected = static_cast<size_t>(parser.getInt("--expect-frames"));
+        const int expectArg = parser.getInt("--expect-frames");
+        if (expectArg < 0) {
+            std::fprintf(
+                stderr,
+                "jitter_probe: --expect-frames expects a non-negative count (got %d)\n",
+                expectArg
+            );
+            return 2;
+        }
+        const size_t expected = static_cast<size_t>(expectArg);
         if (args.frames_.size() != expected) {
             std::fprintf(
                 stderr,

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -19,6 +19,7 @@
 //     [--stationary]       assert the centroid does NOT move (pivot-pin check)
 //     [--max-deviation PX] PINNED verdict requires deviation <= this (default 1.50)
 //     [--verbose]          print the per-frame centroid + residual table
+//     [--expect-frames N]  fail (exit 2) unless exactly N frames were passed
 //
 // Capture the sequence with an ISOLATED shape on a black field so the centroid
 // is clean — e.g. `shape_debug --spin-shape box --spin-shape-voxel --pan-sweep`
@@ -226,6 +227,11 @@ int main(int argc, char **argv) {
     parser.flag("--stationary", "Assert the centroid does NOT move (rotation-pivot pin check)");
     parser.number("--max-deviation", "PINNED verdict requires deviation <= this (px)", 1.50f);
     parser.flag("--verbose", "Print the per-frame centroid + residual table");
+    parser.integer(
+        "--expect-frames",
+        "Fail unless exactly this many frames were passed (0 = no check)",
+        0
+    );
     parser.variadic("frames", "Frame PNGs in capture order (>= 3)", 3);
     parser.parse(argc, argv);
 
@@ -241,10 +247,35 @@ int main(int argc, char **argv) {
         args.useColor_ = true;
         const std::string color = parser.getString("--color");
         if (std::sscanf(
-                color.c_str(), "%d,%d,%d,%d", &args.colorR_, &args.colorG_, &args.colorB_,
+                color.c_str(),
+                "%d,%d,%d,%d",
+                &args.colorR_,
+                &args.colorG_,
+                &args.colorB_,
                 &args.colorTol_
             ) != 4) {
             std::fprintf(stderr, "jitter_probe: --color expects R,G,B,T\n");
+            return 2;
+        }
+    }
+
+    // The capture dir is never cleared between runs and VideoManager numbers
+    // *around* leftovers, so a shell glob silently widens to earlier runs and to
+    // ROI crops. Scoring the wrong set does not fail — it produces a confident
+    // verdict, indistinguishable from a real regression. See README.md
+    // §"Wipe before every capture" for the measured case.
+    if (parser.wasProvided("--expect-frames")) {
+        const size_t expected = static_cast<size_t>(parser.getInt("--expect-frames"));
+        if (args.frames_.size() != expected) {
+            std::fprintf(
+                stderr,
+                "jitter_probe: expected %zu frames but got %zu — the glob picked up a "
+                "different set than the run produced (stale captures from an earlier run, "
+                "or ROI crop files). Wipe the screenshots dir before capturing and match "
+                "full frames only.\n",
+                expected,
+                args.frames_.size()
+            );
             return 2;
         }
     }


### PR DESCRIPTION
## Summary

The hand-run jitter recipes capture into `save_files/screenshots/` and then glob
it. The engine **never** clears that directory and `VideoManager::reserveNextScreenshotIndex`
deliberately numbers *around* leftovers, so a second run appends rather than
replaces — the glob then scores this run's frames plus every earlier run's, plus
any ROI crop files (crops share the `screenshot_<index>` prefix; a 128x128 crop
has no usable foreground).

Scoring the wrong set does not fail. It produces a *confident* verdict,
indistinguishable from a real regression, on the gate the S1/S3 shadow work and
#2427/#2544 rely on.

Every **scripted** harness already defends itself — `render-verify.py`,
`cull-verify.py` and `pivot-verify.py` all `rmtree` the shots dir (via
`verify_common.run_pass`), and `render-verify.py` additionally matches full
frames only (`_FULL_FRAME_RE`) and asserts the shot count. None of that
discipline reached the two prose recipes agents follow by hand. This PR closes
that gap.

- `tools/jitter_probe/main.cpp` — new `--expect-frames N`: when supplied and the
  positional count differs, exit 2 with a diagnostic naming both counts,
  **before** any scoring. Inert when the count matches.
- `engine/render/CLAUDE.md` §"Verifying temporal stability", `tools/jitter_probe/README.md`
  §"Capturing a clean sweep" — wipe step first, 6-digit full-frame-only glob,
  and `--expect-frames` wired to the `--auto-screenshot` count. New README
  subsection explains why all three are load-bearing.

## Test plan

- [x] `fleet-build --target jitter_probe` — clean (macOS/Metal preset).
- [x] Determinism baseline: same 6 files twice, no flag → byte-identical stdout.
- [x] Positive: 6 files + `--expect-frames 6` → byte-identical to the no-flag run.
- [x] Negative: 7 files + `--expect-frames 6` → exit 2, diagnostic, no verdict line.
- [x] Unguarded baseline: 7 files, no flag → still exits 1 with a confident
      `verdict=JITTER` and *shifted* metrics — the defect reproduced in miniature.

## Acceptance evidence

Frames used: the first 6–7 full-frame captures under
`build/creations/editors/voxel_editor/save_files/screenshots/` (a directory that
had accumulated **89** files across runs — the defect, live in the tree).

| Criterion | Check run | Observed |
|---|---|---|
| 1. Wipe step in both recipes | `git diff origin/master -- engine/render/CLAUDE.md tools/jitter_probe/README.md` | `find <ss_dir> -name '*.png' -delete` added to both, path ended at `.../screenshots`, `-delete` rationale inline |
| 2. Full-frame-only glob | as above | both recipes now use `screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png` |
| 3. `--expect-frames` fails before scoring | `jitter_probe --expect-frames 6 <7 files>` | `rc=2`; `jitter_probe: expected 6 frames but got 7 — …`; no verdict line emitted |
| 4a. Positive control (count matches ⇒ inert) | `jitter_probe --expect-frames 6 <6 files>` vs same without the flag | `rc=1` both; `cmp` → **byte-identical** |
| 4b. Determinism baseline for 4a | same 6-file command run twice, no flag | `cmp` → byte-identical (`verdict=JITTER  x: max_residual=125.36px`) |
| 4c. Opposite direction (unguarded) | `jitter_probe <7 files>` (no flag) | `rc=1`, `frames=7 … verdict=JITTER`, `x: max_residual=109.53px` vs 125.36px on the correct 6 — one stale file silently moved every metric while the verdict stayed confident |
| 5. Bad glob retired | `grep -n 'screenshot_0\*' engine/render/CLAUDE.md tools/jitter_probe/README.md` | no hits |

4c is the point of the change: absence of a failure proves nothing, so the
guard is demonstrated in both directions against the same binary.

## Notes / audited but deliberately not folded in

Siblings surfaced by a `git ls-files | xargs grep` sweep, left for follow-ups
rather than bundled here:

- `.claude/skills/render-debug-loop/SKILL.md:82` and `.cursor/skills/render-debug-loop/SKILL.md:98`
  cite `screenshot_*.png` with no wipe. The `.claude` copy is **gated
  self-config** — no worker class can push it.
- `scripts/cull-verify.py:87` and `verify_common.py:237` glob the crop-inclusive
  `screenshot_*.png`. Safe against *stale* input today (both `rmtree` first), but
  whether their demos emit ROI crops into the same run is unaudited. Not verified
  this session, so not filed.

Closes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment — fleet review round 1 (commit `23bdc4898`)

**Needs-fix (confirmed by reproduction, not accepted on assertion).**
`tools/jitter_probe/README.md:97-99` claimed `fleet-build --target <Demo>Assets`
would *not* restore assets a too-broad `find` deleted, and told the reader to
hand-copy `engine/render/data`. Both halves were wrong — and this was the one
bullet in the PR citing an unmeasured claim as the fix, i.e. exactly the standard
4c sets for everything else here.

| Check | Command | Observed |
|---|---|---|
| Rebuild-Assets restores a deleted staged asset | delete `build/creations/demos/shape_debug/data/images/irreden_engine_logo_v6_alpha.png`, then `fleet-build --target IRShapeDebugAssets` | file returns, `md5 = 2d41ae79a4d388fb0501864a5b746833` **before and after** — byte-identical |
| Why it restores | `cmake/ir_functions.cmake` `irreden_bundle_assets` | `add_custom_target(${target}Assets ...)` — no `OUTPUT`, and `copy_directory` (not `copy_if_different`), so an explicit build always re-runs it |
| Hand-copy would not have fixed the cited symptom | `git ls-files \| grep irreden_engine_logo_v6_alpha` | lives in `engine/data/images/`, not `engine/render/data/`; the staged `data/` is a **merge** of both trees |

**Nits, both graded against a pre-change control** (rebuilt the pre-amend
`main.cpp` and ran it, rather than reasoning about the old behavior):

| Nit | Pre-change (measured) | Post-change |
|---|---|---|
| `--expect-frames` help said "(0 = no check)" but the gate is `wasProvided()` | help printed `(0 = no check)`; `--expect-frames 0` still checks and fails | help reads `(omit to disable)`; `--expect-frames 0` fails with the truthful `expected 0 frames but got 6` |
| negative input wrapped through `static_cast<size_t>` | `--expect-frames -1` → `expected 18446744073709551615 frames but got 6` | `--expect-frames -1` → `jitter_probe: --expect-frames expects a non-negative count (got -1)` |

Exit code was already `2` on both sides of the negative case, so that nit is
diagnostic quality — not a behavior change.

**Positive control re-run after the amendment** (the guard must stay inert):
`--expect-frames 6` against 6 frames is byte-identical to the same run with no
flag, against a two-run no-flag determinism baseline that is itself
byte-identical. `fleet-build --target jitter_probe` clean.

**Sibling sweep** (the fixed defect is "a doc asserts unmeasured build-system
behavior", so the class was re-enumerated tree-wide, not just in the touched
files): `git ls-files | xargs grep -l` for the hand-copy / "won't restore" /
"up to date by timestamp" forms returns **zero** hits after this fix, and every
other `*Assets` mention in the tree already states the correct behavior
(`.claude/skills/platform-catchup/SKILL.md:158` "its `*Assets` target re-copies
it", `.fleet/plans/issue-1888.md:72` "re-stages on every run"). This README
bullet was the lone outlier — no follow-up filed.
