### PR TITLE
scripts: hoist the ROI-crop glob guard into verify_common (#2819)

### DIFF
--- a/scripts/cull-verify.py
+++ b/scripts/cull-verify.py
@@ -84,7 +84,10 @@ CULL_THRESHOLDS: dict[str, Any] = {
 
 
 def _collect_shots(shots_dir: Path) -> list[Path]:
-    shots = sorted(shots_dir.glob("screenshot_*.png"))
+    # Full frames only — the live/frozen pairing is positional (shots[i] vs
+    # shots[i + POSES_PER_PHASE + 1]), so a crop sorting between full frames
+    # shifts every index. Rationale: verify_common.FULL_FRAME_RE.
+    shots = verify_common.collect_full_frames(shots_dir)
     if len(shots) < TOTAL_SHOTS:
         raise SystemExit(
             f"expected {TOTAL_SHOTS} screenshots in {shots_dir}, got {len(shots)}"

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -59,7 +59,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import shutil
 import subprocess
 import sys
@@ -90,15 +89,11 @@ def _load_manifest(demo_dir: Path) -> dict[str, Any]:
     return data
 
 
-# Full-frame captures are ``screenshot_<6-digit-index>.png``. ROI crop files
-# share the prefix but append ``_<shotLabel>__crop_<crop>.png`` (see
-# VideoManager::writePendingRoiCrops). A bare ``screenshot_*.png`` glob matches
-# both, and since ``.`` < ``_`` the crops sort *between* full frames — so the
-# first-N slice below would pick 128x128 crops as full shots. Match the
-# index-only form so crops never enter the *full-frame* shot->reference
-# mapping. Crops are still compared, but via the separate manifest-driven
-# ``crops`` gate (see ``evaluate_shots``), not this index mapping.
-_FULL_FRAME_RE = re.compile(r"screenshot_\d+\.png")
+# Crop-exclusion (the reason a bare ``screenshot_*.png`` glob is wrong) lives in
+# verify_common.FULL_FRAME_RE / collect_full_frames — one definition for the
+# whole harness family (#2819). Crops are still compared here, but via the
+# manifest-driven ``crops`` gate (see ``evaluate_shots``), which *constructs*
+# each crop filename from its full frame rather than globbing.
 
 
 def _collect_all_shots(shots_dir: Path) -> list[Path]:
@@ -111,10 +106,7 @@ def _collect_all_shots(shots_dir: Path) -> list[Path]:
     appends the compare shots at the tail — so its mapping is positional into
     the full list, resolved by the pass's ``capture_offset``.
     """
-    return sorted(
-        p for p in shots_dir.glob("screenshot_*.png")
-        if _FULL_FRAME_RE.fullmatch(p.name)
-    )
+    return verify_common.collect_full_frames(shots_dir)
 
 
 def _collect_shots(shots_dir: Path, num_shots: int) -> list[Path]:

--- a/scripts/tests/test_verify_common_full_frames.py
+++ b/scripts/tests/test_verify_common_full_frames.py
@@ -1,0 +1,172 @@
+"""Tests for the shared full-frame / ROI-crop glob guard (#2819).
+
+``VideoManager::writePendingRoiCrops`` writes ROI crops as
+``screenshot_<n>_<shotLabel>__crop_<cropLabel>.png`` into the *same* directory
+as the full frames (``screenshot_<n>.png``). A bare ``screenshot_*.png`` glob
+matches both, and because ``.`` < ``_`` the crops sort *between* full frames —
+so any positional shot->label/reference mapping built on that glob silently
+shifts.
+
+These tests pin the guard at its shared home (``collect_full_frames``) and at
+every consumer, so a harness cannot silently regain an unfiltered glob — a
+consumer is only ever *accidentally* safe when its demo happens to attach no
+crops, which is a property of the demo's shot table, not of the harness
+(see #2819).
+
+Filenames only — no PNG contents, no engine, no GL/Metal build. Import the
+dashed-name scripts via importlib, matching test_render_verify.py.
+"""
+import importlib.machinery
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_SCRIPTS))
+
+import verify_common  # noqa: E402  (needs the sys.path insert above)
+
+
+def _load(mod_name: str, file_name: str):
+    loader = importlib.machinery.SourceFileLoader(
+        mod_name, str(_SCRIPTS / file_name))
+    spec = importlib.util.spec_from_loader(mod_name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+_cv = _load("cull_verify", "cull-verify.py")
+_rv = _load("render_verify", "render-verify.py")
+
+
+def _seed(shots_dir: Path, num_frames: int, crops_on: tuple[int, ...] = ()) -> None:
+    """Write ``num_frames`` full frames, with ROI crops on the given indices."""
+    for i in range(num_frames):
+        (shots_dir / f"screenshot_{i:06d}.png").touch()
+        if i in crops_on:
+            (shots_dir / f"screenshot_{i:06d}_cv_live_{i:03d}__crop_center.png").touch()
+
+
+class TestSortInterleave(unittest.TestCase):
+    """The premise the guard rests on: crops sort between full frames."""
+
+    def test_crops_sort_between_full_frames(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, 3, crops_on=(0, 1, 2))
+            unfiltered = sorted(p.name for p in d.glob("screenshot_*.png"))
+            # Interleaved, not grouped: frame, its crop, next frame, ...
+            self.assertEqual(
+                unfiltered,
+                [
+                    "screenshot_000000.png",
+                    "screenshot_000000_cv_live_000__crop_center.png",
+                    "screenshot_000001.png",
+                    "screenshot_000001_cv_live_001__crop_center.png",
+                    "screenshot_000002.png",
+                    "screenshot_000002_cv_live_002__crop_center.png",
+                ],
+            )
+            # The positional hazard, stated as an assertion: a first-N slice of
+            # the unfiltered glob puts a CROP where full frame 1 belongs.
+            self.assertTrue(unfiltered[1].endswith("__crop_center.png"))
+
+
+class TestCollectFullFrames(unittest.TestCase):
+    def test_excludes_crops_and_preserves_index_order(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, 3, crops_on=(0, 1, 2))
+            got = [p.name for p in verify_common.collect_full_frames(d)]
+            self.assertEqual(
+                got,
+                ["screenshot_000000.png",
+                 "screenshot_000001.png",
+                 "screenshot_000002.png"],
+            )
+
+    def test_no_crops_present_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, 4)
+            self.assertEqual(len(verify_common.collect_full_frames(d)), 4)
+
+    def test_empty_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(verify_common.collect_full_frames(Path(td)), [])
+
+    def test_unrelated_files_ignored(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, 2)
+            (d / "notes.txt").touch()
+            (d / "screenshot_000000.diff.png").touch()
+            self.assertEqual(len(verify_common.collect_full_frames(d)), 2)
+
+
+class TestCullVerifyCollectShots(unittest.TestCase):
+    """Positive control: this is the site that does the first-N slice.
+
+    Against the pre-#2819 body (``sorted(shots_dir.glob("screenshot_*.png"))``)
+    the crop case returns a crop at index 1 and the live/frozen pairing shifts.
+    """
+
+    def test_crops_do_not_enter_the_positional_index(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, _cv.TOTAL_SHOTS, crops_on=tuple(range(_cv.TOTAL_SHOTS)))
+            shots = _cv._collect_shots(d)
+            self.assertEqual(len(shots), _cv.TOTAL_SHOTS)
+            for p in shots:
+                self.assertNotIn("__crop_", p.name)
+            # The live/frozen pairing this harness performs stays aligned.
+            for i in range(_cv.POSES_PER_PHASE):
+                self.assertEqual(shots[i].name, f"screenshot_{i:06d}.png")
+                frozen = i + _cv.POSES_PER_PHASE + 1
+                self.assertEqual(shots[frozen].name, f"screenshot_{frozen:06d}.png")
+
+    def test_short_capture_still_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            # Enough files to satisfy a *bare* glob, but one full frame short —
+            # the crops must not paper over a genuinely truncated capture.
+            _seed(d, _cv.TOTAL_SHOTS - 1, crops_on=(0, 1))
+            with self.assertRaises(SystemExit):
+                _cv._collect_shots(d)
+
+
+class TestRenderVerifyUnchanged(unittest.TestCase):
+    """render-verify already filtered; routing it through the shared helper
+    must not change what it returns."""
+
+    def test_collect_all_shots_still_excludes_crops(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, 3, crops_on=(0, 2))
+            got = [p.name for p in _rv._collect_all_shots(d)]
+            self.assertEqual(
+                got,
+                ["screenshot_000000.png",
+                 "screenshot_000001.png",
+                 "screenshot_000002.png"],
+            )
+
+    def test_collect_shots_slice_maps_to_full_frames(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            _seed(d, 5, crops_on=(0, 1, 2, 3, 4))
+            got = [p.name for p in _rv._collect_shots(d, 3)]
+            self.assertEqual(
+                got,
+                ["screenshot_000000.png",
+                 "screenshot_000001.png",
+                 "screenshot_000002.png"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_common.py
+++ b/scripts/verify_common.py
@@ -46,6 +46,30 @@ GUI_ASSERT_RE = re.compile(
     r"actual=(.*)"
 )
 
+# Full-frame captures are ``screenshot_<6-digit-index>.png``. ROI crop files
+# share that prefix but append ``_<shotLabel>__crop_<crop>.png`` and land in the
+# same directory (see VideoManager::writePendingRoiCrops). A bare
+# ``screenshot_*.png`` glob matches both, and since ``.`` < ``_`` the crops sort
+# *between* full frames — so a first-N slice of that glob picks 128x128 crops as
+# full shots, and any positional shot->label/reference mapping silently shifts.
+# Match the index-only form so crops never enter a full-frame index mapping.
+# Crops are still compared where a harness wants them, but by *constructing* the
+# filename from the full frame (render-verify.py's crop gate), never by globbing.
+FULL_FRAME_RE = re.compile(r"screenshot_\d+\.png")
+
+
+def collect_full_frames(shots_dir: Path) -> list[Path]:
+    """Full-frame captures in ``shots_dir``, index-ordered, crops excluded.
+
+    The single crop-exclusion point for the verify-harness family — see
+    ``FULL_FRAME_RE`` for why a bare glob is wrong. Harnesses that need a count
+    expectation layer it on top of this list rather than re-deriving the
+    filter; a second private copy is how the guard goes missing from a sibling
+    (see #2819).
+    """
+    return sorted(p for p in shots_dir.glob("screenshot_*.png")
+                  if FULL_FRAME_RE.fullmatch(p.name))
+
 
 def run(cmd: list[str], cwd: Path | None = None, check: bool = True,
         env: dict[str, str] | None = None, timeout: int | None = None) -> int:
@@ -220,7 +244,10 @@ def compare(actual: Path, reference: Path, diff_out: Path | None,
 
 def run_pass(cmd: list[str], cwd: Path, shots_dir: Path,
              timeout: int | None = None) -> tuple[int, str, list[Path]]:
-    """Clear ``shots_dir``, run ``cmd``, and collect the resulting screenshots.
+    """Clear ``shots_dir``, run ``cmd``, and collect the resulting full frames.
+
+    The returned list is ``collect_full_frames(shots_dir)`` — ROI crops are
+    excluded, so callers may index it positionally against a shot table.
 
     Callers that run multiple passes against the same ``shots_dir`` (e.g.
     light-verify's domain-matrix / boundary-sweep / hover-sweep flags) must
@@ -234,5 +261,4 @@ def run_pass(cmd: list[str], cwd: Path, shots_dir: Path,
         shutil.rmtree(shots_dir)
     shots_dir.mkdir(parents=True, exist_ok=True)
     rc, output = run_capture(cmd, cwd=cwd, timeout=timeout)
-    images = sorted(shots_dir.glob("screenshot_*.png"))
-    return rc, output, images
+    return rc, output, collect_full_frames(shots_dir)


### PR DESCRIPTION
## Summary
- `render-verify.py` already knew a bare `screenshot_*.png` glob also matches the ROI crops `VideoManager::writePendingRoiCrops` writes beside the full frames — and that since `.` < `_` those crops sort *between* frames, so a first-N slice picks 128x128 crops as full shots. It guarded with a private `_FULL_FRAME_RE` and documented why.
- The other two globs in `scripts/` never got the guard. `cull-verify.py:87` feeds the exact first-N slice the comment warns about (`shots[:TOTAL_SHOTS]`), and `verify_common.run_pass()` returns a list its callers (`light-verify`, `pivot-verify`, `cull-verify`) index positionally.
- Hoists `FULL_FRAME_RE` + its rationale into `verify_common.collect_full_frames()` and routes all three sites through it, leaving one definition. Drops the now-dead `import re` from render-verify.
- Adds `scripts/tests/test_verify_common_full_frames.py` (9 tests) pinning the guard at the shared home and at every consumer.

**Latent, not live** — and deliberately so in the body: neither unguarded site's demo attaches crops today, so nothing is currently miscomparing. But that safety is a property of three *demo shot tables*, not of the scripts. `shape_debug`'s static `kShots[]` already attaches crops on three entries (`main.cpp:107,114,146`), so one added `shot.crops_` on a `--cull-validate` or lighting shot would shift every index behind nothing louder than cull-verify's benign `warning: captured N shots, expected M; ignoring extras`.

Crop-consuming paths are untouched: render-verify reaches crops by *constructing* the filename from the full frame (`_crop_capture_path`), never by globbing, and `scripts/dev/shape-rotate-jitter-sweep:100` globs the crop-only form deliberately.

## Test plan
- [x] New suite green: `PYTHONPATH=scripts python3 scripts/tests/test_verify_common_full_frames.py` → `Ran 9 tests … OK`.
- [x] **Positive control** — reverted only the three scripts to `origin/master` (holding the new test fixed) and re-ran: `FAILED (failures=2, errors=4)`. The two load-bearing failures are both on the defective site, `cull-verify._collect_shots`:
  - `test_crops_do_not_enter_the_positional_index` → `AssertionError: '__crop_' unexpectedly found in 'screenshot_000000_cv_live_000__crop_center.png'`
  - `test_short_capture_still_raises` → `AssertionError: SystemExit not raised` (crops masked a truncated capture)
  - The control run also emitted `[cull-verify] warning: captured 52 shots, expected 26; ignoring extras` — the benign-looking line that is the only signal the index is corrupt.
- [x] No regression in the existing gate: `PYTHONPATH=scripts python3 scripts/tests/test_render_verify.py` → `Ran 30 tests … OK` (render-verify's crop gate + slice behaviour unchanged by the routing).
- [x] All 7 `scripts/tests/` suites green (clip, coverage, jitter, shadow, silhouette, render_verify, new suite).
- [x] `ruff check scripts/` → `All checks passed!`

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Every `screenshot_` glob routes through the shared filter (or is a deliberate crop-only glob) | `git ls-files \| xargs grep -n 'glob("screenshot_'` | 3 hits: `verify_common.py` (the definition), `cull-verify.py:87` and `render-verify.py:115` both now `verify_common.collect_full_frames(...)`. `scripts/dev/shape-rotate-jitter-sweep:100` is the deliberate crop-only form, unchanged. |
| Guard defined once; no second private copy | `git grep -n "_FULL_FRAME_RE\|FULL_FRAME_RE"` | Sole definition `verify_common.py:57`; render-verify's private `_FULL_FRAME_RE` deleted. |
| Positive control goes red pre-fix, green post-fix | reverted 3 scripts, held test fixed | pre-fix `FAILED (failures=2, errors=4)`; post-fix `Ran 9 tests … OK`. Failures discriminate on the crop landing at index 1, not merely on "something raised". |
| `test_render_verify.py` green (render-verify crop behaviour unchanged) | `PYTHONPATH=scripts python3 scripts/tests/test_render_verify.py` | `Ran 30 tests in 1.086s … OK` |

## Notes for the reviewer
- **No CI runs `scripts/tests/`.** Verified: `.github/workflows/` has `auto-rereview`, `fleet-tests` (which runs `scripts/fleet/tests/`, a different tree), `perf-gate`, `quality`; none invokes these suites. The five pre-existing `test_render_*.py` siblings are equally unwired, so this suite matches convention — but the coverage is hand-run, and I'd rather state that than imply a gate exists. Not fixed here (out of scope for this defect).
- **Pre-existing, not introduced:** `python3 scripts/tests/test_render_verify.py` from the repo root fails at `import verify_common` unless `scripts/` is on `sys.path` — confirmed identical on `origin/master`. The new suite inserts `scripts/` on `sys.path` itself, so it runs either way. Left the sibling alone rather than widen the diff.

Closes #2819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
