### PR TITLE
ci: execute the scripts/tests render-harness suites (#2825)

### DIFF
--- a/.github/workflows/render-harness-tests.yml
+++ b/.github/workflows/render-harness-tests.yml
@@ -4,13 +4,13 @@ name: Render Harness Tests
 # not CMake tests, so `ctest` never sees them — without this workflow nothing
 # executes them and a suite can go red silently (#2825).
 #
-# Standalone for the same reason fleet-tests.yml and header-checks.yml are:
-# the only other CI surface that would reach these (quality.yml's ruff/ctest
-# job) is disabled at the repo level, so a step added there is inert until it
-# is re-enabled (#2718). These suites need no compiler, no GL, and no CMake.
+# Standalone for the same reason fleet-tests.yml is: the only other CI surface
+# that would reach these (quality.yml's ruff/ctest job) is disabled at the repo
+# level, so a step added there is inert until it is re-enabled (#2718). These
+# suites need no compiler, no GL, and no CMake.
 #
-# Path-filtered to the **subjects** (scripts/*.py — where all ten dashed
-# harness scripts and the two shared modules they import live) as well as the
+# Path-filtered to the **subjects** (scripts/*.py — where every dashed harness
+# script and the shared modules they import live) as well as the
 # suites themselves, not just the suites' own directory. Filtering on the
 # suites' location alone is the shape #2810 records against fleet-tests.yml:
 # a PR that breaks a subject then skips the only coverage guarding it.

--- a/.github/workflows/render-harness-tests.yml
+++ b/.github/workflows/render-harness-tests.yml
@@ -1,0 +1,57 @@
+name: Render Harness Tests
+
+# The render-verify harness's own unittest suites (scripts/tests/). They are
+# not CMake tests, so `ctest` never sees them — without this workflow nothing
+# executes them and a suite can go red silently (#2825).
+#
+# Standalone for the same reason fleet-tests.yml and header-checks.yml are:
+# the only other CI surface that would reach these (quality.yml's ruff/ctest
+# job) is disabled at the repo level, so a step added there is inert until it
+# is re-enabled (#2718). These suites need no compiler, no GL, and no CMake.
+#
+# Path-filtered to the **subjects** (scripts/*.py — where all ten dashed
+# harness scripts and the two shared modules they import live) as well as the
+# suites themselves, not just the suites' own directory. Filtering on the
+# suites' location alone is the shape #2810 records against fleet-tests.yml:
+# a PR that breaks a subject then skips the only coverage guarding it.
+# `scripts/*` does not match across `/`, so scripts/fleet/** is excluded —
+# that tree has its own workflow. The two path lists are duplicated because
+# GitHub Actions does not support YAML anchors — keep them in sync.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/*.py'
+      - 'scripts/tests/**'
+      - '.github/workflows/render-harness-tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/*.py'
+      - 'scripts/tests/**'
+      - '.github/workflows/render-harness-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  render-harness-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The suites are hermetic — synthetic PNGs, no engine binary, no GL
+      # context, no committed references — so a plain checkout is the whole
+      # environment. python3 is preinstalled on ubuntu-latest.
+      #
+      # No separate "prove the gate still fires" step: run_all.sh's own
+      # negative controls ship as test_run_all.py and run as one of the
+      # suites below. It asserts the runner reports a failing suite, exits
+      # non-zero on an empty directory (so a glob that matches nothing cannot
+      # read as green), and — the #2825 lock — that a suite depending on a
+      # sibling's sys.path insert FAILS under the runner while passing under a
+      # shared-interpreter discover.
+      - name: Run render harness tests
+        run: bash scripts/tests/run_all.sh

--- a/scripts/tests/run_all.sh
+++ b/scripts/tests/run_all.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# run_all.sh — run every render-harness test suite in this directory once.
+#
+# These suites are unittest, not CMake tests, so `ctest` never sees them; this
+# runner and the `render-harness-tests.yml` workflow that calls it are the only
+# things that execute them. Keep that workflow wired — an unexecuted suite goes
+# red silently (#2825).
+#
+# One process per suite, and that is the point. These suites put scripts/ on
+# sys.path themselves so they can import the dashed-name subjects. Run in a
+# shared interpreter (`python3 -m unittest discover`), one suite's insert
+# satisfies the next one's import, so a suite that forgot the line still reports
+# green — the mask this runner exists to prevent (#2825).
+#
+# The fleet tooling tree has a same-shaped runner at
+# scripts/fleet/tests/run_all.sh with a wider option surface (--only, --list,
+# --timeout, bash+python dispatch). This one stays minimal deliberately: every
+# suite here is python, hermetic, and sub-second, so the shared core is a
+# ~10-line loop rather than a library worth factoring out.
+#
+# Usage:
+#   run_all.sh [<dir>]     # <dir> defaults to this script's directory
+#
+# The directory argument exists so CI can point the runner at a fixture
+# directory and prove it still reports failure — a green runner looks identical
+# whether it ran everything or nothing.
+#
+# Exit status:
+#   0  every suite passed
+#   1  at least one suite failed, or no suite was found
+set -uo pipefail
+
+PROG=$(basename "$0")
+TESTS_DIR=${1:-$(cd "$(dirname "$0")" && pwd)}
+
+if [[ ! -d "$TESTS_DIR" ]]; then
+    echo "$PROG: not a directory: $TESTS_DIR" >&2
+    exit 1
+fi
+
+suites=()
+for f in "$TESTS_DIR"/test_*.py; do
+    [[ -f "$f" ]] || continue                       # unmatched glob
+    suites+=("$f")
+done
+
+if [[ ${#suites[@]} -eq 0 ]]; then
+    echo "$PROG: no test_*.py suites found in $TESTS_DIR" >&2
+    exit 1
+fi
+
+passed=0
+failed_names=()
+
+for f in "${suites[@]}"; do
+    name=$(basename "$f")
+    # Each suite in its own interpreter — see the header. cwd is deliberately
+    # left alone: the suites resolve their subjects from __file__, so a run
+    # that depends on cwd is itself a defect.
+    if out=$(python3 "$f" 2>&1); then
+        passed=$((passed + 1))
+        printf 'PASS  %s\n' "$name"
+    else
+        rc=$?
+        failed_names+=("$name")
+        printf 'FAIL  %s (exit %s)\n' "$name" "$rc"
+        printf '%s\n' "$out" | sed 's/^/      | /'
+    fi
+done
+
+echo
+echo "$PROG: ${#suites[@]} suite(s) — $passed passed, ${#failed_names[@]} failed"
+if [[ ${#failed_names[@]} -gt 0 ]]; then
+    echo "$PROG: failed: ${failed_names[*]}" >&2
+    exit 1
+fi

--- a/scripts/tests/test_render_shadow_metric.py
+++ b/scripts/tests/test_render_shadow_metric.py
@@ -14,6 +14,12 @@ import unittest
 from pathlib import Path
 
 _SCRIPTS = Path(__file__).resolve().parent.parent
+# Uniform with the other suites here: a subject that bare-imports a sibling
+# module (verify_common, render_metric_util) needs scripts/ on sys.path. This
+# file's subjects import neither today, so the line is latent rather than
+# load-bearing — kept so the convention holds across the directory (#2825).
+sys.path.insert(0, str(_SCRIPTS))
+
 _loader = importlib.machinery.SourceFileLoader(
     "render_shadow_metric", str(_SCRIPTS / "render-shadow-metric.py"))
 _spec = importlib.util.spec_from_loader("render_shadow_metric", _loader)

--- a/scripts/tests/test_render_verify.py
+++ b/scripts/tests/test_render_verify.py
@@ -22,6 +22,11 @@ import unittest
 from pathlib import Path
 
 _SCRIPTS = Path(__file__).resolve().parent.parent
+# render-verify.py does a bare `import verify_common` (#2461), which resolves
+# only if scripts/ is on sys.path. Without this the suite dies at import when
+# run on its own, and passes only when an alphabetically-earlier sibling in
+# this directory happens to insert the path first (#2825).
+sys.path.insert(0, str(_SCRIPTS))
 
 
 def _load(mod_name: str, file_name: str):

--- a/scripts/tests/test_run_all.py
+++ b/scripts/tests/test_run_all.py
@@ -1,0 +1,128 @@
+"""Tests for run_all.sh — the render-harness suite runner.
+
+The runner's whole reason to exist is that it runs each suite in its own
+interpreter. A shared-interpreter runner (`python3 -m unittest discover`)
+lets one suite's `sys.path.insert` satisfy the next suite's import, so a
+suite that forgot the line reports green (#2825).
+
+`test_isolation_*` below is the regression lock for exactly that: a fixture
+directory whose second suite imports a module only the first suite puts on
+the path. The runner must report it FAILED; the positive control asserts the
+same fixture passes under a shared-interpreter discover, which is what proves
+the fixture reproduces the masking rather than being trivially broken.
+
+Fixtures are synthesized in a temp directory — nothing here touches the real
+suites.
+"""
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_SCRIPTS))
+
+_RUN_ALL = Path(__file__).resolve().parent / "run_all.sh"
+
+_TRIVIAL_CASE = """
+import unittest
+
+
+class T(unittest.TestCase):
+    def test_ok(self):
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    unittest.main()
+"""
+
+
+def _run_runner(directory: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_RUN_ALL), str(directory)],
+        capture_output=True, text=True)
+
+
+def _write(directory: Path, name: str, body: str) -> None:
+    (directory / name).write_text(body)
+
+
+class RunAllRunnerTest(unittest.TestCase):
+
+    def test_all_passing_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(Path(d), "test_a.py", _TRIVIAL_CASE)
+            _write(Path(d), "test_b.py", _TRIVIAL_CASE)
+            r = _run_runner(Path(d))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("2 suite(s) — 2 passed, 0 failed", r.stdout)
+
+    def test_failing_suite_exits_nonzero_and_is_named(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(Path(d), "test_good.py", _TRIVIAL_CASE)
+            _write(Path(d), "test_bad.py", "import sys\nsys.exit(3)\n")
+            r = _run_runner(Path(d))
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("FAIL  test_bad.py (exit 3)", r.stdout)
+            self.assertIn("test_bad.py", r.stderr)
+            # The passing sibling must still be reported as passing — a runner
+            # that aborts on first failure hides the rest of the tally.
+            self.assertIn("PASS  test_good.py", r.stdout)
+
+    def test_empty_directory_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as d:
+            r = _run_runner(Path(d))
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("no test_*.py suites found", r.stderr)
+
+    def test_missing_directory_exits_nonzero(self):
+        r = _run_runner(Path("/nonexistent-dir-for-run-all-test"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("not a directory", r.stderr)
+
+    # ------------------------------------------------------------------
+    # The #2825 regression lock: per-process isolation.
+    # ------------------------------------------------------------------
+
+    def _isolation_fixture(self, d: Path) -> None:
+        """A dir whose 2nd suite imports a module only the 1st puts on path."""
+        (d / "lib").mkdir()
+        _write(d / "lib", "fixture_mod.py", "VALUE = 1\n")
+        # Alphabetically first: inserts lib/ on sys.path, then imports.
+        _write(d, "test_aaa_inserter.py",
+               "import sys\n"
+               "from pathlib import Path\n"
+               "sys.path.insert(0, str(Path(__file__).resolve().parent / 'lib'))\n"
+               "import fixture_mod\n"
+               + _TRIVIAL_CASE)
+        # Alphabetically second: bare import, no insert of its own.
+        _write(d, "test_zzz_dependent.py",
+               "import fixture_mod\n" + _TRIVIAL_CASE)
+
+    def test_isolation_runner_reports_the_dependent_suite_failed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            self._isolation_fixture(d)
+            r = _run_runner(d)
+            self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+            self.assertIn("PASS  test_aaa_inserter.py", r.stdout)
+            self.assertIn("FAIL  test_zzz_dependent.py", r.stdout)
+            self.assertIn("ModuleNotFoundError", r.stdout)
+
+    def test_isolation_positive_control_shared_interpreter_hides_it(self):
+        """Same fixture, one interpreter — green. This is the masking."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            self._isolation_fixture(d)
+            r = subprocess.run(
+                [sys.executable, "-m", "unittest", "discover",
+                 "-s", str(d), "-t", str(d)],
+                capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("OK", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `scripts/tests/` (6 unittest suites, 83 tests) had **no executor**: `fleet-tests.yml` is path-filtered to `scripts/fleet/**`, `quality.yml`'s `ctest`+ruff job is disabled at the repo level (#2718), and no `add_test` references them. This is the sibling tree #2712 left behind.
- `test_render_verify.py` had been **red on master since 2026-07-20** — `d7b9df25a` (#2461) gave `render-verify.py:69` a bare `import verify_common`, and the suite never gained the matching `sys.path` entry.
- It read **green under a whole-directory `unittest discover`**: the suites put `scripts/` on `sys.path` themselves, so an alphabetically-earlier sibling's insert satisfied the broken one's import. `run_all.sh` runs **one process per suite** for exactly that reason.
- `test_run_all.py` locks the isolation property with the fixture that reproduces the mask, plus a positive control asserting the *same fixture* passes under a shared interpreter — the half that proves the fixture reproduces the defect rather than being trivially broken.
- The workflow is **standalone**, following `fleet-tests.yml` / `header-checks.yml` (#2794/#2797) — a step in `quality.yml` would be inert. Its `paths:` covers the **subjects** (`scripts/*.py`) as well as the suites, the gap #2810 records against `fleet-tests.yml`.

**Correction to the issue's §4 census** (recorded as [a comment on #2825](https://github.com/jakildev/IrredenEngine/issues/2825#issuecomment-5152180883)): there are **two** shared modules, not one. `verify_common.py` is bare-imported by 6 subjects, `render_metric_util.py` by 4. So the `sys.path.insert` in the four suites that already carried it is **load-bearing, not defensive** — reverting it from `test_render_clip_metric.py` (a `render_metric_util` consumer) also fails the runner. The runner catches the regression from either direction.

## Test plan
- [x] All 7 suites pass individually from the repo root with no `PYTHONPATH` — `for t in scripts/tests/test_*.py; do python3 "$t"; done`, every one rc=0
- [x] `bash scripts/tests/run_all.sh` → `7 suite(s) — 7 passed, 0 failed`, rc=0
- [x] Negative control: `sys.path.insert` reverted out of `test_render_verify.py` → runner rc=1, `FAIL  test_render_verify.py (exit 1)`, `failed: test_render_verify.py`
- [x] Second negative control (unplanned): same revert on `test_render_clip_metric.py` → runner rc=1, `ModuleNotFoundError` on `render_metric_util`
- [x] `test_run_all.py` alone: `Ran 6 tests … OK` — covers pass/fail/empty-dir/missing-dir plus both halves of the isolation lock
- [x] `ruff check scripts/` → `All checks passed!`; `bash -n scripts/tests/run_all.sh` clean; workflow YAML parses and matches `fleet-tests.yml`'s structure

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. Every suite passes individually, repo root, no `PYTHONPATH` | `for t in scripts/tests/test_*.py; do python3 "$t" \|\| echo RED; done` | no `RED` lines; pre-fix the same loop printed `RED scripts/tests/test_render_verify.py` |
| 2. Runner: separate process per suite, per-suite tally, non-zero on failure | `bash scripts/tests/run_all.sh` | `PASS  <name>` ×7 then `run_all.sh: 7 suite(s) — 7 passed, 0 failed`; rc=0. Failure path in criterion 4 |
| 3. CI executes it; filter covers subjects **and** suites | `.github/workflows/render-harness-tests.yml` | `run: bash scripts/tests/run_all.sh`; `paths: ['scripts/*.py', 'scripts/tests/**', '.github/workflows/render-harness-tests.yml']`. `scripts/*` does not match across `/`, so `scripts/fleet/**` stays with its own workflow. **Live:** the workflow fired on this PR and passed on ubuntu-latest in 14s ([run](https://github.com/jakildev/IrredenEngine/actions/runs/30707105256/job/91387999459)) |
| 4. Negative control on the runner | revert the insert from `test_render_verify.py`, rerun | rc=**1**, `FAIL  test_render_verify.py (exit 1)`, `run_all.sh: failed: test_render_verify.py`; restored → rc=0. Permanent form: `test_run_all.py::test_isolation_runner_reports_the_dependent_suite_failed` |
| 5. Not a step in `quality.yml` | `.github/workflows/` | new standalone `render-harness-tests.yml`; `quality.yml` untouched |

The runner's own gate-ness is covered rather than asserted: `test_run_all.py` also requires a non-zero exit on an empty directory, so a glob that matches nothing cannot read as green.

## Out of scope — reported, not bundled
`docs/agents/BUILD.md:212-213` says the `Python lint` step in `quality.yml` "gates it on every PR". It does not — `quality.yml` has been disabled since 2026-04-11 (#2718). Pre-existing drift in a file this PR does not touch.

Closes #2825

🤖 Generated with [Claude Code](https://claude.com/claude-code)

