### PR TITLE
fleet-heartbeat: reject flag-shaped args as role names (#2784)

### DIFF
--- a/scripts/fleet/fleet-heartbeat
+++ b/scripts/fleet/fleet-heartbeat
@@ -43,11 +43,22 @@ if [[ -z "${1:-}" ]]; then
     exit 2
 fi
 
+case "$1" in
+    -h|--help)
+        sed -n '28,34p' "$0"
+        exit 0
+        ;;
+esac
+
 role="$1"
 
-# Sanity-check the role name: alphanumeric, dash, underscore only. No
-# slashes (which would escape the heartbeats dir) or shell metachars.
-if ! [[ "$role" =~ ^[A-Za-z0-9_-]+$ ]]; then
+# Sanity-check the role name: alphanumeric, dash, underscore only, and no
+# leading dash — a leading dash is always a flag typo (no real role name
+# starts with one: pool-1..pool-9, opus-architect, game-architect, merger,
+# sonnet-reviewer, opus-reviewer, epic-steward), so reject it here instead
+# of silently touching a file named after the flag. No slashes (which would
+# escape the heartbeats dir) or other shell metachars either.
+if ! [[ "$role" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]]; then
     echo "fleet-heartbeat: invalid role name '$role' — must match [A-Za-z0-9_-]+" >&2
     exit 2
 fi

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -82,7 +82,7 @@ fleet-heartbeat <agent-name>
 
 Touches ~/.fleet/heartbeats/<name> so witness knows the agent is alive.
 
-No --help flag. See scripts/fleet/fleet-heartbeat header.
+fleet-heartbeat -h|--help prints the script's usage block.
 EOF
             ;;
         witness)

--- a/scripts/fleet/tests/test_fleet_heartbeat_flag_args.sh
+++ b/scripts/fleet/tests/test_fleet_heartbeat_flag_args.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Tests for fleet-heartbeat's flag-arg handling (#2784).
+#
+# The role-name validator's regex allowed a leading '-', so any flag-shaped
+# argument (--help, -h, --once, ...) fell through to `touch
+# "$heartbeats_dir/$role"` instead of being rejected — --help in particular
+# silently created a `--help` file instead of printing usage. Fixed by
+# adding an explicit -h|--help case ahead of the validator and tightening
+# the regex to reject a leading dash.
+#
+#   T1: --help prints the usage block, exits 0, creates no heartbeat file
+#   T2: -h same as --help
+#   T3: --help's printed usage block does not leak any post-header code
+#       line (guards the hardcoded `sed -n 'N,Mp'` range per
+#       scripts/fleet/CLAUDE.md's --help-drift rule, #2433)
+#   T4: --bogus (an unrecognized flag) is rejected with the invalid-role
+#       diagnostic, rc=2, no file created
+#   T5: a normal role name still touches its heartbeat file, rc=0
+#       (regression pin — the fix must not touch the working path)
+#   T6: no-arg invocation is unchanged (rc=2, usage to stderr)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HEARTBEAT="$SCRIPT_DIR/fleet-heartbeat"
+
+if [[ ! -x "$HEARTBEAT" ]]; then
+    echo "test setup: fleet-heartbeat not executable at $HEARTBEAT" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+
+cleanup() {
+    if [[ -n "$TMPROOT" && -d "$TMPROOT" ]]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT"
+
+# --- T1: --help prints usage, exits 0, no file ------------------------------
+echo "T1: --help prints usage block, exits 0, creates no heartbeat file"
+set +e
+out=$(HOME="$TMPROOT" "$HEARTBEAT" --help 2>&1)
+rc=$?
+set -e
+assert_eq "$rc" "0" "--help exits 0"
+assert_contains "$out" "fleet-heartbeat <role-name>" "--help output names the usage form"
+if [[ -e "$TMPROOT/.fleet/heartbeats/--help" ]]; then
+    bad "--help must not create a heartbeat file"
+else
+    ok "--help creates no heartbeat file"
+fi
+
+# --- T2: -h behaves like --help ---------------------------------------------
+echo "T2: -h prints usage block, exits 0, creates no heartbeat file"
+set +e
+out=$(HOME="$TMPROOT" "$HEARTBEAT" -h 2>&1)
+rc=$?
+set -e
+assert_eq "$rc" "0" "-h exits 0"
+assert_contains "$out" "fleet-heartbeat <role-name>" "-h output names the usage form"
+if [[ -e "$TMPROOT/.fleet/heartbeats/-h" ]]; then
+    bad "-h must not create a heartbeat file"
+else
+    ok "-h creates no heartbeat file"
+fi
+
+# --- T3: printed usage block does not leak code lines -----------------------
+echo "T3: --help output does not leak post-header code lines (#2433 shape)"
+help_out=$(HOME="$TMPROOT" "$HEARTBEAT" --help 2>&1)
+assert_absent "$help_out" "set -euo pipefail" "--help does not leak the set -e line"
+assert_absent "$help_out" "heartbeats_dir=" "--help does not leak script body"
+
+# --- T4: an unrecognized flag is rejected, not silently accepted -----------
+echo "T4: --bogus is rejected as an invalid role name"
+set +e
+out=$(HOME="$TMPROOT" "$HEARTBEAT" --bogus 2>&1)
+rc=$?
+set -e
+assert_eq "$rc" "2" "--bogus exits 2"
+assert_contains "$out" "invalid role name" "--bogus gets the invalid-role diagnostic"
+if [[ -e "$TMPROOT/.fleet/heartbeats/--bogus" ]]; then
+    bad "--bogus must not create a heartbeat file"
+else
+    ok "--bogus creates no heartbeat file"
+fi
+
+# --- T5: a normal role name still works (regression pin) -------------------
+echo "T5: a normal role name still touches its heartbeat file"
+set +e
+out=$(HOME="$TMPROOT" "$HEARTBEAT" pool-2 2>&1)
+rc=$?
+set -e
+assert_eq "$rc" "0" "pool-2 exits 0"
+if [[ -e "$TMPROOT/.fleet/heartbeats/pool-2" ]]; then
+    ok "pool-2 creates its heartbeat file"
+else
+    bad "pool-2 must create its heartbeat file"
+fi
+
+# --- T6: no-arg invocation is unchanged --------------------------------------
+echo "T6: no-arg invocation still prints usage to stderr, exits 2"
+set +e
+out=$(HOME="$TMPROOT" "$HEARTBEAT" 2>&1)
+rc=$?
+set -e
+assert_eq "$rc" "2" "no-arg exits 2"
+assert_contains "$out" "usage: fleet-heartbeat <role-name>" "no-arg prints usage"
+
+summarize "fleet-heartbeat flag-arg tests"


### PR DESCRIPTION
## Summary
- `fleet-heartbeat`'s role-name validator allowed a leading `-`, so any flag-shaped argument (`--help`, `-h`, `--bogus`, ...) fell through to `touch "$heartbeats_dir/$role"` instead of being rejected — `--help` silently created a `--help` file instead of printing usage.
- Added an explicit `-h|--help` case (mirrors `witness:31-37`) that prints the header's usage block and exits 0, and tightened the validator regex to reject a leading dash so any other flag typo gets the existing invalid-role-name diagnostic (rc=2) instead of silently touching a file.
- Corrected `fleet-help`'s `fleet-heartbeat` entry, which claimed "No --help flag" — now stale given the fix.

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_heartbeat_flag_args.sh` — 15/15 assertions pass against the fixed script.
- [x] `fleet-positive-control scripts/fleet/tests/test_fleet_heartbeat_flag_args.sh origin/master` — MEANINGFUL: 7 of 15 assertions fail against pre-fix `origin/master`, confirming the suite actually detects the bug.
- [x] `bash scripts/fleet/tests/run_all.sh` — full suite, 110/110 suites pass (no regressions).
- [x] `bash -n` syntax-check on all three touched/added bash files.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `--help`/`-h` print usage, exit 0, create no heartbeat file | T1/T2 in the new suite | `ok: --help exits 0`, `ok: --help creates no heartbeat file` (and same for `-h`) |
| `--bogus` exits non-zero with invalid-role-name diagnostic, creates no file | T4 | `ok: --bogus exits 2`, `ok: --bogus gets the invalid-role diagnostic`, `ok: --bogus creates no heartbeat file` |
| `pool-2` still touches its file, exits 0 (unchanged) | T5 | `ok: pool-2 exits 0`, `ok: pool-2 creates its heartbeat file` |
| No-arg still prints usage, rc=2 (unchanged) | T6 | `ok: no-arg exits 2`, `ok: no-arg prints usage` |
| Test lands in `scripts/fleet/tests/`, wired into `run_all.sh`, positive-controlled | `run_all.sh --only heartbeat` + `fleet-positive-control` | `PASS test_fleet_heartbeat_flag_args.sh`; control shows 7/15 red on pre-fix |

**Host residue not fixed here (by design, per the issue):** `~/.fleet/heartbeats/--help` still exists on this macOS fleet host (dated Aug 1 08:37) from the original bug. That's host state, not repo state — the human should delete it by hand; this PR doesn't touch it.

Closes #2784

🤖 Generated with [Claude Code](https://claude.com/claude-code)