### PR TITLE
build: filter the quality-file glob through the engine's own .gitignore

### DIFF
--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -8,6 +8,70 @@ if(APPLE)
     )
 endif()
 
+# Drop candidate paths the engine repo's own .gitignore excludes. The glob
+# in irreden_collect_quality_files walks the filesystem, not the repository,
+# so a gitignored nested checkout under a search root (e.g. a private
+# creation's own repo, or an agent worktree inside one) is on disk and would
+# otherwise be swept in — untracked content with no owner able to fix a
+# header-convention violation reported against it, and a `format` run would
+# rewrite files live in another agent's in-progress worktree.
+#
+# Batches the whole candidate list through one `git check-ignore --stdin`
+# call rather than a per-file execute_process (cheap for the ~2k-entry list
+# this function produces; per-file would be ~2k process spawns per configure).
+function(_irreden_drop_gitignored_files file_list_var)
+    find_program(IRREDEN_GIT_EXECUTABLE NAMES git)
+    if(NOT IRREDEN_GIT_EXECUTABLE)
+        # No git at configure time — leave the candidate list as-is (the
+        # pre-fix behavior). git is required to obtain this source tree in
+        # the first place, so an absent git at configure time is not a
+        # realistic case on any supported host; there is no reject-chain
+        # regex fallback here on purpose — a path-substring match can't
+        # distinguish a nested checkout under a search root from the
+        # engine's own enclosing worktree path also matching the same
+        # substring (an agent worktree's own root is
+        # ".../.claude/worktrees/<name>", so a "/.claude/worktrees/" test
+        # against the *absolute* path matches every file in the tree, not
+        # just nested ones — caught in review before this shipped).
+        return()
+    endif()
+
+    set(candidates "${${file_list_var}}")
+    list(LENGTH candidates candidate_count)
+    if(candidate_count EQUAL 0)
+        return()
+    endif()
+
+    set(stdin_file "${CMAKE_BINARY_DIR}/irreden_quality_files_check_ignore_input.txt")
+    string(REPLACE ";" "\n" stdin_contents "${candidates}")
+    file(WRITE "${stdin_file}" "${stdin_contents}\n")
+
+    execute_process(
+        COMMAND "${IRREDEN_GIT_EXECUTABLE}" -C "${PROJECT_SOURCE_DIR}" check-ignore --stdin
+        INPUT_FILE "${stdin_file}"
+        OUTPUT_VARIABLE ignored_out
+        RESULT_VARIABLE ignored_rc
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    file(REMOVE "${stdin_file}")
+
+    # check-ignore exits 0 (some input matched) or 1 (none matched) on a
+    # normal run; anything higher means it errored (e.g. PROJECT_SOURCE_DIR
+    # isn't a git repository) — leave the candidate list untouched rather
+    # than trust a failed query's (empty) output.
+    if(ignored_rc GREATER 1)
+        return()
+    endif()
+    if(ignored_out STREQUAL "")
+        return()
+    endif()
+
+    string(REPLACE "\n" ";" ignored_list "${ignored_out}")
+    list(REMOVE_ITEM candidates ${ignored_list})
+    set(${file_list_var} "${candidates}" PARENT_SCOPE)
+endfunction()
+
 # `INCLUDE_RENDER_BACKENDS` keeps the generated / vendored graphics sources that
 # the style tools skip. See the reject chain below for which consumer wants what.
 function(irreden_collect_quality_files out_var)
@@ -81,6 +145,7 @@ function(irreden_collect_quality_files out_var)
     endforeach()
 
     list(REMOVE_DUPLICATES filtered_files)
+    _irreden_drop_gitignored_files(filtered_files)
     set(${out_var} "${filtered_files}" PARENT_SCOPE)
 endfunction()
 

--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -22,17 +22,17 @@ endif()
 function(_irreden_drop_gitignored_files file_list_var)
     find_program(IRREDEN_GIT_EXECUTABLE NAMES git)
     if(NOT IRREDEN_GIT_EXECUTABLE)
-        # No git at configure time — leave the candidate list as-is (the
-        # pre-fix behavior). git is required to obtain this source tree in
-        # the first place, so an absent git at configure time is not a
-        # realistic case on any supported host; there is no reject-chain
-        # regex fallback here on purpose — a path-substring match can't
-        # distinguish a nested checkout under a search root from the
-        # engine's own enclosing worktree path also matching the same
-        # substring (an agent worktree's own root is
+        # No git at configure time — leave the candidate list unfiltered
+        # (fail open; never over-filter). git is required to obtain this
+        # source tree in the first place, so an absent git at configure
+        # time is not a realistic case on any supported host; there is no
+        # reject-chain regex fallback here on purpose — a path-substring
+        # match can't distinguish a nested checkout under a search root
+        # from the engine's own enclosing worktree path also matching the
+        # same substring (an agent worktree's own root is
         # ".../.claude/worktrees/<name>", so a "/.claude/worktrees/" test
         # against the *absolute* path matches every file in the tree, not
-        # just nested ones — caught in review before this shipped).
+        # just nested ones).
         return()
     endif()
 

--- a/scripts/fleet/tests/test_quality_files_gitignore.sh
+++ b/scripts/fleet/tests/test_quality_files_gitignore.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Tests for irreden_collect_quality_files' gitignore filtering (#2791).
+#
+# The function (cmake/ir_quality_tools.cmake) walks four search roots with
+# file(GLOB_RECURSE) — a filesystem walk, not a repository walk. Before this
+# fix nothing dropped content the engine repo's own .gitignore excludes, so
+# a gitignored nested checkout under a search root (a private creation's own
+# repo, or an agent worktree inside one) was swept into QUALITY_FILES: the
+# `header-checks` / `lint` targets reported violations no one could fix from
+# the flagged PR, and `format` rewrote files live in another agent's
+# in-progress worktree.
+#
+# This suite configures a throwaway CMake project against a fixture git repo
+# (real search-root layout, a .gitignore modeled on the engine's own
+# creations/* rule, and a nested .claude/worktrees/ dir) and asserts the
+# gitignored entries never reach the collected list while tracked-equivalent
+# entries do.
+#
+# The fixture repo has no commits — git check-ignore evaluates pathname
+# rules only, not tracked status, so an uncommitted .gitignore is sufficient
+# and keeps the fixture setup to a `git init` with no add/commit.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+QUALITY_CMAKE="$REPO_ROOT/cmake/ir_quality_tools.cmake"
+
+if [[ ! -f "$QUALITY_CMAKE" ]]; then
+    echo "test setup: cmake module not found at $QUALITY_CMAKE" >&2
+    exit 1
+fi
+if ! command -v cmake >/dev/null 2>&1; then
+    echo "test setup: cmake not found on PATH" >&2
+    exit 1
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "test setup: git not found on PATH" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- Fixture repo -------------------------------------------------------
+FIXTURE="$WORKDIR/fixture"
+mkdir -p \
+    "$FIXTURE/engine/foo" \
+    "$FIXTURE/creations/demos/bar" \
+    "$FIXTURE/creations/game/.claude/worktrees/pool-1" \
+    "$FIXTURE/test" \
+    "$FIXTURE/tools"
+
+git -C "$FIXTURE" init -q
+
+# Mirrors the engine's own .gitignore: creations/* is ignored except the
+# demos subtree, which is re-included.
+cat > "$FIXTURE/.gitignore" <<'GITIGNORE'
+creations/*
+!creations/demos/
+!creations/demos/**
+GITIGNORE
+
+touch "$FIXTURE/engine/foo/real.hpp"
+touch "$FIXTURE/creations/demos/bar/demo.hpp"
+touch "$FIXTURE/creations/game/private.hpp"
+touch "$FIXTURE/creations/game/.claude/worktrees/pool-1/nested.hpp"
+
+# --- Driver project — configures against the fixture, calls the real
+#     function, and prints what it collected -----------------------------
+DRIVER="$WORKDIR/driver"
+mkdir -p "$DRIVER"
+cat > "$DRIVER/CMakeLists.txt" <<DRIVER_EOF
+cmake_minimum_required(VERSION 3.20)
+project(irreden_quality_files_test NONE)
+set(PROJECT_SOURCE_DIR "$FIXTURE")
+include("$QUALITY_CMAKE")
+irreden_collect_quality_files(result)
+foreach(f IN LISTS result)
+    message("FOUND: \${f}")
+endforeach()
+DRIVER_EOF
+
+OUT=$(cmake -S "$DRIVER" -B "$WORKDIR/build" 2>&1) || {
+    echo "test setup: cmake configure failed:" >&2
+    echo "$OUT" >&2
+    exit 1
+}
+
+assert_contains "$OUT" "FOUND: $FIXTURE/engine/foo/real.hpp" \
+    "tracked engine-root file is collected"
+assert_contains "$OUT" "FOUND: $FIXTURE/creations/demos/bar/demo.hpp" \
+    "re-included creations/demos file is collected"
+assert_absent "$OUT" "FOUND: $FIXTURE/creations/game/private.hpp" \
+    "gitignored creation content is dropped"
+assert_absent "$OUT" "FOUND: $FIXTURE/creations/game/.claude/worktrees/pool-1/nested.hpp" \
+    "nested agent worktree content is dropped"
+
+summarize "irreden_collect_quality_files gitignore filtering"

--- a/scripts/fleet/tests/test_quality_files_gitignore.sh
+++ b/scripts/fleet/tests/test_quality_files_gitignore.sh
@@ -47,6 +47,7 @@ trap 'rm -rf "$WORKDIR"' EXIT
 FIXTURE="$WORKDIR/fixture"
 mkdir -p \
     "$FIXTURE/engine/foo" \
+    "$FIXTURE/engine/render/include/irreden/render/gl_wrap" \
     "$FIXTURE/creations/demos/bar" \
     "$FIXTURE/creations/game/.claude/worktrees/pool-1" \
     "$FIXTURE/test" \
@@ -63,6 +64,7 @@ creations/*
 GITIGNORE
 
 touch "$FIXTURE/engine/foo/real.hpp"
+touch "$FIXTURE/engine/render/include/irreden/render/gl_wrap/GL.h"
 touch "$FIXTURE/creations/demos/bar/demo.hpp"
 touch "$FIXTURE/creations/game/private.hpp"
 touch "$FIXTURE/creations/game/.claude/worktrees/pool-1/nested.hpp"
@@ -80,6 +82,10 @@ irreden_collect_quality_files(result)
 foreach(f IN LISTS result)
     message("FOUND: \${f}")
 endforeach()
+irreden_collect_quality_files(wide_result INCLUDE_RENDER_BACKENDS)
+foreach(f IN LISTS wide_result)
+    message("WIDE: \${f}")
+endforeach()
 DRIVER_EOF
 
 OUT=$(cmake -S "$DRIVER" -B "$WORKDIR/build" 2>&1) || {
@@ -96,5 +102,18 @@ assert_absent "$OUT" "FOUND: $FIXTURE/creations/game/private.hpp" \
     "gitignored creation content is dropped"
 assert_absent "$OUT" "FOUND: $FIXTURE/creations/game/.claude/worktrees/pool-1/nested.hpp" \
     "nested agent worktree content is dropped"
+
+# The filter runs inside irreden_collect_quality_files, below the reject
+# chain, so it applies to BOTH lists the function produces — including the
+# wider INCLUDE_RENDER_BACKENDS one that backs header-checks (#2815). That
+# list is a correctness gate, not a style one, so it needs its own lock:
+# without these, the filter could be made conditional on the narrow arm and
+# every assertion above would still pass.
+assert_absent "$OUT" "FOUND: $FIXTURE/engine/render/include/irreden/render/gl_wrap/GL.h" \
+    "generated GL wrapper stays out of the style-tool list"
+assert_contains "$OUT" "WIDE: $FIXTURE/engine/render/include/irreden/render/gl_wrap/GL.h" \
+    "INCLUDE_RENDER_BACKENDS widens the list back over the GL wrapper (#2815)"
+assert_absent "$OUT" "WIDE: $FIXTURE/creations/game/private.hpp" \
+    "gitignore filtering also applies to the widened header-check list"
 
 summarize "irreden_collect_quality_files gitignore filtering"


### PR DESCRIPTION
## Summary
- `irreden_collect_quality_files()` (`cmake/ir_quality_tools.cmake`) now batches its candidate list through one `git check-ignore --stdin` call and drops every path the engine repo's own `.gitignore` excludes — a gitignored nested checkout under a search root (a private creation's own repo, or an agent worktree inside one) is on disk but was never engine-tracked content.
- Deliberately **no regex fallback** for a missing `git` executable. An earlier version of this fix added a `/.claude/worktrees/` absolute-path substring reject as a fallback; every fleet worktree's own root is itself `.../.claude/worktrees/<name>`, so that check matched the *enclosing* worktree path and silently emptied the entire quality-file list on every host running from a worktree. Caught by rebuilding `header-checks` against this very worktree before it shipped — see the commit message for the full story.
- Adds `scripts/fleet/tests/test_quality_files_gitignore.sh`: a hermetic regression test that configures a throwaway CMake project against a fixture git repo (real search-root layout + a `.gitignore` modeled on the engine's own `creations/*` rule + a nested `.claude/worktrees/` dir) and asserts gitignored entries never reach the collected list.
- **Rebased onto `6e804773e` after a semantic conflict with #2818.** That PR added the `INCLUDE_RENDER_BACKENDS` parameter and a *second*, wider collection for `header-checks`; this PR adds the gitignore filter to the same function. Both sides kept in full — the diff vs master is now purely additive (165 insertions, 0 deletions). Third commit adds the coverage the merge made necessary (see below).

## Test plan
- [x] `bash scripts/fleet/tests/test_quality_files_gitignore.sh` (run **alone**, not via a whole-directory sweep) → `7 passed, 0 failed`.
- [x] `bash scripts/fleet/tests/run_all.sh` → `120 suite(s) — 120 passed, 0 failed, 0 skipped`.
- [x] `fleet-positive-control scripts/fleet/tests/test_quality_files_gitignore.sh origin/master --include cmake` → **MEANINGFUL**: **3** of 7 assertions fail against pre-fix `origin/master` (`6e804773e`); the **4** that still pass are non-regression assertions. (4 + 3 = 7, the full suite.)
- [x] **Targeted A/B for the new widened-list assertion**: making the filter conditional (`if(NOT arg_INCLUDE_RENDER_BACKENDS)`) → `6 passed, 1 failed`, red on exactly `gitignore filtering also applies to the widened header-check list`. Restoring the file byte-identically → `7 passed, 0 failed`. The assertion is keyed on that property alone and cannot pass vacuously.
- [x] `cmake --preset macos-debug` (reconfigure) then `cmake --build build --target header-checks` → `Header convention checks scanned 573 header file(s); 0 file(s) baselined for header-global violations, 1 for anonymous namespaces.` — clean, on this worktree (which has no nested `creations/game` checkout to filter).
- [x] `fleet-build --target format-changed` → `diff vs origin/master touches no formattable sources (2 changed file(s) examined, 0 on the quality list)` — expected, `.cmake`/`.sh` aren't in clang-format's scope.

## Conflict resolution — the seam with #2818

The two sides meet inside one function, so "both compile" is not sufficient evidence. Measured on the reconfigured tree, from the two generated lists:

| Property | Observed |
|---|---|
| `irreden_quality_files.cmake` (style tools) | 810 entries |
| `irreden_header_check_files.cmake` (header-checks) | 826 entries |
| header-only entries — #2818's widening survives the filter | **16** (the `gl_wrap/` + `metal/` headers) |
| format-only entries — header list is still a strict superset | **0** |
| gitignored entries surviving in *either* list — #2791's filter reaches both | **0** and **0** |

The filter sits below the reject chain and is unconditional, so it applies to both lists by construction. The fixture, however, only ever called the narrow arm — leaving the wider list, which backs a **correctness** gate rather than a style one (`.claude/rules/cpp-globals.md` §Detection), with no lock on the filtering behaviour. Commit 3 adds a `gl_wrap`-shaped fixture file, a second driver call, and three assertions covering the intersection: wrapper absent from the style list, present in the widened one (#2815), gitignored content absent from the widened one (#2791).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| On a host where the nested gitignored checkout is present, `header-checks` exits 0 | Hermetic fixture in `test_quality_files_gitignore.sh` mirrors the nested-checkout shape (real search roots + `.claude/worktrees/` under a gitignored `creations/<x>/`) | 7/7 assertions pass on the fixture; positive control proves the same fixture fails 3/7 pre-fix |
| `QUALITY_FILES` contains zero paths `git check-ignore` matches | Piped both generated lists back through `git check-ignore --stdin` after reconfigure | 0 survivors in the style list, 0 in the header-check list |
| A regression test covers `irreden_collect_quality_files` (none existed) | Added `scripts/fleet/tests/test_quality_files_gitignore.sh`, discovered by `run_all.sh`'s glob (no registration needed) | Suite runs and passes; positive-controlled per above |
| `format-check`/`lint` verdicts are consistent with and without the nested checkout | This worktree has **no** nested `creations/game` checkout, so I could not directly A/B the same host both ways — noting this honestly. `header-checks` is clean here (nothing to filter); the fixture test proves the filtering logic itself is correct when a nested checkout *is* present. The underlying mechanism (`git check-ignore`) degrades to a no-op when there's nothing ignored, so consistency follows from the same code path handling both cases | `header-checks`: 573 headers scanned, 0 violations (no nested checkout present) |

Closes #2791

🤖 Generated with [Claude Code](https://claude.com/claude-code)
