### PR TITLE
fleet: run_all.sh must not count a subject-missing skip as a pass

### DIFF
--- a/.github/workflows/fleet-tests.yml
+++ b/.github/workflows/fleet-tests.yml
@@ -10,7 +10,11 @@ name: Fleet Tests
 # CMake, so they have no reason to ride along with a build job anyway.
 #
 # Path-filtered to the fleet tooling surface — engine, shader, and asset
-# PRs skip this entirely (same convention as perf-gate.yml).
+# PRs skip this entirely (same convention as perf-gate.yml). Two suites
+# reach outside scripts/fleet/** for their subject under test
+# (test_format_changed_line_scoping.sh, test_ir_build_dir_resolution.sh) —
+# their subjects are listed explicitly below so a PR touching only one of
+# them still runs this workflow (#2786).
 
 on:
   push:
@@ -18,10 +22,14 @@ on:
     paths:
       - 'scripts/fleet/**'
       - '.github/workflows/fleet-tests.yml'
+      - 'cmake/run_clang_format_changed.cmake'
+      - 'engine/tools/lib/concurrency_helpers.sh'
   pull_request:
     paths:
       - 'scripts/fleet/**'
       - '.github/workflows/fleet-tests.yml'
+      - 'cmake/run_clang_format_changed.cmake'
+      - 'engine/tools/lib/concurrency_helpers.sh'
   workflow_dispatch:
 
 permissions:

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -42,6 +42,18 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   `fleet-tests.yml` workflow calls the runner directly on every push and PR
   that touches `scripts/fleet/**`. That workflow is the only thing gating
   them; an unexecuted suite goes red silently (see #2712).
+- **A suite whose subject under test is missing must not report success.**
+  A guard shaped `if [[ ! -f "$SUBJECT" ]]; then echo "SKIP: ..."; exit 0;
+  fi` reports the same exit status as a real pass, so `run_all.sh` folds a
+  suite that verified nothing into its "N passed" tally — the vacuous-pass
+  failure mode #2712 wired execution to prevent, one level down (#2786).
+  Exit **3** instead — the shared skip status `run_all.sh` recognizes and
+  tallies separately as "skipped", never "passed". Reserve the `SKIP:`
+  stderr prefix for this case (an environment-dependency skip like "git not
+  available" can stay `exit 0`; only a missing *subject* is a #2786 case).
+  If the subject lives outside `scripts/fleet/**`, also add its path to
+  `fleet-tests.yml`'s `paths:` filter — otherwise a PR that moves or edits
+  only that file never runs the suite that would have caught the break.
 - **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
   `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
   `summarize` exit idiom — don't re-copy the helpers into a new test.

--- a/scripts/fleet/tests/run_all.sh
+++ b/scripts/fleet/tests/run_all.sh
@@ -24,8 +24,13 @@
 #   --timeout <secs>    Per-suite timeout (default 120). 0 disables.
 #   -h, --help          Show this help.
 #
+# A suite that cannot find its subject under test should print
+# "SKIP: <reason>" to stderr and exit 3 — that is the shared skip status
+# this runner recognizes. Do not `exit 0` from a guard that never actually
+# exercised the subject; that counts as an unverified PASS (#2786).
+#
 # Exit status:
-#   0  every selected suite passed (or --list / --help)
+#   0  every selected suite passed or was skipped (or --list / --help)
 #   1  at least one suite failed, timed out, or none matched --only
 #   2  usage error
 #
@@ -101,6 +106,11 @@ cd "$TESTS_DIR" || exit 1
 
 passed=0
 failed_names=()
+skipped_names=()
+
+# Skip status: a suite whose subject under test is missing exits with this
+# code instead of 0, so a vacuous run is never folded into "passed" (#2786).
+SKIP_STATUS=3
 
 for f in "${suites[@]}"; do
     name=$(basename "$f")
@@ -109,11 +119,16 @@ for f in "${suites[@]}"; do
         *)    interp=(bash) ;;
     esac
 
-    if out=$($timeout_cmd "${interp[@]}" "$f" 2>&1); then
+    out=$($timeout_cmd "${interp[@]}" "$f" 2>&1)
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
         passed=$((passed + 1))
         printf 'PASS  %s\n' "$name"
+    elif [[ "$rc" -eq "$SKIP_STATUS" ]]; then
+        skipped_names+=("$name")
+        printf 'SKIP  %s\n' "$name"
+        printf '%s\n' "$out" | sed 's/^/      | /'
     else
-        rc=$?
         failed_names+=("$name")
         # 124 is coreutils timeout's "killed on deadline" status.
         if [[ "$rc" -eq 124 ]]; then
@@ -126,7 +141,10 @@ for f in "${suites[@]}"; do
 done
 
 echo
-echo "$PROG: ${#suites[@]} suite(s) — $passed passed, ${#failed_names[@]} failed"
+echo "$PROG: ${#suites[@]} suite(s) — $passed passed, ${#failed_names[@]} failed, ${#skipped_names[@]} skipped"
+if [[ ${#skipped_names[@]} -gt 0 ]]; then
+    echo "$PROG: skipped: ${skipped_names[*]}"
+fi
 if [[ ${#failed_names[@]} -gt 0 ]]; then
     echo "$PROG: failed: ${failed_names[*]}" >&2
     exit 1

--- a/scripts/fleet/tests/test_classify_auto_rereview.sh
+++ b/scripts/fleet/tests/test_classify_auto_rereview.sh
@@ -23,7 +23,7 @@ SCRIPT="$SCRIPT_DIR/classify-auto-rereview.sh"
 
 if [[ ! -f "$SCRIPT" ]]; then
     echo "SKIP: script not found at $SCRIPT" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 if ! command -v git >/dev/null 2>&1; then
     echo "SKIP: git not available" >&2

--- a/scripts/fleet/tests/test_clone_freshness.sh
+++ b/scripts/fleet/tests/test_clone_freshness.sh
@@ -15,7 +15,7 @@ HELPER="$SCRIPT_DIR/fleet-clone-freshness.sh"
 
 if [[ ! -f "$HELPER" ]]; then
     echo "SKIP: helper not found at $HELPER" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 if ! command -v git >/dev/null 2>&1; then
     echo "SKIP: git not available" >&2

--- a/scripts/fleet/tests/test_fleet_claim_symlink_lib_dir.sh
+++ b/scripts/fleet/tests/test_fleet_claim_symlink_lib_dir.sh
@@ -19,7 +19,7 @@ FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
 
 if [[ ! -x "$FLEET_CLAIM" ]]; then
     echo "SKIP: fleet-claim not found at $FLEET_CLAIM" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 
 PASS=0

--- a/scripts/fleet/tests/test_fleet_net_guard.sh
+++ b/scripts/fleet/tests/test_fleet_net_guard.sh
@@ -15,7 +15,7 @@ SHIM="$SCRIPT_DIR/timeout-shim.py"
 
 if [[ ! -f "$LIB" ]]; then
     echo "SKIP: lib not found at $LIB" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 
 PASS=0

--- a/scripts/fleet/tests/test_fleet_rebase_hung_lock.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_hung_lock.sh
@@ -19,7 +19,7 @@ REBASE="$SCRIPT_DIR/fleet-rebase"
 
 if [[ ! -x "$REBASE" ]]; then
     echo "SKIP: fleet-rebase not found/executable at $REBASE" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 
 PASS=0

--- a/scripts/fleet/tests/test_format_changed_line_scoping.sh
+++ b/scripts/fleet/tests/test_format_changed_line_scoping.sh
@@ -26,7 +26,7 @@ STYLE_FILE="$SCRIPT_DIR/.clang-format"
 
 if [[ ! -f "$CMAKE_SCRIPT" ]]; then
     echo "SKIP: script under test not found at $CMAKE_SCRIPT" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 for tool in cmake clang-format git; do
     if ! command -v "$tool" >/dev/null 2>&1; then

--- a/scripts/fleet/tests/test_install_refresh.sh
+++ b/scripts/fleet/tests/test_install_refresh.sh
@@ -17,7 +17,7 @@ HELPER="$SCRIPT_DIR/fleet-common.sh"
 
 if [[ ! -f "$HELPER" ]]; then
     echo "SKIP: helper not found at $HELPER" >&2
-    exit 0
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
 fi
 if ! command -v git >/dev/null 2>&1; then
     echo "SKIP: git not available" >&2

--- a/scripts/fleet/tests/test_run_all.sh
+++ b/scripts/fleet/tests/test_run_all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Tests for run_all.sh (#2712) — the runner that executes every fleet test
-# suite in this directory.
+# Tests for run_all.sh (#2712, #2786) — the runner that executes every
+# fleet test suite in this directory.
 #
 # Hermetic: every case copies run_all.sh into a temp dir alongside SYNTHETIC
 # fixture suites and runs it there. The runner discovers suites relative to
@@ -30,7 +30,10 @@ new_sandbox() {  # $1 = sandbox name -> echoes the dir
 }
 
 fixture_pass() { printf '#!/usr/bin/env bash\nexit 0\n' > "$1/test_$2.sh"; }
-fixture_fail() { printf '#!/usr/bin/env bash\necho "boom in %s"\nexit 3\n' "$2" > "$1/test_$2.sh"; }
+fixture_fail() { printf '#!/usr/bin/env bash\necho "boom in %s"\nexit 1\n' "$2" > "$1/test_$2.sh"; }
+# exit 3 is the shared skip status (#2786) — a distinct fixture so it's
+# never confused with fixture_fail's ordinary failure.
+fixture_skip() { printf '#!/usr/bin/env bash\necho "SKIP: %s subject missing" >&2\nexit 3\n' "$2" > "$1/test_$2.sh"; }
 
 echo "T1: all-passing suites exit 0 and are counted"
 d=$(new_sandbox t1)
@@ -39,7 +42,7 @@ fixture_pass "$d" beta
 printf 'import sys\nsys.exit(0)\n' > "$d/test_gamma.py"
 out=$(bash "$d/run_all.sh" 2>&1); rc=$?
 assert_eq "$rc" "0" "T1 exit 0 when every suite passes"
-assert_contains "$out" "3 suite(s) — 3 passed, 0 failed" "T1 summary counts all three"
+assert_contains "$out" "3 suite(s) — 3 passed, 0 failed, 0 skipped" "T1 summary counts all three"
 assert_contains "$out" "PASS  test_alpha.sh" "T1 per-suite PASS line"
 assert_contains "$out" "PASS  test_gamma.py" "T1 .py suite ran under python3"
 
@@ -49,9 +52,9 @@ fixture_pass "$d" alpha
 fixture_fail "$d" broken
 out=$(bash "$d/run_all.sh" 2>&1); rc=$?
 assert_eq "$rc" "1" "T2 exit 1 when a suite fails"
-assert_contains "$out" "FAIL  test_broken.sh (exit 3)" "T2 FAIL line carries the exit code"
+assert_contains "$out" "FAIL  test_broken.sh (exit 1)" "T2 FAIL line carries the exit code"
 assert_contains "$out" "boom in broken" "T2 failing suite's output is echoed for triage"
-assert_contains "$out" "1 passed, 1 failed" "T2 summary counts the failure"
+assert_contains "$out" "1 passed, 1 failed, 0 skipped" "T2 summary counts the failure"
 assert_contains "$out" "failed: test_broken.sh" "T2 names the failing suite"
 
 echo "T3: a failing .py suite is caught too"
@@ -139,5 +142,27 @@ fixture_pass "$d" alpha
 out=$(bash "$d/run_all.sh" --timeout 0 2>&1); rc=$?
 assert_eq "$rc" "0" "T11 --timeout 0 still runs suites"
 assert_contains "$out" "1 passed" "T11 --timeout 0 reports normally"
+
+# #2786: a suite whose subject under test is missing exits 3 (the shared
+# skip status), not 0 — a vacuous run must never be folded into "passed".
+echo "T12: a skipping suite (exit 3) is counted separately, not as a pass"
+d=$(new_sandbox t12)
+fixture_pass "$d" alpha
+fixture_skip "$d" skippy
+out=$(bash "$d/run_all.sh" 2>&1); rc=$?
+assert_eq "$rc" "0" "T12 exit 0 — a skip alone does not fail the run"
+assert_contains "$out" "2 suite(s) — 1 passed, 0 failed, 1 skipped" "T12 summary distinguishes skipped from passed"
+assert_contains "$out" "SKIP  test_skippy.sh" "T12 per-suite SKIP line"
+assert_contains "$out" "skipped: test_skippy.sh" "T12 names the skipped suite"
+assert_absent "$out" "PASS  test_skippy.sh" "T12 skip is never reported as PASS"
+
+echo "T13: a real failure still fails the run alongside a skip (negative control)"
+d=$(new_sandbox t13)
+fixture_fail "$d" broken
+fixture_skip "$d" skippy
+out=$(bash "$d/run_all.sh" 2>&1); rc=$?
+assert_eq "$rc" "1" "T13 exit 1 — a skip must not mask a real failure"
+assert_contains "$out" "0 passed, 1 failed, 1 skipped" "T13 summary counts failures and skips independently"
+assert_contains "$out" "failed: test_broken.sh" "T13 still names the real failure"
 
 summarize "run_all.sh tests"


### PR DESCRIPTION
## Summary
- Seven `scripts/fleet/tests/` suites `exit 0` when their subject under test is missing, so `run_all.sh` folds a suite that verified nothing into its "N passed" tally — the vacuous-pass failure mode #2712 wired suite execution to prevent, one level down.
- `run_all.sh` now recognizes exit **3** as a shared skip status, tallied separately ("N passed, M failed, S skipped") and never counted as a pass; the seven guards switch onto it.
- `fleet-tests.yml`'s `paths:` filter is widened to the two out-of-tree subjects (`cmake/run_clang_format_changed.cmake`, `engine/tools/lib/concurrency_helpers.sh`) so a PR touching only one of them still runs the workflow.
- The convention is recorded in `scripts/fleet/CLAUDE.md` alongside the existing execution-hermeticity rules.

## Test plan
- [x] `bash scripts/fleet/tests/run_all.sh` — full tree run: `109 suite(s) — 109 passed, 0 failed, 0 skipped`.
- [x] `bash scripts/fleet/tests/test_run_all.sh` — 44/44 assertions pass, including new T12 (skip counted separately, never as PASS) and T13 (a real failure still fails the run alongside a skip — negative control).
- [x] Positive control: `fleet-positive-control scripts/fleet/tests/test_run_all.sh origin/master` reports MEANINGFUL — 7 of 44 assertions fail against pre-fix `origin/master`, isolating exactly the new skip-status assertions.
- [x] Reproduced the issue's own positive control (stage `test_format_changed_line_scoping.sh` without its subject) — now reports `SKIP: script under test not found at ...` and `exit=3` instead of a silent `exit=0`.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Positive control reports skipped/failed, never passed | issue repro against staged suite | `SKIP: script under test not found at .../cmake/run_clang_format_changed.cmake`, `exit=3` |
| `run_all.sh` green on master, summary distinguishes passed/failed/skipped | `bash scripts/fleet/tests/run_all.sh` | `109 suite(s) — 109 passed, 0 failed, 0 skipped` |
| Regression suite covers skip handling, with negative control against current master | `bash scripts/fleet/tests/test_run_all.sh` + `fleet-positive-control` | 44/44 pass on working tree; 7/44 fail (T12/T13) against `origin/master` |
| Editing only `cmake/run_clang_format_changed.cmake` triggers `fleet-tests.yml` | read `.github/workflows/fleet-tests.yml` `paths:` | path now listed explicitly in both `push` and `pull_request` triggers |

Closes #2786

🤖 Generated with [Claude Code](https://claude.com/claude-code)