### PR TITLE
fleet: host-gate the smoke lane at dispatch (#2839)

### DIFF
--- a/.fleet/plans/issue-2839.md
+++ b/.fleet/plans/issue-2839.md
@@ -1,0 +1,139 @@
+## Plan: the smoke lane has no host gate in code
+
+- **Issue:** #2839
+- **Model:** opus
+- **Date:** 2026-08-04
+
+### Verified current state
+
+Source-checked and repro'd against `origin/master` @ `34c7f7f46` (full evidence
+in the issue body). The control run — same live `state.json`, same Darwin host,
+only `_SMOKE_PENDING_LABELS` differing — returns `smoke_worker_actionable ==
+True` post-#2809 and `False` on the pre-#2809 control, with the projection
+holding 3 `fleet:needs-windows-smoke` PRs (2659, 2683, 2812) and zero macOS
+smoke work. The live dispatcher log shows 4 no-op smoke dispatches in 43
+minutes and 2 empty-exit backoff cap-hits.
+
+Give the smoke lane the code-level host gate that #1998 (tasks) and #2695
+(feedback PRs) already gave the other two lanes, so a host is only woken for
+smoke work it can actually perform. #2809's addition of
+`fleet:needs-windows-smoke` to `_SMOKE_PENDING_LABELS` stays — this supplies
+the host dimension that its "routing stays the role's job" rationale assumed
+would exist.
+
+### Approach
+
+The gate is one predicate — *does this PR's smoke label name my host?* — placed
+dispatch-side. Take **(A)**; **(B)** is recorded only as the rejected
+alternative, so the implementer does not re-derive the comparison.
+
+**(A) Dispatch-side — this is the plan.** Keep the scout host-agnostic; filter
+where the existing host gate already lives. This mirrors both precedents:
+`fleet_task_class.py:_host_incompatible` gates at *election*, not in the scout,
+and `fleet-dispatcher`'s `worker_rearm_should_fire()` already exists precisely
+to stop re-arming a lane for work this host cannot claim. Add the symmetric
+`smoke_worker_should_fire()` and host-filter `smoke_worker_actionable`.
+
+**(B) Scout-side — rejected.** Host-filtering `project_smoke_worker` /
+`slice_smoke_worker` directly is a smaller diff, but it makes a scout
+projection **host-dependent** for the first time — two hosts' scouts would
+derive different projections from identical GitHub state. That new precedent
+for `state.json`, and the loss of the projection as the cross-host record of
+outstanding smoke debt, is why (A) wins.
+
+Steps:
+
+1. Add a canonical host→smoke-label map beside `GL_CAPABLE_HOSTS` in
+   `fleet_task_class.py`. **Mind the vocabulary split** (#1383): `_current_host()`
+   returns `mac`, while the label and `role-smoke-worker.md` step 4 both use
+   `macos`. The map is the single place that reconciles them:
+   `{"linux": "fleet:needs-linux-smoke", "mac": "fleet:needs-macos-smoke",
+   "windows": "fleet:needs-windows-smoke"}`. Fail-closed on `unknown` (no label
+   ⇒ never actionable), matching `_host_incompatible`'s existing stance.
+2. Export a `smoke_pr_for_host(labels, host)` predicate next to it.
+3. `fleet-up` — `smoke_worker_actionable` filters `smoke_pending_prs` by that
+   predicate before the `bool()`. This kills the boot-dispatch, which is the
+   level-triggered half and the one the empty-exit backoff cannot durably
+   suppress.
+4. `fleet-dispatcher` — add `smoke_worker_should_fire()` modelled on
+   `worker_rearm_should_fire()` and consult it before dispatching on a standing
+   smoke trigger, so a projection-hash flip driven purely by another host's
+   label does not spend a pane.
+5. Leave `_SMOKE_PENDING_LABELS` and both scout functions **unchanged** — the
+   projection stays the host-agnostic record of all outstanding smoke debt,
+   which is what `platform-catchup` and any cross-host reporting want.
+6. Extend `scripts/fleet/tests/test_smoke_worker_projection.py` with the
+   host-routing cases (it is already the harness #2809 added for exactly these
+   two functions).
+
+### Affected files
+
+- `scripts/fleet/fleet_task_class.py` — host→smoke-label map + `smoke_pr_for_host`
+- `scripts/fleet/fleet-up` — `smoke_worker_actionable` host filter
+- `scripts/fleet/fleet-dispatcher` — `smoke_worker_should_fire()` gate on the
+  standing smoke trigger
+- `scripts/fleet/tests/test_smoke_worker_projection.py` — host-routing cases
+
+`fleet-state-scout` is deliberately **not** in this list — under (A) it does
+not change.
+
+### Acceptance criteria
+
+Inherits the five in the issue body. The decisive one is the control run
+already recorded there — it must **invert**: on Darwin with only
+`fleet:needs-windows-smoke` pending, `smoke_worker_actionable` goes `True` →
+`False`, while a `FLEET_TEST_HOST=windows` run on the same `state.json` stays
+`True` and still slices PRs 2659 / 2683 / 2812. Use the existing
+`FLEET_TEST_HOST` seam (`fleet_task_class.py:_current_host`) rather than
+mocking `platform.system`.
+
+Plus: `scripts/fleet/tests/run_all.sh` green.
+
+### Plan-review constraints (binding — opus-reviewer, pool-5)
+
+**Constraint 1 — how bash/heredoc reaches the predicate is not free.**
+`smoke_worker_actionable` lives inside `fleet-up`'s standalone bootstrap
+heredoc (`python3 - <<'PY'`, imports `json` + `pathlib` only) with no path to
+`FLEET_LIB_DIR`, and the heredoc runs under `|| true` — an `ImportError` from
+sys.path plumbing is swallowed and the bootstrap trigger dies **for all six
+roles at once**, silently. `fleet-dispatcher` reaches the module only by
+*executing* it, and `main()` hard-fails `len(argv) not in (4, 5)`, so a bare
+exported function is not callable from step 4 either. Resolution:
+
+- `fleet-up` — **inline** the host key + label map in the heredoc, mirroring
+  `_current_host`'s documented inlining precedent (#1750/#1578): same
+  `FLEET_TEST_HOST` override, same `Darwin/Linux/MINGW|MSYS|CYGWIN|Windows`
+  mapping, same fail-closed `unknown`.
+- `fleet-dispatcher` — add an explicit **CLI arm** to `fleet_task_class.py`
+  (placed before the arity check, like the existing `--plan-pick` arm) so
+  `smoke_worker_should_fire()` shells out the way `resolve_worker_class` does.
+- `fleet_task_class.py` stays the canonical map; the heredoc copy carries a
+  `keep in sync` comment naming it, and a pinned per-host test covers **both**
+  copies.
+
+**Constraint 2 — the gate is dispatch-side only (disclosure, not scope).**
+#1998 / #2695 enforce at two layers: the election predicate *and*
+`fleet-claim`'s outright refusal. This change adds dispatch/boot only —
+`fleet-claim review-claim` has no host term, and widening it would break the
+reviewer lanes it is shared with (a macOS opus reviewer reviewing a
+`needs-windows-smoke` PR is legitimate). Correctly out of scope; state the
+residual explicitly in the PR body rather than claiming full parity.
+
+### Gotchas
+
+- **`env -u FLEET_PLAN_ISSUE` before running `run_all.sh`** — an ambient
+  `FLEET_PLAN_ISSUE` reddens the dispatch-wrap suite (#2836), and the suite
+  needs a ~10-minute timeout.
+- **Run the changed suite alone as well as via the whole-dir runner.** The
+  shared-process runner can launder a red suite green (#2825).
+- **Do not "fix" this by reverting #2809.** Removing
+  `fleet:needs-windows-smoke` from the pending set re-opens #2804 (the native-
+  Windows lane loses its trigger entirely). The label belongs in the set; the
+  host filter belongs downstream of it.
+- **Two host vocabularies** (`mac` vs `macos`) — #1383 reconciled the
+  *detectors*, not the spelling. Getting this wrong means no label ever matches
+  ⇒ the host is never actionable ⇒ the smoke lane silently dies, the same
+  failure mode as #2804. Pin it with an explicit test per host key.
+- `smoke_worker_actionable`'s current form is quoted verbatim in
+  `test_smoke_worker_projection.py` as the fleet-up predicate; that assertion
+  must move in lock-step or it will encode the pre-fix behaviour.

--- a/docs/agents/FLEET-CROSS-HOST-SMOKE.md
+++ b/docs/agents/FLEET-CROSS-HOST-SMOKE.md
@@ -152,6 +152,20 @@ so no `cmd /c` hand-wrapping is needed. When no Windows fleet is online, the
 `platform-catchup` workflow (#1093) is the manual fallback for clearing
 `fleet:needs-windows-smoke`.
 
+This routing is also **enforced in code**, one layer above the protocol below
+(#2839): `fleet_task_class.HOST_SMOKE_LABELS` maps each host key to its own
+pending label, `fleet-up`'s boot predicate and `fleet-dispatcher`'s
+`smoke_worker_should_fire` filter the smoke projection through it, and a host
+with no smoke work of its own is never woken. (The map's key for macOS is
+`mac`, matching `_current_host()`; the label keeps the `macos` spelling, and the
+map is where the two vocabularies meet — #1383.) The scout's projection itself
+stays host-agnostic, so `state.json` remains the cross-host record of all
+outstanding smoke debt that `platform-catchup` reads. The gate is
+dispatch-side only: `fleet-claim review-claim` below has no host term, because
+it is shared with the reviewer lanes where a cross-host claim is legitimate — so
+the step-4 detection above is still the thing that stops a pane reached by
+another route from smoking another host's PR.
+
 ### Picking a PR
 
 From the cached `repos.engine.prs[]`, pick PRs whose `labels` array:

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -72,6 +72,18 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   at the definition site and inside the callee — an edit to one twin
   otherwise silently mis-maps every element past the imbalance point
   (#2454).
+- **`fleet-up`'s bootstrap heredoc cannot import — inline, and guard the
+  copy with a test.** That block is a standalone `python3 - <<'PY'` with no
+  path to `FLEET_LIB_DIR`, run under `|| true`: an `ImportError` from sys.path
+  plumbing is swallowed silently and takes the bootstrap trigger down for
+  *every* role at once, which is strictly worse than whatever the import was
+  buying. Copy the constant/predicate in (the precedent is
+  `fleet_task_class._current_host`, #1578), name the canonical copy in a
+  `keep in sync` comment, and ship a drift guard that lifts the heredoc's defs
+  and asserts they still agree — a duplicate with no guard is the whole cost of
+  inlining. `test_smoke_worker_projection.py`'s `TwoCopiesAgree` is the
+  reference shape. Bash reaches `fleet_task_class.py` the other way, through a
+  CLI arm (`--plan-pick`, `--smoke-check`), never an import.
 - **Concurrently-read state writers use `write_atomic`, never plain
   `write_text`.** A JSON/state/cache file that another process may read
   mid-write is persisted with the module's `write_atomic()` helper

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1520,6 +1520,33 @@ worker_rearm_should_fire() {
     (( DISPATCH_DEFER == 0 )) && [[ -n "$DISPATCH_CLASS" ]]
 }
 
+# Host gate for the smoke lane (#2839). Returns 0 (dispatch) iff at least one PR
+# in the smoke-worker slice carries THIS host's pending smoke label, and sets
+# SMOKE_SERVABLE_PRS to those numbers (newline-separated) for the log line.
+#
+# Smoke is the one lane whose work is definitionally host-specific — only a
+# native-Windows host can clear `fleet:needs-windows-smoke` — while the scout's
+# projection is deliberately host-agnostic, because it is the cross-host record
+# of outstanding smoke debt that `platform-catchup` reads. So the host dimension
+# is applied here, at dispatch: the same layer `_host_incompatible` gates the
+# task (#1998) and feedback-PR (#2695) lanes at, and the symmetric counterpart of
+# `worker_rearm_should_fire` above, which exists for exactly this reason on the
+# worker lane.
+#
+# Shells out to fleet_task_class.py rather than importing it — that module is a
+# CLI seam from bash, the same way resolve_worker_class and plan_assign_for_pane
+# reach it. A missing, unreadable, or host-empty slice yields no numbers, i.e.
+# don't fire.
+SMOKE_SERVABLE_PRS=""
+smoke_worker_should_fire() {
+    local slice="$STATE_DIR/projections/smoke-worker.json"
+    SMOKE_SERVABLE_PRS=""
+    [[ -f "$slice" ]] || return 1
+    SMOKE_SERVABLE_PRS=$(python3 "$FLEET_LIB_DIR/fleet_task_class.py" \
+        --smoke-check "$slice" 2>/dev/null) || SMOKE_SERVABLE_PRS=""
+    [[ -n "$SMOKE_SERVABLE_PRS" ]]
+}
+
 dispatch_role() {
     local role="$1"
     local trigger_file="$TRIGGERS_DIR/$role"
@@ -1528,6 +1555,20 @@ dispatch_role() {
     LAST_ROLE_DISPATCH_COUNT=0
 
     if [[ ! -f "$trigger_file" ]]; then
+        return
+    fi
+
+    # Smoke-lane host gate (#2839). The scout's smoke projection is host-agnostic
+    # by design, so a standing trigger only means "SOME host owes smoke work" —
+    # on every other host, dispatching it is a guaranteed no-op iteration. The
+    # empty-exit backoff below does fire on that shape, but it only consumes the
+    # standing trigger, so the scout re-arms on the next projection change and
+    # the cycle repeats indefinitely. Consume the trigger here for the same
+    # reason the backoff does — the scout re-arms when the projection next
+    # changes, which is exactly when this host's own smoke debt would appear.
+    if [[ "$role" == "smoke-worker" ]] && ! smoke_worker_should_fire; then
+        rm -f "$trigger_file"
+        log "smoke-worker: no smoke work pending for this host; standing down — scout re-arms on new work"
         return
     fi
 
@@ -2400,6 +2441,18 @@ case "${1:-}" in
             echo "rearm class=$DISPATCH_CLASS"
         else
             echo "skip (defer=$DISPATCH_DEFER class=$DISPATCH_CLASS)"
+        fi
+        exit 0
+        ;;
+    --smoke-check)
+        # Test/debug: would the smoke lane dispatch on this host against the
+        # current smoke-worker projection? Prints "fire prs=<n1,n2,...>" when at
+        # least one pending PR carries this host's smoke label, else "quiet".
+        # Does NOT touch the trigger. Mirrors the live gate exactly (#2839).
+        if smoke_worker_should_fire; then
+            echo "fire prs=$(echo "$SMOKE_SERVABLE_PRS" | paste -sd, -)"
+        else
+            echo "quiet"
         fi
         exit 0
         ;;

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1360,7 +1360,9 @@ fi
 if command -v python3 >/dev/null 2>&1; then
     python3 - <<'PY' || true
 import json
+import os
 import pathlib
+import platform
 
 proj_dir = pathlib.Path("~/.fleet/state/projections").expanduser()
 trig_dir = pathlib.Path("~/.fleet/state/triggers").expanduser()
@@ -1389,8 +1391,47 @@ def sonnet_reviewer_actionable(p):
 def opus_reviewer_actionable(p):
     return bool(p.get("flagged_prs"))
 
+# Host key + smoke-label map, INLINED from fleet_task_class.py
+# (_current_host / HOST_SMOKE_LABELS, the canonical copies) — keep in sync.
+# This bootstrap heredoc is a standalone `python3 -` with no path to
+# FLEET_LIB_DIR, and it runs under `|| true`: an ImportError from sys.path
+# plumbing would be swallowed silently and take the bootstrap trigger down for
+# ALL six roles at once, which is strictly worse than the churn this gate
+# removes. Same reason fleet_task_class's own _current_host is inlined rather
+# than imported (#1578).
+def _current_host():
+    override = os.environ.get("FLEET_TEST_HOST")
+    if override:
+        return override
+    sysname = platform.system()
+    if sysname == "Darwin":
+        return "mac"
+    if sysname == "Linux":
+        return "linux"
+    if sysname.startswith(("Windows", "MINGW", "MSYS", "CYGWIN")):
+        return "windows"
+    return "unknown"
+
+HOST_SMOKE_LABELS = {
+    "linux": "fleet:needs-linux-smoke",
+    "mac": "fleet:needs-macos-smoke",
+    "windows": "fleet:needs-windows-smoke",
+}
+
 def smoke_worker_actionable(p):
-    return bool(p.get("smoke_pending_prs"))
+    # Host-gated (#2839). Smoke work is definitionally host-specific — only a
+    # native-Windows host can clear fleet:needs-windows-smoke — while the
+    # scout's projection is host-agnostic by design (the cross-host record of
+    # outstanding smoke debt). This is the level-triggered half of the lane, so
+    # an unfiltered bool() boot-dispatches a pane for another host's backlog on
+    # every restart, and the empty-exit backoff can only suppress it until the
+    # next projection change. Fail-closed on an unknown host key: no label ⇒
+    # never actionable.
+    want = HOST_SMOKE_LABELS.get(_current_host())
+    if not want:
+        return False
+    return any(want in (pr.get("labels") or [])
+               for pr in (p.get("smoke_pending_prs") or []))
 
 def epic_steward_actionable(p):
     return bool(p.get("triggers"))

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -90,6 +90,12 @@ prints ordered ``repo:number`` lines — the slice's ``needs_plan[]`` entries
 `_plan_class` matches ``<class>``. The dispatcher walks these attempting
 ``fleet-claim planning-claim`` until one is granted; that issue becomes the
 dispatch's pre-claimed planning assignment (#2197).
+
+A third CLI mode, ``--smoke-check <smoke-worker-slice.json>``, prints the PR
+numbers in the slice's ``smoke_pending_prs`` whose pending smoke label names
+THIS host (`HOST_SMOKE_LABELS` / `smoke_pr_for_host`). Empty output means this
+host owes no smoke work, and the dispatcher stands the lane down instead of
+spending a pane on another host's backlog (#2839).
 """
 
 import json
@@ -112,6 +118,54 @@ GL_CAPABLE_HOSTS = {"linux", "windows"}
 # The raw label behind that scout field. PR records carry labels but no derived
 # `needs_gl_host`, so the feedback dimension of the gate matches on this.
 GL_HOST_LABEL = "fleet:needs-gl-host"
+
+# Smoke validation is the one lane whose work is *definitionally* host-specific:
+# only a native-Windows host can clear `fleet:needs-windows-smoke`. The scout's
+# smoke projection is host-agnostic on purpose — it is the cross-host record of
+# outstanding smoke debt that `platform-catchup` reads — so the host dimension is
+# applied dispatch-side instead, the same layer `_host_incompatible` gates the
+# task (#1998) and feedback-PR (#2695) lanes at. Without it, a standing
+# Windows-pending set kept every non-Windows host dispatching no-op smoke panes
+# on every projection change (#2839).
+#
+# Keys are `_current_host()` host keys. #1383 reconciled the host *detectors*,
+# not the spelling, so the `mac` host key maps to a `macos` label; this map is
+# the single place the two vocabularies meet. An unrecognized host key resolves
+# to no label at all — fail-closed, matching `_host_incompatible`'s stance on
+# `unknown`.
+#
+# `fleet-state-scout`'s `_SMOKE_PENDING_LABELS` holds the same three labels as a
+# flat set — the host-agnostic half, which is what makes the projection readable
+# from any host. A new smoke host needs an entry in both.
+#
+# Keep in sync with the inlined copy in `fleet-up`'s bootstrap heredoc, which
+# cannot import this module (see `smoke_pr_for_host`).
+HOST_SMOKE_LABELS = {
+    "linux": "fleet:needs-linux-smoke",
+    "mac": "fleet:needs-macos-smoke",
+    "windows": "fleet:needs-windows-smoke",
+}
+
+
+def smoke_pr_for_host(labels, host):
+    """True when a smoke-pending PR's label names ``host``.
+
+    `fleet-up`'s bootstrap heredoc carries an inlined copy of this predicate
+    rather than importing it: that heredoc is a standalone `python3 - <<'PY'`
+    running under `|| true`, so an ImportError from sys.path plumbing would be
+    swallowed and kill the bootstrap trigger for *every* role at once — the
+    same reason `_current_host` above is itself inlined rather than imported
+    (#1578). `fleet-dispatcher` reaches this one through the
+    ``--smoke-check`` CLI arm in `main`, the seam it already uses for
+    ``--plan-pick``.
+    """
+    want = HOST_SMOKE_LABELS.get(host)
+    return bool(want) and want in (labels or [])
+
+
+def smoke_prs_for_host(prs, host):
+    """The subset of a smoke slice's ``smoke_pending_prs`` this host can serve."""
+    return [pr for pr in (prs or []) if smoke_pr_for_host(pr.get("labels"), host)]
 
 
 def _current_host():
@@ -458,6 +512,24 @@ def main(argv):
             return 0  # empty output -> nothing to assign
         for line in plan_pick(slice_data, argv[3], argv[4] == "1"):
             print(line)
+        return 0
+    if argv[1:2] == ["--smoke-check"]:
+        # --smoke-check <smoke-worker-slice.json>: print the PR numbers in the
+        # slice's `smoke_pending_prs` that THIS host can actually validate, one
+        # per line. Empty output = nothing servable here, i.e. don't dispatch.
+        # fleet-dispatcher's `smoke_worker_should_fire` shells out to this
+        # (see `smoke_pr_for_host` for why it is a CLI seam and not an import).
+        if len(argv) != 3:
+            print("usage: fleet_task_class.py --smoke-check <slice.json>",
+                  file=sys.stderr)
+            return 2
+        slice_data = _load_slice(argv[2])
+        if slice_data is None:
+            return 0  # empty output -> nothing servable
+        for pr in smoke_prs_for_host(slice_data.get("smoke_pending_prs"),
+                                     _current_host()):
+            if pr.get("number") is not None:
+                print(pr["number"])
         return 0
     # Optional 4th arg: comma-separated classes to exclude (the dispatcher's
     # cross-class fan-out re-resolve). Absent -> exclude nothing.

--- a/scripts/fleet/tests/test_dispatcher_smoke_host_gate.sh
+++ b/scripts/fleet/tests/test_dispatcher_smoke_host_gate.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Tests for the smoke lane's dispatch-side host gate (#2839) — fleet-dispatcher's
+# smoke_worker_should_fire, exercised through the --smoke-check hook and one
+# real dispatch_role tick per arm.
+#
+# Smoke is the only fleet lane whose work is definitionally host-specific: only a
+# native-Windows host can clear fleet:needs-windows-smoke. The scout's projection
+# is deliberately host-agnostic (it is the cross-host record of outstanding smoke
+# debt that platform-catchup reads), so before this gate a standing
+# Windows-pending set kept every non-Windows host dispatching smoke panes for
+# work they could never do — measured at 4 no-op dispatches in 43 minutes on a
+# macOS host, with the empty-exit backoff hitting its cap twice and the scout
+# re-arming after each.
+#
+# The positive arm (T9) is the load-bearing one: a fix that simply silences the
+# lane would pass every negative assertion here.
+#
+# Host routing under test is the fleet_task_class.py HOST_SMOKE_LABELS map, whose
+# `mac` host key maps to a `macos` label (#1383 reconciled the host detectors,
+# not the spelling). The python-side per-host pins live in
+# test_smoke_worker_projection.py; this suite covers the bash gate and the
+# trigger lifecycle around it.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+[[ -x "$DISPATCHER" ]] || { echo "test setup: fleet-dispatcher not found at $DISPATCHER" >&2; exit 1; }
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_CONF="$TMPROOT/fleet-up.conf"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_SESSION="fleet-test-$$"
+export FLEET_DISPATCH_MIN_GAP_SECONDS=0     # no stagger between ticks
+export FLEET_CONCURRENCY_SMOKE_WORKER=1
+export BOOT_FANOUT_WINDOW_SECONDS=0         # post-window steady state
+mkdir -p "$FLEET_STATE_DIR/projections" "$FLEET_STATE_DIR/dispatch" \
+         "$FLEET_STATE_DIR/triggers" "$FLEET_RESERVATIONS_DIR"
+touch "$FLEET_CONF"
+
+WINDOWS="fleet:needs-windows-smoke"
+LINUX="fleet:needs-linux-smoke"
+MACOS="fleet:needs-macos-smoke"
+
+# One idle pool pane; pgrep exits 1 so it reads as not running a wrapper.
+STUB_BIN="$TMPROOT/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    list-panes) printf '%%1|pool|zsh\n'; exit 0 ;;
+    display-message)
+        pane=""; fmt=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            echo "/fake/worktrees/pool-${pane#%}"
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            echo "1"
+        fi
+        exit 0
+        ;;
+    send-keys) exit 0 ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$STUB_BIN/tmux"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB_BIN/pgrep"
+chmod +x "$STUB_BIN/pgrep"
+export PATH="$STUB_BIN:$PATH"
+
+SLICE="$FLEET_STATE_DIR/projections/smoke-worker.json"
+TRIGGER="$FLEET_STATE_DIR/triggers/smoke-worker"
+
+write_slice() {  # write_slice <label...> — one approved PR per label, #101+
+    local n=101 body="" first=1 label
+    for label in "$@"; do
+        [[ $first -eq 1 ]] || body+=","
+        first=0
+        body+="{\"number\":$n,\"labels\":[\"fleet:approved\",\"$label\"]}"
+        n=$((n + 1))
+    done
+    printf '{"smoke_pending_prs":[%s]}\n' "$body" > "$SLICE"
+}
+
+# Bound every dispatcher invocation. fleet-dispatcher's argument `case` falls
+# through an unrecognized flag to `main`, i.e. the daemon loop — so running this
+# suite against a PRE-FIX tree (which has no --smoke-check arm) would hang
+# forever instead of failing, and the positive control that proves the suite
+# non-vacuous could never terminate. coreutils `timeout` is absent on a stock
+# macOS host, where the guard is simply skipped rather than failing the run —
+# the same stance run_all.sh takes for its own per-suite guard.
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+fi
+
+run_dispatcher() {  # run_dispatcher <host> <args...>
+    local host="$1"; shift
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        FLEET_TEST_HOST="$host" "$TIMEOUT_BIN" 20 "$DISPATCHER" "$@"
+    else
+        FLEET_TEST_HOST="$host" "$DISPATCHER" "$@"
+    fi
+}
+
+check() { run_dispatcher "$1" --smoke-check; }
+
+tick() {  # tick <host> — one dispatch_role smoke-worker tick; prints the log
+    rm -f "$FLEET_STATE_DIR/dispatch"/*.json
+    : > "$TRIGGER"
+    run_dispatcher "$1" --dispatch-role smoke-worker 2>&1 >/dev/null
+}
+
+echo "T1: Windows-pending PR on a Windows host -> fire"
+write_slice "$WINDOWS"
+assert_eq "$(check windows)" "fire prs=101" "windows host serves its own smoke label"
+
+echo "T2: the same PR on a macOS host -> quiet (the #2839 defect)"
+assert_eq "$(check mac)" "quiet" "mac host stands down on windows-only smoke work"
+
+echo "T3: ... and on a Linux host -> quiet"
+assert_eq "$(check linux)" "quiet" "linux host stands down on windows-only smoke work"
+
+echo "T4: macOS-pending PR on a macOS host -> fire (mac host key, macos label)"
+write_slice "$MACOS"
+assert_eq "$(check mac)" "fire prs=101" "the mac/macos vocabulary split is reconciled"
+assert_eq "$(check windows)" "quiet" "windows host stands down on macos-only work"
+
+echo "T5: a mixed slice reports only this host's PRs"
+write_slice "$WINDOWS" "$MACOS" "$LINUX"
+assert_eq "$(check windows)" "fire prs=101" "windows sees only #101"
+assert_eq "$(check mac)" "fire prs=102" "mac sees only #102"
+assert_eq "$(check linux)" "fire prs=103" "linux sees only #103"
+
+echo "T6: an unrecognized host key fails closed"
+assert_eq "$(check unknown)" "quiet" "unknown host key matches no label"
+
+echo "T7: a missing slice is quiet, not an error"
+mv "$SLICE" "$SLICE.bak"
+assert_eq "$(check windows)" "quiet" "absent projection -> stand down"
+mv "$SLICE.bak" "$SLICE"
+
+echo "T8: a tick on a non-serving host consumes the trigger and dispatches nothing"
+write_slice "$WINDOWS"
+out=$(tick mac)
+assert_contains "$out" "no smoke work pending for this host" "stand-down is logged"
+assert_absent "$out" "dispatching smoke-worker" "no pane is spent"
+if [[ -f "$TRIGGER" ]]; then
+    bad "trigger consumed (scout re-arms on the next projection change)"
+else
+    ok "trigger consumed (scout re-arms on the next projection change)"
+fi
+
+echo "T9: positive control — a tick on the serving host still dispatches"
+out=$(tick windows)
+assert_contains "$out" "dispatching smoke-worker" "windows host still gets its pane"
+assert_absent "$out" "no smoke work pending for this host" "the gate does not fire on real work"
+
+summarize "fleet-dispatcher smoke host gate"

--- a/scripts/fleet/tests/test_smoke_worker_projection.py
+++ b/scripts/fleet/tests/test_smoke_worker_projection.py
@@ -18,11 +18,17 @@ The regression these tests lock in (#2804):
   — on a fleet whose only smoke-pending PRs are Windows, the documented
   primary path was unreachable.
 
-Host *routing* is deliberately not this projection's job: the role derives its
-host key from `uname -s` at its step 4 and polls only that host's label, so a
-Linux/macOS dispatch woken by a Windows-pending PR finds nothing and exits.
-The trigger is transition-keyed, so that costs one wake per set change —
-exactly what linux/macos already pay.
+Host *routing* is deliberately not this PROJECTION's job — it stays the
+host-agnostic cross-host record of outstanding smoke debt, which is what
+`platform-catchup` reads. But routing is no longer doc-only either: #2839 added
+the code-level host gate one layer downstream, at dispatch, where
+`_host_incompatible` already gates the task (#1998) and feedback-PR (#2695)
+lanes. `fleet_task_class.HOST_SMOKE_LABELS` / `smoke_pr_for_host` is the
+canonical map; `fleet-up`'s bootstrap heredoc carries an inlined copy (it cannot
+import — see below) and `fleet-dispatcher`'s `smoke_worker_should_fire` reaches
+it through the `--smoke-check` CLI arm. Before that gate, a standing
+Windows-pending set kept every non-Windows host boot-dispatching and re-arming
+smoke panes for work it could never do.
 
 This harness pins:
   - a Windows-only pending PR appears in the projection and flips the hash.
@@ -31,11 +37,22 @@ This harness pins:
   - the skip-label and approval gates apply to Windows exactly as to the
     other two hosts.
   - the projection stays engine-only.
+  - the dispatch-side host gate routes each host key to its own label, fails
+    closed on an unknown host, and leaves the projection host-agnostic.
+  - fleet-up's inlined copy of that map agrees with the canonical one — a
+    duplicate with no drift guard is the whole risk of inlining it.
 """
 import importlib.machinery
 import importlib.util
+import json
+import os
+import platform
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
 _loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
@@ -46,9 +63,42 @@ project_smoke_worker = _mod.project_smoke_worker
 slice_smoke_worker = _mod.slice_smoke_worker
 stable_hash = _mod.stable_hash
 
+_TASK_CLASS = Path(__file__).parent.parent / "fleet_task_class.py"
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from fleet_task_class import (  # noqa: E402
+    HOST_SMOKE_LABELS,
+    smoke_pr_for_host,
+    smoke_prs_for_host,
+)
+
 WINDOWS = "fleet:needs-windows-smoke"
 LINUX = "fleet:needs-linux-smoke"
 MACOS = "fleet:needs-macos-smoke"
+
+
+def _fleet_up_boot_predicate():
+    """fleet-up's INLINED smoke_worker_actionable, lifted out of its heredoc.
+
+    The heredoc is a standalone `python3 - <<'PY'` with no path to
+    FLEET_LIB_DIR, running under `|| true` — an ImportError there would be
+    swallowed and would kill the bootstrap trigger for every role at once, so
+    the map is deliberately duplicated rather than imported
+    (`fleet_task_class.smoke_pr_for_host` documents why). A duplicate needs its
+    own coverage, hence this lift; `TwoCopiesAgree` below is the drift guard.
+
+    Only the function definitions are sliced out and exec'd: the heredoc's
+    module-level statements mkdir under $HOME, which a hermetic test must not
+    touch (scripts/fleet/CLAUDE.md). Bash-function equivalent of the same trick:
+    test_fleet_up_resume_boot.sh's `extract_fn`.
+    """
+    src = (Path(__file__).parent.parent / "fleet-up").read_text().splitlines()
+    start = next(i for i, ln in enumerate(src)
+                 if ln.startswith("def _current_host():"))
+    end = next(i for i, ln in enumerate(src)
+               if ln.startswith("for role, predicate in ["))
+    ns = {"os": os, "platform": platform}
+    exec("\n".join(src[start:end]), ns)  # noqa: S102 — defs only, sliced above
+    return ns
 
 
 def _state(prs, game_prs=None):
@@ -117,10 +167,24 @@ class BootDispatchSeesWindows(unittest.TestCase):
         self.assertEqual([p["number"] for p in out["smoke_pending_prs"]], [101])
         self.assertIn(WINDOWS, out["smoke_pending_prs"][0]["labels"])
 
-    def test_slice_nonempty_so_boot_dispatch_fires(self):
-        # bool(p["smoke_pending_prs"]) is fleet-up's predicate verbatim.
+    def test_slice_nonempty_so_boot_dispatch_fires_on_windows(self):
+        # The slice reaching fleet-up's predicate non-empty is necessary but no
+        # longer sufficient: #2839 host-filters it, so the boot dispatch fires
+        # on a Windows host and NOT on the other two. Asserted against the real
+        # predicate rather than a hand-copy of `bool(p["smoke_pending_prs"])` —
+        # the hand-copy this replaces would have gone on passing while encoding
+        # the pre-fix behaviour.
         out = slice_smoke_worker(_state([_approved(101, WINDOWS)]))
         self.assertTrue(bool(out["smoke_pending_prs"]))
+        actionable = _fleet_up_boot_predicate()["smoke_worker_actionable"]
+        with mock.patch.dict(os.environ, {"FLEET_TEST_HOST": "windows"}):
+            self.assertTrue(actionable(out))
+        for host in ("mac", "linux"):
+            with self.subTest(host=host), \
+                    mock.patch.dict(os.environ, {"FLEET_TEST_HOST": host}):
+                self.assertFalse(
+                    actionable(out),
+                    f"{host} must not boot-dispatch on Windows-only smoke work")
 
 
 class OtherHostsUnchanged(unittest.TestCase):
@@ -170,6 +234,152 @@ class EngineOnly(unittest.TestCase):
         state = _state([], game_prs=[_approved(99, WINDOWS)])
         self.assertEqual(project_smoke_worker(state), [])
         self.assertEqual(slice_smoke_worker(state)["smoke_pending_prs"], [])
+
+
+class HostGateRoutesEachHostKey(unittest.TestCase):
+    """The canonical dispatch-side gate: fleet_task_class.smoke_pr_for_host.
+
+    Every host key is pinned explicitly. The `mac` host key vs the `macos`
+    label is the trap (#1383 reconciled the host detectors, not the spelling):
+    a mismatch matches no label, the host is never actionable, and the smoke
+    lane silently dies — the #2804 failure mode from the other direction.
+    """
+
+    def test_each_host_matches_only_its_own_label(self):
+        for host, own in (("linux", LINUX), ("mac", MACOS),
+                          ("windows", WINDOWS)):
+            for label in (LINUX, MACOS, WINDOWS):
+                with self.subTest(host=host, label=label):
+                    self.assertEqual(smoke_pr_for_host([label], host),
+                                     label == own)
+
+    def test_mac_host_key_maps_to_the_macos_label(self):
+        # Pinned on its own: this is the one pair whose two spellings differ.
+        self.assertEqual(HOST_SMOKE_LABELS["mac"], MACOS)
+        self.assertTrue(smoke_pr_for_host([MACOS], "mac"))
+        self.assertFalse(smoke_pr_for_host([MACOS], "macos"))
+
+    def test_unknown_host_is_fail_closed(self):
+        for host in ("unknown", "", None, "macos"):
+            with self.subTest(host=host):
+                self.assertFalse(smoke_pr_for_host([LINUX, MACOS, WINDOWS],
+                                                   host))
+
+    def test_multi_host_pr_is_servable_by_each_named_host(self):
+        # A PR pending on two hosts is real work for BOTH; the gate must not
+        # collapse it to the first label.
+        self.assertTrue(smoke_pr_for_host([WINDOWS, LINUX], "linux"))
+        self.assertTrue(smoke_pr_for_host([WINDOWS, LINUX], "windows"))
+        self.assertFalse(smoke_pr_for_host([WINDOWS, LINUX], "mac"))
+
+    def test_no_labels_never_matches(self):
+        for labels in ([], None, ["fleet:approved"]):
+            with self.subTest(labels=labels):
+                self.assertFalse(smoke_pr_for_host(labels, "linux"))
+
+    def test_filter_keeps_only_this_hosts_prs(self):
+        prs = slice_smoke_worker(_state([
+            _approved(101, WINDOWS), _approved(102, MACOS),
+            _approved(103, WINDOWS, LINUX),
+        ]))["smoke_pending_prs"]
+        got = {h: [p["number"] for p in smoke_prs_for_host(prs, h)]
+               for h in ("windows", "mac", "linux", "unknown")}
+        self.assertEqual(got, {"windows": [101, 103], "mac": [102],
+                               "linux": [103], "unknown": []})
+
+    def test_projection_itself_stays_host_agnostic(self):
+        # Approach (A)'s load-bearing property: the scout's output is identical
+        # on every host, so state.json stays the cross-host record of smoke debt
+        # that platform-catchup reads. Only the dispatch-side filter differs.
+        state = _state([_approved(101, WINDOWS), _approved(102, MACOS)])
+        per_host = []
+        for host in ("windows", "mac", "linux"):
+            with mock.patch.dict(os.environ, {"FLEET_TEST_HOST": host}):
+                per_host.append(stable_hash(project_smoke_worker(state)))
+        self.assertEqual(len(set(per_host)), 1)
+
+
+class TwoCopiesAgree(unittest.TestCase):
+    """fleet-up's inlined map/host-key must not drift from the canonical one.
+
+    The inlining is deliberate (`fleet_task_class.smoke_pr_for_host` says why),
+    which makes drift the standing risk it buys — so it gets a guard rather
+    than a comment.
+    """
+
+    def setUp(self):
+        self.ns = _fleet_up_boot_predicate()
+
+    def test_label_maps_are_identical(self):
+        self.assertEqual(self.ns["HOST_SMOKE_LABELS"], HOST_SMOKE_LABELS)
+
+    def test_host_detection_agrees_per_uname(self):
+        # Both copies map uname -s the same way, including the Windows family
+        # and the fail-closed default.
+        cases = {"Darwin": "mac", "Linux": "linux", "Windows_NT": "windows",
+                 "MINGW64_NT-10.0": "windows", "MSYS_NT-10.0": "windows",
+                 "CYGWIN_NT-10.0": "windows", "Plan9": "unknown"}
+        for sysname, expected in cases.items():
+            with self.subTest(sysname=sysname), \
+                    mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("FLEET_TEST_HOST", None)
+                with mock.patch.object(platform, "system",
+                                       return_value=sysname):
+                    self.assertEqual(self.ns["_current_host"](), expected)
+
+    def test_fleet_test_host_override_honored(self):
+        with mock.patch.dict(os.environ, {"FLEET_TEST_HOST": "windows"}):
+            self.assertEqual(self.ns["_current_host"](), "windows")
+
+
+class SmokeCheckCli(unittest.TestCase):
+    """`fleet_task_class.py --smoke-check` — the seam fleet-dispatcher uses.
+
+    It shells out rather than imports, so the CLI contract (host-filtered PR
+    numbers on stdout, empty = stand down) is what the dispatcher's gate
+    actually depends on.
+    """
+
+    def _run(self, slice_data, host):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "smoke-worker.json"
+            path.write_text(json.dumps(slice_data))
+            env = {**os.environ, "FLEET_TEST_HOST": host}
+            return subprocess.run(
+                [sys.executable, str(_TASK_CLASS), "--smoke-check", str(path)],
+                capture_output=True, text=True, env=env, check=False)
+
+    def _slice(self):
+        return slice_smoke_worker(_state([
+            _approved(101, WINDOWS), _approved(102, MACOS),
+        ]))
+
+    def test_prints_only_this_hosts_prs(self):
+        for host, expected in (("windows", "101"), ("mac", "102"),
+                               ("linux", ""), ("unknown", "")):
+            with self.subTest(host=host):
+                res = self._run(self._slice(), host)
+                self.assertEqual(res.returncode, 0, res.stderr)
+                self.assertEqual(res.stdout.strip(), expected)
+
+    def test_missing_slice_is_quiet_not_an_error(self):
+        # The dispatcher runs this every tick a trigger stands; a missing or
+        # unreadable slice must mean "don't fire", never a crash it would
+        # swallow into the same verdict by accident.
+        with tempfile.TemporaryDirectory() as tmp:
+            res = subprocess.run(
+                [sys.executable, str(_TASK_CLASS), "--smoke-check",
+                 str(Path(tmp) / "absent.json")],
+                capture_output=True, text=True, check=False)
+        self.assertEqual(res.returncode, 0)
+        self.assertEqual(res.stdout.strip(), "")
+
+    def test_bad_arity_is_a_usage_error(self):
+        res = subprocess.run(
+            [sys.executable, str(_TASK_CLASS), "--smoke-check"],
+            capture_output=True, text=True, check=False)
+        self.assertEqual(res.returncode, 2)
+        self.assertIn("usage:", res.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Smoke is the only fleet lane whose work is **definitionally host-specific** —
  only a native-Windows host can clear `fleet:needs-windows-smoke` — and it was
  the only lane with no host gate in code. Routing rested entirely on
  `role-smoke-worker.md` step 4, an LLM-read doc instruction, so every
  non-Windows host woke smoke panes for the standing Windows backlog.
- Adds the gate **dispatch-side**, the layer `_host_incompatible` already gates
  the task (#1998) and feedback-PR (#2695) lanes at:
  `fleet_task_class.HOST_SMOKE_LABELS` + `smoke_pr_for_host` map each host key
  to its own pending label, `fleet-up`'s boot predicate filters
  `smoke_pending_prs` through it, and `fleet-dispatcher`'s
  `smoke_worker_should_fire` consults it before spending a pane on a standing
  trigger (consuming that trigger, exactly as the empty-exit backoff does).
- **`fleet-state-scout` is deliberately untouched.** The projection stays the
  host-agnostic record of outstanding smoke debt that `platform-catchup` reads —
  that property is why the filter belongs at dispatch and not in the scout
  (approach (A) vs the rejected (B) in the plan). Pinned by
  `test_projection_itself_stays_host_agnostic`.
- **#2809 stays discharged.** `fleet:needs-windows-smoke` belongs in
  `_SMOKE_PENDING_LABELS`; only the host filter downstream of it is new. The
  positive-fire criterion below is what keeps a "just silence the lane" fix from
  passing.
- The map is **duplicated** into `fleet-up`'s bootstrap heredoc rather than
  imported: that block is a standalone `python3 - <<'PY'` with no path to
  `FLEET_LIB_DIR`, running under `|| true` — an `ImportError` there is swallowed
  and takes the bootstrap trigger down for **all six roles at once**, strictly
  worse than the churn being fixed. `TwoCopiesAgree` is the drift guard, and
  `scripts/fleet/CLAUDE.md` now carries the rule. (Plan-review Constraint 1.)

### Residual — the gate is dispatch-side only

#1998 / #2695 enforce at **two** layers: the election predicate *and*
`fleet-claim`'s outright refusal. This PR adds dispatch/boot only.
`fleet-claim review-claim` has **no host term**, and that is deliberate — it is
shared with the reviewer lanes, where a cross-host claim is legitimate (a macOS
opus reviewer reviewing a `needs-windows-smoke` PR is normal), so a naive label
gate there would break reviewers. A smoke pane started by any other route still
falls back to `role-smoke-worker.md` step 4. This PR does **not** claim full
parity with #1998 / #2695. (Plan-review Constraint 2.)

## Test plan

- [x] `scripts/fleet/tests/run_all.sh --timeout 600` → **110 suite(s) — 110
      passed, 0 failed** (run with `env -u FLEET_PLAN_ISSUE`, per #2836).
- [x] Both touched suites run **alone** as well as through the whole-dir runner
      (#2825): `test_smoke_worker_projection.py` 26/26,
      `test_dispatcher_smoke_host_gate.sh` 15/15.
- [x] **Positive control** — `fleet-positive-control
      scripts/fleet/tests/test_dispatcher_smoke_host_gate.sh origin/master`
      reports **MEANINGFUL: 12 of 15 assertions fail against origin/master
      (34c7f7f46)**; the 3 that still pass are the non-regression assertions.
      The pre-fix run reproduces the defect literally — on a `mac` host with
      only Windows-pending work it logs `dispatching smoke-worker -> %1`.
- [x] Positive control for the python suite, staged the same way (whole-dir
      `git archive`, per #2713): against `origin/master` it fails at import —
      `cannot import name 'HOST_SMOKE_LABELS' from 'fleet_task_class'` — i.e.
      the entire API under test is absent pre-fix, so every new assertion is
      unreachable there.
- [x] `ruff check scripts/` → `All checks passed!`
- [x] Live gate on this macOS host: `fleet-dispatcher --smoke-check` → `quiet`;
      `FLEET_TEST_HOST=windows fleet-dispatcher --smoke-check` →
      `fire prs=2659,2683,2812`.

No build target was exercised: the diff is Python/bash/markdown only, no C++,
shaders, or CMake. The gate for a scripts-only change is the fleet suites above.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| 1. macOS host, only `needs-windows-smoke` pending ⇒ `smoke_worker_actionable` False and no pane dispatched | fleet-up's inlined predicate against **live** `~/.fleet/state/state.json`; `fleet-dispatcher --dispatch-role smoke-worker` (suite T8) | `smoke_worker_actionable on THIS host (Darwin -> mac): False` (was `True` pre-fix). T8: `no smoke work pending for this host` logged, **no** `dispatching smoke-worker`, trigger consumed |
| 2. Windows host, same state, still triggers and slices 2659 / 2683 / 2812 — #2804 stays discharged | same live state with `FLEET_TEST_HOST=windows`; suite T9 | `FLEET_TEST_HOST=windows: True`; `--smoke-check` → `fire prs=2659,2683,2812`. T9 positive control: `dispatching smoke-worker` still fires |
| 3. `linux` / `macos` routing unregressed | suite T4/T5 + `smoke_prs_for_host` per-host filter test | macOS-pending PR on a `mac` host → `fire prs=101`; mixed slice routes `{windows:[101,103], mac:[102], linux:[103], unknown:[]}`. `HOST_SMOKE_LABELS["mac"] == fleet:needs-macos-smoke` pinned on its own (the #1383 spelling split) |
| 4. The control run inverts | control command from the issue body, re-run post-fix | **Inverted.** Read as the plan restates it (`smoke_worker_actionable` `True` → `False`), **not** as "the projection is `[]`": under approach (A) the projection is intentionally unchanged and still reports `[2659, 2683, 2812]` on every host — that host-agnostic projection is (A)'s load-bearing property and is itself pinned by `test_projection_itself_stays_host_agnostic` |
| 5. `test_smoke_worker_projection.py` extended with host-routing cases; `run_all.sh` green | see Test plan | +4 classes / 26 tests, plus a new `test_dispatcher_smoke_host_gate.sh` (15) for the bash gate; `run_all.sh` 110/110 |

**Note on criterion 4's wording.** The issue phrases it as "the post-fix
projection on Darwin is `[]`". Taken literally that describes the *rejected*
approach (B) — host-filtering the scout. The plan (and its review) resolve this
in favour of (A) and restate the criterion as the `smoke_worker_actionable`
inversion; the row above is graded against that reading, and the projection
deliberately still holds all three PRs.

## Reviewer notes

- One pre-existing citation drift found and **not** fixed here (unrelated-cleanup
  rule): `fleet_task_class.py:176`, the `_current_host` comment, cites
  `(#1750/#1578)` for `FLEET_LIB_DIR`/`~/bin`-symlink fragility. #1578 is that
  issue; **#1750 is "state.json non-atomic write race"** and is unrelated. New
  lines in this PR cite #1578 only.
- `fleet-positive-control` runs every suite under `bash` regardless of
  extension, so it cannot drive a `.py` suite (`run_all.sh` dispatches by
  extension; this tool does not). The python control above was therefore staged
  by hand with the same whole-dir `git archive` the tool uses. Filed as #2848.

Closes #2839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

