### PR TITLE
fleet: un-gate the retired stack-park cleanup so no PR is lane-orphaned

### DIFF
--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -11,8 +11,10 @@
 # (sonnet) merger iteration. The LLM pass is therefore only ever spent on
 # work that actually needs judgment.
 #
-# Eligibility (deliberately conservative — tier-0 must never fight an
-# agent or human for a branch):
+# Eligibility for the rebase pass (deliberately conservative — tier-0 must
+# never fight an agent or human for a branch). The stale-label cleanups
+# below are NOT bound by it: they do no branch work, so there is no branch
+# to fight over (#2840).
 #   - PR carries fleet:approved and none of the skip labels below.
 #   - Stacked PRs (base != master): plain rebase onto the updated base
 #     branch only. Retargeting to master and the inherited-prefix drop
@@ -85,7 +87,11 @@ for arg in "$@"; do
         --auto)          AUTO=1 ;;
         --rearm-trigger) REARM=1 ;;
         --dry-run)       DRY_RUN=1 ;;
-        -h|--help)       sed -n '2,31p' "$0"; exit 0 ;;
+        # Header end is derived from content (first non-# line), never a
+        # hardcoded range: the old `sed -n '2,31p'` silently dropped every
+        # section past the stale-label bullets — Usage included — and any
+        # header edit moved the cut (#2433's shape, re-hit in #2840).
+        -h|--help)       awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0"; exit 0 ;;
         *) echo "fleet-rebase: unknown argument '$arg'" >&2; exit 2 ;;
     esac
 done
@@ -321,15 +327,19 @@ cleanup_stale_conflict() {
 # Remove a retired stack-park label (fleet:awaiting-base /
 # fleet:needs-base-update) from a PR whose base IS master. The park is
 # provably discharged there — a PR cannot be waiting on a base branch that
-# is master — and nothing else will ever remove it. The sole remover is
-# merger step 2.5, whose candidate filter is `baseRefName != "master"`;
-# GitHub retargets a native-stack child to master synchronously with its
-# parent's merge, so the child leaves 2.5's candidate set at the very
-# moment 2.5 would have cleared the label. The slice triage and merger
-# step 3 then both hard-skip it, stranding an approved PR from every
-# automated lane (#2764). Live-reverified before touching: confirms OPEN,
-# base still master, and the label still present, so a PR retargeted back
-# off master between the scout tick and now is never cleared.
+# is master — and nothing else will ever remove it.
+#
+# This function is the ONLY remover of these labels tree-wide — the loop
+# below is the sole `--remove-label` site for either one. Merger step 2.5
+# used to share the job; it retired with the native-stacked-PRs migration
+# (#2657, `role-merger.md` step 2.5), so there is nothing left to defer to
+# and no lane behind this one. That is why its triage gate is deliberately
+# permissive — no approved / skip-label guards; see has_stale_base_park
+# (#2764, #2840).
+#
+# Live-reverified before touching: confirms OPEN, base still master, and the
+# label still present, so a PR retargeted back off master between the scout
+# tick and now is never cleared.
 cleanup_stale_base_park() {
     local repo_key="$1" pr="$2"
     local repo_slug
@@ -648,19 +658,25 @@ for pr in data.get("prs", []):
         and mergeable == "MERGEABLE"
         and not any(skip_re.search(l) for l in labels if l != "fleet:semantic-conflict")
     )
-    # Retired stack-park labels, still minted by the merger role doc.
-    # base == master proves the park is discharged — a PR cannot be waiting
-    # on a base branch that is master — so route it to cleanup rather than
-    # parking it (why nothing else ever clears it: cleanup_stale_base_park,
-    # #2764). Same guards as the stale-conflict case: approved, and no other
-    # skip label claiming the branch.
+    # Retired stack-park labels (the minter died with #2657, so on a live PR
+    # these are pure residue). base == master proves the park is discharged —
+    # a PR cannot be waiting on a base branch that is master — so route it to
+    # cleanup rather than parking it (why nothing else ever clears it:
+    # cleanup_stale_base_park, #2764).
+    #
+    # Deliberately NOT guarded on `approved` or on other skip labels, unlike
+    # the stale-conflict case above — do not "unify" the two predicates
+    # (#2840). Those guards mean "don't touch a PR another agent owns", which
+    # is correct for every lane that does branch work; this verdict does none.
+    # It removes one retired label whose discharge base == master already
+    # proves, independent of who owns the branch, and a PR that is genuinely
+    # parked keeps its real park label and routes to skip-labels next tick.
+    # The guards also defeat each other here: the merger strips fleet:approved
+    # at the same moment it adds fleet:semantic-conflict, and that label leads
+    # SKIP_LABEL_RE — so a conflicted retargeted child fails both at once and
+    # lands on skip-labels, which no lane revisits.
     stack_park = {"fleet:needs-base-update", "fleet:awaiting-base"} & set(labels)
-    has_stale_base_park = (
-        stack_park
-        and base == "master"
-        and approved
-        and not any(skip_re.search(l) for l in labels if l not in stack_park)
-    )
+    has_stale_base_park = bool(stack_park) and base == "master"
     if has_stale_conflict:
         verdict = "stale-conflict"
     elif has_stale_base_park:
@@ -668,8 +684,10 @@ for pr in data.get("prs", []):
     elif any(skip_re.search(l) for l in labels):
         verdict = "skip-labels"
     elif stack_park:
-        # base != master (or not approved): a straggler still anchored to a
-        # real base, mid-legacy-sequence. The LLM pass owns it, never tier-0.
+        # base != master: a straggler still anchored to a real base,
+        # mid-legacy-sequence, so the park still describes the PR. The LLM
+        # pass owns it, never tier-0. (base == master can no longer reach
+        # here — it is the whole stale-base-park gate, #2840.)
         verdict = "llm-other"
     elif approved and (base != "master" or mergeable not in ("MERGEABLE", "UNKNOWN", "", None)):
         verdict = "attempt"

--- a/scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh
@@ -17,18 +17,33 @@
 # llm-other. A straggler still anchored to a real base (base != master) keeps
 # the old llm-other routing.
 #
+# The gate is base == master alone — no fleet:approved requirement and no
+# skip-label exclusion (#2840). Those guards belong to lanes that do branch
+# work; this verdict does none. They also defeat each other here: the merger
+# strips fleet:approved at the same moment it adds fleet:semantic-conflict,
+# and that label leads SKIP_LABEL_RE, so a conflicted retargeted child fails
+# both at once and lands on skip-labels, which no lane revisits — while
+# worker step 1c and the scout projection both exclude fleet:awaiting-base,
+# so no human-facing lane sees it either. T7 pins that shape.
+#
 #   T1: fleet:awaiting-base + base=master + approved -> cleanup fires
 #       (dry-run: logs "would remove").
 #   T2: fleet:needs-base-update + base=master + approved -> cleanup fires
 #       (the twin retired label takes the same path).
 #   T3: fleet:awaiting-base + base != master -> llm-other, NOT cleaned
-#       (genuine mid-sequence straggler; the LLM pass owns it).
-#   T4: fleet:awaiting-base + base=master + fleet:wip -> skip-labels, not
-#       cleaned (the WIP guard outranks the cleanup, as for stale-conflict).
-#   T5: fleet:awaiting-base + base=master but NOT approved -> llm-other,
-#       not cleaned (tier-0 never acts on an unapproved branch).
+#       (genuine mid-sequence straggler; the LLM pass owns it). UNCHANGED by
+#       #2840 — that park is still real.
+#   T4: fleet:awaiting-base + base=master + fleet:wip -> cleaned (#2840).
+#       The WIP park is not discharged by this; it is preserved on the PR and
+#       re-routes to skip-labels on the next tick — see T8.
+#   T5: fleet:awaiting-base + base=master but NOT approved -> cleaned (#2840).
 #   T6: CONFLICTING + base=master + no park label -> the normal attempt
 #       path is untouched by this change.
+#   T7: the #2840 live shape — awaiting-base + semantic-conflict + base=master
+#       + NOT approved (both dropped guards failing at once) -> cleaned.
+#   T8: fleet:wip + base=master + no park label -> skip-labels. This is T4's
+#       PR on the tick after cleanup: the real park still parks it, so
+#       removing the residue never unparks anyone.
 #
 # All run --auto --dry-run: cleanup_stale_base_park logs its intent and
 # returns before calling gh (which is gated behind DRY_RUN=0).
@@ -148,8 +163,8 @@ assert_absent   "$T3" "would remove" \
 assert_contains "$T3" "llm_remaining=1" \
     "T3 straggler still routes to the LLM pass"
 
-# === T4: fleet:wip guard outranks the cleanup ================================
-echo "T4: fleet:wip + fleet:awaiting-base + base=master -> skip-labels (WIP wins)"
+# === T4: another skip label no longer blocks the cleanup (#2840) =============
+echo "T4: fleet:wip + fleet:awaiting-base + base=master -> cleaned (#2840)"
 write_slice '[{
   "repo":"engine","number":403,
   "headRefName":"feat-retargeted","baseRefName":"master",
@@ -157,13 +172,15 @@ write_slice '[{
   "labels":["fleet:approved","fleet:awaiting-base","fleet:wip"]
 }]'
 T4=$(run_rebase)
-assert_absent "$T4" "would remove" \
-    "T4 fleet:wip + stack-park not cleaned (WIP guard wins)"
+assert_contains "$T4" "retired stack-park label on a base=master PR — would remove" \
+    "T4 a co-resident skip label no longer blocks the cleanup"
+assert_absent "$T4" "clean rebase onto" \
+    "T4 cleanup still does no branch work on someone else's WIP branch"
 assert_absent "$T4" "llm_remaining=1" \
-    "T4 WIP goes to skip-labels, not the LLM pass"
+    "T4 cleanup does not count toward LLM_REMAINING"
 
-# === T5: unapproved PR is never touched by tier-0 ============================
-echo "T5: fleet:awaiting-base + base=master but not approved -> llm-other"
+# === T5: an unapproved PR is cleaned too (#2840) =============================
+echo "T5: fleet:awaiting-base + base=master but not approved -> cleaned (#2840)"
 write_slice '[{
   "repo":"engine","number":404,
   "headRefName":"feat-retargeted","baseRefName":"master",
@@ -171,10 +188,12 @@ write_slice '[{
   "labels":["fleet:awaiting-base"]
 }]'
 T5=$(run_rebase)
-assert_absent   "$T5" "would remove" \
-    "T5 unapproved PR is not cleaned (tier-0 stays conservative)"
-assert_contains "$T5" "llm_remaining=1" \
-    "T5 unapproved straggler still routes to the LLM pass"
+assert_contains "$T5" "retired stack-park label on a base=master PR — would remove" \
+    "T5 fleet:approved is no longer required to discharge the park"
+assert_absent   "$T5" "llm_remaining=1" \
+    "T5 the unapproved straggler no longer falls through to the LLM pass"
+assert_absent   "$T5" "clean rebase onto" \
+    "T5 cleanup does no branch work on an unapproved branch"
 
 # === T6: no park label -> the normal attempt path is unchanged ===============
 echo "T6: no park label + CONFLICTING + base=master -> normal attempt path"
@@ -189,6 +208,44 @@ assert_absent   "$T6" "would remove" \
     "T6 no park label -> no cleanup"
 assert_contains "$T6" "attempted=1" \
     "T6 the ordinary rebase path is untouched by this change"
+
+# === T7: the #2840 live shape — both dropped guards failing at once ==========
+# PR #2746's state once its base merged and GitHub retargeted it to master.
+# The merger strips fleet:approved as it adds fleet:semantic-conflict, and
+# that label leads SKIP_LABEL_RE, so this single PR failed BOTH original
+# guards. Pre-#2840 it landed on skip-labels, which no lane revisits, while
+# worker step 1c and the scout projection excluded it on fleet:awaiting-base.
+echo "T7: awaiting-base + semantic-conflict + base=master + not approved -> cleaned"
+write_slice '[{
+  "repo":"engine","number":406,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:stacked","fleet:awaiting-base","fleet:authored-on-macos","fleet:semantic-conflict"]
+}]'
+T7=$(run_rebase)
+assert_contains "$T7" "retired stack-park label on a base=master PR — would remove" \
+    "T7 the conflicted retargeted child is cleaned, unstranding worker step 1c"
+assert_absent   "$T7" "clean rebase onto" \
+    "T7 cleanup does no branch work on a conflicted branch"
+
+# === T8: removing the residue never unparks a genuinely parked PR ============
+# T4's PR on the tick after its cleanup: fleet:awaiting-base is gone, the real
+# park label remains. It must route to skip-labels — the widened gate discharges
+# only the retired residue, never the park a live label still expresses.
+echo "T8: fleet:wip + base=master + no park label -> skip-labels (park survives)"
+write_slice '[{
+  "repo":"engine","number":407,
+  "headRefName":"feat-retargeted","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved","fleet:wip"]
+}]'
+T8=$(run_rebase)
+assert_absent "$T8" "would remove" \
+    "T8 nothing left to clean once the residue is gone"
+assert_absent "$T8" "clean rebase onto" \
+    "T8 the WIP park still keeps tier-0 off the branch"
+assert_absent "$T8" "llm_remaining=1" \
+    "T8 the PR rests on skip-labels, exactly as it did before #2840"
 
 # --- Summary ------------------------------------------------------------------
 summarize "fleet-rebase stale stack-park cleanup tests"


### PR DESCRIPTION
## Summary

`cleanup_stale_base_park` exists to strip a retired stack-park label from a
`base == master` PR — in the script header's own words, such a label "would
otherwise park it outside every automated lane forever." Two guards inherited
from the lanes that do **branch work** (`fleet:approved`, and "no other skip
label") made it unreachable in exactly the state that needs it most, because
both fail together: the merger strips `fleet:approved` at the same moment it
adds `fleet:semantic-conflict`, and that label leads `SKIP_LABEL_RE`. The PR
fell through to `skip-labels` — "neither tier touches it" — while worker step 1c
and the scout's `SEMANTIC_CONFLICT_EXCLUDE_LABELS` both exclude
`fleet:awaiting-base`, so no human-facing lane saw it either. Nobody owned it.

- **Both guards drop.** The gate is now `state == OPEN` + `base == master` +
  label-present (the first and third already re-verified live inside
  `cleanup_stale_base_park`). This verdict does no branch work, so there is no
  branch to fight over, and `base == master` alone proves the park discharged.
- **The docstring no longer names merger step 2.5 as the sole remover.** That
  pass retired with the native-stacked-PRs migration (#2657) —
  `role-merger.md:141` reads "2.5. **(Retired.)**" — leaving this function the
  only remover of either label tree-wide (verified: its loop is the sole
  `--remove-label` site for `fleet:awaiting-base` / `fleet:needs-base-update`
  at `origin/master`).
- **Drive-by in the same file:** `--help` sliced its own header with a
  hardcoded `sed -n '2,31p'`. That already truncated — silently dropping the
  auto-merge lane, trigger protocol, **and the Usage section** — and my header
  edit moved the cut mid-sentence. Now derived from content (first non-`#`
  line), per `scripts/fleet/CLAUDE.md`'s rule for exactly this shape (#2433).

### Scope note — T4 also flips, which the issue's test list doesn't name

The acceptance criteria say the gate fires "regardless of other skip labels",
which necessarily re-expresses **T4** (`fleet:wip` + park + `base=master`) from
`skip-labels` to `stale-base-park`, not just T5. The issue names T5 and T3 but
not T4. I implemented the criteria as written; **T8 is new and pins the reason
that is safe** — once the residue is gone, the real park label still routes the
PR to `skip-labels`, so the cleanup never unparks anyone. Flag if you'd rather
T4 keep its old verdict; that would require re-adding a narrowed guard.

## Test plan

- [x] `bash scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh` →
      **19 passed, 0 failed**, exit 0 (run alone, not via a whole-dir sweep).
- [x] **Positive control** via `fleet-positive-control` (not hand-staged, #2713):
      against pre-fix `origin/master` (`34c7f7f46`) the suite reports
      **MEANINGFUL: 4 of 19 assertions fail**; the 15 that still pass are the
      non-regression assertions (15 + 4 = 19). Pre-fix verdicts match the issue's
      analysis exactly — T7 shows `llm_remaining=0` (the `skip-labels` strand),
      T5 shows `llm_remaining=1` (`llm-other`).
- [x] `bash scripts/fleet/tests/run_all.sh` → **109 suite(s) — 109 passed, 0
      failed**, exit 0. No other consumer of the triage regressed.
- [x] `ruff check scripts/` → `All checks passed!`
- [x] `bash -n` clean on both edited files.
- [x] `fleet-rebase --help` → 53 lines, `# Usage:` present, **0** non-comment
      lines (no code leak).

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `has_stale_base_park` fires regardless of `fleet:approved` | T5 (`["fleet:awaiting-base"]`, base=master) | `retired stack-park label on a base=master PR — would remove`; pre-fix the same case gave `llm_remaining=1` |
| …and regardless of other skip labels | T7 (`awaiting-base + semantic-conflict`, not approved) + T4 (`+fleet:wip`) | both log `would remove`; pre-fix T7 gave `llm_remaining=0` (skip-labels) |
| `OPEN` + `base==master` + label-present remain the whole gate | `has_stale_base_park = bool(stack_park) and base == "master"`; live re-verify unchanged in `cleanup_stale_base_park` | T3 still `llm-other`; T6 attempt path untouched (`attempted=1`) |
| New case: `awaiting-base + semantic-conflict + base=master + not approved` → `stale-base-park` | T7 | `would remove`, and `assert_absent "clean rebase onto"` — cleanup only, no branch work |
| T5 re-expressed as `stale-base-park` | T5 | passes |
| **T3 unchanged** (`base != master` → `llm-other`) | T3 | `llm_remaining=1`, not cleaned — that park is still real |
| Docstring no longer cites merger step 2.5 as sole remover | `scripts/fleet/fleet-rebase:321-331` | now records it is itself the only remover tree-wide, citing #2657 for 2.5's retirement |
| Re-run the suite | `bash scripts/fleet/tests/test_fleet_rebase_stale_base_park_cleanup.sh` | 19 passed, 0 failed |

## Follow-up spotted, deliberately not bundled

Three other fleet scripts still slice `--help` with a hardcoded range — the
shape `scripts/fleet/CLAUDE.md` forbids: `fleet-net-doctor:45` (`2,32p`),
`witness:34` (`2,20p`), `solo-architect:78` (`3,33p`).

Measured, so the bar is clear: **none of the three misbehaves today.**
`fleet-net-doctor`'s slice ends one line short of its header, but that line is
blank, so nothing visible is lost; `witness` and `solo-architect` are exactly
aligned. They are *latent* — any header edit silently moves the cut, which is
precisely what this PR hit on `fleet-rebase`. Out of scope here — filed as
**#2849** rather than widening this diff.

Closes #2840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
