### PR TITLE
fleet: derive three more --help slices from header content

### DIFF
--- a/scripts/fleet/fleet-net-doctor
+++ b/scripts/fleet/fleet-net-doctor
@@ -42,7 +42,7 @@ HOST_OS="${FLEET_NET_DOCTOR_OS:-$(uname -s)}"
 kill_hung=0
 case "${1:-}" in
     --kill-hung) kill_hung=1 ;;
-    -h|--help) sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     "") ;;
     *) echo "fleet-net-doctor: unknown option: $1 (try --help)" >&2; exit 64 ;;
 esac

--- a/scripts/fleet/solo-architect
+++ b/scripts/fleet/solo-architect
@@ -75,7 +75,7 @@ while [[ $# -gt 0 ]]; do
     --no-scout) RUN_SCOUT=0; shift ;;
     --dry-run)  MODE="dry-run"; shift ;;
     --)         shift; PASSTHRU+=("$@"); break ;;
-    -h|--help)  sed -n '3,33p' "$0"; exit 0 ;;
+    -h|--help)  awk 'NR<=2 {next} /^#/ {print; next} {exit}' "$0"; exit 0 ;;
     *) echo "solo-architect: unknown argument '$1'" >&2; exit 2 ;;
   esac
 done


### PR DESCRIPTION
## Summary
- `fleet-net-doctor` and `solo-architect` each sliced their own header for
  `-h|--help` with a hardcoded `sed -n 'N,Mp' "$0"` range — latent fragility
  per `scripts/fleet/CLAUDE.md`'s rule (#2433).
- Replaced each with the content-derived `awk` scan landed as precedent in
  `fleet-rebase` by PR #2847, preserving each script's existing output shape
  (`fleet-net-doctor`'s comment-prefix strip via the trailing `sed`,
  `solo-architect`'s line-3 start since line 2 is a blank `#` separator).

**Rebase note (2026-08-04):** this PR originally carried a third script,
`witness`. Master's #2772 (`afb7c5192`) applied the *same* `awk` fix to
`witness` as a side change while this PR was open — the two sides differed only
in whitespace inside the awk program. The semantic conflict was resolved by
taking master's version, so `witness` is no longer in this diff
(`git diff origin/master -- scripts/fleet/witness` is empty). #2849's third
offender is therefore already fixed on master, not dropped.

## Test plan
- [x] `bash scripts/fleet/tests/run_all.sh` — **119 suite(s), 119 passed, 0
      failed, 0 skipped** (matches master's baseline; was 109 when this PR was
      first opened — master has since added suites).
- [x] `bash scripts/fleet/tests/test_witness_roster.sh` alone — 33 passed, 0
      failed (the conflicted file's own suite, run standalone).
- [x] `bash -n` clean on all three scripts.

## Verification

**Differential — resolved vs `origin/master`, both changed scripts.** Coverage:
2 of 2 scripts produced non-empty output on both arms (31 stdout lines each,
exit 0, empty stderr) — so the agreement below is a real comparison, not two
silently-empty runs.

| Script | exit (old→new) | stdout lines (old→new) | output |
|---|---|---|---|
| `fleet-net-doctor` | 0 → 0 | 31 → 31 | byte-identical |
| `solo-architect` | 0 → 0 | 31 → 31 | byte-identical |

**Positive control — the measurement that shows the fix does its job.**
Byte-identity today only proves no regression; it does not prove the slice now
tracks the header. Appending two sentinel `#` lines to the end of each script's
header and re-running both arms:

| Script | old (hardcoded range) | new (content-derived) |
|---|---|---|
| `fleet-net-doctor` | 31 lines, **0 of 2 sentinels** — silently truncated | 33 lines, **2 of 2 sentinels** |
| `solo-architect` | 31 lines, **0 of 2 sentinels** — silently truncated | 33 lines, **2 of 2 sentinels** |

That is #2433's original failure mode reproduced on the pre-fix arm and absent
on the post-fix arm.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| No `-h\|--help)` handler under `scripts/fleet/` slices its header with a hardcoded line range | `grep -rEn "help\).*sed -n '[0-9]" scripts/fleet/` (the issue's own criterion) | no matches (exit 1) |
| Each `--help` exits 0, emits its full header, leaks zero non-comment lines | `bash scripts/fleet/<script> --help` for both | exit 0 each; last header line present; `fleet-net-doctor --help \| grep "set -u"` finds nothing; `witness --help \| grep -c 'set -euo'` = 0 |
| `bash scripts/fleet/tests/run_all.sh` stays green | ran the suite | `119 suite(s) — 119 passed, 0 failed, 0 skipped` |

**Scope caveat on criterion 1 (filed as follow-up, not fixed here).** #2849's
acceptance grep only matches a `sed -n 'N,Mp' "$0"` that sits on the *same line*
as its `-h|--help)` case arm — which is the shape all three enumerated offenders
happened to have. A tree-wide sweep for the underlying pattern finds **10 more
`scripts/fleet` scripts** whose `--help` slices the header by hardcoded range
from a *continuation line* inside a multi-line handler; the issue's grep is
structurally blind to every one of them, so criterion 1 reports green with all
10 standing. **5 of the 10 are already silently wrong** — not latent: 3 truncate
(`fleet-down` 8 lines, `fleet-pr-clear-feedback-labels` 6 lines including its
whole exit-code table, `fleet-heartbeat` 3 lines) and 2 overrun, of which
`fleet-pr-checkout-detached --help` leaks `set -euo pipefail` and
`if [[ $# -lt 1 ]]; then` into its own help output — #2433's original failure
mode, live on master today.

That is out of scope for this PR, which implements #2849 as written; filed as
**#2885** with the per-script measurements.

Closes #2849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
