### PR TITLE
fleet: positive-control drives .py suites under python3 (#2848)

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -57,7 +57,12 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   (#2713: a mis-stage read 2 passed / 21 failed where the truth was 14 / 9,
   inflating the fix's apparent coverage). `fleet-positive-control <test-file>
   <ref>` stages the whole directory with `git archive`, reports MEANINGFUL vs
-  VACUOUS, and emits the test-plan line with its arithmetic shown.
+  VACUOUS, and emits the test-plan line with its arithmetic shown. It drives
+  both suite types — `.sh` under bash, `.py` under python3, dispatched on the
+  extension exactly as `run_all.sh` does, since neither carries a shebang
+  (#2848) — and reads each one's own summary line for the counts, so a suite
+  that prints none, or that runs zero assertions, is a setup failure rather
+  than a verdict.
   `require_fleet_lib_dir` in `lib_assert.sh` is the backstop for controls still
   run by hand — it fires automatically for suites that set `SCRIPT_DIR` before
   sourcing.

--- a/scripts/fleet/fleet-positive-control
+++ b/scripts/fleet/fleet-positive-control
@@ -24,11 +24,18 @@
 #   fleet-positive-control <test-file> <ref> [--include <pathspec>]...
 #
 #   <test-file>  the suite to run — your working-tree copy, which is the
-#                version under development and the thing being validated
+#                version under development and the thing being validated.
+#                `.sh` runs under bash, `.py` under python3, matching
+#                tests/run_all.sh; any other extension is refused
 #   <ref>        the pre-fix baseline (e.g. origin/master, or the sha the
 #                fix landed on top of)
 #   --include    stage an extra pathspec beside scripts/fleet (repeatable),
 #                for a suite that reads outside this directory
+#
+# The suite is driven by an interpreter, never by its own shebang — the
+# test_*.py suites carry none, and executing one hands a Python file to the
+# shell (#2848). Counts come from the suite's own summary line: summarize()'s
+# tally for bash, unittest's `Ran N tests` + OK/FAILED trailer for python.
 #
 # Output ends with a copy-pasteable line for the PR body's test plan, with the
 # arithmetic already checked — the #2708 nit was a miscounted fail count.
@@ -37,7 +44,8 @@
 #   0  control is meaningful — at least one assertion failed on the old code
 #   1  control is VACUOUS — the suite passes unchanged against the old code,
 #      so it does not test the fix
-#   2  usage error, bad ref, or the suite aborted as a setup failure
+#   2  usage error, bad ref, unsupported suite type, or the suite aborted as
+#      a setup failure (no summary line, or it ran zero assertions)
 
 set -euo pipefail
 
@@ -91,6 +99,17 @@ TEST_ABS=$(cd "$(dirname "$TEST_FILE")" && pwd)/$(basename "$TEST_FILE")
 TEST_REL=${TEST_ABS#"$REPO_ROOT"/}
 [[ "$TEST_REL" != "$TEST_ABS" ]] || die "test file is outside the repo: $TEST_FILE"
 
+# Dispatch by extension, exactly as tests/run_all.sh does. The suites carry no
+# shebang, so each is driven by an interpreter rather than executed — handing a
+# Python suite to the shell aborts on the first prose line of its docstring
+# (#2848). Resolved before staging, so an unsupported suite type is never
+# reported as a staging failure.
+case "$TEST_REL" in
+    *.sh) INTERP=(bash);    SUMMARY_FORM="summarize()'s \"passed: N  failed: M\" line" ;;
+    *.py) INTERP=(python3); SUMMARY_FORM="unittest's \"Ran N tests\" line and its OK/FAILED trailer" ;;
+    *)    die "unsupported suite type: $(basename "$TEST_FILE") — this tool drives .sh (bash) and .py (python3) suites, matching tests/run_all.sh" ;;
+esac
+
 STAGE=$(mktemp -d)
 cleanup() { [[ -n "${STAGE:-}" && -d "$STAGE" ]] && rm -rf "$STAGE"; }
 trap cleanup EXIT
@@ -102,42 +121,105 @@ git -C "$REPO_ROOT" archive "$REF" scripts/fleet "${INCLUDES[@]+"${INCLUDES[@]}"
 # Drop the working-tree suite over the old tree: new test, old code.
 mkdir -p "$STAGE/$(dirname "$TEST_REL")"
 cp "$TEST_ABS" "$STAGE/$TEST_REL"
-chmod +x "$STAGE/$TEST_REL"
 
 echo "positive control: $(basename "$TEST_FILE") vs $REF_LABEL"
 echo "  staged scripts/fleet${INCLUDES[*]+ + ${INCLUDES[*]}} into $STAGE"
 echo ""
 
 set +e
-"$STAGE/$TEST_REL" > "$STAGE/.out" 2>&1
+"${INTERP[@]}" "$STAGE/$TEST_REL" > "$STAGE/.out" 2>&1
 RC=$?
 set -e
 cat "$STAGE/.out"
 
-# summarize's own line is the authority on the counts — parsing it keeps this
-# wrapper honest about what the suite actually reported. The `|| true` matters:
-# no match is the no-tally case handled below, and under `set -o pipefail` it
-# would otherwise kill the script here with rc=1, which reads as "vacuous".
-TALLY=$(grep -E '^(passed: [0-9]+  failed: [0-9]+|.*: [0-9]+ passed, [0-9]+ failed)$' "$STAGE/.out" | tail -1 || true)
-if [[ -z "$TALLY" ]]; then
+# The suite's own summary line is the authority on the counts — parsing it keeps
+# this wrapper honest about what the suite actually reported, rather than reading
+# a verdict off its exit status. Each suite type has its own format, so the
+# parser is keyed by the same extension the interpreter was.
+no_tally() {
     echo ""
     echo "fleet-positive-control: the suite printed no tally (exit $RC)." >&2
-    echo "  It aborted before summarize — treat this as a setup failure, not a result." >&2
+    echo "  Ran as: ${INTERP[*]} <stage>/$TEST_REL" >&2
+    echo "  Expected $SUMMARY_FORM." >&2
+    echo "  The suite aborted before summarizing — treat this as a setup failure," >&2
+    echo "  not a result. The whole scripts/fleet tree was staged, so read the" >&2
+    echo "  suite's own output above first: an import or syntax error, an early" >&2
+    echo "  exit, or a path it reads that needs --include." >&2
     exit 2
+}
+
+# Pull `<key>=<n>` out of unittest's OK/FAILED parenthetical; 0 when absent. The
+# leading `(`-or-space anchor stops the `failures=` needle from also matching the
+# tail of `expected failures=`, which would score expected failures as real ones.
+unittest_count() {
+    local key="$1" line="$2" re
+    # Held in a variable: the keys contain spaces, and a space is not writable
+    # inline in a `[[ =~ ]]` right operand.
+    re="[( ]$key=([0-9]+)"
+    [[ "$line" =~ $re ]] && printf '%s' "${BASH_REMATCH[1]}" || printf '0'
+}
+
+# The `|| true` on each grep matters: no match is the no-tally case, and under
+# `set -o pipefail` it would otherwise kill the script here with rc=1 — which
+# reads as "vacuous".
+S=0
+if [[ "${INTERP[0]}" == bash ]]; then
+    TALLY=$(grep -E '^(passed: [0-9]+  failed: [0-9]+|.*: [0-9]+ passed, [0-9]+ failed)$' "$STAGE/.out" | tail -1 || true)
+    [[ -n "$TALLY" ]] || no_tally
+
+    if [[ "$TALLY" =~ ^passed:\ ([0-9]+)\ \ failed:\ ([0-9]+)$ ]]; then
+        P=${BASH_REMATCH[1]}; F=${BASH_REMATCH[2]}
+    else
+        [[ "$TALLY" =~ ([0-9]+)\ passed,\ ([0-9]+)\ failed$ ]] || die "could not parse tally: $TALLY"
+        P=${BASH_REMATCH[1]}; F=${BASH_REMATCH[2]}
+    fi
+    TOTAL=$((P + F))
+else
+    # unittest prints its trailer to stderr, which the run above folded into the
+    # same capture: `Ran N tests in Xs` then `OK`, `OK (skipped=1)`, or
+    # `FAILED (failures=2, errors=1)`.
+    # `NO TESTS RAN` is a third trailer, and matching it is what routes an empty
+    # suite to the 0-assertion error below rather than to the vaguer no-tally one.
+    RAN=$(grep -E '^Ran [0-9]+ tests? in ' "$STAGE/.out" | tail -1 || true)
+    VERDICT=$(grep -E '^(OK|FAILED)( \(.+\))?$|^NO TESTS RAN$' "$STAGE/.out" | tail -1 || true)
+    [[ -n "$RAN" && -n "$VERDICT" ]] || no_tally
+
+    ran_re='^Ran ([0-9]+) tests? in '
+    [[ "$RAN" =~ $ran_re ]] || die "could not parse tally: $RAN"
+    TOTAL=${BASH_REMATCH[1]}
+
+    # An expected failure is a pass, and its key ends in the word the failure
+    # needle matches — drop it before counting rather than out-clevering it.
+    COUNTS=$(sed -E 's/expected failures=[0-9]+//g' <<< "$VERDICT")
+    # The three tallies that make unittest report FAILED. An unexpected success
+    # belongs with them: the suite asserted the old code would fail here and it
+    # did not, which is a real distinction between the two trees.
+    F=$(( $(unittest_count 'failures' "$COUNTS")
+        + $(unittest_count 'errors' "$COUNTS")
+        + $(unittest_count 'unexpected successes' "$COUNTS") ))
+    S=$(unittest_count 'skipped' "$COUNTS")
+    P=$((TOTAL - F - S))
 fi
 
-if [[ "$TALLY" =~ ^passed:\ ([0-9]+)\ \ failed:\ ([0-9]+)$ ]]; then
-    P=${BASH_REMATCH[1]}; F=${BASH_REMATCH[2]}
-else
-    [[ "$TALLY" =~ ([0-9]+)\ passed,\ ([0-9]+)\ failed$ ]] || die "could not parse tally: $TALLY"
-    P=${BASH_REMATCH[1]}; F=${BASH_REMATCH[2]}
+# A suite that ran nothing is neither meaningful nor vacuous, and `Ran 0 tests`
+# would otherwise print as "all 0 assertions pass" — a VACUOUS verdict with no
+# evidence behind it.
+if [[ "$TOTAL" -eq 0 ]]; then
+    echo ""
+    echo "fleet-positive-control: the suite reported 0 assertions (exit $RC)." >&2
+    echo "  A control that runs nothing cannot distinguish the refs — treat this" >&2
+    echo "  as a setup failure, not a result." >&2
+    exit 2
 fi
-TOTAL=$((P + F))
 
 echo ""
 echo "--- positive control result ---"
 if [[ "$F" -eq 0 ]]; then
-    echo "VACUOUS: all $TOTAL assertions pass against $REF_LABEL."
+    if [[ "$S" -gt 0 ]]; then
+        echo "VACUOUS: no assertion fails against $REF_LABEL ($P pass, $S skipped)."
+    else
+        echo "VACUOUS: all $TOTAL assertions pass against $REF_LABEL."
+    fi
     echo "The suite does not distinguish the fix from the code it replaces."
     exit 1
 fi
@@ -146,5 +228,12 @@ echo "MEANINGFUL: $F of $TOTAL assertions fail against $REF_LABEL."
 echo ""
 echo "For the PR body's test plan:"
 echo "- [x] **Positive control**: the suite run against the pre-fix \`$REF\` (\`$REF_SHA\`)"
-echo "      fails **$F** assertions; the **$P** that still pass are the non-regression"
-echo "      assertions. ($P + $F = $TOTAL, the full suite.)"
+# A skipped test neither passed nor failed, so folding it into $P would put a
+# claim in the PR body the run does not support.
+if [[ "$S" -gt 0 ]]; then
+    echo "      fails **$F** assertions; the **$P** that still pass are the non-regression"
+    echo "      assertions, with **$S** skipped. ($P + $F + $S = $TOTAL, the full suite.)"
+else
+    echo "      fails **$F** assertions; the **$P** that still pass are the non-regression"
+    echo "      assertions. ($P + $F = $TOTAL, the full suite.)"
+fi

--- a/scripts/fleet/tests/test_positive_control.sh
+++ b/scripts/fleet/tests/test_positive_control.sh
@@ -10,6 +10,14 @@
 # 14 / 9). These tests pin both halves of the fix: the guard makes a partial
 # stage abort with no tally, and the wrapper makes correct staging the easy path.
 #
+# The last block covers interpreter dispatch (#2848): the wrapper used to exec
+# the staged suite, which only works for a self-executing script. The 32
+# test_*.py suites carry no shebang — run_all.sh supplies python3 — so the shell
+# interpreted them and the first prose line of the module docstring came back as
+# a syntax error, reported as a *staging* failure, the one thing that had gone
+# right. Dispatch by extension needs a second tally parser, so those tests pin
+# unittest's arithmetic alongside it.
+#
 # Purely local: no network, no ~/.fleet, no gh.
 
 set -euo pipefail
@@ -241,5 +249,143 @@ run "$WRAPPER" "$NOTALLY" HEAD
 assert_eq "$RC" "2" "no tally exits 2 rather than inventing a result"
 assert_contains "$OUT" "printed no tally" "the no-tally error names the cause"
 rm -f "$NOTALLY"
+
+# --- interpreter dispatch: .sh under bash, .py under python3 (#2848) ---------
+echo "--- a .py suite runs under python3 and reports a real verdict ---"
+# Same untracked-marker discriminator as the bash MEANINGFUL fixture above, and
+# for the same reason: `git archive <ref>` only emits tracked content, so the
+# stage cannot hold it for any ref while the working tree always can.
+PYMARK="$SCRIPT_DIR/fleet-zz-tmp-added-by-fix-2848"
+STRAYS+=("$PYMARK")
+: > "$PYMARK"
+PYMEAN="$SCRIPT_DIR/tests/test_zz_tmp_meaningful_2848.py"
+STRAYS+=("$PYMEAN")
+cat > "$PYMEAN" <<'FIXTURE'
+"""A docstring whose first prose line carries (parentheses) and "quotes".
+
+That is the shape the shell choked on when this file was exec'd rather than
+handed to python3 — the #2848 symptom, reproduced deliberately.
+"""
+import unittest
+from pathlib import Path
+
+_FLEET = Path(__file__).parent.parent
+
+
+class Control(unittest.TestCase):
+    def test_marker_the_fix_adds_is_present(self):
+        self.assertTrue((_FLEET / "fleet-zz-tmp-added-by-fix-2848").is_file())
+
+    def test_non_regression_holds_on_both_refs(self):
+        self.assertEqual("kept", "kept")
+
+
+unittest.main()
+FIXTURE
+run "$WRAPPER" "$PYMEAN" HEAD
+assert_eq "$RC" "0" "a meaningful .py suite exits 0"
+assert_contains "$OUT" "Ran 2 tests" "the suite reaches python3 rather than the shell"
+assert_absent "$OUT" "syntax error" "the shell never interprets the Python file (#2848)"
+assert_contains "$OUT" "MEANINGFUL: 1 of 2 assertions fail" "unittest's trailer is parsed into real counts"
+assert_contains "$OUT" "(1 + 1 = 2, the full suite.)" "the PR-body line shows its own arithmetic"
+rm -f "$PYMEAN" "$PYMARK"
+
+echo "--- a .py suite that cannot distinguish the ref is reported VACUOUS ---"
+PYVAC="$SCRIPT_DIR/tests/test_zz_tmp_vacuous_2848.py"
+STRAYS+=("$PYVAC")
+cat > "$PYVAC" <<'FIXTURE'
+import unittest
+
+
+class Control(unittest.TestCase):
+    def test_tautology_holds_on_any_ref(self):
+        self.assertEqual("a", "a")
+
+
+unittest.main()
+FIXTURE
+run "$WRAPPER" "$PYVAC" HEAD
+assert_eq "$RC" "1" "a vacuous .py suite exits 1"
+assert_contains "$OUT" "VACUOUS" "the vacuous verdict names itself"
+rm -f "$PYVAC"
+
+echo "--- unittest's tally: errors are failures, skips and expected failures are not ---"
+PYMIX="$SCRIPT_DIR/tests/test_zz_tmp_tally_2848.py"
+STRAYS+=("$PYMIX")
+cat > "$PYMIX" <<'FIXTURE'
+import unittest
+
+
+class Control(unittest.TestCase):
+    def test_pass_a(self):
+        self.assertTrue(True)
+
+    def test_pass_b(self):
+        self.assertTrue(True)
+
+    def test_plain_failure(self):
+        self.assertEqual(1, 2)
+
+    def test_error(self):
+        raise RuntimeError("an exception distinguishes the trees too")
+
+    @unittest.skip("a skip neither passed nor failed")
+    def test_skipped(self):
+        pass
+
+    @unittest.expectedFailure
+    def test_expected_failure(self):
+        self.assertEqual(1, 2)
+
+
+unittest.main()
+FIXTURE
+run "$WRAPPER" "$PYMIX" HEAD
+# 6 ran: 1 failure + 1 error = 2 fail, 1 skip, and 3 pass (2 clean + the
+# expected failure). `expected failures=` ends in the same word as `failures=`,
+# so a needle without the wrapper's anchor scores that expected one as real.
+assert_contains "$OUT" "MEANINGFUL: 2 of 6 assertions fail" "an error counts with the failures, an expected failure does not"
+assert_contains "$OUT" "with **1** skipped. (3 + 2 + 1 = 6, the full suite.)" "the PR-body line accounts for the skip instead of calling it a pass"
+rm -f "$PYMIX"
+
+echo "--- a suite that runs zero assertions is a setup failure, not VACUOUS ---"
+PYEMPTY="$SCRIPT_DIR/tests/test_zz_tmp_empty_2848.py"
+STRAYS+=("$PYEMPTY")
+cat > "$PYEMPTY" <<'FIXTURE'
+import unittest
+
+unittest.main()
+FIXTURE
+run "$WRAPPER" "$PYEMPTY" HEAD
+assert_eq "$RC" "2" "zero assertions exits 2 rather than reporting a verdict"
+assert_contains "$OUT" "reported 0 assertions" "the empty-run error names the cause"
+assert_absent "$OUT" "VACUOUS" "an empty run never claims the suite failed to distinguish the refs"
+rm -f "$PYEMPTY"
+
+echo "--- the no-tally diagnostic names the interpreter it used ---"
+PYABORT="$SCRIPT_DIR/tests/test_zz_tmp_abort_2848.py"
+STRAYS+=("$PYABORT")
+cat > "$PYABORT" <<'FIXTURE'
+import this_module_does_not_exist_2848
+
+print(this_module_does_not_exist_2848)
+FIXTURE
+run "$WRAPPER" "$PYABORT" HEAD
+assert_eq "$RC" "2" "a .py suite that aborts before summarizing exits 2"
+assert_contains "$OUT" "Ran as: python3" "the diagnostic names the interpreter, so a dispatch fault is legible"
+assert_contains "$OUT" "needs --include" "the diagnostic lists the causes rather than pinning it on staging"
+rm -f "$PYABORT"
+
+echo "--- an unsupported suite type names itself, not the staging ---"
+WEIRD="$SCRIPT_DIR/tests/test_zz_tmp_unsupported_2848.rb"
+STRAYS+=("$WEIRD")
+echo 'puts "never reached"' > "$WEIRD"
+run "$WRAPPER" "$WEIRD" HEAD
+assert_eq "$RC" "2" "an unsupported suite type exits 2"
+assert_contains "$OUT" "unsupported suite type" "the error names the suite type as the cause"
+# The refusal lands before mktemp/git archive, so staging cannot be misread as
+# the culprit.
+assert_absent "$OUT" "staged scripts/fleet" "the refusal comes before staging, so staging is never implicated"
+rm -f "$WEIRD"
 
 summarize "fleet-positive-control tests"

--- a/scripts/fleet/tests/test_positive_control.sh
+++ b/scripts/fleet/tests/test_positive_control.sh
@@ -348,6 +348,34 @@ assert_contains "$OUT" "MEANINGFUL: 2 of 6 assertions fail" "an error counts wit
 assert_contains "$OUT" "with **1** skipped. (3 + 2 + 1 = 6, the full suite.)" "the PR-body line accounts for the skip instead of calling it a pass"
 rm -f "$PYMIX"
 
+echo "--- unittest's tally: an unexpected success counts with the failures ---"
+PYUNEXP="$SCRIPT_DIR/tests/test_zz_tmp_unexpected_2848.py"
+STRAYS+=("$PYUNEXP")
+cat > "$PYUNEXP" <<'FIXTURE'
+import unittest
+
+
+class Control(unittest.TestCase):
+    def test_pass(self):
+        self.assertTrue(True)
+
+    def test_plain_failure(self):
+        self.assertEqual(1, 2)
+
+    @unittest.expectedFailure
+    def test_unexpectedly_passes(self):
+        self.assertEqual(1, 1)
+
+
+unittest.main()
+FIXTURE
+run "$WRAPPER" "$PYUNEXP" HEAD
+# 3 ran: 1 plain failure + 1 unexpected success (an expectedFailure test that
+# passed anyway — a real distinction between the trees) = 2 fail, 1 pass.
+# Exercises the `unittest_count 'unexpected successes' ...` branch.
+assert_contains "$OUT" "MEANINGFUL: 2 of 3 assertions fail" "an unexpected success counts with the failures"
+rm -f "$PYUNEXP"
+
 echo "--- a suite that runs zero assertions is a setup failure, not VACUOUS ---"
 PYEMPTY="$SCRIPT_DIR/tests/test_zz_tmp_empty_2848.py"
 STRAYS+=("$PYEMPTY")


### PR DESCRIPTION
## Summary

- `fleet-positive-control` exec'd the staged suite (`"$STAGE/$TEST_REL"`), which only works for a self-executing script. The `test_*.py` suites carry **no shebang** — `run_all.sh` supplies `python3` — so the shell interpreted them and the first prose line of the module docstring came back as a syntax error, reported as a setup failure that named *staging*, the one part of the run that had gone right.
- Dispatch is now by extension, mirroring `run_all.sh`'s `case`, and is resolved **before** staging, so an unsupported suite type can never be misread as a mis-stage.
- That needs a second tally parser: unittest's `Ran N tests` line and its `OK` / `FAILED` / `NO TESTS RAN` trailer alongside `summarize()`'s. Errors and unexpected successes count with the failures; skips and expected failures do not.
- A skip is reported on its own term rather than folded into the pass count (`P + F + S = TOTAL`), because the copy-pasteable PR line calls `$P` "the assertions that still pass" — a claim a skipped test does not support.
- A run that summarizes nothing, or that runs zero assertions, is a setup failure rather than a `VACUOUS` verdict. `Ran 0 tests` would otherwise print as "all 0 assertions pass".

**Correction to the issue's headline count.** Measured at the ref the issue cites (`34c7f7f46`): 32 `test_*.py` and **77** `test_*.sh`, so the gap was 32 of **109**, not 32 of 110. `run_all.sh` reports 109 suites, which corroborates it.

## Test plan

- [x] The issue's exact repro now runs under `python3`: `test_smoke_worker_projection.py` vs `origin/master` reports `VACUOUS: all 13 assertions pass` — the correct verdict, since the fix that suite locks (#2809) is merged.
- [x] Same suite vs its **true** pre-fix ref `f7d388da1` (parent of `bf6ccf942`, which added it) reports `MEANINGFUL: 5 of 13 assertions fail`.
- [x] Bash behaviour is byte-identical: the pre-change wrapper extracted from `origin/master` and the new one produce identical output on the same MEANINGFUL and VACUOUS bash controls (stage paths normalized; `diff` clean).
- [x] unittest tally arithmetic, on a fixture with 1 failure + 1 error + 1 skip + 1 expected failure + 2 clean passes: `MEANINGFUL: 2 of 6` and `with **1** skipped. (3 + 2 + 1 = 6, the full suite.)` — the error counts, the expected failure does not, the skip is not called a pass.
- [x] `expected failures=` collision guarded: a fixture whose trailer is `FAILED (errors=1, expected failures=2)` — no plain `failures=` present — scores `MEANINGFUL: 1 of 4`, not 3.
- [x] Zero-assertion runs exit 2 on both suite types (`NO TESTS RAN`, and bash's `passed: 0  failed: 0`).
- [x] `bash scripts/fleet/tests/run_all.sh` → `109 suite(s) — 109 passed, 0 failed`.
- [x] `ruff check scripts/` → `All checks passed!`
- [x] `test_positive_control.sh` run **alone** (not only via the whole-directory runner) → `56 passed, 0 failed`.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| 1. A `test_*.py` suite runs under `python3` and reports a real MEANINGFUL/VACUOUS verdict, verified against a suite known meaningful at its pre-fix ref | `fleet-positive-control scripts/fleet/tests/test_smoke_worker_projection.py f7d388da1` | `Ran 13 tests` → `MEANINGFUL: 5 of 13 assertions fail against f7d388da1.` (and `VACUOUS: all 13 assertions pass` vs `origin/master`) |
| 2. `test_*.sh` behaviour unchanged | pre-change wrapper (`git show origin/master:…`) vs new, same bash controls | `diff` → `IDENTICAL` on both the MEANINGFUL and the VACUOUS arm |
| 3. An undriveable suite type names *that* as the cause, not staging | `fleet-positive-control …/test_zz_tmp_unsupported.rb HEAD` | `unsupported suite type: … — this tool drives .sh (bash) and .py (python3) suites, matching tests/run_all.sh`, rc=2, and **no** `staged scripts/fleet` line (refusal precedes `mktemp`/`git archive`) |
| 4. `run_all.sh` green | `bash scripts/fleet/tests/run_all.sh` | `run_all.sh: 109 suite(s) — 109 passed, 0 failed` |

## Positive control

`scripts/fleet/CLAUDE.md` requires a positive control on the new assertions. **`fleet-positive-control` cannot drive its own suite**: `test_positive_control.sh` resolves `REPO_ROOT=$SCRIPT_DIR/../..` and runs `git -C "$REPO_ROOT" archive`, but a `git archive` stage is never a git repo, so the staged run dies with `fatal: not a git repository`. (Pre-existing property of that suite, not introduced here — and the new diagnostic is what made it legible rather than a bare "aborted before summarize".)

So the control was run the equivalent way: a real clone pinned at the pre-fix ref `34c7f7f46`, with the suite copied in. Four arms, so the result is attributable to the fix rather than to the harness:

| # | Suite | Tree | Result |
|---|---|---|---|
| 1 | new (56 assertions) | fixed (this branch) | 56 passed, **0 failed** |
| 2 | original (38) | pre-fix `34c7f7f46` | 38 passed, **0 failed** — the control is clean, nothing fails for harness reasons |
| 3 | new (56) | pre-fix `34c7f7f46` | 42 passed, **14 failed** ← the positive control |
| 4 | original (38) | fixed tool | 38 passed, **0 failed** — no pre-existing assertion regresses |

- [x] **Positive control**: the suite run against the pre-fix `34c7f7f46` fails **14** assertions. All 14 are new `#2848` assertions; the other 4 added ones are non-regression assertions that hold on both trees. (38 pre-existing + 18 added = 56.)

One caveat worth recording: a first run of arm 3 from a `/tmp` path produced 6 extra failures that were a macOS `/tmp`→`/private/tmp` artifact (`git rev-parse --show-toplevel` returns the physical path, bash `pwd` the logical one, so the wrapper's inside-the-repo check rejected every fixture). Re-run from the physical path, that contamination is gone — arm 2 proves it.

## Notes

- `scripts/fleet/CLAUDE.md`'s positive-control bullet gained the suite-type dispatch and the summary-line contract (§9b code→doc drift): the rule reads "never by hand", and before this fix a `.py` suite could not comply.
- The vestigial `chmod +x` on the staged copy is dropped — the tool now always supplies the interpreter.

Closes #2848

🤖 Generated with [Claude Code](https://claude.com/claude-code)
