### PR TITLE
build: remove dead IrredenEngine_copyLuaFiles cmake function

### DIFF
--- a/cmake/ir_functions.cmake
+++ b/cmake/ir_functions.cmake
@@ -97,38 +97,6 @@ function(
     endif()
 endfunction()
 
-function(
-    IrredenEngine_copyLuaFiles
-)
-    # Set the output directory for copied files
-    set(OUTPUT_DIR "${PROJECT_BINARY_DIR}/lua_files")
-
-    # Find all .lua files recursively from the current source directory
-    file(GLOB_RECURSE LUA_FILES "${CMAKE_SOURCE_DIR}/*.lua")
-
-    # Create a custom command for each Lua file to copy it to the build directory
-    foreach(LUA_FILE ${LUA_FILES})
-        # Get relative path and destination file
-        file(RELATIVE_PATH REL_PATH ${CMAKE_SOURCE_DIR} ${LUA_FILE})
-        set(DEST_FILE "${OUTPUT_DIR}/${REL_PATH}")
-
-        # Create any necessary directories
-        add_custom_command(
-            OUTPUT "${DEST_FILE}"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${DEST_FILE}>"
-            COMMAND ${CMAKE_COMMAND} -E copy "${LUA_FILE}" "${DEST_FILE}"
-            COMMENT "Copying ${LUA_FILE} to ${DEST_FILE}"
-            VERBATIM
-        )
- 
-        # Add to target
-        list(APPEND COPY_COMMANDS "${DEST_FILE}")
-    endforeach()
-
-    # Add a custom target that depends on all copy commands
-    add_custom_target(copy_all_lua_files ALL DEPENDS ${COPY_COMMANDS})
-endfunction()
-
 # irreden_lua_codegen — build a C++ header from one or more Lua component
 # schemas. Wraps cmake/lua_codegen/main.cpp's CLI as a CMake-friendly helper.
 #

--- a/test/script/lua_system_coexistence_test.cpp
+++ b/test/script/lua_system_coexistence_test.cpp
@@ -51,10 +51,10 @@ class LuaSystemCoexistenceTest : public testing::Test {
         m_lua.setEcsDefaultMode(IRScript::CodegenRegistry::kDefaultEcsMode);
     }
 
-    // Path to the .lua fixture relative to the test binary's working dir.
-    // The fixture lives next to the test source; the build copies it into
-    // the binary tree via the `copy_all_lua_files` target wired in
-    // creations/template/CMakeLists.txt-equivalent (see test/CMakeLists.txt).
+    // Absolute source-tree path to the .lua fixture, supplied via the
+    // IR_LUA_COEXIST_FIXTURE_PATH compile definition (test/CMakeLists.txt)
+    // per test/CLAUDE.md's "Fixture paths reach the test through compile
+    // definitions, never a relative path."
     std::string fixturePath() const {
         return std::string{IR_LUA_COEXIST_FIXTURE_PATH};
     }


### PR DESCRIPTION
## Summary
- Removed the dead `IrredenEngine_copyLuaFiles()` cmake function (`cmake/ir_functions.cmake`) — zero callers anywhere in the tree, so `copy_all_lua_files` was never created and nothing was ever copied.
- Corrected the stale comment on `lua_system_coexistence_test.cpp`'s `fixturePath()` that credited the dead target and a nonexistent `creations/template/CMakeLists.txt` for placing the fixture.

## Test plan
- [x] `grep -rn "copy_all_lua_files\|IrredenEngine_copyLuaFiles"` over the tree (excluding build dirs and worktrees) — no hits.
- [x] `fleet-build --target IrredenEngineTest` — clean.
- [x] `fleet-run IrredenEngineTest --gtest_filter='LuaSystemCoexistenceTest.*'` — 4/4 passed.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. No orphaned reference to the dead function/target | `grep -rn "copy_all_lua_files\|IrredenEngine_copyLuaFiles"` (excl. build/worktrees) | no hits — function removed entirely |
| 2. N/A — chose removal, not rewiring | — | function deleted rather than kept+wired, per the issue's own "Tracing says the former" conclusion |
| 3. Test comment describes actual behavior | inspection of `test/script/lua_system_coexistence_test.cpp:54-57` | now states the fixture path comes from the `IR_LUA_COEXIST_FIXTURE_PATH` compile definition, with no reference to `copy_all_lua_files`/`creations/template` |
| 4. Build + fixture still resolves | `fleet-build --target IrredenEngineTest` then `fleet-run IrredenEngineTest --gtest_filter='LuaSystemCoexistenceTest.*'` | build clean; `[PASSED] 4 tests` |

Closes #2796

🤖 Generated with [Claude Code](https://claude.com/claude-code)