### PR TITLE
fleet: stack/molecule record carries its own --repo namespace (#2857)

### DIFF
--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -612,11 +612,11 @@ Do the work, then exit cleanly:
      jump straight to step 6 ("Work it"); the task is already claimed
      via the molecule. After committing, run
      `fleet-claim molecule advance <your-worktree-name> <issue-#> done pr=<PR-URL> commit=<sha>`
-     (add `--repo game` for game-side molecules — `--repo` is a
-     global flag parsed before the subcommand). For cross-repo
-     molecules, cd into your game twin worktree before
-     resuming so `commit-and-push` targets the right repo (see step
-     4 for the cd path).
+     (`--repo` is a no-op here — `advance` is keyed on `<agent>` alone;
+     see [`FLEET.md`](../../docs/agents/FLEET.md) § "Cross-repo molecules"
+     for the exact per-subcommand table). For cross-repo molecules, cd
+     into your game twin worktree before resuming so `commit-and-push`
+     targets the right repo (see step 4 for the cd path).
    - **Stdout is empty** — proceed with normal pickup below.
 
    **Normal pickup (no active molecule)** — pick from either queue.
@@ -722,7 +722,11 @@ Do the work, then exit cleanly:
    forms: see § Cross-repo model above. **Always pass the issue
    number**, and pass your worktree basename (`pool-1` … `pool-9`)
    as the agent name so it's visible in `fleet-claim list`. Mirror
-   `--repo game` in `release` / `release-stack` calls later.
+   `--repo game` in a plain `release` call later — it's load-bearing
+   there (`slugify` reads the flag directly). A `release-stack` call
+   auto-adopts the recorded namespace when `--repo` is omitted (see
+   [`FLEET.md`](../../docs/agents/FLEET.md) § "Cross-repo molecules"),
+   so passing it is optional but still matches the record.
 
    - **Exit 0** — you own it. Proceed.
    - **Exit 1 (already taken)** — go back to step 3, pick another.

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -829,9 +829,9 @@ Always exits 0 (safe to include in a parallel tool batch with
   It is now (or remains) marked `fleet:in-progress`. Skip normal
   issue pickup and jump straight to the role's work step. If the
   issue's PR is already open, `fleet-claim stack-pr-state
-  <your-worktree-name>` (add `--repo game` for game-side molecules
-  — `--repo` is a global flag parsed before the subcommand) shows
-  its URL and branch. Check out the issue's branch and continue
+  <your-worktree-name>` shows its URL and branch (this one keys on
+  `<agent>` alone — `--repo` changes nothing, see "Cross-repo
+  molecules" below). Check out the issue's branch and continue
   committing normally — one issue per branch means the branch
   itself is the per-issue anchor, so no special commit-subject
   prefix is required.
@@ -855,12 +855,30 @@ Always exits 0 (safe to include in a parallel tool batch with
   instead of `done` and surface the failure to the human before
   continuing.
 
-  **Cross-repo molecules**: if the in-flight molecule's issues live
-  in the game repo (claimed with `--repo game`), all
-  `fleet-claim molecule advance/complete` calls must include
-  `--repo game` too. Cd into your game twin worktree (same `pool-<N>`
-  basename under the game root) before
-  resuming so `commit-and-push` targets the right repo.
+  **Cross-repo molecules**: `fleet-claim stack` stamps its namespace
+  into the record it writes (`_stack_<agent>/ns` plus a `repo:` line in
+  the molecule, #2857), so you do **not** re-supply `--repo` to keep the
+  stack straight across iterations. `molecule resume` prints the
+  namespace on stderr — that is how a fresh context learns which repo a
+  bare issue id belongs to, since every game id is also a live engine
+  id. Then cd into that repo's twin worktree (same `pool-<N>` basename)
+  before resuming so `commit-and-push` targets the right repo.
+
+  Do not read the four no-op `--repo` cases as evidence the flag never
+  matters here — exactly one is load-bearing:
+
+  | subcommand | does `--repo` change anything? |
+  |---|---|
+  | `molecule resume` / `show` / `list`, `stack-pr-state` | **No** — keyed by `<agent>` alone |
+  | `molecule advance` | **No** — keyed by `<agent>`; warns if the flag contradicts the record |
+  | `molecule complete` → `release-stack` | **Yes** — it re-slugifies the claims to release |
+
+  `release-stack` adopts the recorded namespace when `--repo` is absent
+  and **refuses** (exit 2, releasing and archiving nothing) when an
+  explicit `--repo` contradicts the record. It has to refuse rather than
+  guess: the releases and the archive are the same call, so a wrong
+  namespace orphans every claim *and* destroys the record they could be
+  rebuilt from (#2857).
 
 - **Stdout is empty** — nothing to resume. Either no molecule exists
   for this agent (overwhelming common case) or a molecule exists but
@@ -868,8 +886,10 @@ Always exits 0 (safe to include in a parallel tool batch with
   you which: `"no molecule for agent: ..."` for the former, or
   `"molecule fully complete (no remaining tasks)"` for the latter.
   If the latter, also run
-  `fleet-claim molecule complete <your-worktree-name>` (add
-  `--repo game` for game-side) to archive it. The complete command
+  `fleet-claim molecule complete <your-worktree-name>` to archive it —
+  it resolves the namespace from the record, so `--repo game` is
+  optional on a game-side molecule and must not contradict it (see
+  "Cross-repo molecules" above). The complete command
   is itself idempotent (exits 0 with a stderr note if there's
   nothing to archive), so calling it speculatively after every
   empty resume is also safe. Either way, proceed with the normal

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -97,6 +97,16 @@ __remove_claim() {
 # Parsed BEFORE the subcommand so it doesn't collide with cleanup's own
 # `--repo <owner/repo>` flag (cleanup parses --repo args after its own
 # subcommand name, so they're scoped to that subcommand).
+#
+# `stack` STAMPS the namespace into its own record (`_stack_<agent>/ns` plus a
+# `repo:` line in the molecule), so the stack/molecule subcommands do not depend
+# on the caller re-passing --repo on every later invocation. `release-stack`
+# adopts the recorded namespace when --repo is absent and REFUSES on a
+# contradiction — before it releases or archives anything. Passing --repo to
+# `molecule advance` / `show` / `list` / `stack-pr-state` changes nothing (those
+# key on <agent> alone); advance warns when the flag contradicts the record.
+# Pre-#2857 records carry no namespace and keep the old caller-supplied
+# behavior.
 
 REPO_NS=""
 while [[ $# -gt 0 && "$1" == --* ]]; do
@@ -220,6 +230,15 @@ slugify() {
     else
         echo "$n"
     fi
+}
+
+# _ns_token
+#   Canonical on-disk spelling of the active namespace: the `--repo` token, or
+#   the literal "engine" for the default (unprefixed) namespace, which slugify
+#   leaves unprefixed. Spelling the default explicitly is what makes a recorded
+#   namespace distinguishable from a pre-#2857 record, which has no such field.
+_ns_token() {
+    echo "${REPO_NS:-engine}"
 }
 
 # --- cross-machine GitHub-label lock --------------------------------------
@@ -3554,6 +3573,9 @@ cmd_stack() {
     mkdir -p "$stack_dir"
     printf '%s\n' "${tasks[@]}" > "$stack_dir/tasks"
     date +%s > "$stack_dir/created"
+    # `tasks` holds RAW ids; the namespace lives only in the claim-dir slugs, so
+    # stamp it here too or release-stack has no way to rebuild them (#2857).
+    _ns_token > "$stack_dir/ns"
 
     molecule_write_initial "$agent" "${tasks[@]}"
 
@@ -3569,6 +3591,13 @@ cmd_release_stack() {
         echo "no stack claim for agent: $agent"
         molecule_archive "$agent"
         return 0
+    fi
+
+    # Resolve the namespace BEFORE the releases and the archive below: those two
+    # are the same call, so a wrong namespace here orphans every claim AND
+    # destroys the only record they could be rebuilt from (#2857).
+    if ! _adopt_recorded_ns release-stack "$agent"; then
+        return 2
     fi
 
     local released=0
@@ -3694,6 +3723,61 @@ molecule_file() {
     echo "$MOLECULES_DIR/$1.yml"
 }
 
+# _molecule_repo_ns <agent>
+#   Echo the namespace this agent's stack was claimed under, or "" when the
+#   record predates the field. The stack dir is authoritative (stamped at claim
+#   time); the molecule's `repo:` meta is the fallback for a stack dir already
+#   swept.
+#
+#   Why the namespace has to live in the RECORD (#2857): $MOLECULES_DIR and
+#   $CLAIMS_DIR/_stack_<agent>/tasks both key on RAW issue ids, so only
+#   $CLAIMS_DIR's slug carries the namespace. Every game id is also a live
+#   engine id, so a raw id never self-disambiguates — and release-stack's
+#   `cmd_release` re-slugifies from REPO_NS. A stack outlives the process that
+#   claimed it, so the namespace cannot be an argument the next caller supplies
+#   from memory.
+_molecule_repo_ns() {
+    local agent="$1"
+    local ns_file="$CLAIMS_DIR/_stack_${agent}/ns"
+    if [[ -f "$ns_file" ]]; then
+        head -1 "$ns_file"
+        return 0
+    fi
+    local mol
+    mol=$(molecule_file "$agent")
+    if [[ -f "$mol" ]]; then
+        sed -n 's/^repo:[[:space:]]*//p' "$mol" | head -1
+    fi
+}
+
+# _adopt_recorded_ns <cmd-name> <agent>
+#   Reconcile the caller's --repo against the namespace recorded for <agent>.
+#   Sets REPO_NS from the record when the caller passed nothing. Returns 2 on a
+#   genuine conflict so the caller can refuse before mutating anything.
+_adopt_recorded_ns() {
+    local cmd_name="$1" agent="$2"
+    local rec_ns
+    rec_ns=$(_molecule_repo_ns "$agent")
+    # No recorded namespace (pre-#2857 record) — keep legacy behavior exactly.
+    [[ -n "$rec_ns" ]] || return 0
+    [[ "$rec_ns" != "$(_ns_token)" ]] || return 0
+
+    if [[ -z "$REPO_NS" ]]; then
+        if [[ "$rec_ns" == "engine" ]]; then
+            REPO_NS=""
+        else
+            REPO_NS="$rec_ns"
+        fi
+        echo "fleet-claim ${cmd_name}: agent ${agent}'s stack was claimed under namespace '${rec_ns}'; adopting it (no --repo passed)" >&2
+        return 0
+    fi
+
+    local corrective="--repo ${rec_ns}"
+    [[ "$rec_ns" == "engine" ]] && corrective="no --repo flag"
+    echo "fleet-claim ${cmd_name}: refusing — agent ${agent}'s stack was claimed under namespace '${rec_ns}', but --repo says '$(_ns_token)'. Nothing released; the stack record and molecule are preserved. Re-run with ${corrective}." >&2
+    return 2
+}
+
 molecule_archive_dir() {
     echo "$MOLECULES_DIR/done"
 }
@@ -3716,6 +3800,7 @@ molecule_write_initial() {
         echo "agent: $agent"
         echo "created: $created"
         echo "branch: $branch"
+        echo "repo: $(_ns_token)"
         echo "tasks:"
         for tid in "${tasks[@]}"; do
             echo "  - id: $tid"
@@ -3806,7 +3891,9 @@ def parse(path):
 
 def emit(path, meta, tasks, notes):
     out = []
-    for k in ('name', 'agent', 'created', 'branch'):
+    # `repo` must survive every rewrite — it is the namespace release-stack
+    # resolves the claim slugs from when the caller omits --repo (#2857).
+    for k in ('name', 'agent', 'created', 'branch', 'repo'):
         if k in meta:
             out.append(f"{k}: {meta[k]}")
     out.append("tasks:")
@@ -3897,7 +3984,11 @@ cmd_molecule_list() {
         found=1
         local agent
         agent=$(basename "$file" .yml)
-        echo "molecule: $agent  ($file)"
+        # `load` drops meta rows below, so annotate the namespace here — the
+        # task ids it prints are raw and collide across repos (#2857).
+        local ns
+        ns=$(_molecule_repo_ns "$agent")
+        echo "molecule: $agent  [${ns:-namespace unrecorded}]  ($file)"
         local task_line
         while IFS= read -r line; do
             case "$line" in
@@ -3949,6 +4040,15 @@ cmd_molecule_resume() {
         echo "no molecule for agent: $agent (nothing to resume)" >&2
         return 0
     fi
+    # Stdout stays a bare issue id — authoring roles discriminate on it. The
+    # namespace goes to stderr, because a resumed cross-repo molecule otherwise
+    # hands a fresh context an id with no hint which repo it belongs to and
+    # every game id is also a live engine id (#2857).
+    local rec_ns
+    rec_ns=$(_molecule_repo_ns "$agent")
+    if [[ -n "$rec_ns" ]]; then
+        echo "molecule namespace: ${rec_ns} (pass $( [[ "$rec_ns" == engine ]] && echo "no --repo" || echo "--repo ${rec_ns}" ) to fleet-claim; cd to that repo's worktree)" >&2
+    fi
     molecule_python resume "$file"
 }
 
@@ -3962,6 +4062,15 @@ cmd_molecule_advance() {
     if [[ ! -f "$file" ]]; then
         echo "no molecule for agent: $agent" >&2
         return 2
+    fi
+    # advance keys on <agent> alone, so --repo cannot change what it writes.
+    # Say so when the caller passes one that contradicts the record, rather than
+    # letting them learn "the flag is decorative" and then drop it at
+    # `molecule complete`, where it IS load-bearing (#2857).
+    local rec_ns
+    rec_ns=$(_molecule_repo_ns "$agent")
+    if [[ -n "$REPO_NS" && -n "$rec_ns" && "$rec_ns" != "$(_ns_token)" ]]; then
+        echo "fleet-claim molecule advance: WARN --repo says '$(_ns_token)' but agent ${agent}'s stack is namespace '${rec_ns}'; advance is keyed by agent only, so the flag changes nothing here" >&2
     fi
     molecule_python advance "$file" "$task_id" "$new_state" "$@"
 }

--- a/scripts/fleet/tests/test_fleet_claim_stack_namespace.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stack_namespace.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Tests that `fleet-claim`'s stack/molecule record CARRIES its --repo namespace
+# (#2857), so a cross-repo stack can be released without the caller re-supplying
+# the flag from memory on a later invocation.
+#
+# The incident this locks: $CLAIMS_DIR/_stack_<agent>/tasks and the molecule both
+# store RAW issue ids, while only the claim-dir slug is namespaced (game-45).
+# `release-stack` re-slugifies via REPO_NS, so a game stack released without
+# `--repo game` released NOTHING, printed "released stack (2 tasks)", exited 0,
+# and deleted both the stack dir and the molecule in the same call — orphaning
+# every claim with no record left to reconstruct them from. Every game id is also
+# a live engine id, so the raw id could never disambiguate on its own.
+#
+# The state is seeded by hand rather than via `fleet-claim stack`, which does
+# live blocker checks. Releases DO reach _release_inactive_issue_labels, so gh is
+# stubbed to a failing no-op: hermetic per scripts/fleet/CLAUDE.md — a stub miss
+# cannot fall through to the real gh, because the stub IS the whole PATH entry.
+#
+# Covers:
+#   - stack stamps the namespace into _stack_<agent>/ns and the molecule
+#   - release-stack with no --repo adopts the recorded namespace (the regression)
+#   - release-stack with the matching --repo still works (positive control)
+#   - engine-lane stack with no --repo still works (negative control)
+#   - a contradicting --repo refuses AND preserves the stack dir + molecule
+#   - a pre-#2857 record (no ns file, no repo: meta) keeps legacy behavior
+#   - molecule resume keeps stdout a bare id and reports the namespace on stderr
+#   - the repo: meta survives a molecule rewrite (advance/resume re-emit)
+
+set -euo pipefail
+
+export FLEET_SKIP_CLONE_FRESHNESS=1
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+# gh stub: logs and fails, so no assertion can be satisfied by live GitHub.
+mkdir -p "$TMPROOT/bin"
+cat > "$TMPROOT/bin/gh" <<'STUB'
+#!/bin/sh
+echo "gh $*" >> "$GH_LOG"
+exit 1
+STUB
+chmod +x "$TMPROOT/bin/gh"
+export GH_LOG="$TMPROOT/gh.log"
+: > "$GH_LOG"
+
+AGENT=pool-Z
+
+assert_exit() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" -eq "$expected" ]]; then
+        ok "$msg"
+    else
+        bad "$msg"
+        echo "        expected exit: $expected"
+        echo "        actual exit:   $actual"
+    fi
+}
+
+# seed <case> <ns-token|--legacy> <slug>...
+#   Build the on-disk state `fleet-claim stack` produces: one claim dir per
+#   namespaced slug, a stack dir whose `tasks` holds RAW ids, and a molecule.
+#   `--legacy` omits both namespace fields (the pre-#2857 record shape).
+seed() {
+    local case_dir="$TMPROOT/$1" ns="$2"; shift 2
+    rm -rf "$case_dir"
+    mkdir -p "$case_dir/claims" "$case_dir/mol" "$case_dir/res"
+    local slug raw
+    : > "$case_dir/raws"
+    for slug in "$@"; do
+        raw="${slug#game-}"
+        mkdir -p "$case_dir/claims/$slug"
+        echo "$AGENT" > "$case_dir/claims/$slug/owner"
+        echo "$raw"   > "$case_dir/claims/$slug/title"
+        date +%s      > "$case_dir/claims/$slug/created"
+        echo stack    > "$case_dir/claims/$slug/stack"
+        echo "$raw"  >> "$case_dir/raws"
+    done
+    mkdir -p "$case_dir/claims/_stack_$AGENT"
+    cp "$case_dir/raws" "$case_dir/claims/_stack_$AGENT/tasks"
+    date +%s > "$case_dir/claims/_stack_$AGENT/created"
+    {
+        echo "name: $AGENT-probe"
+        echo "agent: $AGENT"
+        echo "created: 2026-08-04T00:00:00Z"
+        echo "branch: claude/probe"
+        [[ "$ns" == "--legacy" ]] || echo "repo: $ns"
+        echo "tasks:"
+        for slug in "$@"; do
+            echo "  - id: ${slug#game-}"
+            echo "    state: done"
+        done
+    } > "$case_dir/mol/$AGENT.yml"
+    [[ "$ns" == "--legacy" ]] || echo "$ns" > "$case_dir/claims/_stack_$AGENT/ns"
+}
+
+# fc <case> <fleet-claim args...>
+fc() {
+    local case_dir="$TMPROOT/$1"; shift
+    PATH="$TMPROOT/bin:$PATH" \
+    FLEET_CLAIMS_DIR="$case_dir/claims" \
+    FLEET_MOLECULES_DIR="$case_dir/mol" \
+    FLEET_RESERVATIONS_DIR="$case_dir/res" \
+        bash "$FLEET_CLAIM" "$@" 2>&1
+}
+
+claim_dirs() {
+    ls "$TMPROOT/$1/claims" 2>/dev/null | grep -v '^_stack_' | sort | tr '\n' ' '
+}
+
+# --- T1: stack stamps the namespace into its own record ----------------------
+# Driven through molecule_write_initial + the stack-dir writer rather than
+# `fleet-claim stack` (which does live blocker checks) by sourcing the lib seam.
+echo "T1: a game-namespace stack records its namespace in both stores"
+T1="$TMPROOT/t1"; mkdir -p "$T1/claims" "$T1/mol"
+(
+    export FLEET_CLAIMS_DIR="$T1/claims" FLEET_MOLECULES_DIR="$T1/mol"
+    export FLEET_CLAIM_LIB=1
+    # shellcheck disable=SC1090
+    source "$FLEET_CLAIM"
+    REPO_NS=game
+    mkdir -p "$FLEET_CLAIMS_DIR/_stack_$AGENT"
+    _ns_token > "$FLEET_CLAIMS_DIR/_stack_$AGENT/ns"
+    molecule_write_initial "$AGENT" 9001 9002
+) >/dev/null 2>&1 || true
+assert_eq "$(cat "$T1/claims/_stack_$AGENT/ns" 2>/dev/null)" "game" \
+    "stack dir records ns=game"
+assert_contains "$(cat "$T1/mol/$AGENT.yml")" "repo: game" \
+    "molecule records repo: game"
+
+echo "T2: the engine (default) namespace is recorded explicitly, not as empty"
+T2="$TMPROOT/t2"; mkdir -p "$T2/claims" "$T2/mol"
+(
+    export FLEET_CLAIMS_DIR="$T2/claims" FLEET_MOLECULES_DIR="$T2/mol"
+    export FLEET_CLAIM_LIB=1
+    # shellcheck disable=SC1090
+    source "$FLEET_CLAIM"
+    REPO_NS=""
+    molecule_write_initial "$AGENT" 9001
+) >/dev/null 2>&1 || true
+assert_contains "$(cat "$T2/mol/$AGENT.yml")" "repo: engine" \
+    "default namespace records as 'engine' (distinguishable from unrecorded)"
+
+# --- T3: THE REGRESSION -----------------------------------------------------
+echo "T3: game stack, release-stack WITHOUT --repo — adopts the record"
+seed rel-adopt game game-9001 game-9002
+out=$(fc rel-adopt release-stack "$AGENT")
+assert_contains "$out" "adopting it (no --repo passed)" \
+    "release-stack reports adopting the recorded namespace"
+assert_contains "$out" "slug: game-9001" \
+    "release-stack released the game-namespaced slug"
+assert_eq "$(claim_dirs rel-adopt)" "" \
+    "no orphaned claim dirs remain (pre-fix: game-9001 game-9002 survived)"
+assert_absent "$out" "not claimed: #9001" \
+    "no 'not claimed' miss (pre-fix: both ids missed under the engine slug)"
+
+echo "T4: positive control — same state WITH the matching --repo game"
+seed rel-flag game game-9001 game-9002
+out=$(fc rel-flag --repo game release-stack "$AGENT")
+assert_contains "$out" "released stack (2 tasks)" "release-stack reports success"
+assert_eq "$(claim_dirs rel-flag)" "" "both game claims released"
+assert_absent "$out" "adopting it" "no adopt notice when the flag already matches"
+
+echo "T5: negative control — engine-lane stack, no flag, unchanged behavior"
+seed rel-engine engine 9001 9002
+out=$(fc rel-engine release-stack "$AGENT")
+assert_contains "$out" "slug: 9001" "engine slug released"
+assert_eq "$(claim_dirs rel-engine)" "" "both engine claims released"
+assert_absent "$out" "adopting it" "no adopt notice on the engine lane"
+
+# --- T6: a contradiction must refuse AND preserve ---------------------------
+echo "T6: --repo contradicts the record — refuse, release nothing, preserve"
+seed rel-conflict game game-9001 game-9002
+actual=0; out=$(fc rel-conflict --repo other release-stack "$AGENT") || actual=$?
+assert_exit "$actual" 2 "contradicting --repo → exit 2"
+assert_contains "$out" "refusing" "refusal is explicit"
+assert_contains "$out" "Re-run with --repo game" "names the corrective invocation"
+assert_eq "$(claim_dirs rel-conflict)" "game-9001 game-9002 " \
+    "claims preserved on refusal"
+[[ -f "$TMPROOT/rel-conflict/claims/_stack_$AGENT/tasks" ]] \
+    && ok "stack record preserved on refusal" \
+    || bad "stack record preserved on refusal"
+[[ -f "$TMPROOT/rel-conflict/mol/$AGENT.yml" ]] \
+    && ok "molecule preserved on refusal (not archived)" \
+    || bad "molecule preserved on refusal (not archived)"
+
+echo "T7: engine record + --repo game also refuses (both directions)"
+seed rel-conflict2 engine 9001
+actual=0; out=$(fc rel-conflict2 --repo game release-stack "$AGENT") || actual=$?
+assert_exit "$actual" 2 "engine record vs --repo game → exit 2"
+assert_contains "$out" "Re-run with no --repo flag" \
+    "corrective for the engine lane is 'no --repo flag'"
+
+# --- T8: legacy records keep the old behavior -------------------------------
+echo "T8: a pre-#2857 record (no ns, no repo: meta) keeps legacy behavior"
+seed rel-legacy --legacy game-9001
+out=$(fc rel-legacy release-stack "$AGENT")
+assert_contains "$out" "not claimed: #9001" \
+    "legacy record still resolves against the caller's namespace"
+assert_absent "$out" "adopting it" "no adopt notice without a recorded namespace"
+assert_absent "$out" "refusing" "a legacy record is never treated as a conflict"
+
+# --- T9: resume keeps stdout parseable, reports the namespace on stderr ------
+echo "T9: molecule resume — bare id on stdout, namespace on stderr"
+seed res game game-9001 game-9002
+python3 - "$TMPROOT/res/mol/$AGENT.yml" <<'PY'
+import sys
+p = sys.argv[1]
+# Read fully before opening for write — the one-liner form truncates first.
+body = open(p).read().replace("state: done", "state: pending")
+open(p, "w").write(body)
+PY
+res_out=$(PATH="$TMPROOT/bin:$PATH" FLEET_CLAIMS_DIR="$TMPROOT/res/claims" \
+    FLEET_MOLECULES_DIR="$TMPROOT/res/mol" FLEET_RESERVATIONS_DIR="$TMPROOT/res/res" \
+    bash "$FLEET_CLAIM" molecule resume "$AGENT" 2>"$TMPROOT/res.err")
+assert_eq "$res_out" "9001" "stdout is exactly the bare issue id"
+assert_contains "$(cat "$TMPROOT/res.err")" "molecule namespace: game" \
+    "stderr names the namespace a fresh context would otherwise have to guess"
+
+echo "T10: the repo: meta survives the rewrite resume performs"
+assert_contains "$(cat "$TMPROOT/res/mol/$AGENT.yml")" "repo: game" \
+    "repo: meta re-emitted after resume rewrote the molecule"
+
+echo "T11: molecule list annotates the namespace beside the agent"
+assert_contains "$(fc res molecule list)" "[game]" \
+    "molecule list shows the namespace (its task ids are raw)"
+
+# --- T12: hermeticity -------------------------------------------------------
+echo "T12: no live GitHub reached"
+if grep -qE '^gh (issue|pr) (edit|create|close)' "$GH_LOG"; then
+    bad "gh mutation attempted through the stub (would have been live without it)"
+else
+    ok "no gh mutation escaped the stub"
+fi
+
+summarize


### PR DESCRIPTION
## Summary
- `fleet-claim stack` now stamps its namespace into the record it writes —
  `$CLAIMS_DIR/_stack_<agent>/ns` plus a `repo:` line in the molecule — so the
  repo is a property of the **record**, not of the caller re-supplying `--repo`
  at a later invocation in a fresh context.
- `release-stack` (reached by `molecule complete`) resolves the namespace from
  that record: it **adopts** when `--repo` is absent, and **refuses** (exit 2,
  nothing released, stack dir + molecule preserved) when an explicit `--repo`
  contradicts it. Resolution happens *before* the releases and the archive,
  which are the same call.
- `molecule resume` reports the namespace on **stderr** — stdout stays a bare
  issue id, which authoring roles discriminate on. `molecule list` annotates it;
  `molecule advance` warns when a passed `--repo` disagrees with the record.
- `emit()` re-emits `repo:` on every molecule rewrite, so `advance`/`resume`
  can't silently drop it.
- Records written before this carry no namespace field and keep the previous
  caller-supplied behavior exactly.
- `docs/agents/FLEET.md` § "Molecule resume protocol" now separates the one
  load-bearing `--repo` prescription from the four no-ops instead of presenting
  all five as a single uniform rule.

## Test plan
- [x] New suite `scripts/fleet/tests/test_fleet_claim_stack_namespace.sh`:
      **29 passed / 0 failed**, run standalone (not only via the whole-dir
      runner, which can let a sibling's setup launder a red suite).
- [x] Positive control via `fleet-positive-control` against pre-fix
      `origin/master` (`34c7f7f46`): **MEANINGFUL — 17 of 29 assertions fail**;
      the 12 that still pass are the non-regression assertions (engine lane,
      legacy record, stdout shape, hermeticity). 12 + 17 = 29.
- [x] Full fleet suite `bash scripts/fleet/tests/run_all.sh`: **110 suites,
      110 passed, 0 failed**.
- [x] Adjacent claim suites re-run individually: `test_fleet_claim_safety_guards.sh`
      25/0, `test_fleet_claim_branch_check.sh` 14/0, `test_fleet_claim_acquire.sh`
      13/0.
- [x] `bash -n` clean on both changed/added shell files.
- [x] Hermetic: `gh` is a failing PATH stub for the whole suite, and T12 asserts
      no `gh issue|pr edit|create|close` reached it. No live GitHub, no live
      `~/.fleet` (claims/molecules/reservations dirs are all env-overridden).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1 — namespace persisted in the stack record **and** the molecule meta | `bash scripts/fleet/tests/test_fleet_claim_stack_namespace.sh` (T1, T2) | `ok: stack dir records ns=game` · `ok: molecule records repo: game` · `ok: default namespace records as 'engine' (distinguishable from unrecorded)` |
| 2 — release-stack releases the right slugs without `--repo`; refuses + preserves on mismatch; legacy unchanged | same suite (T3, T5, T6, T7, T8) | T3 `ok: no orphaned claim dirs remain (pre-fix: game-9001 game-9002 survived)` · T6 `ok: contradicting --repo → exit 2`, `ok: claims preserved on refusal`, `ok: molecule preserved on refusal (not archived)` · T7 `ok: corrective for the engine lane is 'no --repo flag'` · T8 `ok: legacy record still resolves against the caller's namespace` |
| 3 — `resume` / `show` surface the namespace | same suite (T9, T10, T11) | `ok: stdout is exactly the bare issue id` · `ok: stderr names the namespace a fresh context would otherwise have to guess` · `ok: repo: meta re-emitted after resume rewrote the molecule` · `ok: molecule list shows the namespace (its task ids are raw)` |
| 4 — suite locks arms 1–4; firing fails loudly, controls pass | `fleet-positive-control scripts/fleet/tests/test_fleet_claim_stack_namespace.sh origin/master` | `MEANINGFUL: 17 of 29 assertions fail against origin/master (34c7f7f46).` — and 29/29 pass on this branch |
| 5 — FLEET.md stops presenting the four no-ops as equivalent | `git diff origin/master -- docs/agents/FLEET.md` | § "Cross-repo molecules" now carries a per-subcommand table marking `resume`/`show`/`list`/`stack-pr-state`/`advance` **No** and `molecule complete` → `release-stack` **Yes**; the two prescriptions outside that block point at it |

## Notes for reviewer
- **The defect was latent, not fired.** `~/.fleet/molecules/done/` holds 5
  archived molecules, all engine-lane (`opus-worker-*`, Apr–Jun); no cross-repo
  molecule has run on this host. It is reachable today — `role-worker.md` step 3's
  stackable-fallback tier and step 4's stack-claim both cover game tasks, and
  FLEET.md documents cross-repo molecules as supported. Filed and fixed on the
  standing rule that a guard which never propagated to a sibling store is a
  defect even when non-firing; the orphan it produces is unrecoverable, and the
  claim-label TTL sweeps that would otherwise mop up are themselves inert
  (#2781/#2782).
- **Why refuse rather than guess** on a contradicting `--repo`: the releases and
  `molecule_archive` are the same call, so a wrong namespace orphans every claim
  *and* destroys the record they could be rebuilt from. Adopt-on-absent is safe
  (the record is the only source); adopt-on-contradiction would silently override
  an explicit operator instruction.
- **`engine` is spelled explicitly** in the record rather than stored as the
  empty string `slugify` uses. That is what keeps a namespaced record
  distinguishable from a pre-#2857 one, which is how T8's legacy arm stays green.
- **Two findings surfaced by `simplify` that I did not bundle** (both need a
  scope call that isn't this PR's):
  - `fleet-claim:1941` — `cmd_cleanup` hardcodes its own slug→repo mapping
    (`[[ "$slug" == game-* ]]` → `jakildev/irreden`) instead of routing through
    `repo_from_ns`, and `fleet_branch_match.py:72` holds a third copy of the
    `game-` prefix knowledge. Pre-existing, in a function this PR doesn't touch.
  - `scripts/fleet/CLAUDE.md` — its authoring-rules list has no entry for "a
    record that outlives its creating process carries its own namespace, never a
    re-supplied flag." Generalizable, but rule additions belong to the
    `assess-coding-improvement` channel's human-cued judgment, not a fix PR.

Closes #2857

🤖 Generated with [Claude Code](https://claude.com/claude-code)