### PR TITLE
build: enable_testing() so ctest discovers the C++ test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if(IRREDEN_USER_PROJECTS)
 endif()
 
 if(IRREDEN_BUILD_TESTS)
+    enable_testing()
     add_subdirectory(${PROJECT_SOURCE_DIR}/test)
 endif()
 


### PR DESCRIPTION
## Summary
- `enable_testing()` was missing from the top-level `CMakeLists.txt`, so
  `gtest_discover_tests(IrredenEngineTest ...)` in `test/CMakeLists.txt`
  wrote discovery output that CMake never wired into `CTestTestfile.cmake`.
  `ctest` found 0 of 1474 C++ tests and exited 0 on every preset, so
  `quality.yml`'s C++ test gate could never fail regardless of outcome.
- One-line fix: `enable_testing()` in the `IRREDEN_BUILD_TESTS` block.

## Test plan
- [x] `cmake --preset macos-debug` — clean reconfigure with the fix.
- [x] `fleet-build --target IrredenEngineTest` — clean build.
- [x] `find build -name CTestTestfile.cmake` — now non-empty (`build/CTestTestfile.cmake`,
      `build/test/CTestTestfile.cmake`, plus dependency subdirs).
- [x] `ctest --preset macos-default-tests -N` — 1474 tests registered (was 0).
- [x] `ctest --preset macos-default-tests -j8` — 1473/1474 pass, exit code 8.
      The one failure is `SaveTrait.InventoryIsComplete` (#2834), a
      pre-existing master defect unrelated to this fix — this is the gate
      correctly going red, not a regression.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `ctest --preset <host>-default-tests` reports 1474 tests, not 0 | `ctest --preset macos-default-tests -N` | `Total Tests: 1474` |
| `find <build-dir> -name CTestTestfile.cmake` is non-empty | `find build -name CTestTestfile.cmake` | `build/CTestTestfile.cmake`, `build/test/CTestTestfile.cmake` (+ deps) |
| With #2834 unfixed, exits non-zero and names `SaveTrait.InventoryIsComplete` | `ctest --preset macos-default-tests -j8` | `The following tests FAILED: 1396 - SaveTrait.InventoryIsComplete (Failed)`, exit code 8 |

Closes #2858

🤖 Generated with [Claude Code](https://claude.com/claude-code)