### PR TITLE
fleet/worker: discharge the [WIP] PR-title marker at finalize (#2788)

### DIFF
--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -195,11 +195,18 @@ hand-waved table costs a review round-trip.
 
 Use the `commit-and-push` skill to push your work commits to the
 existing PR branch (commit-and-push uses cwd's git repo automatically).
-Then remove the WIP label and release the claim.
+Then remove the WIP label, strip any trailing `[WIP]` the claim-time
+title picked up, and release the claim. The `[WIP]` marker is a worker
+convention with no minting site to key on — only the label is load-bearing
+for the fleet's own tooling — but a squash-merge writes the PR *title* into
+master's commit history, so a stale trailing marker ships into permanent
+history if left on the title (#2788):
 
 ```
 # engine task
-gh pr edit <N> --remove-label "fleet:wip"
+title="$(gh pr view <N> --json title -q .title)"
+stripped_title="$(sed -E 's/[[:space:]]*\[WIP\][[:space:]]*$//' <<< "$title")"
+[[ -n "$stripped_title" ]] && gh pr edit <N> --remove-label "fleet:wip" --title "$stripped_title"
 fleet-claim release <issue-#>
 ```
 
@@ -210,7 +217,9 @@ so the right PR + the right slug are targeted:
 
 ```
 # game task
-gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip"
+title="$(gh pr view <N> --repo jakildev/irreden --json title -q .title)"
+stripped_title="$(sed -E 's/[[:space:]]*\[WIP\][[:space:]]*$//' <<< "$title")"
+[[ -n "$stripped_title" ]] && gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip" --title "$stripped_title"
 fleet-claim --repo game release <issue-#>
 ```
 

--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -204,9 +204,10 @@ history if left on the title (#2788):
 
 ```
 # engine task
+gh pr edit <N> --remove-label "fleet:wip"
 title="$(gh pr view <N> --json title -q .title)"
 stripped_title="$(sed -E 's/[[:space:]]*\[WIP\][[:space:]]*$//' <<< "$title")"
-[[ -n "$stripped_title" ]] && gh pr edit <N> --remove-label "fleet:wip" --title "$stripped_title"
+[[ -n "$stripped_title" && "$stripped_title" != "$title" ]] && gh pr edit <N> --title "$stripped_title"
 fleet-claim release <issue-#>
 ```
 
@@ -217,9 +218,10 @@ so the right PR + the right slug are targeted:
 
 ```
 # game task
+gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip"
 title="$(gh pr view <N> --repo jakildev/irreden --json title -q .title)"
 stripped_title="$(sed -E 's/[[:space:]]*\[WIP\][[:space:]]*$//' <<< "$title")"
-[[ -n "$stripped_title" ]] && gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip" --title "$stripped_title"
+[[ -n "$stripped_title" && "$stripped_title" != "$title" ]] && gh pr edit <N> --repo jakildev/irreden --title "$stripped_title"
 fleet-claim --repo game release <issue-#>
 ```
 

--- a/scripts/fleet/fleet-decisions
+++ b/scripts/fleet/fleet-decisions
@@ -111,9 +111,16 @@ fi
 # default raises on the report's em-dash / middle-dot glyphs).
 PYTHONIOENCODING=utf-8 python3 - "$manifest" "$feedback_f" "$marker_age_days" << 'PYEOF'
 import json
+import re
 import sys
 
 SHORT = {"jakildev/IrredenEngine": "engine", "jakildev/irreden": "game"}
+
+# An approved PR's title still carrying [WIP] with no fleet:wip label is a
+# desync the fleet's own labels never catch: GitHub squash-merge uses the
+# title as the commit subject, so this ships [WIP] into master's permanent
+# history (#2788) unless a human strips it before merging.
+WIP_TITLE_RE = re.compile(r"\[WIP\]")
 
 # Drain thresholds: past these, a backlog cue flips to OVERDUE. Values per
 # the 2026-07-30 triage retrospective — batches past ~a dozen tickets cost
@@ -155,7 +162,7 @@ def names(item):
     return [label["name"] for label in item.get("labels", [])]
 
 
-merge_queue = []   # (repo, item, has_nits, smoke_holds)
+merge_queue = []   # (repo, item, has_nits, smoke_holds, wip_title_mismatch)
 decisions = []     # (repo, kind, item, tags)
 coding_improvements = 0
 untriaged = []
@@ -170,7 +177,8 @@ for repo, prs, issues in repos:
                 label for label in labels
                 if label.startswith("fleet:needs-") and label.endswith("-smoke")
             ]
-            merge_queue.append((repo, pr, "fleet:has-nits" in labels, smoke))
+            wip_mismatch = bool(WIP_TITLE_RE.search(pr["title"])) and "fleet:wip" not in labels
+            merge_queue.append((repo, pr, "fleet:has-nits" in labels, smoke, wip_mismatch))
         tags = [DECISION_TAGS[label] for label in labels if label in DECISION_TAGS]
         if tags:
             decisions.append((repo, "PR", pr, tags))
@@ -193,11 +201,16 @@ print(f"fleet-decisions: {total} decision(s) waiting   [{scope}]")
 
 if merge_queue:
     print(f"\n## Merge queue ({len(merge_queue)})")
-    for repo, pr, has_nits, smoke in merge_queue:
+    for repo, pr, has_nits, smoke, wip_mismatch in merge_queue:
         nits = "+nits" if has_nits else ""
         print(f"  {repo} PR #{pr['number']}  {pr['title']}  [approved{nits}]")
         for label in smoke:
             print(f"      hold: {label} outstanding")
+        if wip_mismatch:
+            print(
+                "      warn: title still carries [WIP] with no fleet:wip label — "
+                "strip before merge (squash uses the title as the commit subject)"
+            )
 
 if decisions:
     print(f"\n## Decisions ({len(decisions)})")

--- a/scripts/fleet/tests/test_decisions.sh
+++ b/scripts/fleet/tests/test_decisions.sh
@@ -8,6 +8,8 @@
 #
 # Covers:
 #   - merge queue: approved PR listed; +nits annotation; smoke-hold sub-line
+#   - merge queue: an approved PR whose title still carries [WIP] with no
+#     fleet:wip label gets a warn sub-line; clean approved PRs get none
 #   - decisions: gated / design-blocked PRs and human:review-plan issues
 #   - a wip-only PR appears in no decision bucket
 #   - cues: coding-improvement count, untriaged count, unread feedback roles
@@ -48,7 +50,9 @@ cat > "$TMP/engine-prs.json" << 'EOF'
   {"number": 104, "title": "render: needs design answer", "url": "u",
    "labels": [{"name": "fleet:design-blocked"}, {"name": "fleet:wip"}]},
   {"number": 105, "title": "engine: plain wip", "url": "u",
-   "labels": [{"name": "fleet:wip"}]}
+   "labels": [{"name": "fleet:wip"}]},
+  {"number": 106, "title": "engine: approved but title still says [WIP]", "url": "u",
+   "labels": [{"name": "fleet:approved"}]}
 ]
 EOF
 
@@ -114,12 +118,16 @@ err=$(cat "$TMP/err.txt")
 assert_eq "$status" "0" "default run exits 0 despite unreachable game repo"
 assert_contains "$err" "skipping jakildev/irreden" "unreachable repo warned on stderr"
 
-assert_contains "$out" "6 decision(s) waiting" "headline counts merge queue + decisions"
-assert_contains "$out" "Merge queue (2)" "merge queue counts both approved PRs"
+assert_contains "$out" "7 decision(s) waiting" "headline counts merge queue + decisions"
+assert_contains "$out" "Merge queue (3)" "merge queue counts all three approved PRs"
 assert_contains "$out" "engine PR #101" "clean approved PR listed"
 assert_contains "$out" "#102" "approved-with-nits PR listed"
 assert_contains "$out" "[approved+nits]" "has-nits annotated"
 assert_contains "$out" "hold: fleet:needs-linux-smoke outstanding" "smoke hold sub-line"
+assert_contains "$out" "engine PR #106" "approved PR with a stale [WIP] title is listed"
+assert_contains "$out" "warn: title still carries [WIP] with no fleet:wip label" "wip-title/label mismatch is flagged"
+warn_lines=$(grep -c "warn: title still carries \[WIP\]" "$TMP/out.txt")
+assert_eq "$warn_lines" "1" "only the mismatched PR gets the warn line, not #101/#102"
 assert_contains "$out" "Decisions (4)" "decision bucket counts gated + design-blocked + plan hold + triage verdict"
 assert_contains "$out" "engine PR #103" "gated PR in decisions"
 assert_contains "$out" "gated self-config edit" "gated tag rendered"
@@ -135,7 +143,7 @@ assert_contains "$out" "untriaged (no state labels): 1" "untriaged cue counts la
 assert_contains "$out" "engine #203" "untriaged cue names the issue"
 assert_contains "$out" "merger" "feedback role newer than marker is unread"
 assert_absent  "$out" "role-worker" "feedback role older than marker is not unread"
-assert_contains "$out" "engine: 5 open PR(s) · 1 queued · 1 needs-plan" "status footer"
+assert_contains "$out" "engine: 6 open PR(s) · 1 queued · 1 needs-plan" "status footer"
 
 # --- drain thresholds: both arms of each cue --------------------------------
 


### PR DESCRIPTION
## Summary
- `docs/agents/AUTHOR-PIPELINE.md` § "Finalize the PR" — strip a trailing
  `[WIP]` from the PR title in the same edit that clears `fleet:wip`, for
  both the engine and game task variants. GitHub squash-merge uses the PR
  title as the commit subject, so a marker left on the title ships into
  master's permanent history even after the label is cleared correctly.
- `scripts/fleet/fleet-decisions` — the merge-queue render now flags any
  `fleet:approved` PR whose title still carries `[WIP]` with no `fleet:wip`
  label, as a standing warn sub-line (mirrors the existing smoke-hold
  sub-lines). This is a guard independent of whether the finalize step
  above actually ran — the convention has no minting site, so nothing else
  in `scripts/fleet/` was ever going to catch a drift back.
- Verified `FLEET-FEEDBACK-HANDLING.md`'s finalize path never clears
  `fleet:wip` (grepped — only mentions it as a reviewer-skip label), so it
  needed no matching change.
- `scripts/fleet/tests/test_decisions.sh` — new fixture PR (title carries
  `[WIP]`, `fleet:approved` only, no `fleet:wip`) plus assertions that the
  warn line renders once and only for the mismatched PR.

Note: the issue's "fix #2654's title before it merges" action item is now
moot — #2654 merged mid-fix (see master's `34c7f7f46`, subject still ends
`[WIP]`). That instance is unrecoverable; this PR prevents the next one.

## Test plan
- [x] `bash scripts/fleet/tests/test_decisions.sh` → `43 passed, 0 failed`
      (up from 40; new fixture PR #106 exercises the mismatch guard)
- [x] `bash scripts/fleet/tests/run_all.sh` → `109 passed, 0 failed`
- [x] `ruff check scripts/` → `All checks passed!`
- [x] Manually verified the title-strip `sed` against the real merged
      title `render: sun-shadow splat coverage r6->r7 — Phase-0 measured
      (#2385) [WIP]` → strips to `... (#2385)`; a no-`[WIP]` title is a
      no-op.

Closes #2788

🤖 Generated with [Claude Code](https://claude.com/claude-code)