### PR TITLE
render: null PERF_STATS_OVERLAY's cached text-entity id across resetGameplay

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_camera_mouse_rotate.hpp
+++ b/engine/prefabs/irreden/render/systems/system_camera_mouse_rotate.hpp
@@ -108,7 +108,21 @@ template <> struct System<CAMERA_MOUSE_ROTATE> {
         // boot-time FATAL in `validateAllPipelineGroups` instead of a
         // heisenbug. Not `Spawns`: T-225 lifted MUTATOR_IN_PARALLEL_GROUP, so
         // it would document the mutation without preventing it.
-        return registerSystem<CAMERA_MOUSE_ROTATE, C_Camera, MainThread>("CameraMouseRotate");
+        SystemId id =
+            registerSystem<CAMERA_MOUSE_ROTATE, C_Camera, MainThread>("CameraMouseRotate");
+        // pivotIndicator_ is not C_Persistent, so IREntity::resetGameplay()
+        // destroys it (destroyAllExceptPreserved destroys per-entity via
+        // destroyEntity, which fires this hook). Null the cached id so
+        // endTick's `pivotIndicator_ == kNullEntity` lazy-respawn guard
+        // rebuilds it on the next cursor-pivot drag instead of reaching
+        // through a dead handle.
+        auto *params = getSystemParams<System<CAMERA_MOUSE_ROTATE>>(id);
+        IREntity::getEntityManager().registerPreDestroyHook([params](IREntity::EntityId destroyed) {
+            if (params->pivotIndicator_ == destroyed) {
+                params->pivotIndicator_ = IREntity::kNullEntity;
+            }
+        });
+        return id;
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -146,7 +146,19 @@ template <> struct System<PERF_STATS_OVERLAY> {
     }
 
     static SystemId create() {
-        return registerSystem<PERF_STATS_OVERLAY, C_PerfStatsOverlayTag>("PerfStatsOverlay");
+        SystemId id = registerSystem<PERF_STATS_OVERLAY, C_PerfStatsOverlayTag>("PerfStatsOverlay");
+        // textEntity_ is not C_Persistent, so IREntity::resetGameplay() destroys
+        // it (destroyAllExceptPreserved destroys per-entity via destroyEntity,
+        // which fires this hook). Null the cached id so the lazy-respawn guard
+        // in endTick rebuilds it on next use instead of reaching through a dead
+        // handle.
+        auto *params = getSystemParams<System<PERF_STATS_OVERLAY>>(id);
+        IREntity::getEntityManager().registerPreDestroyHook([params](IREntity::EntityId destroyed) {
+            if (params->textEntity_ == destroyed) {
+                params->textEntity_ = IREntity::kNullEntity;
+            }
+        });
+        return id;
     }
 
   private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(IrredenEngineTest
   render/gpu_compute_dispatch_test.cpp
   render/opengl_shader_include_test.cpp
   render/per_canvas_light_scope_test.cpp
+  render/perf_stats_overlay_reset_test.cpp
   render/picking_aim_iso_pixel_test.cpp
   render/picking_face_normal_test.cpp
   render/sun_direction_test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(IrredenEngineTest
   math/ir_math_trixel_index_test.cpp
   math/ir_math_yaw_deformation_test.cpp
   math/sdf_test.cpp
+  render/camera_mouse_rotate_reset_test.cpp
   render/camera_pan_pivot_test.cpp
   render/camera_yaw_test.cpp
   render/detached_world_depth_test.cpp

--- a/test/render/camera_mouse_rotate_reset_test.cpp
+++ b/test/render/camera_mouse_rotate_reset_test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/render/systems/system_camera_mouse_rotate.hpp>
+
+namespace {
+
+// #2681: CAMERA_MOUSE_ROTATE caches the cursor-pivot marker's id in a
+// System<N> member (`pivotIndicator_`). The entity is not C_Persistent, so
+// IREntity::resetGameplay() destroys it; without the pre-destroy hook the
+// cached id would dangle and the next drag's lazy-respawn check
+// (`pivotIndicator_ == kNullEntity`) would never fire, reaching through a
+// dead id instead of rebuilding. Mirrors
+// perf_stats_overlay_reset_test.cpp's PERF_STATS_OVERLAY coverage.
+class CameraMouseRotateResetTest : public testing::Test {
+  protected:
+    CameraMouseRotateResetTest()
+        : m_entity_manager{}
+        , m_system_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(CameraMouseRotateResetTest, PivotIndicatorDangleIsClearedAcrossResetGameplay) {
+    const auto sysId = IRSystem::createSystem<IRSystem::CAMERA_MOUSE_ROTATE>();
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::CAMERA_MOUSE_ROTATE>>(sysId);
+    ASSERT_NE(params, nullptr);
+
+    // Stand in for IRPrefab::CursorPivot::createIndicator()'s lazy spawn
+    // without needing a full drag — any non-persistent entity dangles
+    // identically.
+    params->pivotIndicator_ = IREntity::createEntity();
+    ASSERT_NE(params->pivotIndicator_, IREntity::kNullEntity);
+
+    IREntity::resetGameplay();
+
+    EXPECT_EQ(params->pivotIndicator_, IREntity::kNullEntity)
+        << "pre-destroy hook must null the cached id so the next drag's "
+           "lazy-respawn guard rebuilds the indicator instead of reaching "
+           "through a dead id";
+}
+
+TEST_F(CameraMouseRotateResetTest, UnrelatedEntityDestructionLeavesPivotIndicatorIntact) {
+    const auto sysId = IRSystem::createSystem<IRSystem::CAMERA_MOUSE_ROTATE>();
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::CAMERA_MOUSE_ROTATE>>(sysId);
+    ASSERT_NE(params, nullptr);
+
+    const auto indicator = IREntity::createEntity();
+    params->pivotIndicator_ = indicator;
+    const auto other = IREntity::createEntity();
+
+    // Direct EntityManager::destroyEntity, not the deferred IREntity:: free
+    // function — the pre-destroy hook fires synchronously inside the
+    // immediate destroy path, and this test needs that ordering guarantee.
+    m_entity_manager.destroyEntity(other);
+
+    EXPECT_EQ(params->pivotIndicator_, indicator)
+        << "the hook must only null the cached id on an exact match, not on any destruction";
+}
+
+} // namespace

--- a/test/render/perf_stats_overlay_reset_test.cpp
+++ b/test/render/perf_stats_overlay_reset_test.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/render/systems/system_perf_stats_overlay.hpp>
+
+namespace {
+
+// #2681: PERF_STATS_OVERLAY caches its text entity's id in a System<N>
+// member (`textEntity_`). The entity is not C_Persistent, so
+// IREntity::resetGameplay() destroys it; without the pre-destroy hook the
+// cached id would dangle and the next endTick's lazy-respawn check
+// (`textEntity_ == kNullEntity`) would never fire, reaching through a dead
+// id instead of rebuilding.
+class PerfStatsOverlayResetTest : public testing::Test {
+  protected:
+    PerfStatsOverlayResetTest()
+        : m_entity_manager{}
+        , m_system_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(PerfStatsOverlayResetTest, TextEntityDangleIsClearedAcrossResetGameplay) {
+    const auto sysId = IRSystem::createSystem<IRSystem::PERF_STATS_OVERLAY>();
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::PERF_STATS_OVERLAY>>(sysId);
+    ASSERT_NE(params, nullptr);
+
+    // Stand in for createTextEntity()'s lazy spawn without needing a GUI
+    // canvas — any non-persistent entity dangles identically.
+    params->textEntity_ = IREntity::createEntity();
+    ASSERT_NE(params->textEntity_, IREntity::kNullEntity);
+
+    IREntity::resetGameplay();
+
+    EXPECT_EQ(params->textEntity_, IREntity::kNullEntity)
+        << "pre-destroy hook must null the cached id so endTick's lazy-respawn "
+           "guard rebuilds the entity instead of reaching through a dead id";
+}
+
+TEST_F(PerfStatsOverlayResetTest, UnrelatedEntityDestructionLeavesTextEntityIntact) {
+    const auto sysId = IRSystem::createSystem<IRSystem::PERF_STATS_OVERLAY>();
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::PERF_STATS_OVERLAY>>(sysId);
+    ASSERT_NE(params, nullptr);
+
+    const auto textEntity = IREntity::createEntity();
+    params->textEntity_ = textEntity;
+    const auto other = IREntity::createEntity();
+
+    // Direct EntityManager::destroyEntity, not the deferred IREntity:: free
+    // function — the pre-destroy hook fires synchronously inside the
+    // immediate destroy path, and this test needs that ordering guarantee.
+    m_entity_manager.destroyEntity(other);
+
+    EXPECT_EQ(params->textEntity_, textEntity)
+        << "the hook must only null the cached id on an exact match, not on any destruction";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- `System<PERF_STATS_OVERLAY>::create()` and `System<CAMERA_MOUSE_ROTATE>::create()`
  each now register a pre-destroy hook that nulls their cached overlay-entity
  member (`textEntity_` / `pivotIndicator_`) when that entity is destroyed,
  so `IREntity::resetGameplay()` no longer leaves a dangling id behind —
  the existing lazy-respawn guards rebuild the entities on next use instead
  of reaching through a dead handle.
- Added `test/render/perf_stats_overlay_reset_test.cpp` and
  `test/render/camera_mouse_rotate_reset_test.cpp`, each exercising the fix
  directly against the `System<N>` instance (no GUI canvas / drag input
  needed, since `create()` and the pre-destroy hook don't require one) plus
  a guard test confirming an unrelated entity's destruction leaves the
  cached id untouched.

## Both halves of #2681, landed across this session

This started as the perf-stats-overlay half only — the camera-mouse-rotate
half (`pivotIndicator_`) depended on `cursor_pivot.hpp`, which existed only
in open, unmerged PR #2659 (a 2026-08-01 worker pass on #2681 found the same
blocker and released without touching it). **PR #2659 merged into `master`
partway through this session**, which is what made the second half
fixable — rebased onto the fresh `master` and applied the identical fix to
`system_camera_mouse_rotate.hpp`.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Post-reset cursor-pivot drag shows marker correctly, no getComponent on a dead/recycled id | `CameraMouseRotateResetTest.PivotIndicatorDangleIsClearedAcrossResetGameplay` | PASS (fails without the fix — see Test plan) |
| Same for the perf-stats overlay's text entity | `PerfStatsOverlayResetTest.TextEntityDangleIsClearedAcrossResetGameplay` | PASS (fails without the fix — see Test plan) |
| `fleet-build --target IRShapeDebug` clean | build | clean, exit 0 |
| `python3 scripts/pivot-verify.py --blocks cursor-latch` still FOCUS-OK, gate not regressed | `pivot-verify.py --blocks cursor-latch` | `cursor-latch@z4 FOCUS-OK` — "pivot-verify: all 1 passes met their gate" |

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean
- [x] `fleet-build --target IrredenEngineTest` clean; full suite
  1477/1478 pass (the sole failure, `SaveTrait.InventoryIsComplete`, is the
  pre-existing #2834 defect, unrelated to this change)
- [x] Positive control on **both** new tests: reverted each fix
  individually, rebuilt, confirmed the matching
  `*DangleIsClearedAcrossResetGameplay` test fails with the dangling id
  surviving the reset; restored each fix and confirmed green again
- [x] `python3 scripts/pivot-verify.py --blocks cursor-latch` —
  `FOCUS-OK`, "all 1 passes met their gate"
- [x] `fleet-run IRPerfGrid --auto-screenshot` (the demo that registers
  `PERF_STATS_OVERLAY`) — clean run, exit 0, all 7 shots captured,
  `RESULT=CLEAN`

Closes #2681

🤖 Generated with [Claude Code](https://claude.com/claude-code)