### PR TITLE
fleet/CI: fleet-tests.yml path-filters on suites' location, not subjects (#2810)

### DIFF
--- a/.github/workflows/fleet-tests.yml
+++ b/.github/workflows/fleet-tests.yml
@@ -10,11 +10,16 @@ name: Fleet Tests
 # CMake, so they have no reason to ride along with a build job anyway.
 #
 # Path-filtered to the fleet tooling surface — engine, shader, and asset
-# PRs skip this entirely (same convention as perf-gate.yml). Two suites
-# reach outside scripts/fleet/** for their subject under test
-# (test_format_changed_line_scoping.sh, test_ir_build_dir_resolution.sh) —
-# their subjects are listed explicitly below so a PR touching only one of
-# them still runs this workflow (#2786).
+# PRs skip this entirely (same convention as perf-gate.yml). Three suites
+# reach outside scripts/fleet/** for their subject under test — their
+# subjects are listed explicitly below so a PR touching only one of them
+# still runs this workflow (#2786, #2810):
+#   test_format_changed_line_scoping.sh -> cmake/run_clang_format_changed.cmake
+#   test_ir_build_dir_resolution.sh     -> engine/tools/lib/concurrency_helpers.sh
+#   test_fleet_transition.sh            -> docs/agents/fleet-state-machine.json
+# The two `paths:` blocks are duplicated because GitHub Actions has no YAML
+# anchors — keep them in sync (same note as header-checks.yml);
+# scripts/fleet/tests/test_fleet_tests_workflow_paths.sh ratchets that they do.
 
 on:
   push:
@@ -24,12 +29,14 @@ on:
       - '.github/workflows/fleet-tests.yml'
       - 'cmake/run_clang_format_changed.cmake'
       - 'engine/tools/lib/concurrency_helpers.sh'
+      - 'docs/agents/fleet-state-machine.json'
   pull_request:
     paths:
       - 'scripts/fleet/**'
       - '.github/workflows/fleet-tests.yml'
       - 'cmake/run_clang_format_changed.cmake'
       - 'engine/tools/lib/concurrency_helpers.sh'
+      - 'docs/agents/fleet-state-machine.json'
   workflow_dispatch:
 
 permissions:

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -68,6 +68,13 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   If the subject lives outside `scripts/fleet/**`, also add its path to
   `fleet-tests.yml`'s `paths:` filter — otherwise a PR that moves or edits
   only that file never runs the suite that would have caught the break.
+  **This is executed** — add the path to `OUT_OF_TREE_SUBJECTS` in
+  `tests/test_fleet_tests_workflow_paths.sh` in the same change, and the
+  ratchet asserts it appears in **both** `paths:` blocks (they are
+  hand-duplicated — GitHub Actions has no YAML anchors — so they drift
+  independently). The list is the ratchet's whole domain: a subject absent
+  from it is a subject nothing guards, however green the suite runs
+  (#2810).
 - **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
   `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
   `summarize` exit idiom — don't re-copy the helpers into a new test.

--- a/scripts/fleet/tests/test_fleet_tests_workflow_paths.sh
+++ b/scripts/fleet/tests/test_fleet_tests_workflow_paths.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Tests for .github/workflows/fleet-tests.yml's path filters (#2810).
+#
+# The workflow path-filters on scripts/fleet/** — the LOCATION of its
+# suites, not the SUBJECTS they test. Three suites test files that live
+# outside that path (test_format_changed_line_scoping.sh covers
+# cmake/run_clang_format_changed.cmake; test_ir_build_dir_resolution.sh
+# covers engine/tools/lib/concurrency_helpers.sh; test_fleet_transition.sh
+# covers docs/agents/fleet-state-machine.json), so a PR touching only one
+# of those subjects previously got no fleet-tests run at all — the only
+# regression coverage for that subject silently never fired.
+#
+# This is deliberately a hardcoded ratchet, not a parse of each suite's
+# variable assignments (same shape as header_global_baseline in
+# cmake/run_header_convention_checks.cmake): it asserts every known
+# out-of-tree subject is present in BOTH `paths:` blocks of the
+# workflow (push and pull_request — GitHub Actions has no YAML anchors,
+# so the two lists are hand-duplicated and can drift independently).
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
+WORKFLOW="$SCRIPT_DIR/.github/workflows/fleet-tests.yml"
+
+# shellcheck source=lib_assert.sh
+source "$(dirname "$0")/lib_assert.sh"
+
+if [[ ! -f "$WORKFLOW" ]]; then
+    echo "SKIP: workflow under test not found at $WORKFLOW" >&2
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
+fi
+
+# The out-of-tree subjects each suite actually needs triggered on. Extend
+# this list (and add the matching suite to scripts/fleet/tests/) whenever
+# a new suite tests a file outside scripts/fleet/.
+OUT_OF_TREE_SUBJECTS=(
+    'cmake/run_clang_format_changed.cmake'
+    'engine/tools/lib/concurrency_helpers.sh'
+    'docs/agents/fleet-state-machine.json'
+)
+
+# paths_block <file> <section> — the raw text of the named top-level `on:`
+# sub-block (`push` or `pull_request`), from its own header line up to
+# (not including) the next sibling key at the same two-space indent. A
+# plain sed range keeps this independent of any YAML parser being present
+# on the runner.
+paths_block() {
+    local file="$1" section="$2"
+    sed -n "/^  ${section}:/,/^  [a-zA-Z_]\+:/p" "$file" | sed '1d;$d'
+}
+
+# missing_subjects <file> — prints one "<block> <subject>" line per
+# (block, subject) pair NOT found in that block of <file>. Empty output
+# means every subject is covered in both blocks. Pure check, no ok/bad —
+# callers decide what the presence/absence of output means for them.
+missing_subjects() {
+    local file="$1"
+    local push_block pr_block subject
+    push_block=$(paths_block "$file" push)
+    pr_block=$(paths_block "$file" pull_request)
+    for subject in "${OUT_OF_TREE_SUBJECTS[@]}"; do
+        printf '%s' "$push_block" | grep -qF -- "$subject" || echo "push $subject"
+        printf '%s' "$pr_block" | grep -qF -- "$subject" || echo "pull_request $subject"
+    done
+}
+
+echo "T1: the real workflow lists every out-of-tree subject in both paths: blocks"
+real_missing=$(missing_subjects "$WORKFLOW")
+assert_eq "$real_missing" "" "fleet-tests.yml: no missing out-of-tree subjects"
+
+echo "T2: positive control — deleting a subject from the workflow makes the check fail"
+MUTATED=$(mktemp -t fleet-tests-workflow-mutated.XXXXXX.yml)
+trap 'rm -f "$MUTATED"' EXIT
+# Drop every line naming the first subject from both blocks, in a fresh
+# temp copy — the real file under test is never touched.
+grep -vF "${OUT_OF_TREE_SUBJECTS[0]}" "$WORKFLOW" > "$MUTATED"
+
+mutated_missing=$(missing_subjects "$MUTATED")
+assert_contains "$mutated_missing" "push ${OUT_OF_TREE_SUBJECTS[0]}" \
+    "control fires: mutated copy reports the deleted subject missing from push"
+assert_contains "$mutated_missing" "pull_request ${OUT_OF_TREE_SUBJECTS[0]}" \
+    "control fires: mutated copy reports the deleted subject missing from pull_request"
+# The mutated copy's OTHER subjects must all still be found — isolates the
+# control to the one deleted entry rather than a blanket empty-block bug.
+# Looping the whole tail is what keeps the isolation complete as the list
+# grows: a single-index assert would leave every later subject unexercised.
+if (( ${#OUT_OF_TREE_SUBJECTS[@]} > 1 )); then
+    for untouched in "${OUT_OF_TREE_SUBJECTS[@]:1}"; do
+        assert_absent "$mutated_missing" "$untouched" \
+            "control isolation: untouched $untouched is not reported missing"
+    done
+fi
+
+echo "T3: restoring the deleted path returns the check to passing (the file itself, untouched, still passes)"
+restored_missing=$(missing_subjects "$WORKFLOW")
+assert_eq "$restored_missing" "" "fleet-tests.yml: unaffected by the mutated copy, still clean"
+
+summarize "fleet-tests.yml workflow path ratchet"


### PR DESCRIPTION
## Summary
- Both `paths:` blocks in `.github/workflows/fleet-tests.yml` (`push` and `pull_request`) now list all **three** out-of-tree subjects — `cmake/run_clang_format_changed.cmake`, `engine/tools/lib/concurrency_helpers.sh`, `docs/agents/fleet-state-machine.json` — so a PR touching only one of them still runs the suite that regression-tests it.
- Added `scripts/fleet/tests/test_fleet_tests_workflow_paths.sh`, a hardcoded ratchet asserting every subject appears in **both** blocks, plus a positive control proving the check fires on a mutated copy with one subject deleted.
- `scripts/fleet/CLAUDE.md`'s out-of-tree-subject rule now names the ratchet that enforces it — a detection spec with no named executor drifts silently (#2727).

## Rebase note (addresses review feedback)

This branch was cut from a master snapshot predating `4b247135c` (#2786/#2844). That commit changed three things this PR overlaps; all three are carried forward, none dropped:

| Pre-rebase state | Now |
|---|---|
| 2-entry `paths:` list — a "take mine" resolution would have silently dropped #2844's entry | 5 entries per block: `scripts/fleet/**`, the workflow itself, and all three out-of-tree subjects |
| `OUT_OF_TREE_SUBJECTS` had 2 entries, so the ratchet did **not** guard the subject #2844 had just added | 3 entries — deleting #2844's `paths:` entry now fails 3 assertions (pre-rebase it failed 0) |
| subject-missing guard used `exit 0` — the vacuous-pass shape #2786 exists to ban | `exit 3`, matching `test_format_changed_line_scoping.sh` |

Git's auto-merge of the two `paths:` blocks emitted a **duplicated** `cmake/run_clang_format_changed.cmake` entry in each — resolved by hand, not by taking either side.

The `same note as header-checks.yml` comment reference was preserved through the rebase (per the review nit); `.github/workflows/header-checks.yml` verified present on `origin/master`.

## Test plan
- [x] New suite standalone: `bash scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` — **6/6 passed** (the control's isolation arm now loops the whole subject tail, so it grew by one assertion).
- [x] `bash scripts/fleet/tests/run_all.sh` — **120 suites, 120 passed, 0 failed, 0 skipped**.
- [x] `fleet-positive-control scripts/fleet/tests/test_fleet_tests_workflow_paths.sh origin/master --include .github/workflows/fleet-tests.yml` — **MEANINGFUL, 3 of 6** assertions fail against pre-fix `origin/master` (`6e804773e`).
- [x] **Ratchet now guards #2844's subject** (the review's second needs-fix): deleting `engine/tools/lib/concurrency_helpers.sh` from both blocks fails 3 assertions (T1, the control-isolation arm, and T3); restoring returns 6/6. Pre-rebase that deletion failed **zero**.
- [x] `fleet-build --target format-changed` — 3 changed files examined, 0 on the quality list (CI/docs/bash only).
- [x] `bash -n scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` — clean.
- [x] `gh pr view 2867 --json mergeable` — **MERGEABLE** (was `CONFLICTING`).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. Both `paths:` blocks carry every out-of-tree subject | `bash scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` (T1) | All three present in both blocks; no duplicate entries |
| 2. Ratchet asserts the hardcoded list appears in both blocks, fails otherwise | Same run | `6 passed, 0 failed` |
| 3. Positive control: deleting a path fails, restoring passes | Same run (T2/T3) + the #2844-subject deletion above | Both mutations fail; both restorations return clean |
| 4. `run_all.sh` stays green | `bash scripts/fleet/tests/run_all.sh` | `120 suite(s) — 120 passed, 0 failed, 0 skipped` |
| 5. Suite is not a vacuous pass when its subject is absent | Code review of the guard against `run_all.sh`'s `SKIP_STATUS` | `exit 3`, tallied as skipped, never passed (#2786) |

Closes #2810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
