### PR TITLE
fleet: check that rules-doc fleet-* command citations resolve (#2823)

### DIFF
--- a/.github/workflows/fleet-tests.yml
+++ b/.github/workflows/fleet-tests.yml
@@ -10,13 +10,21 @@ name: Fleet Tests
 # CMake, so they have no reason to ride along with a build job anyway.
 #
 # Path-filtered to the fleet tooling surface — engine, shader, and asset
-# PRs skip this entirely (same convention as perf-gate.yml). Three suites
+# PRs skip this entirely (same convention as perf-gate.yml). Four suites
 # reach outside scripts/fleet/** for their subject under test — their
 # subjects are listed explicitly below so a PR touching only one of them
-# still runs this workflow (#2786, #2810):
+# still runs this workflow (#2786, #2810, #2823):
 #   test_format_changed_line_scoping.sh -> cmake/run_clang_format_changed.cmake
 #   test_ir_build_dir_resolution.sh     -> engine/tools/lib/concurrency_helpers.sh
 #   test_fleet_transition.sh            -> docs/agents/fleet-state-machine.json
+#   test_lint_rules_commands.py         -> .claude/rules/**, docs/agents/**
+# That last one's subjects are globs rather than single files — it checks
+# every rules/protocol doc's fenced Detection/command blocks, so a PR that
+# edits only a rules or protocol doc must still trigger this workflow;
+# without those paths the exact PR that landed a doc-ahead-of-executor
+# citation (ce2d2c57a) would not have run it (#2823). `docs/agents/**`
+# subsumes docs/agents/fleet-state-machine.json — the narrower entry stays
+# because the ratchet below asserts that subject by name.
 # The two `paths:` blocks are duplicated because GitHub Actions has no YAML
 # anchors — keep them in sync (same note as header-checks.yml);
 # scripts/fleet/tests/test_fleet_tests_workflow_paths.sh ratchets that they do.
@@ -26,6 +34,8 @@ on:
     branches: [master]
     paths:
       - 'scripts/fleet/**'
+      - '.claude/rules/**'
+      - 'docs/agents/**'
       - '.github/workflows/fleet-tests.yml'
       - 'cmake/run_clang_format_changed.cmake'
       - 'engine/tools/lib/concurrency_helpers.sh'
@@ -33,6 +43,8 @@ on:
   pull_request:
     paths:
       - 'scripts/fleet/**'
+      - '.claude/rules/**'
+      - 'docs/agents/**'
       - '.github/workflows/fleet-tests.yml'
       - 'cmake/run_clang_format_changed.cmake'
       - 'engine/tools/lib/concurrency_helpers.sh'

--- a/scripts/fleet/lint_rules_commands.py
+++ b/scripts/fleet/lint_rules_commands.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Verify command-position `fleet-*` citations in rules/protocol docs resolve.
+
+`.claude/rules/*.md` and `docs/agents/*.md` prescribe executable commands
+inside their `## Detection` (or equivalent) fenced code blocks. A rule doc can
+land ahead of the tool it cites — #2823: `.claude/rules/cpp-math.md` mandated
+`fleet-rules-sweep` as the *only* correct Detection command a full PR cycle
+before the PR adding that script (#2744) merged, leaving the block
+unexecutable by anyone reading master with no signal that it was broken.
+Nothing checked this: `fleet-validate-roles` validates role/wrapper matching,
+not command resolution, and no workflow, test, or CMake target read a rules
+doc's Detection block at all.
+
+Predicate (measured against the tree in #2823 — 34 files, exactly one true
+positive, zero false positives): scan fenced code blocks only; the FIRST
+whitespace-delimited token of each line, with an optional leading `$ `
+prompt stripped, is a candidate. A candidate matching `fleet-[\\w-]+` must
+resolve against a git-tracked file's basename or stem (`fleet-common` ->
+`fleet-common.sh`) or a name on `PATH`. Command position only, deliberately
+narrow: a naive "any `fleet-[a-z-]+` token anywhere in the file" predicate
+produced 22 hits in the #2823 audit, all noise — doc filenames like
+`fleet-labels-reference.md`, prose like "fleet-wide", the
+`.git/fleet-amend-ref` sentinel, `.sh`-suffixed script names in running text.
+
+Suppress a specific, deliberately-not-yet-executable citation with
+`<!-- lint: rules-cmd-ok <token> -- <reason> -->` on the last non-blank line
+before the opening fence — mirrors the `# lint: state-mtime-ok <reason>`
+opt-out in `lint_state_mtime.py`. Never delete the Detection block itself to
+silence this check; the block is documentation of intent even when its cited
+tool hasn't landed yet.
+
+Exit 0: every fenced `fleet-*` citation resolves (or is suppressed). Exit 1:
+at least one does not, printed as `file:line: <message>`.
+"""
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+FENCE_RE = re.compile(r"^\s*```")
+ALLOW_RE = re.compile(r"^<!--\s*lint:\s*rules-cmd-ok\s+(\S+)")
+FLEET_TOKEN_RE = re.compile(r"^fleet-[a-zA-Z0-9_-]+$")
+
+DEFAULT_DOC_GLOBS = (".claude/rules/*.md", "docs/agents/*.md")
+
+_SELF = Path(__file__).resolve()
+
+
+def _first_token(line):
+    stripped = line.strip()
+    if stripped.startswith("$ "):
+        stripped = stripped[2:].lstrip()
+    parts = stripped.split(None, 1)
+    return parts[0] if parts else None
+
+
+def find_candidates(path):
+    """Return (lineno, token, allowed) for each command-position `fleet-*`
+    token inside a fenced block. `allowed` is True when the fence's opening
+    line was immediately preceded by a matching `rules-cmd-ok` marker naming
+    that token."""
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    findings = []
+    in_fence = False
+    pending_allow = set()
+    fence_allow = set()
+    for idx, line in enumerate(lines):
+        if FENCE_RE.match(line):
+            if not in_fence:
+                in_fence = True
+                fence_allow = pending_allow
+            else:
+                in_fence = False
+                fence_allow = set()
+            pending_allow = set()
+            continue
+        if in_fence:
+            token = _first_token(line)
+            if token:
+                base = token.rsplit("/", 1)[-1]
+                if FLEET_TOKEN_RE.match(base):
+                    findings.append((idx + 1, base, base in fence_allow))
+            continue
+        stripped = line.strip()
+        if stripped == "":
+            pending_allow = set()
+            continue
+        m = ALLOW_RE.match(stripped)
+        pending_allow = {m.group(1).rstrip(":,")} if m else set()
+    return findings
+
+
+def resolve(token, tracked_basenames, tracked_stems):
+    if token in tracked_basenames or token in tracked_stems:
+        return True
+    return shutil.which(token) is not None
+
+
+def collect_tracked_names(repo_root):
+    """(basenames, stems) of every git-tracked file under repo_root.
+
+    Falls back to a plain filesystem walk when repo_root isn't a git repo
+    (e.g. a hermetic test fixture) rather than raising — the resolution
+    predicate is still meaningful there."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        rels = out.splitlines()
+    except (subprocess.CalledProcessError, OSError):
+        rels = [str(p.relative_to(repo_root)) for p in Path(repo_root).rglob("*")
+                if p.is_file() and ".git" not in p.parts]
+    basenames, stems = set(), set()
+    for rel in rels:
+        name = Path(rel).name
+        basenames.add(name)
+        stems.add(Path(rel).stem)
+    return basenames, stems
+
+
+def scan_file(path, tracked_basenames, tracked_stems):
+    """Return sorted (lineno, token) for unresolved, unsuppressed citations."""
+    findings = [
+        (lineno, token)
+        for lineno, token, allowed in find_candidates(path)
+        if not allowed and not resolve(token, tracked_basenames, tracked_stems)
+    ]
+    return sorted(findings)
+
+
+def iter_docs(repo_root, doc_globs=DEFAULT_DOC_GLOBS):
+    for pattern in doc_globs:
+        yield from sorted(Path(repo_root).glob(pattern))
+
+
+def main(argv):
+    repo_root = Path(argv[1]) if len(argv) > 1 else _SELF.parent.parent.parent
+    tracked_basenames, tracked_stems = collect_tracked_names(repo_root)
+    total = 0
+    for doc in iter_docs(repo_root):
+        rel = doc.relative_to(repo_root)
+        for lineno, token in scan_file(doc, tracked_basenames, tracked_stems):
+            print(f"{rel.as_posix()}:{lineno}: unresolved command '{token}' — "
+                  f"not a tracked file's basename/stem or on PATH")
+            total += 1
+    if total:
+        print(f"\n{total} unresolved fleet-* citation(s) found.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/fleet/tests/test_fleet_tests_workflow_paths.sh
+++ b/scripts/fleet/tests/test_fleet_tests_workflow_paths.sh
@@ -2,13 +2,14 @@
 # Tests for .github/workflows/fleet-tests.yml's path filters (#2810).
 #
 # The workflow path-filters on scripts/fleet/** — the LOCATION of its
-# suites, not the SUBJECTS they test. Three suites test files that live
+# suites, not the SUBJECTS they test. Four suites test files that live
 # outside that path (test_format_changed_line_scoping.sh covers
 # cmake/run_clang_format_changed.cmake; test_ir_build_dir_resolution.sh
 # covers engine/tools/lib/concurrency_helpers.sh; test_fleet_transition.sh
-# covers docs/agents/fleet-state-machine.json), so a PR touching only one
-# of those subjects previously got no fleet-tests run at all — the only
-# regression coverage for that subject silently never fired.
+# covers docs/agents/fleet-state-machine.json; test_lint_rules_commands.py
+# covers every doc under .claude/rules/ and docs/agents/), so a PR touching
+# only one of those subjects previously got no fleet-tests run at all — the
+# only regression coverage for that subject silently never fired.
 #
 # This is deliberately a hardcoded ratchet, not a parse of each suite's
 # variable assignments (same shape as header_global_baseline in
@@ -32,11 +33,19 @@ fi
 
 # The out-of-tree subjects each suite actually needs triggered on. Extend
 # this list (and add the matching suite to scripts/fleet/tests/) whenever
-# a new suite tests a file outside scripts/fleet/.
+# a new suite tests a file outside scripts/fleet/. An entry is matched as a
+# literal substring of the block, so a subject whose suite covers a whole
+# directory is listed as the glob the workflow actually carries — the two
+# `**` entries below are test_lint_rules_commands.py's doc globs (#2823),
+# not single files. `docs/agents/**` subsumes fleet-state-machine.json;
+# the narrower entry stays so the ratchet keeps naming that subject even
+# if the glob is ever tightened.
 OUT_OF_TREE_SUBJECTS=(
     'cmake/run_clang_format_changed.cmake'
     'engine/tools/lib/concurrency_helpers.sh'
     'docs/agents/fleet-state-machine.json'
+    '.claude/rules/**'
+    'docs/agents/**'
 )
 
 # paths_block <file> <section> — the raw text of the named top-level `on:`

--- a/scripts/fleet/tests/test_lint_rules_commands.py
+++ b/scripts/fleet/tests/test_lint_rules_commands.py
@@ -1,0 +1,196 @@
+"""Unit + integration tests for lint_rules_commands.py (#2823).
+
+The lint scans fenced code blocks in `.claude/rules/*.md` / `docs/agents/*.md`
+for command-position `fleet-*` tokens (first whitespace-delimited token per
+line, optional `$ ` prompt stripped) and requires each to resolve against a
+git-tracked file's basename/stem or PATH. These cases lock the contract:
+
+  - positive: unresolved fleet-* token in a fenced block       -> flagged
+  - resolves via tracked basename (`fleet-common`)              -> clean
+  - resolves via tracked stem (`fleet-common.sh`)                -> clean
+  - resolves via PATH                                            -> clean
+  - prose outside a fence, not command position                  -> clean
+  - mid-line (not first-token) mention inside a fence             -> clean
+  - `rules-cmd-ok` marker immediately above the fence              -> clean
+  - marker separated from the fence by a blank line               -> still flagged
+  - `$ fleet-x` prompt-prefixed command position                  -> flagged like bare
+  - `docs/agents/*.md` is scanned, not just `.claude/rules/*.md`  -> covered
+  - the committed `.claude/rules/*.md` + `docs/agents/*.md` tree is green
+
+stdlib-only; every fixture is written under a TemporaryDirectory (no network,
+no repo mutation). Tracked-name sets are passed in directly for the unit
+tests below (no live `git ls-files` call) — only the CommittedTree class
+exercises `main()` end-to-end against this repo's real working tree. Host
+PATH is pinned empty for every case (see PathPinnedTest) so resolution is
+decided by the fixtures, never by what happens to be installed.
+"""
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import lint_rules_commands as lint
+
+_FLEET_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _run_main(repo_root):
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        return lint.main(["lint_rules_commands.py", str(repo_root)])
+
+
+class PathPinnedTest(unittest.TestCase):
+    """Base class: `shutil.which` resolves nothing unless a case says otherwise.
+
+    `resolve()` falls back to a live PATH lookup, so any case whose
+    expectation depends on whether a token resolves is otherwise only as
+    stable as the host's `~/bin`. The fixtures here cite real fleet tool
+    names, and `install.sh` symlinks those onto every fleet host — so when
+    `fleet-rules-sweep` landed (#2744) it inverted five cases at once: the
+    four "should be flagged" assertions failed, and the marker-suppression
+    case began passing vacuously (#2823 review). Pinning the lookup empty
+    keeps each case deciding on the tracked-name sets it passes in, and
+    matches what CI sees: a bare checkout with nothing installed.
+
+    Cases that mean to exercise the PATH arm call `set_path_resolver`.
+    """
+
+    def setUp(self):
+        self.set_path_resolver(lambda name: None)
+
+    def set_path_resolver(self, resolver):
+        real = lint.shutil.which
+        lint.shutil.which = resolver
+        self.addCleanup(setattr, lint.shutil, "which", real)
+
+
+class TmpTreeTest(PathPinnedTest):
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, rel, body):
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        return path
+
+
+class ScanFile(TmpTreeTest):
+    def test_unresolved_command_position_token_is_flagged(self):
+        path = self.write(".claude/rules/example.md",
+                          "## Detection\n\n"
+                          "```\n"
+                          "fleet-rules-sweep --glob 'x'\n"
+                          "```\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [(4, "fleet-rules-sweep")])
+
+    def test_resolves_via_tracked_basename(self):
+        path = self.write(".claude/rules/example.md",
+                          "```\nfleet-common\n```\n")
+        self.assertEqual(lint.scan_file(path, {"fleet-common"}, set()), [])
+
+    def test_resolves_via_tracked_stem(self):
+        # fleet-common.sh is tracked; the citation names the bare stem.
+        path = self.write(".claude/rules/example.md",
+                          "```\nfleet-common\n```\n")
+        self.assertEqual(lint.scan_file(path, set(), {"fleet-common"}), [])
+
+    def test_resolves_via_path(self):
+        path = self.write(".claude/rules/example.md",
+                          "```\nfleet-definitely-on-path\n```\n")
+        self.set_path_resolver(
+            lambda name: "/usr/bin/x" if name == "fleet-definitely-on-path" else None)
+        self.assertEqual(lint.scan_file(path, set(), set()), [])
+
+    def test_prose_outside_fence_is_not_scanned(self):
+        path = self.write(".claude/rules/example.md",
+                          "Run `fleet-nonexistent-tool` to check this.\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [])
+
+    def test_mid_line_mention_inside_fence_is_not_command_position(self):
+        # Only the FIRST token of a fenced line counts — an argument or
+        # trailing mention of a fleet-* name is not itself a command.
+        path = self.write(".claude/rules/example.md",
+                          "```\necho 'see fleet-nonexistent-tool for details'\n```\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [])
+
+    def test_marker_immediately_above_fence_suppresses(self):
+        path = self.write(".claude/rules/example.md",
+                          "<!-- lint: rules-cmd-ok fleet-rules-sweep -- not yet landed -->\n"
+                          "```\nfleet-rules-sweep --glob 'x'\n```\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [])
+
+    def test_marker_separated_by_blank_line_does_not_suppress(self):
+        # The marker must be the LAST non-blank line before the fence,
+        # mirroring the trailing/line-above adjacency of the Python opt-out.
+        path = self.write(".claude/rules/example.md",
+                          "<!-- lint: rules-cmd-ok fleet-rules-sweep -- not yet landed -->\n"
+                          "\n"
+                          "```\nfleet-rules-sweep --glob 'x'\n```\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [(4, "fleet-rules-sweep")])
+
+    def test_dollar_prompt_prefixed_command_is_flagged_like_bare(self):
+        path = self.write(".claude/rules/example.md",
+                          "```\n$ fleet-rules-sweep --glob 'x'\n```\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [(2, "fleet-rules-sweep")])
+
+    def test_non_fleet_token_is_never_flagged(self):
+        path = self.write(".claude/rules/example.md",
+                          "```\nrg -n 'pattern' .\n```\n")
+        self.assertEqual(lint.scan_file(path, set(), set()), [])
+
+
+class IterDocsAndMain(TmpTreeTest):
+    def test_docs_agents_tree_is_scanned(self):
+        self.write("docs/agents/FLEET.md",
+                  "```\nfleet-nonexistent-tool\n```\n")
+        self.assertEqual(_run_main(self.root), 1)
+
+    def test_clean_tree_exits_zero(self):
+        self.write(".claude/rules/example.md", "prose only, no fences\n")
+        self.assertEqual(_run_main(self.root), 0)
+
+    def test_repo_wide_tracked_file_resolves_citation(self):
+        # collect_tracked_names walks the whole repo (git ls-files), not just
+        # the doc directories — a tool tracked anywhere resolves.
+        self.write("scripts/fleet/fleet-real-tool", "#!/usr/bin/env bash\n")
+        self.write(".claude/rules/example.md",
+                  "```\nfleet-real-tool\n```\n")
+        import subprocess
+        subprocess.run(["git", "-C", str(self.root), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "add", "-A"], check=True)
+        self.assertEqual(_run_main(self.root), 0)
+
+
+class CommittedTree(PathPinnedTest):
+    def test_committed_rules_and_agent_docs_are_green(self):
+        # Acceptance: every fleet-* citation in the committed rules/protocol
+        # docs resolves against a tracked file. PATH is pinned empty by the
+        # base class, so this is the ratchet CI runs — a citation that only
+        # resolves because the reader happens to have the tool installed is
+        # a finding here, not a pass.
+        self.assertEqual(_run_main(_FLEET_ROOT), 0)
+
+    def test_cpp_math_citation_is_flagged_when_nothing_resolves(self):
+        # Positive control (#2823 AC2): the #2823 offender, cpp-math.md:87,
+        # scanned with no tracked names and no PATH. It must still be
+        # flagged — that proves the green above is resolution finding the
+        # tracked `scripts/fleet/fleet-rules-sweep` (landed in #2744), not
+        # the predicate going blind on this file.
+        real = (_FLEET_ROOT / ".claude" / "rules" / "cpp-math.md").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "rules" / "cpp-math.md"
+            path.parent.mkdir(parents=True)
+            path.write_text(real, encoding="utf-8")
+            findings = lint.scan_file(path, set(), set())
+        self.assertIn("fleet-rules-sweep", [token for _, token in findings])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `scripts/fleet/lint_rules_commands.py` scans `.claude/rules/*.md` + `docs/agents/*.md` for command-position `fleet-*` tokens in fenced code blocks and requires each to resolve against a tracked file's basename/stem or `PATH` — modeled on `lint_state_mtime.py`'s shape, with a markdown-appropriate `<!-- lint: rules-cmd-ok <token> -- <reason> -->` opt-out mirroring the `# lint: state-mtime-ok` convention.
- `.github/workflows/fleet-tests.yml` `paths:` gains `.claude/rules/**` and `docs/agents/**` so a PR editing only a rules/protocol doc still triggers the suite. Both `paths:` blocks and the header comment union with #2810 / #2867's out-of-tree-subject listing, which landed on master while this PR was in review.
- **`scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` gains this suite's two subjects.** #2867 landed a hardcoded ratchet asserting every out-of-tree subject appears in **both** `paths:` blocks, and `scripts/fleet/CLAUDE.md` makes extending `OUT_OF_TREE_SUBJECTS` mandatory *"in the same change"* — *"the list is the ratchet's whole domain: a subject absent from it is a subject nothing guards, however green the suite runs"*. This PR's suite is the fourth out-of-tree case, so its two doc globs join the list. See "Rebase reconciliation (round 2)".
- **This PR no longer touches `.claude/rules/cpp-math.md`.** #2744 merged at `2026-08-04T18:20:54Z` — 2 minutes after this branch's commits — so `cpp-math.md:87` now resolves on its own against the tracked `scripts/fleet/fleet-rules-sweep`. The suppression marker and "not yet executable" note this PR originally added came back out on rebase (see "Rebase reconciliation").

## Test plan
- [x] `python3 scripts/fleet/lint_rules_commands.py` on the committed tree (rebased onto `12b8a49c8`) — exit 0, no findings. This re-run matters: master's delta added three docs inside this linter's own scan domain (`.claude/rules/cpp-lua-enums.md`, `docs/agents/AUTHOR-PIPELINE.md`, `docs/agents/PLANNING-PROTOCOL.md`) and none of them introduces an unresolvable citation.
- [x] `bash scripts/fleet/tests/run_all.sh` — 125 suites, **124 passed, 1 failed, 0 skipped**. The single failure is `test_cross_repo_shared_file_parity.sh` and is **pre-existing on master, not from this PR** — control below.
- [x] `bash scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` — **8 passed, 0 failed** (was 6 assertions before this PR; the ratchet's control-isolation loop now also exercises the two new subjects).
- [x] `bash scripts/fleet/tests/run_all.sh --only lint_rules_commands` / `python3 …/test_lint_rules_commands.py` — 15/15 cases
- [x] `ruff check` on both new files — clean
- [x] Ran `cpp-math.md`'s Detection block for real: **exit 1 (= real clean pass), 785 files swept / 3937 walked, 0 matches** — the block is executable, which is what makes the removed "not yet executable" note false

### The one failing suite is master's, not this PR's
`test_cross_repo_shared_file_parity.sh` reports `.github/workflows/auto-rereview.yml: DRIFTED between engine and downstream origin/master`.

- This PR's whole diff is 4 files — `.github/workflows/fleet-tests.yml`, `scripts/fleet/lint_rules_commands.py`, `scripts/fleet/tests/test_lint_rules_commands.py`, `scripts/fleet/tests/test_fleet_tests_workflow_paths.sh`. It never touches `auto-rereview.yml`.
- **Control:** the same suite run from the clean main clone at `12b8a49c8` (untouched master, no part of this branch) fails identically — `1 passed, 1 failed`, same message.
- It does not affect this PR's CI: the suite `exit 3` (SKIP) when the downstream repo is absent, which is the case on the Actions runner. It is red only on a dev host with both repos checked out.

Already tracked outside this PR — it is master's own regression (the executor landed red) and out of this PR's scope, so it is deliberately not folded in here.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| AC1 — resolves command-position `fleet-*` citations, fence-aware, basename+stem+PATH | `python3 scripts/fleet/lint_rules_commands.py .` | exit 0 on the committed tree; the issue's single measured hit (`cpp-math.md:87`) is reproduced under a pinned-empty PATH by the AC2 control below, zero false positives across the 34-file audit surface |
| AC2 — positive control: non-zero naming `cpp-math.md:87`, then zero once resolved | `test_cpp_math_citation_is_flagged_when_nothing_resolves` — scans the **real** `cpp-math.md` with no tracked names and no PATH | citation still flagged. This is what proves the committed-tree green is *resolution finding the tracked script*, not the predicate going blind on that file |
| AC3 — `fleet-tests.yml` `paths:` triggers on a rules-doc-only PR | the issue's own `ce2d2c57a` path-match probe | before this PR: NO MATCH (per the issue body); after: `.claude/rules/cpp-math.md` — matches |
| AC4 — live instance discharged | `gh pr view 2744 --json state,mergedAt` | `MERGED`, `2026-08-04T18:20:54Z`. The live instance is discharged **by resolution**, not by a suppression note: `git ls-tree origin/master -- scripts/fleet/fleet-rules-sweep` returns the blob, so the citation resolves with no marker. The opt-out mechanism stays in the linter (unit-covered, 2 cases) for the next doc-ahead-of-executor case |

## Rebase reconciliation (round 2 — semantic conflict vs #2867)
The merger flagged `fleet:semantic-conflict` against master's `7f047d5e8` (#2810 / #2867). The textual conflict was confined to `fleet-tests.yml`'s header comment — the two `paths:` blocks auto-merged into a correct union — but the *semantic* half was in a file that never conflicted:

**#2867 turned the out-of-tree-subject convention into an executed ratchet.** Its `OUT_OF_TREE_SUBJECTS` list is, in `scripts/fleet/CLAUDE.md`'s words, "the ratchet's whole domain". This PR adds the fourth out-of-tree suite, so resolving only the comment would have landed two `paths:` entries that nothing guards — the exact silent-drift shape #2727 / #2810 exist to prevent. Both sides' intent is preserved by extending the list.

- Header comment: unioned — master's three-suite table plus this PR's suite as a fourth row, master's `paths:`-blocks-are-hand-duplicated note kept verbatim.
- `OUT_OF_TREE_SUBJECTS` gains `.claude/rules/**` and `docs/agents/**`. These are globs, not single files, so the list comment now says so; `docs/agents/**` subsumes `docs/agents/fleet-state-machine.json` and the narrower entry deliberately **stays**, because the ratchet asserts that subject by name.
- Which suite makes the globs load-bearing: `CommittedTree.test_committed_rules_and_agent_docs_are_green` runs the linter's `main()` against the real working tree, so a doc-only PR that does not trigger `fleet-tests.yml` gets no tree-wide scan at all.

**Both new ratchet entries were controlled, not assumed** — deleting either subject from both `paths:` blocks turns the ratchet red (`5 passed, 3 failed`: T1, its own isolation assert, and T3), while the *other* new subject's isolation assert stays green. So the two entries discriminate independently and neither is vacuous. Restored file: 8/8.

## Rebase reconciliation (review round 1)
The review caught two real issues that only existed because #2744 merged mid-review. Both are fixed:

1. **Dropped the stale `cpp-math.md` note + marker.** Left standing they would have shipped a doc claim ("not yet executable… #2744 is open") contradicting the prose #2744 itself added a few lines above in the same file, plus a permanent suppression for a citation that no longer needs one. Verified three ways: #2744 `MERGED`; the script is tracked on `origin/master`; the Detection block runs clean (exit 1, 785 files).
2. **Pinned `shutil.which` empty for every test case** (`PathPinnedTest`). `resolve()` falls back to a live PATH lookup, and the fixtures cite real fleet tool names — once `install.sh` symlinked `fleet-rules-sweep`, **five** cases inverted, not four:
   - the 4 the review named failed loudly, **and**
   - `test_marker_immediately_above_fence_suppresses` began passing **vacuously**.

   A/B control on that fifth case, with marker suppression deliberately broken in `find_candidates`:

   | suite | result |
   |---|---|
   | fixed (PATH pinned) | **FAILED** — the marker case catches the break |
   | original (live PATH), that case run alone | **OK** — passes with suppression fully broken |

   Pinning the lookup makes every case decide on the tracked-name sets it passes in — which is also what CI sees on a bare `ubuntu-latest` checkout with nothing installed. The one case that means to exercise the PATH arm (`test_resolves_via_path`) opts in via `set_path_resolver`.

3. **Workflow comment hand-unioned**, per the review's nit. Superseded by round 2 above, which re-unioned it against master's newer three-suite listing.

Positive-control note: `fleet-positive-control` doesn't apply cleanly here — it stages a pre-fix *ref* and re-runs the working-tree test against it, which assumes the module under test already existed pre-fix. This PR adds a net-new module, so staging `origin/master` alone makes the import fail before any assertion runs (`ModuleNotFoundError: No module named 'lint_rules_commands'`). The AC2 row and the A/B control above are the control for this net-new-module case.

Closes #2823

🤖 Generated with [Claude Code](https://claude.com/claude-code)
