### PR TITLE
fleet: plan-lint catches an imperative-mood deferred-approach fork

### DIFF
--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -134,6 +134,14 @@ For each `fleet:needs-plan` issue:
      reframe it as an explicit **investigation spike** (the literal
      phrase in the title/body; see
      [`architect-protocol.md § Carve-offs`](architect-protocol.md)).
+     The same rule covers a fork phrased as an **instruction to the
+     implementer** rather than a self-describing punt — "check whether
+     the narrowed predicate should apply there as well or only to issue
+     claims; decide explicitly rather than by omission" reads as rigor,
+     not deferral, but hands the same undecided A-or-B choice downstream
+     (#2820, caught by the plan-review pass, not the lint, until #2824
+     widened `fleet-plan-lint`'s deferred-approach matcher to this
+     imperative/interrogative mood).
    - **Sibling + in-flight reconciliation.** Check the parent ticket's
      other carve-offs and every open PR touching the same surface — a
      plan that duplicates or contradicts an active PR or a sibling's

--- a/scripts/fleet/fleet-plan-lint
+++ b/scripts/fleet/fleet-plan-lint
@@ -19,11 +19,15 @@
 # Checks (HARD => bounce):
 #   - no `## Plan` comment exists on the issue
 #   - a deferred-approach phrase ("decide during implementation", "option A or B",
-#     "TBD", "likely suspects", "decide explicitly rather than by omission", an
-#     imperative-mood fork ("check/decide/determine whether X ... or Y" in one
-#     sentence), or an either/or fork named in an Approach/Gotchas section, ...)
+#     "TBD", "likely suspects", "decide explicitly rather than by omission", ...)
 #     — the "one approach, picked" violation (relaxed to a warning when the
 #     plan is an explicit investigation spike)
+#   - a fork named in an Approach/Gotchas section — either an imperative-mood
+#     one ("check/decide/determine whether X ... or Y" in one sentence) or an
+#     either/or one carrying a hedging modal. Both are scoped to those sections
+#     so prose that names alternatives without deferring a design choice
+#     (acceptance criteria enumerating outcomes, a settled decision tree) does
+#     not bounce a sound plan.
 #   - >= 2 of the core sections (Scope / Approach / Acceptance) absent
 # Checks (WARN => Opus weighs, no auto-bounce):
 #   - exactly one core section absent (format variance, not necessarily broken)
@@ -93,9 +97,10 @@ title = data.get("title", "")
 
 def sections(body):
     """Yield (heading text, body text) for each markdown heading in body,
-    depth 1-4. Used to scope the either/or fork check to Approach/Gotchas
-    prose rather than firing on an unrelated section (e.g. Acceptance
-    criteria enumerating pass/fail outcomes)."""
+    depth 1-4. Used to scope BOTH fork checks (either/or and imperative-mood)
+    to Approach/Gotchas prose rather than firing on an unrelated section (e.g.
+    Acceptance criteria enumerating pass/fail outcomes, or an architect-decision
+    section spelling out a settled decision tree)."""
     heads = list(re.finditer(r"(?im)^\s*#{1,4}\s+(.*)$", body))
     for i, m in enumerate(heads):
         start = m.end()
@@ -171,43 +176,60 @@ if re.search(r"(?i)\btbd\b", plan):
 if "likely suspects" in low:
     hits.append("likely suspects")
 
+# Both fork checks below are scoped to Approach/Gotchas prose and require an
+# "or"-named alternative in the SAME sentence as their trigger phrase.
+#
 # Imperative/interrogative-mood fork (#2824): a fork phrased as an
 # instruction to the implementer ("check whether the narrowed predicate
 # should apply there as well or only to issue claims") matches none of the
 # self-describing DEFER phrases above and reads as rigor, not deferral —
-# but it hands the same undecided A-or-B choice downstream. Require "or" in
-# the SAME sentence as the whether-verb so a plain confirmation ("check
-# whether the build is green") — no named alternative — does not fire.
+# but it hands the same undecided A-or-B choice downstream. Two narrowings
+# keep it off prose that names alternatives without deferring anything: the
+# "or" requirement clears a plain confirmation ("check whether the build is
+# green"), and the section scoping clears both a QA-style acceptance
+# criterion ("Check whether the fix resolves the crash or introduces a new
+# regression") and a settled decision tree stated elsewhere — corpus-measured
+# on `.fleet/plans/issue-1596.md`'s "Architect decision" section, whose "or"
+# is a parenthetical sub-clause of the thing being checked and whose branches
+# are both already decided ("If yes, bake that ... If not, add ONE resolve").
 FORK_WHETHER_RE = re.compile(r"\b(?:check|decide|determine)\s+whether\b", re.IGNORECASE)
-for sentence in sentences(plan):
-    if FORK_WHETHER_RE.search(sentence) and re.search(r"\bor\b", sentence, re.IGNORECASE):
-        hits.append('imperative-mood fork ("...whether X ... or Y" in one sentence)')
-        break
 
-# either/or fork named in Approach/Gotchas prose — scoped to those sections
-# so an either/or naming test *outcomes* (e.g. in Acceptance criteria) does
-# not false-positive. Also requires a hedging modal ("should"/"could"/...) in
-# the same sentence: an either/or *describing already-settled branches* (a
-# decision tree with a defined follow-up per branch, or a rejected
-# alternative's downside in a "why not X" aside) is declarative, not a live
-# fork — corpus-measured false positives on `.fleet/plans/issue-2197.md`
-# ("this is either already-planned... or the re-plan state") and
-# `issue-2540.md` ("Either every parallel vector needs a phantom slot 0
-# ..., or every index site needs a -1 shift") had no modal; the genuine
-# #2820 defect reads "...should apply there as well or only to...".
+# either/or fork named in Approach/Gotchas prose. Also requires a hedging
+# modal ("should"/"could"/...) in the same sentence: an either/or *describing
+# already-settled branches* (a decision tree with a defined follow-up per
+# branch, or a rejected alternative's downside in a "why not X" aside) is
+# declarative, not a live fork — corpus-measured false positives on
+# `.fleet/plans/issue-2197.md` ("this is either already-planned... or the
+# re-plan state") and `issue-2540.md` ("Either every parallel vector needs a
+# phantom slot 0 ..., or every index site needs a -1 shift") had no modal;
+# the genuine #2820 defect reads "...should apply there as well or only to...".
 EITHER_OR_RE = re.compile(r"\beither\b", re.IGNORECASE)
 MODAL_RE = re.compile(r"\b(?:should|could|would|might|may|ought)\b", re.IGNORECASE)
-for heading, body in sections(plan):
+OR_RE = re.compile(r"\bor\b", re.IGNORECASE)
+
+
+def is_design_section(heading):
+    """True for the Approach/Design/Implementation/Gotchas prose where a live
+    design fork belongs — the only sections the fork checks read."""
     hl = heading.lower()
-    if any(k in hl for k in ("approach", "design", "implementation")) or "gotcha" in hl:
-        for sentence in sentences(body):
-            if (EITHER_OR_RE.search(sentence) and re.search(r"\bor\b", sentence, re.IGNORECASE)
-                    and MODAL_RE.search(sentence)):
-                hits.append("either/or fork named in Approach/Gotchas section")
-                break
-        else:
+    return any(k in hl for k in ("approach", "design", "implementation")) or "gotcha" in hl
+
+
+fork_whether_hit = either_or_hit = False
+for heading, body in sections(plan):
+    if not is_design_section(heading):
+        continue
+    for sentence in sentences(body):
+        if not OR_RE.search(sentence):
             continue
-        break
+        if FORK_WHETHER_RE.search(sentence):
+            fork_whether_hit = True
+        if EITHER_OR_RE.search(sentence) and MODAL_RE.search(sentence):
+            either_or_hit = True
+if fork_whether_hit:
+    hits.append('imperative-mood fork ("...whether X ... or Y" in one sentence)')
+if either_or_hit:
+    hits.append("either/or fork named in Approach/Gotchas section")
 
 if hits:
     msg = "deferred-approach phrase(s): " + ", ".join(sorted(set(hits)))

--- a/scripts/fleet/fleet-plan-lint
+++ b/scripts/fleet/fleet-plan-lint
@@ -19,8 +19,11 @@
 # Checks (HARD => bounce):
 #   - no `## Plan` comment exists on the issue
 #   - a deferred-approach phrase ("decide during implementation", "option A or B",
-#     "TBD", "likely suspects", ...) — the "one approach, picked" violation
-#     (relaxed to a warning when the plan is an explicit investigation spike)
+#     "TBD", "likely suspects", "decide explicitly rather than by omission", an
+#     imperative-mood fork ("check/decide/determine whether X ... or Y" in one
+#     sentence), or an either/or fork named in an Approach/Gotchas section, ...)
+#     — the "one approach, picked" violation (relaxed to a warning when the
+#     plan is an explicit investigation spike)
 #   - >= 2 of the core sections (Scope / Approach / Acceptance) absent
 # Checks (WARN => Opus weighs, no auto-bounce):
 #   - exactly one core section absent (format variance, not necessarily broken)
@@ -88,6 +91,25 @@ data = json.loads(out)
 title = data.get("title", "")
 
 
+def sections(body):
+    """Yield (heading text, body text) for each markdown heading in body,
+    depth 1-4. Used to scope the either/or fork check to Approach/Gotchas
+    prose rather than firing on an unrelated section (e.g. Acceptance
+    criteria enumerating pass/fail outcomes)."""
+    heads = list(re.finditer(r"(?im)^\s*#{1,4}\s+(.*)$", body))
+    for i, m in enumerate(heads):
+        start = m.end()
+        end = heads[i + 1].start() if i + 1 < len(heads) else len(body)
+        yield m.group(1).strip(), body[start:end]
+
+
+def sentences(text):
+    # Split on ". "/"! "/"? " (punctuation + whitespace), NOT bare "." — a
+    # bare-period split would break mid-sentence on any inline filename
+    # ("foo.cpp"), which plan prose is full of.
+    return re.split(r"(?<=[.!?])\s+", text)
+
+
 def is_plan_heading(body):
     # The plan comment's first line is "## Plan" or "## Plan: <title>" —
     # anchored so a "## Plan review — ..." verdict comment (same leading
@@ -141,12 +163,52 @@ DEFER = [
     "decide during investigation", "confirm during investigation",
     "confirm during design", "decide later", "decide in the pr",
     "figure out during", "option a or b", "to be decided",
+    "decide explicitly rather than by omission",
 ]
 hits = [p for p in DEFER if p in low]
 if re.search(r"(?i)\btbd\b", plan):
     hits.append("TBD")
 if "likely suspects" in low:
     hits.append("likely suspects")
+
+# Imperative/interrogative-mood fork (#2824): a fork phrased as an
+# instruction to the implementer ("check whether the narrowed predicate
+# should apply there as well or only to issue claims") matches none of the
+# self-describing DEFER phrases above and reads as rigor, not deferral —
+# but it hands the same undecided A-or-B choice downstream. Require "or" in
+# the SAME sentence as the whether-verb so a plain confirmation ("check
+# whether the build is green") — no named alternative — does not fire.
+FORK_WHETHER_RE = re.compile(r"\b(?:check|decide|determine)\s+whether\b", re.IGNORECASE)
+for sentence in sentences(plan):
+    if FORK_WHETHER_RE.search(sentence) and re.search(r"\bor\b", sentence, re.IGNORECASE):
+        hits.append('imperative-mood fork ("...whether X ... or Y" in one sentence)')
+        break
+
+# either/or fork named in Approach/Gotchas prose — scoped to those sections
+# so an either/or naming test *outcomes* (e.g. in Acceptance criteria) does
+# not false-positive. Also requires a hedging modal ("should"/"could"/...) in
+# the same sentence: an either/or *describing already-settled branches* (a
+# decision tree with a defined follow-up per branch, or a rejected
+# alternative's downside in a "why not X" aside) is declarative, not a live
+# fork — corpus-measured false positives on `.fleet/plans/issue-2197.md`
+# ("this is either already-planned... or the re-plan state") and
+# `issue-2540.md` ("Either every parallel vector needs a phantom slot 0
+# ..., or every index site needs a -1 shift") had no modal; the genuine
+# #2820 defect reads "...should apply there as well or only to...".
+EITHER_OR_RE = re.compile(r"\beither\b", re.IGNORECASE)
+MODAL_RE = re.compile(r"\b(?:should|could|would|might|may|ought)\b", re.IGNORECASE)
+for heading, body in sections(plan):
+    hl = heading.lower()
+    if any(k in hl for k in ("approach", "design", "implementation")) or "gotcha" in hl:
+        for sentence in sentences(body):
+            if (EITHER_OR_RE.search(sentence) and re.search(r"\bor\b", sentence, re.IGNORECASE)
+                    and MODAL_RE.search(sentence)):
+                hits.append("either/or fork named in Approach/Gotchas section")
+                break
+        else:
+            continue
+        break
+
 if hits:
     msg = "deferred-approach phrase(s): " + ", ".join(sorted(set(hits)))
     if is_spike:

--- a/scripts/fleet/tests/test_fleet_plan_lint.sh
+++ b/scripts/fleet/tests/test_fleet_plan_lint.sh
@@ -133,6 +133,36 @@ EITHER_OR_DECLARATIVE = GOOD.replace(
 EITHER_OR_ACCEPTANCE = GOOD.replace(
     "### Acceptance criteria\nbuilds + tests",
     "### Acceptance criteria\ntest could pass either the fast path or the slow path assertion")
+# The imperative-mood fork is scoped to Approach/Gotchas for the same reason,
+# pinned by the two false-positive shapes an unscoped scan hit:
+#   (1) a QA-style acceptance criterion naming a pass/fail alternative, the
+#       direct mirror of EITHER_OR_ACCEPTANCE above;
+FORK_WHETHER_ACCEPTANCE = GOOD.replace(
+    "### Acceptance criteria\nbuilds + tests",
+    "### Acceptance criteria\n"
+    "1. Check whether the fix resolves the crash or introduces a new regression.\n"
+    "2. Build is green.")
+#   (2) a settled decision tree stated outside Approach/Gotchas, pinned verbatim
+#       from `.fleet/plans/issue-1596.md`'s "Architect decision" section -- the
+#       "or" is a parenthetical sub-clause of the thing being checked and BOTH
+#       branches are already decided, so it is declarative, not a live fork.
+#       This is the corpus regression the pre-scoping matcher drifted PASS->FAIL
+#       on. It is also what makes the scoping an ALLOWLIST (fire only in
+#       Approach/Gotchas) rather than an Acceptance-only exclusion, which would
+#       leave this shape firing.
+FORK_WHETHER_OTHER_SECTION = GOOD.replace(
+    "### Gotchas\nnone",
+    "### Gotchas\nnone\n\n"
+    "### Architect decision\n"
+    "FIRST check whether a main-layout texture containing detached caster depth\n"
+    "already exists at BAKE time (or can be cheaply made available there). If yes,\n"
+    "bake that -- zero new resolve passes. If not, add ONE dedicated resolve.")
+# In-scope positive for the OTHER arm of the scope predicate: the #2820 fixture
+# above sits in Gotchas, so without this one the "approach" keyword arm ships
+# unexercised and a future narrowing of the keyword set goes uncaught.
+FORK_WHETHER_APPROACH = GOOD.replace(
+    "one approach: edit foo.cpp then bar.cpp",
+    "check whether the predicate should apply to foo.cpp as well or only to bar.cpp")
 # #2443 plan-exclusion guard: the mandatory "## Plan: <title>" heading is the
 # ONLY heading here that could match Approach -- Scope + Acceptance concepts are
 # present, no real Approach-shaped heading. "plan" is deliberately NOT an
@@ -183,6 +213,9 @@ F = {
   "117": {"title": "either/or modal task", "comments": [{"body": EITHER_OR_MODAL}]},
   "118": {"title": "either/or declarative task", "comments": [{"body": EITHER_OR_DECLARATIVE}]},
   "119": {"title": "either/or in acceptance task", "comments": [{"body": EITHER_OR_ACCEPTANCE}]},
+  "120": {"title": "fork-whether in acceptance task", "comments": [{"body": FORK_WHETHER_ACCEPTANCE}]},
+  "121": {"title": "fork-whether outside approach/gotchas task", "comments": [{"body": FORK_WHETHER_OTHER_SECTION}]},
+  "122": {"title": "fork-whether in approach task", "comments": [{"body": FORK_WHETHER_APPROACH}]},
 }
 print(json.dumps(F.get(num, {"title": "missing", "comments": []})))
 PYEOF
@@ -267,6 +300,23 @@ case "$either_decl_out" in *"either/or fork"*) bad "either/or declarative false-
 "$LINT" 119 >/dev/null 2>&1; assert_exit $? 0 "either/or + modal in Acceptance -> exit 0 (scoped to Approach/Gotchas only)"
 either_acc_out=$("$LINT" 119 2>&1 || true)
 case "$either_acc_out" in *"either/or fork"*) bad "either/or in Acceptance false-fired: [$either_acc_out]";; *) ok "either/or in Acceptance correctly out of scope";; esac
+# The imperative-mood fork carries the same Approach/Gotchas scoping. Both
+# negatives below hard-failed before the scoping (measured), so each is a live
+# regression pin, not a restatement of the check's shape.
+"$LINT" 120 >/dev/null 2>&1; assert_exit $? 0 "imperative-mood fork in Acceptance -> exit 0 (scoped out; mirror of #119)"
+fork_acc_out=$("$LINT" 120 2>&1 || true)
+case "$fork_acc_out" in *"imperative-mood fork"*) bad "imperative-mood fork in Acceptance false-fired: [$fork_acc_out]";; *) ok "imperative-mood fork in Acceptance correctly out of scope";; esac
+# Corpus regression: the settled decision tree in issue-1596.md's "Architect
+# decision" section is neither Approach/Gotchas nor Acceptance, so only an
+# allowlist scoping clears it.
+"$LINT" 121 >/dev/null 2>&1; assert_exit $? 0 "imperative-mood fork outside Approach/Gotchas (issue-1596 corpus shape) -> exit 0"
+fork_other_out=$("$LINT" 121 2>&1 || true)
+case "$fork_other_out" in *"imperative-mood fork"*) bad "imperative-mood fork outside Approach/Gotchas false-fired (corpus regression): [$fork_other_out]";; *) ok "imperative-mood fork outside Approach/Gotchas correctly out of scope";; esac
+# ...but the scoping must not go so narrow it stops firing where forks belong:
+# in-scope via the "approach" keyword arm (the #114 fixture covers "gotcha").
+"$LINT" 122 >/dev/null 2>&1; assert_exit $? 1 "imperative-mood fork in Approach -> hard fail (scope predicate's approach arm)"
+fork_appr_out=$("$LINT" 122 2>&1 || true)
+case "$fork_appr_out" in *"imperative-mood fork"*) ok "imperative-mood fork still fires in Approach after scoping";; *) bad "imperative-mood fork stopped firing in Approach — scoping too narrow: [$fork_appr_out]";; esac
 set -e
 
 echo "================================"

--- a/scripts/fleet/tests/test_fleet_plan_lint.sh
+++ b/scripts/fleet/tests/test_fleet_plan_lint.sh
@@ -95,6 +95,44 @@ verified current state via grep; one approach: edit foo.cpp
 
 ### Notes
 none'''
+# #2824: imperative-mood fork — a fork phrased as an instruction to the
+# implementer, matching none of the self-describing DEFER phrases. Pinned
+# verbatim from issue #2820's Gotchas section (the live instance that slipped
+# past the pre-#2824 matcher and had to be caught by the Opus plan-review pass
+# instead) — do not re-fetch #2820 live, it has since been replanned.
+FORK_WHETHER = GOOD.replace(
+    "### Gotchas\nnone",
+    "### Gotchas\n"
+    "- **`fleet:needs-gl-host` is valid on PRs too** (`fleet-claim` amending-claim\n"
+    "  path, #2524). Check whether the narrowed predicate should apply there as well\n"
+    "  or only to issue claims; decide explicitly rather than by omission.")
+# Negative fixture (acceptance criteria #3): a plain confirmation ("check
+# whether the build is green") names no alternative ("or Y") and must not fire.
+FORK_WHETHER_NEGATIVE = GOOD.replace(
+    "one approach: edit foo.cpp then bar.cpp",
+    "check whether the build is green; one approach: edit foo.cpp then bar.cpp")
+# investigation-spike downgrade must still apply to the new fork form (acceptance
+# criteria #4).
+FORK_WHETHER_SPIKE = FORK_WHETHER.replace(
+    "## Plan: good", "## Plan: investigation spike - fork")
+# either/or fork named in Approach, with a hedging modal ("could") signaling an
+# undecided choice -- must hard-fail.
+EITHER_OR_MODAL = GOOD.replace(
+    "one approach: edit foo.cpp then bar.cpp",
+    "the fix could either rewrite foo.cpp or patch bar.cpp instead")
+# either/or describing already-settled, declarative branches (no hedging modal)
+# -- corpus-measured false-positive shape (.fleet/plans/issue-2197.md,
+# issue-2540.md both hit a naive either/or check with no modal present) --
+# must NOT fire.
+EITHER_OR_DECLARATIVE = GOOD.replace(
+    "one approach: edit foo.cpp then bar.cpp",
+    "one approach: edit foo.cpp then bar.cpp. Either the reader retries or the "
+    "writer backs off, per the existing protocol")
+# either/or + modal outside Approach/Gotchas (in Acceptance) -- scoped out,
+# must NOT fire.
+EITHER_OR_ACCEPTANCE = GOOD.replace(
+    "### Acceptance criteria\nbuilds + tests",
+    "### Acceptance criteria\ntest could pass either the fast path or the slow path assertion")
 # #2443 plan-exclusion guard: the mandatory "## Plan: <title>" heading is the
 # ONLY heading here that could match Approach -- Scope + Acceptance concepts are
 # present, no real Approach-shaped heading. "plan" is deliberately NOT an
@@ -139,6 +177,12 @@ F = {
   "112": {"title": "re-planned after bounce task", "comments": [
       {"body": SKELETAL_REPLAN_SEED}, {"body": REVIEW_BOUNCE}, {"body": GOOD}]},
   "113": {"title": "review only, no plan task", "comments": [{"body": REVIEW_ONLY}]},
+  "114": {"title": "imperative-mood fork task", "comments": [{"body": FORK_WHETHER}]},
+  "115": {"title": "whether-no-or negative control task", "comments": [{"body": FORK_WHETHER_NEGATIVE}]},
+  "116": {"title": "investigation spike for fork", "comments": [{"body": FORK_WHETHER_SPIKE}]},
+  "117": {"title": "either/or modal task", "comments": [{"body": EITHER_OR_MODAL}]},
+  "118": {"title": "either/or declarative task", "comments": [{"body": EITHER_OR_DECLARATIVE}]},
+  "119": {"title": "either/or in acceptance task", "comments": [{"body": EITHER_OR_ACCEPTANCE}]},
 }
 print(json.dumps(F.get(num, {"title": "missing", "comments": []})))
 PYEOF
@@ -192,6 +236,37 @@ case "$review_out" in *"missing core sections"*) bad "reviewed plan hard-failed 
 "$LINT" 113 >/dev/null 2>&1; assert_exit $? 1 "review present, no plan -> hard fail"
 review_only_out=$("$LINT" 113 2>&1 || true)
 case "$review_only_out" in *"no \`## Plan\` comment found"*) ok "review-only reports 'no ## Plan comment found', does not lint the review";; *) bad "review-only did not report the expected message: [$review_only_out]";; esac
+
+# #2824 — imperative-mood fork ("check whether X ... or Y" in one sentence),
+# pinned verbatim from the live #2820 instance that slipped past the
+# pre-#2824 matcher (acceptance criteria #1).
+"$LINT" 114 >/dev/null 2>&1; assert_exit $? 1 "imperative-mood fork (#2820-shaped) -> hard fail"
+fork_out=$("$LINT" 114 2>&1 || true)
+case "$fork_out" in *"imperative-mood fork"*) ok "imperative-mood fork names itself in the failure";; *) bad "imperative-mood fork message missing: [$fork_out]";; esac
+# Negative fixture (acceptance criteria #3): a plain confirmation with no
+# named alternative ("or Y") must not fire.
+"$LINT" 115 >/dev/null 2>&1; assert_exit $? 0 "'check whether the build is green' (no or-alternative) -> exit 0"
+neg_out=$("$LINT" 115 2>&1 || true)
+case "$neg_out" in *"imperative-mood fork"*) bad "whether-no-or negative control false-fired: [$neg_out]";; *) ok "whether-no-or negative control does not fire";; esac
+# investigation-spike downgrade still applies to the new fork form (acceptance
+# criteria #4).
+"$LINT" 116 >/dev/null 2>&1; assert_exit $? 0 "investigation spike: imperative-mood fork downgraded to warn -> exit 0"
+spike_fork_out=$("$LINT" 116 2>&1 || true)
+case "$spike_fork_out" in warn*"imperative-mood fork"*"investigation spike"*) ok "spike fork downgraded to warn, not silently dropped";; *) bad "spike fork warn missing or malformed: [$spike_fork_out]";; esac
+# either/or fork named in Approach with a hedging modal -> hard fail.
+"$LINT" 117 >/dev/null 2>&1; assert_exit $? 1 "either/or fork w/ modal in Approach -> hard fail"
+either_out=$("$LINT" 117 2>&1 || true)
+case "$either_out" in *"either/or fork"*) ok "either/or fork names itself in the failure";; *) bad "either/or fork message missing: [$either_out]";; esac
+# either/or describing already-settled, declarative branches (no hedging
+# modal) -- corpus-measured false-positive shape (issue-2197.md, issue-2540.md
+# both hit a naive either/or check with no modal present) -- must not fire.
+"$LINT" 118 >/dev/null 2>&1; assert_exit $? 0 "either/or declarative (no modal) -> exit 0 (corpus false-positive shape)"
+either_decl_out=$("$LINT" 118 2>&1 || true)
+case "$either_decl_out" in *"either/or fork"*) bad "either/or declarative false-fired: [$either_decl_out]";; *) ok "either/or declarative does not fire";; esac
+# either/or + modal outside Approach/Gotchas (in Acceptance) -- scoped out.
+"$LINT" 119 >/dev/null 2>&1; assert_exit $? 0 "either/or + modal in Acceptance -> exit 0 (scoped to Approach/Gotchas only)"
+either_acc_out=$("$LINT" 119 2>&1 || true)
+case "$either_acc_out" in *"either/or fork"*) bad "either/or in Acceptance false-fired: [$either_acc_out]";; *) ok "either/or in Acceptance correctly out of scope";; esac
 set -e
 
 echo "================================"


### PR DESCRIPTION
## Summary
- Widen `fleet-plan-lint`'s deferred-approach matcher to catch a fork phrased as an instruction to the implementer ("check whether X ... or Y") and an either/or fork named in Approach/Gotchas prose with a hedging modal — the shape that slipped past the pre-existing self-describing-punt list on issue #2820.
- Both new checks require an "or"-named alternative in the same sentence as the trigger phrase, so a plain confirmation ("check whether the build is green") doesn't fire; the either/or check additionally requires a modal verb, ruled out by a corpus-measured false-positive shape (declarative either/or describing already-settled branches).
- **Both** fork checks are scoped to Approach/Design/Implementation/Gotchas sections via one `is_design_section()` predicate over a single `sections()` walk, so prose that names alternatives without deferring a design choice does not bounce a sound plan.
- Documented the new fork form in the lint's docstring and in `docs/agents/PLANNING-PROTOCOL.md`'s "One approach, picked" section.

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_plan_lint.sh` — 40/40 pass (18 new assertions).
- [x] `fleet-positive-control scripts/fleet/tests/test_fleet_plan_lint.sh origin/master` — 29 passed / 5 failed against the pre-change matcher; the 5 failures are exactly the new fix-dependent assertions (imperative-mood fork, its message, spike downgrade, either/or fork, its message), proving the new tests are non-vacuous. (The tool's automated pass/fail verdict didn't parse this suite's pre-existing custom tally line — the suite defines its own PASS/FAIL counters instead of sourcing `tests/lib_assert.sh`; a gap predating this PR, out of scope here.)
- [x] Positive control for the scoping fix, against this PR's own pre-scoping head `38f4c76c`: **36 passed / 4 failed**, and the 4 failures are exactly the two new negative fixtures (#120, #121), each contributing an exit-code and a message assertion. The two new in-scope positives pass on both revisions, as expected.
- [x] Corpus regression — see the corrected numbers below.
- [x] `bash scripts/fleet/tests/run_all.sh` — 119 suites, 119 passed, 0 failed, 0 skipped.

## Corpus regression — corrected

An earlier revision of this PR claimed `total: 166  drifted: 0`. **That measurement was vacuous over 76% of the corpus and the claim was wrong.** 126 of the 166 `.fleet/plans/` files open with a `# Plan:` **h1**, but `is_plan_heading()` requires `## Plan` (**h2**) on the first line — so a harness that serves raw file content as the comment body gets `no `## Plan` comment found` for each of them, an identical hard-fail on both matcher revisions. Zero *drift*, but only 41 files were actually linted.

Re-measured with the leading heading normalized to h2 so every file is genuinely linted (depth is otherwise irrelevant — `sections()` and the CORE matcher both accept depth 1-4):

| Comparison | Files linted | Drift |
|---|---|---|
| `origin/master` → `38f4c76c` (unscoped, as reviewed) | 166 | **1** — `.fleet/plans/issue-1596.md` PASS → FAIL |
| `origin/master` → this head (scoped) | 166 | **0** |

`issue-1596.md`'s drift is a false positive, and it is the second of the two shapes the scoping fixes: its `## Architect decision` section reads "FIRST check whether a main-layout texture ... already exists at BAKE time (or can be cheaply made available there). If yes, bake that ... If not, add ONE dedicated resolve." The `or` is a parenthetical sub-clause of the thing being checked, and both branches are already decided — declarative, not a live fork. It sits in neither Approach/Gotchas nor Acceptance, which is what makes the fix an **allowlist** (fire only in design sections) rather than the Acceptance-only exclusion also offered in review: an Acceptance-only exclusion would leave this shape firing.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. Imperative-mood fork hard-fails, demonstrated by an executed test, with positive control passing on pre-change matcher | `test_fleet_plan_lint.sh` #114 (fixture pinned verbatim from #2820's Gotchas text) + `fleet-positive-control` | `FAIL #114: ... imperative-mood fork ...` on new matcher; `PASS #200` (same fixture) on `origin/master`'s matcher |
| 2. `.fleet/plans/` corpus produces same PASS/FAIL before/after, listing any genuine new-defect exceptions | corpus regression script (166 files, three matcher revisions, headings normalized so each file is linted) | `drifted: 0` vs `origin/master` at this head. The one drift the unscoped revision carried (`issue-1596.md`) is a false positive, now pinned as fixture #121 |
| 3. `"check whether the build is green"` (no named alternative) does not fire | `test_fleet_plan_lint.sh` #115 | `PASS #115: structure sound (0 warning(s))` |
| 4. Investigation spikes still downgrade the new fork hit to a warning | `test_fleet_plan_lint.sh` #116 | `warn #116: ... imperative-mood fork ... (allowed — investigation spike)` then `PASS #116` |
| 5. Docstring + PLANNING-PROTOCOL.md name the new form | `git diff` | `fleet-plan-lint` header updated (the fork bullet now states the Approach/Gotchas scoping); `PLANNING-PROTOCOL.md`'s "One approach, picked" bullet gained a paragraph citing the #2820 fork verbatim |
| 6. Scoping does not go so narrow the check stops firing where forks belong | `test_fleet_plan_lint.sh` #114 (Gotchas arm) + #122 (Approach arm) | both hard-fail; #122 exists because #114 only exercised the `"gotcha"` arm of the scope predicate |

Closes #2824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
