### PR TITLE
fleet/CI: give the auto-rereview byte-identity contract an executor

### DIFF
--- a/.github/workflows/auto-rereview.yml
+++ b/.github/workflows/auto-rereview.yml
@@ -39,7 +39,9 @@ name: Auto re-review on push to approved PR
 # This file and `scripts/fleet/classify-auto-rereview.sh` are kept
 # byte-identical between the engine repo (jakildev/IrredenEngine) and the game
 # repo (jakildev/irreden) so both repos share one re-review flow. Edit both
-# repos (and both files) when changing it.
+# repos (and both files) when changing it. Parity is checked by
+# `scripts/fleet/tests/test_cross_repo_shared_file_parity.sh` on any host
+# with both repos present (#2827) — a diverged edit here fails that suite.
 
 on:
   pull_request:

--- a/scripts/fleet/tests/test_cross_repo_parity_negative_control.sh
+++ b/scripts/fleet/tests/test_cross_repo_parity_negative_control.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Committed negative control for test_cross_repo_shared_file_parity.sh: drives
+# that suite against two throwaway fixture repos through green → drift → green,
+# so its red arm is a repeatable assertion rather than session prose (#2827).
+#
+# The fixtures set refs/remotes/origin/master with update-ref and never talk to
+# a network: the suite under test compares origin/master blobs via `git show`,
+# so a plain commit plus that ref is the whole dependency. Both repo roots come
+# from FLEET_ENGINE_ROOT / FLEET_GAME_ROOT, which exist for exactly this.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+
+SUBJECT="$SCRIPT_DIR/tests/test_cross_repo_shared_file_parity.sh"
+if [[ ! -f "$SUBJECT" ]]; then
+    echo "SKIP: subject not present at $SUBJECT" >&2
+    exit 3  # skip status — a missing subject is never a pass (#2786)
+fi
+
+TMPROOT=$(mktemp -d)
+cleanup() { rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+# Mirrors the subject's CONTRACT_FILES. The second entry is what proves a
+# drift verdict is file-specific rather than blanket.
+DRIFT_PATH=".github/workflows/auto-rereview.yml"
+STABLE_PATH="scripts/fleet/classify-auto-rereview.sh"
+
+make_fixture_repo() {
+    local root="$1"
+    mkdir -p "$root"
+    git -C "$root" init -q
+    git -C "$root" config user.email fixture@example.invalid
+    git -C "$root" config user.name "parity fixture"
+    for p in "$DRIFT_PATH" "$STABLE_PATH"; do
+        mkdir -p "$root/$(dirname "$p")"
+        printf 'shared contract content for %s\n' "$p" >"$root/$p"
+    done
+    git -C "$root" add -A
+    git -C "$root" commit -qm "fixture: shared contract files"
+    git -C "$root" update-ref refs/remotes/origin/master HEAD
+}
+
+# Commit the fixture's current worktree and re-point origin/master at it —
+# the suite reads only the ref, so an uncommitted edit is invisible to it.
+land_fixture_commit() {
+    local root="$1" msg="$2"
+    git -C "$root" add -A
+    git -C "$root" commit -qm "$msg"
+    git -C "$root" update-ref refs/remotes/origin/master HEAD
+}
+
+run_subject() {
+    FLEET_ENGINE_ROOT="$TMPROOT/engine" FLEET_GAME_ROOT="$TMPROOT/game" \
+        bash "$SUBJECT" 2>&1
+}
+
+make_fixture_repo "$TMPROOT/engine"
+make_fixture_repo "$TMPROOT/game"
+
+# --- green arm: identical contract files on both sides ------------------
+out=$(run_subject) && rc=0 || rc=$?
+assert_eq "$rc" "0" "green arm: identical fixtures exit 0"
+assert_contains "$out" "$DRIFT_PATH: byte-identical" "green arm: workflow reported byte-identical"
+assert_contains "$out" "$STABLE_PATH: byte-identical" "green arm: classifier reported byte-identical"
+assert_absent "$out" "DRIFTED" "green arm: nothing reported as drifted"
+
+# --- red arm: one byte differs on one file ------------------------------
+printf 'x\n' >>"$TMPROOT/game/$DRIFT_PATH"
+land_fixture_commit "$TMPROOT/game" "fixture: one-sided edit"
+
+out=$(run_subject) && rc=0 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+    ok "red arm: one-byte drift exits non-zero"
+else
+    bad "red arm: one-byte drift exits non-zero (got $rc)"
+fi
+assert_contains "$out" "$DRIFT_PATH: DRIFTED" "red arm: names the drifted file exactly"
+# The un-mutated sibling must still pass — a blanket red would satisfy the
+# exit-code assertion above while telling a reader nothing about which file
+# broke the contract.
+assert_contains "$out" "$STABLE_PATH: byte-identical" "red arm: un-mutated sibling still passes"
+assert_absent "$out" "$STABLE_PATH: DRIFTED" "red arm: verdict is file-specific, not blanket"
+
+# --- restore arm: the red is caused by the drift, not by the fixture ----
+printf 'shared contract content for %s\n' "$DRIFT_PATH" >"$TMPROOT/game/$DRIFT_PATH"
+land_fixture_commit "$TMPROOT/game" "fixture: restore the drifted byte"
+
+out=$(run_subject) && rc=0 || rc=$?
+assert_eq "$rc" "0" "restore arm: reverting the drift returns to exit 0"
+assert_absent "$out" "DRIFTED" "restore arm: no file reported as drifted"
+
+# --- skip arm: absent downstream repo is a skip, never a vacuous pass ---
+out=$(FLEET_ENGINE_ROOT="$TMPROOT/engine" FLEET_GAME_ROOT="$TMPROOT/nonexistent" \
+    bash "$SUBJECT" 2>&1) && rc=0 || rc=$?
+assert_eq "$rc" "3" "skip arm: missing downstream repo exits 3, not 0 (#2786)"
+assert_contains "$out" "SKIP: downstream repo not present" "skip arm: prints the SKIP reason"
+
+summarize "cross-repo parity negative control"

--- a/scripts/fleet/tests/test_cross_repo_shared_file_parity.sh
+++ b/scripts/fleet/tests/test_cross_repo_shared_file_parity.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Executes the byte-identity contract declared in
+# .github/workflows/auto-rereview.yml's header comment: that file and
+# scripts/fleet/classify-auto-rereview.sh must stay byte-identical between
+# this repo and its downstream fleet-enabled repo, so both share one
+# re-review flow (#2827).
+#
+# Before this suite, nothing checked the contract — a one-sided edit
+# (#2652) drifted the workflow file for 2 days with no signal. It was only
+# caught because an unrelated downstream PR happened to re-sync the prose
+# by hand.
+#
+# The downstream repo is only visible on a fleet dev host, where it is
+# checked out as a sibling worktree (creations/game/) — CI does not have
+# it (this repo is private and not checked out in the engine's Actions
+# runners). When the sibling is absent, SKIP rather than reporting a
+# vacuous pass (#2786); this is why the check cannot simply be a CI job.
+#
+# Compares each declared file's origin/master blob (not the working tree,
+# which may be dirty) via `git show`, so the result reflects what's
+# actually landed rather than local edits-in-progress.
+#
+# Add a third shared file by adding one entry to CONTRACT_FILES below —
+# no other change needed.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/fleet-common.sh"
+
+# creations/game is gitignored and only ever checked out under the MAIN
+# clone (never per-worktree), so a linked worktree (e.g. a pool worktree)
+# must resolve through fleet_main_clone_root rather than its own toplevel —
+# same resolution fleet-common.sh's install-freshness check uses to find
+# the sibling game repo.
+ENGINE_ROOT="$(fleet_main_clone_root)"
+GAME_ROOT="${FLEET_GAME_ROOT:-$ENGINE_ROOT/creations/game}"
+
+if [[ ! -d "$GAME_ROOT/.git" && ! -f "$GAME_ROOT/.git" ]]; then
+    echo "SKIP: downstream repo not present at $GAME_ROOT" >&2
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
+fi
+if ! git -C "$GAME_ROOT" rev-parse --git-dir &>/dev/null; then
+    echo "SKIP: $GAME_ROOT is not a valid git repo" >&2
+    exit 3
+fi
+
+# The declared contract — see .github/workflows/auto-rereview.yml's header
+# comment. Intentionally NOT the full 18-path shared surface: most of that
+# (CLAUDE.md, README.md, .claude/skills/*, ...) is per-repo by design
+# (docs/design/claude-md-sharing.md, docs/design/skill-sharing.md).
+CONTRACT_FILES=(
+    ".github/workflows/auto-rereview.yml"
+    "scripts/fleet/classify-auto-rereview.sh"
+)
+
+TMPROOT=$(mktemp -d)
+cleanup() { rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+for path in "${CONTRACT_FILES[@]}"; do
+    engine_blob="$TMPROOT/engine.$(basename "$path")"
+    game_blob="$TMPROOT/game.$(basename "$path")"
+
+    if ! git -C "$ENGINE_ROOT" show "origin/master:$path" >"$engine_blob" 2>/dev/null; then
+        bad "$path: missing from engine origin/master"
+        continue
+    fi
+    if ! git -C "$GAME_ROOT" show "origin/master:$path" >"$game_blob" 2>/dev/null; then
+        bad "$path: missing from downstream origin/master"
+        continue
+    fi
+
+    if cmp -s "$engine_blob" "$game_blob"; then
+        ok "$path: byte-identical"
+    else
+        bad "$path: DRIFTED between engine and downstream origin/master"
+    fi
+done
+
+summarize "cross-repo shared-file parity"

--- a/scripts/fleet/tests/test_cross_repo_shared_file_parity.sh
+++ b/scripts/fleet/tests/test_cross_repo_shared_file_parity.sh
@@ -5,11 +5,6 @@
 # this repo and its downstream fleet-enabled repo, so both share one
 # re-review flow (#2827).
 #
-# Before this suite, nothing checked the contract — a one-sided edit
-# (#2652) drifted the workflow file for 2 days with no signal. It was only
-# caught because an unrelated downstream PR happened to re-sync the prose
-# by hand.
-#
 # The downstream repo is only visible on a fleet dev host, where it is
 # checked out as a sibling worktree (creations/game/) — CI does not have
 # it (this repo is private and not checked out in the engine's Actions
@@ -36,7 +31,10 @@ source "$SCRIPT_DIR/fleet-common.sh"
 # must resolve through fleet_main_clone_root rather than its own toplevel —
 # same resolution fleet-common.sh's install-freshness check uses to find
 # the sibling game repo.
-ENGINE_ROOT="$(fleet_main_clone_root)"
+# Both roots are overridable so the committed negative control
+# (test_cross_repo_parity_negative_control.sh) can drive this suite against
+# throwaway fixture repos instead of the live pair.
+ENGINE_ROOT="${FLEET_ENGINE_ROOT:-$(fleet_main_clone_root)}"
 GAME_ROOT="${FLEET_GAME_ROOT:-$ENGINE_ROOT/creations/game}"
 
 if [[ ! -d "$GAME_ROOT/.git" && ! -f "$GAME_ROOT/.git" ]]; then
@@ -61,9 +59,21 @@ TMPROOT=$(mktemp -d)
 cleanup() { rm -rf "$TMPROOT"; }
 trap cleanup EXIT
 
-for path in "${CONTRACT_FILES[@]}"; do
-    engine_blob="$TMPROOT/engine.$(basename "$path")"
-    game_blob="$TMPROOT/game.$(basename "$path")"
+# A differential check's vacuous mode is agreement, not an error: an empty
+# CONTRACT_FILES runs zero comparisons and summarize reports "0 failed" —
+# indistinguishable from a real clean pass. Assert the declared scope so
+# "no drift" always means "compared every declared file". The loop below
+# uses the guarded expansion so this FAIL reaches summarize rather than
+# aborting on an empty [@] under set -u (no bash floor is declared here).
+(( ${#CONTRACT_FILES[@]} > 0 )) || bad "CONTRACT_FILES is empty — nothing to compare"
+
+for path in "${CONTRACT_FILES[@]+"${CONTRACT_FILES[@]}"}"; do
+    # Keyed on the full path, not basename: two declared entries sharing a
+    # basename would otherwise share one pair of temp blobs, so the header's
+    # "add an entry, no other change needed" holds for any path.
+    slug="${path//\//_}"
+    engine_blob="$TMPROOT/engine.$slug"
+    game_blob="$TMPROOT/game.$slug"
 
     if ! git -C "$ENGINE_ROOT" show "origin/master:$path" >"$engine_blob" 2>/dev/null; then
         bad "$path: missing from engine origin/master"


### PR DESCRIPTION
## Summary
- Add `scripts/fleet/tests/test_cross_repo_shared_file_parity.sh`: compares the
  2 declared contract files (`.github/workflows/auto-rereview.yml`,
  `scripts/fleet/classify-auto-rereview.sh`) against `origin/master` in this
  repo and the downstream sibling repo (checked out at `creations/game/` on a
  fleet dev host), SKIPping (exit 3) when the sibling isn't present — CI never
  has it checked out, so this can only run on a dev host.
- Point the contract's header comment in `auto-rereview.yml` at the new suite
  by name so the prose and the executor stay linked.

## Test plan
- [x] `./run_all.sh --list | grep parity` → `test_cross_repo_shared_file_parity.sh`
      (glob-discovered by `run_all.sh`, no registration step needed).
- [x] `./run_all.sh` → `120 suite(s) — 119 passed, 1 failed, 0 skipped` — the 1
      failure is this new suite correctly flagging the real, pre-existing
      drift in `auto-rereview.yml` (measured this session, matches the
      issue's own findings; already being repaired by hand in an approved
      downstream PR — not introduced by this PR, see note below).
- [x] `fleet-positive-control scripts/fleet/tests/test_cross_repo_shared_file_parity.sh origin/master`
      → `MEANINGFUL: 1 of 2 assertions fail against origin/master` (not a
      vacuous pass).
- [x] Negative control on the currently-in-sync file, via a throwaway local
      clone of the downstream repo (real repos never touched): baseline
      reproduced the live 1-pass/1-fail state; appended one byte to
      `classify-auto-rereview.sh` in the clone → suite went red naming
      exactly that file (0 passed, 2 failed); reverted → back to 1
      pass/1 fail. Confirms the suite is not vacuously green.
- [x] SKIP path: `FLEET_GAME_ROOT=/tmp/nonexistent ...` →
      `SKIP: downstream repo not present at /tmp/nonexistent`, exit 3 (the
      code `run_all.sh` requires for a missing-subject skip, #2786).
- [x] `test_suites_are_executable.sh` passes with the new file's `+x` bit
      committed (`100755`).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. Single declared file list, asserts equality against origin/master in both repos | `./test_cross_repo_shared_file_parity.sh` | `ok: scripts/fleet/classify-auto-rereview.sh: byte-identical` / `FAIL: .github/workflows/auto-rereview.yml: DRIFTED...` — both from one `CONTRACT_FILES` array |
| 2. SKIP: line + non-vacuous exit code when sibling repo absent | `FLEET_GAME_ROOT=/tmp/nonexistent ./test_cross_repo_shared_file_parity.sh; echo $?` | `SKIP: downstream repo not present at /tmp/nonexistent` / exit `3` |
| 3. Registered in run_all.sh | `./run_all.sh --list \| grep parity` | `test_cross_repo_shared_file_parity.sh` (glob discovery, no registration step exists in this repo) |
| 4. Negative control: mutate one byte → red naming exact file → restore → green | manual throwaway-clone control (see Test plan) + `fleet-positive-control` | green→red naming `classify-auto-rereview.sh`→green; positive-control reports MEANINGFUL |
| 5. Contract comment points at the suite by name | `git diff .github/workflows/auto-rereview.yml` | added line: "Parity is checked by `scripts/fleet/tests/test_cross_repo_shared_file_parity.sh`..." |

Closes #2827

**Note on the 1 failing suite:** `run_all.sh` on this host (and any host with
both repos checked out) currently reports this new suite red — it's correctly
detecting real, pre-existing drift in `auto-rereview.yml`'s comment block
(unrelated content, already being repaired by hand in an approved downstream
PR per the issue). CI never runs this suite (no sibling checkout there), so
CI is unaffected. This is expected, not a regression from this PR, and should
self-resolve once the downstream repair merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)