### PR TITLE
render/cmake: executed membership check for the image-atomic scratch list (#2878)

### DIFF
--- a/.github/workflows/header-checks.yml
+++ b/.github/workflows/header-checks.yml
@@ -1,9 +1,12 @@
 name: Header Checks
 
-# The header convention checks (header-global ban, anonymous namespaces,
-# `*Detail` namespaces) from cmake/run_header_convention_checks.cmake, plus the
-# Metal threadgroup-registry membership check from
-# cmake/run_metal_kernel_registry_check.cmake.
+# Every text-only convention check the repo runs without a compiler:
+#   - header conventions (header-global ban, anonymous namespaces, `*Detail`
+#     namespaces) — cmake/run_header_convention_checks.cmake (#2794)
+#   - Metal threadgroup registry membership — cmake/run_metal_kernel_registry_check.cmake (#2798)
+#   - Metal image-atomic scratch consumer list — cmake/run_metal_scratch_consumer_check.cmake (#2878)
+# Adding a fourth means extending run_header_checks_standalone.cmake, this
+# list, and the `paths:` filters below in the same change.
 #
 # Standalone for the same reason fleet-tests.yml is: the only other caller of
 # these checks is the `lint` CMake target, which reaches CI solely through
@@ -30,6 +33,7 @@ on:
       - 'cmake/ir_quality_tools.cmake'
       - 'cmake/run_header_convention_checks.cmake'
       - 'cmake/run_metal_kernel_registry_check.cmake'
+      - 'cmake/run_metal_scratch_consumer_check.cmake'
       - 'cmake/run_header_checks_standalone.cmake'
       - 'scripts/fleet/tests/test_header_checks_standalone.sh'
       - '.github/workflows/header-checks.yml'
@@ -42,6 +46,7 @@ on:
       - 'cmake/ir_quality_tools.cmake'
       - 'cmake/run_header_convention_checks.cmake'
       - 'cmake/run_metal_kernel_registry_check.cmake'
+      - 'cmake/run_metal_scratch_consumer_check.cmake'
       - 'cmake/run_header_checks_standalone.cmake'
       - 'scripts/fleet/tests/test_header_checks_standalone.sh'
       - '.github/workflows/header-checks.yml'

--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -248,6 +248,9 @@ function(irreden_add_quality_targets)
         COMMAND ${CMAKE_COMMAND}
             -DPROJECT_ROOT="${PROJECT_SOURCE_DIR}"
             -P "${PROJECT_SOURCE_DIR}/cmake/run_metal_kernel_registry_check.cmake"
+        COMMAND ${CMAKE_COMMAND}
+            -DPROJECT_ROOT="${PROJECT_SOURCE_DIR}"
+            -P "${PROJECT_SOURCE_DIR}/cmake/run_metal_scratch_consumer_check.cmake"
         COMMENT "Running header convention checks"
         VERBATIM
     )
@@ -267,6 +270,9 @@ function(irreden_add_quality_targets)
             COMMAND ${CMAKE_COMMAND}
                 -DPROJECT_ROOT="${PROJECT_SOURCE_DIR}"
                 -P "${PROJECT_SOURCE_DIR}/cmake/run_metal_kernel_registry_check.cmake"
+            COMMAND ${CMAKE_COMMAND}
+                -DPROJECT_ROOT="${PROJECT_SOURCE_DIR}"
+                -P "${PROJECT_SOURCE_DIR}/cmake/run_metal_scratch_consumer_check.cmake"
             COMMENT "Running lint and header convention checks"
             VERBATIM
         )

--- a/cmake/run_header_checks_standalone.cmake
+++ b/cmake/run_header_checks_standalone.cmake
@@ -9,8 +9,9 @@
 #   cmake -DPROJECT_ROOT=<repo-root> -P cmake/run_header_checks_standalone.cmake
 #
 # Deliberately a thin shim. It reuses irreden_collect_quality_files for the file
-# set and delegates every actual rule to run_header_convention_checks.cmake and
-# run_metal_kernel_registry_check.cmake (#2798), so the CI path and the
+# set and delegates every actual rule to run_header_convention_checks.cmake,
+# run_metal_kernel_registry_check.cmake (#2798), and
+# run_metal_scratch_consumer_check.cmake (#2878), so the CI path and the
 # `header-checks` / `lint` targets cannot drift into checking different things —
 # the drift #2727 was filed about.
 
@@ -55,3 +56,4 @@ include("${PROJECT_ROOT}/cmake/run_header_convention_checks.cmake")
 file(REMOVE "${quality_file_list}")
 
 include("${PROJECT_ROOT}/cmake/run_metal_kernel_registry_check.cmake")
+include("${PROJECT_ROOT}/cmake/run_metal_scratch_consumer_check.cmake")

--- a/cmake/run_metal_scratch_consumer_check.cmake
+++ b/cmake/run_metal_scratch_consumer_check.cmake
@@ -1,0 +1,273 @@
+# Executed membership check for metal_pipeline.cpp's
+# functionUsesImageAtomicScratch list (#2878). Twin of
+# run_metal_kernel_registry_check.cmake (#2798), which scoped this second
+# hand-list out.
+#
+# Why it matters in both directions. bindComputeResources binds the sticky
+# per-frame R32I image-atomic scratch ONLY for kernels this list names, and the
+# slot it binds doubles as kBufferIndex_RevoxelizeDetachedParams (the Metal 0-30
+# buffer table has no free index):
+#
+#   * a consumer MISSING from the list never gets the scratch bound -- its
+#     imageAtomicMin writes land nowhere;
+#   * a non-consumer wrongly ON the list gets the scratch bound over whatever
+#     it declared at that slot -- #1619, where c_revoxelize_detached's params
+#     UBO was clobbered and the fill read distance-clear words as its params.
+#
+# So this check compares the two sets both ways rather than only looking for
+# omissions.
+#
+# The expected set is mechanical: a kernel consumes the scratch iff its
+# resolved source -- its own file plus the transitive closure of its
+# `#include "..."` chain, which is how the *_body.metal fragments reach their
+# wrappers -- declares an `atomic_int`/`atomic_uint` parameter at the scratch
+# slot. c_revoxelize_detached declares a plain `constant RevoxelizeParams&` at
+# that same slot, so the atomic qualifier discriminates it structurally and it
+# needs no hand-maintained exclusion entry. That is deliberate: an allowlist
+# naming a kernel the matcher already excludes would be a third hand-list
+# inside the check written to retire the second one, and it would read as
+# load-bearing while protecting nothing. The property is pinned by a negative
+# control arm in scripts/fleet/tests/test_header_checks_standalone.sh instead.
+
+if(NOT DEFINED PROJECT_ROOT OR PROJECT_ROOT STREQUAL "")
+    message(FATAL_ERROR "PROJECT_ROOT is required.")
+endif()
+string(REPLACE "\"" "" PROJECT_ROOT "${PROJECT_ROOT}")
+
+# Read the slot out of the C++ constant rather than hardcoding 16 here. A
+# checker carrying its own copy of a number the engine owns goes stale silently
+# the day the constant moves; parsing it means a rename or a re-slot fails this
+# check loudly instead.
+set(runtime_hpp "${PROJECT_ROOT}/engine/render/include/irreden/render/metal/metal_runtime.hpp")
+if(NOT EXISTS "${runtime_hpp}")
+    message(FATAL_ERROR "Metal scratch-consumer check: ${runtime_hpp} not found.")
+endif()
+file(STRINGS "${runtime_hpp}" runtime_lines
+     REGEX "kMetalImageAtomicScratchSlot[ \t]*=")
+set(scratch_slot "")
+foreach(line IN LISTS runtime_lines)
+    if(line MATCHES "kMetalImageAtomicScratchSlot[ \t]*=[ \t]*([0-9]+)")
+        set(scratch_slot "${CMAKE_MATCH_1}")
+        break()
+    endif()
+endforeach()
+if(scratch_slot STREQUAL "")
+    message(FATAL_ERROR
+        "Metal scratch-consumer check could not read "
+        "kMetalImageAtomicScratchSlot's value from ${runtime_hpp} -- it may "
+        "have been renamed or moved; update this checker's anchor rather than "
+        "letting the scan run against a stale slot number."
+    )
+endif()
+
+set(kernel_dir "${PROJECT_ROOT}/engine/render/src/shaders/metal")
+file(GLOB kernel_files "${kernel_dir}/c_*.metal")
+
+set(kernel_stems "")
+foreach(kernel_file IN LISTS kernel_files)
+    get_filename_component(stem "${kernel_file}" NAME_WE)
+    # *_body.metal files are include-fragments pulled in by a wrapper, not
+    # standalone dispatchable kernels. They are where two of the five real
+    # scratch declarations live, so they are excluded as *entry points* while
+    # still being scanned through their wrappers' include closure below.
+    if(stem MATCHES "_body$")
+        continue()
+    endif()
+    list(APPEND kernel_stems "${stem}")
+endforeach()
+
+list(LENGTH kernel_stems kernel_count)
+if(kernel_count EQUAL 0)
+    message(FATAL_ERROR
+        "Metal scratch-consumer check collected 0 kernel file(s) from "
+        "${kernel_dir} -- the glob is mis-scoped. Fix the path rather than "
+        "trusting a clean result with nothing scanned."
+    )
+endif()
+
+# Transitive `#include "..."` closure, resolved against the directory of the
+# file doing the including -- the same rule metal_pipeline.cpp's
+# loadAndPreprocessMetalSource applies at runtime, with the same visited-set
+# cycle guard. Angle-bracket includes are Metal stdlib headers and are skipped.
+function(ir_resolve_metal_include_closure entry_file out_var)
+    set(pending "${entry_file}")
+    set(visited "")
+    while(pending)
+        list(POP_FRONT pending current)
+        list(FIND visited "${current}" seen_index)
+        if(NOT seen_index EQUAL -1)
+            continue()
+        endif()
+        list(APPEND visited "${current}")
+        get_filename_component(current_dir "${current}" DIRECTORY)
+        file(STRINGS "${current}" include_lines REGEX "^[ \t]*#include[ \t]*\"")
+        foreach(line IN LISTS include_lines)
+            if(NOT line MATCHES "^[ \t]*#include[ \t]*\"([^\"]+)\"")
+                continue()
+            endif()
+            set(included "${current_dir}/${CMAKE_MATCH_1}")
+            if(NOT EXISTS "${included}")
+                # Silently dropping an unresolvable include would shrink the
+                # scanned source of a real consumer and read as "declares no
+                # scratch" -- the false-clean this check exists to prevent.
+                message(FATAL_ERROR
+                    "Metal scratch-consumer check could not resolve "
+                    "#include \"${CMAKE_MATCH_1}\" from ${current} "
+                    "(looked for ${included})."
+                )
+            endif()
+            list(APPEND pending "${included}")
+        endforeach()
+    endwhile()
+    set(${out_var} "${visited}" PARENT_SCOPE)
+endfunction()
+
+set(slot_attribute_regex "\\[\\[[ \t]*buffer\\([ \t]*${scratch_slot}[ \t]*\\)[ \t]*\\]\\]")
+
+set(expected_consumers "")
+set(slot_declaration_sites 0)
+foreach(stem IN LISTS kernel_stems)
+    ir_resolve_metal_include_closure("${kernel_dir}/${stem}.metal" closure)
+    set(declares_scratch FALSE)
+    foreach(source_file IN LISTS closure)
+        file(STRINGS "${source_file}" slot_lines REGEX "${slot_attribute_regex}")
+        foreach(line IN LISTS slot_lines)
+            # Comment-strip before classifying: the qualifier test must read the
+            # declaration itself, not a trailing comment that happens to say
+            # "atomic" (the same declaration-head-vs-whole-line precision note
+            # .claude/rules/cpp-globals.md carries for the header-global scan).
+            string(REGEX REPLACE "//.*" "" line "${line}")
+            if(NOT line MATCHES "${slot_attribute_regex}")
+                continue()
+            endif()
+            math(EXPR slot_declaration_sites "${slot_declaration_sites} + 1")
+            if(line MATCHES "atomic_(int|uint)")
+                set(declares_scratch TRUE)
+            endif()
+        endforeach()
+    endforeach()
+    if(declares_scratch)
+        list(APPEND expected_consumers "${stem}")
+    endif()
+endforeach()
+
+# The attribute spelling is the one thing a reformat could break silently in the
+# *shrinking* direction only if the list were also empty. It is not -- so a
+# broken matcher surfaces as a wall of "listed but does not declare" failures
+# below rather than a clean run. This guard covers the remaining case: a tree
+# where nothing at all matches, which means the spelling changed rather than
+# that the slot genuinely went unused.
+if(slot_declaration_sites EQUAL 0)
+    message(FATAL_ERROR
+        "Metal scratch-consumer check found no [[buffer(${scratch_slot})]] "
+        "declaration anywhere under ${kernel_dir}. The slot is aliased and "
+        "always has consumers, so this means the attribute spelling changed -- "
+        "update this checker's matcher instead of trusting an empty result."
+    )
+endif()
+
+set(pipeline_cpp "${PROJECT_ROOT}/engine/render/src/metal/metal_pipeline.cpp")
+if(NOT EXISTS "${pipeline_cpp}")
+    message(FATAL_ERROR "Metal scratch-consumer check: ${pipeline_cpp} not found.")
+endif()
+
+# Line-scoped scan with an indentation-keyed terminator, for the reason spelled
+# out in run_metal_kernel_registry_check.cmake: CMake's regex engine has no
+# non-greedy quantifier, so a brace-to-brace capture would run to the last "}"
+# in the file.
+file(STRINGS "${pipeline_cpp}" pipeline_lines)
+
+set(in_list FALSE)
+set(found_list FALSE)
+set(found_terminator FALSE)
+set(listed_consumers "")
+foreach(line IN LISTS pipeline_lines)
+    if(NOT in_list)
+        if(line MATCHES "bool[ \t]+functionUsesImageAtomicScratch\\(")
+            set(in_list TRUE)
+            set(found_list TRUE)
+        endif()
+        continue()
+    endif()
+    if(line STREQUAL "}")
+        set(found_terminator TRUE)
+        break()
+    endif()
+    string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
+    foreach(quoted_name IN LISTS quoted_names)
+        string(REPLACE "\"" "" bare_name "${quoted_name}")
+        list(APPEND listed_consumers "${bare_name}")
+    endforeach()
+endforeach()
+
+if(NOT found_list)
+    message(FATAL_ERROR
+        "Metal scratch-consumer check could not locate "
+        "functionUsesImageAtomicScratch's signature in ${pipeline_cpp} -- it "
+        "may have been renamed or reformatted; update this checker's anchor."
+    )
+endif()
+
+if(NOT found_terminator)
+    message(FATAL_ERROR
+        "Metal scratch-consumer check found functionUsesImageAtomicScratch's "
+        "signature but hit EOF before its closing-brace terminator (a line "
+        "that is exactly \"}\") in ${pipeline_cpp} -- the function may have "
+        "been indented or moved; update this checker's terminator."
+    )
+endif()
+
+set(missing_consumers "")
+foreach(stem IN LISTS expected_consumers)
+    list(FIND listed_consumers "${stem}" stem_index)
+    if(stem_index EQUAL -1)
+        list(APPEND missing_consumers "${stem}")
+    endif()
+endforeach()
+
+set(stale_consumers "")
+foreach(name IN LISTS listed_consumers)
+    list(FIND expected_consumers "${name}" name_index)
+    if(name_index EQUAL -1)
+        list(APPEND stale_consumers "${name}")
+    endif()
+endforeach()
+
+list(LENGTH expected_consumers expected_count)
+message(STATUS
+    "Metal scratch-consumer check scanned ${kernel_count} compute kernel(s) "
+    "against functionUsesImageAtomicScratch (${expected_count} declare the "
+    "image-atomic scratch at buffer slot ${scratch_slot})."
+)
+
+set(scratch_failures "")
+if(missing_consumers)
+    list(JOIN missing_consumers ", " missing_joined)
+    list(APPEND scratch_failures
+        "  declares the image-atomic scratch at buffer slot ${scratch_slot} "
+        "but is absent from functionUsesImageAtomicScratch, so "
+        "bindComputeResources never binds the scratch for it and its atomic "
+        "writes land nowhere: ${missing_joined}\n"
+    )
+endif()
+if(stale_consumers)
+    list(JOIN stale_consumers ", " stale_joined)
+    list(APPEND scratch_failures
+        "  is named by functionUsesImageAtomicScratch but declares no "
+        "atomic parameter at buffer slot ${scratch_slot}, so the sticky "
+        "scratch bind overwrites whatever it does declare there (#1619): "
+        "${stale_joined}\n"
+    )
+endif()
+
+if(scratch_failures)
+    list(JOIN scratch_failures "" scratch_failures_joined)
+    message(FATAL_ERROR
+        "Metal image-atomic scratch consumer list is out of sync with the "
+        "kernel sources (${pipeline_cpp}). The following kernel(s):\n"
+        "${scratch_failures_joined}"
+        "The list is the only thing gating the per-kernel scratch bind; fix "
+        "the list, not this check, unless the kernel's slot usage genuinely "
+        "changed."
+    )
+endif()

--- a/cmake/run_metal_scratch_consumer_check.cmake
+++ b/cmake/run_metal_scratch_consumer_check.cmake
@@ -124,24 +124,40 @@ endfunction()
 
 set(slot_attribute_regex "\\[\\[[ \t]*buffer\\([ \t]*${scratch_slot}[ \t]*\\)[ \t]*\\]\\]")
 
+# The qualifier test reads the whole parameter declaration, not the physical
+# line the slot attribute happens to sit on. A Metal kernel parameter is
+# delimited by its neighbours' commas and by the parameter list's own parens, so
+# the maximal run of non-delimiter characters ending at the slot attribute IS
+# that parameter's declaration head. Matching the window rather than the line
+# closes two opposite misreads a line-scoped test is open to:
+#
+#   * a hand-wrapped declaration (`device atomic_int*` on one line, the name and
+#     attribute on the next) reads as declaring no scratch -- the false clean
+#     this check exists to close, reached by a line break alone;
+#   * a NEIGHBOURING parameter's atomic_int on a shared line reads as this one's
+#     qualifier -- a false positive in the #1619 direction.
+set(slot_declaration_regex "[^,;(){}]*${slot_attribute_regex}")
+
 set(expected_consumers "")
 set(slot_declaration_sites 0)
 foreach(stem IN LISTS kernel_stems)
     ir_resolve_metal_include_closure("${kernel_dir}/${stem}.metal" closure)
     set(declares_scratch FALSE)
     foreach(source_file IN LISTS closure)
-        file(STRINGS "${source_file}" slot_lines REGEX "${slot_attribute_regex}")
-        foreach(line IN LISTS slot_lines)
-            # Comment-strip before classifying: the qualifier test must read the
-            # declaration itself, not a trailing comment that happens to say
-            # "atomic" (the same declaration-head-vs-whole-line precision note
-            # .claude/rules/cpp-globals.md carries for the header-global scan).
-            string(REGEX REPLACE "//.*" "" line "${line}")
-            if(NOT line MATCHES "${slot_attribute_regex}")
-                continue()
-            endif()
+        file(READ "${source_file}" source_text)
+        # Strip line comments while the newlines are still there, then collapse
+        # them. Both halves matter: the qualifier test must read the declaration
+        # itself and not a trailing comment that happens to say "atomic" (the
+        # declaration-head-vs-whole-line precision note .claude/rules/cpp-globals.md
+        # carries for the header-global scan), and stripping after the join would
+        # let one comment swallow the rest of the parameter list.
+        string(REGEX REPLACE "//[^\n]*" "" source_text "${source_text}")
+        string(REGEX REPLACE "[\r\n]" " " source_text "${source_text}")
+        string(REGEX MATCHALL "${slot_declaration_regex}" slot_declarations
+               "${source_text}")
+        foreach(declaration IN LISTS slot_declarations)
             math(EXPR slot_declaration_sites "${slot_declaration_sites} + 1")
-            if(line MATCHES "atomic_(int|uint)")
+            if(declaration MATCHES "atomic_(int|uint)")
                 set(declares_scratch TRUE)
             endif()
         endforeach()
@@ -193,6 +209,16 @@ foreach(line IN LISTS pipeline_lines)
         set(found_terminator TRUE)
         break()
     endif()
+    # Comment-strip before harvesting names, for the same reason the kernel-side
+    # scan does it. A commented-out entry is absent from the list as far as
+    # bindComputeResources is concerned, so reading it as present is a false
+    # clean in the forward direction: the consumer stops getting the scratch
+    # bound, its imageAtomicMin writes land nowhere, and this check stays green.
+    # Scope: line comments only. A `/* ... */` around an entry still reads as
+    # present, and the sibling run_metal_kernel_registry_check.cmake's identical
+    # scan strips neither form. Both are #2899 -- fixing one comment form in one
+    # of the two checkers here would leave the pair asymmetric for no gain.
+    string(REGEX REPLACE "//.*" "" line "${line}")
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)
         string(REPLACE "\"" "" bare_name "${quoted_name}")

--- a/docs/design/voxel-feeder-split.md
+++ b/docs/design/voxel-feeder-split.md
@@ -327,10 +327,12 @@ this needs zero engine infra:
    binding 26 onto struct 1; the visible dispatch keeps the original program.
    Metal bookkeeping: the feeder function name must be added to BOTH
    `threadgroupSizeForFunctionName` (2,3,8) **and** `functionUsesImageAtomicScratch`.
-   Unlike `threadgroupSizeForFunctionName` — whose membership is enforced by
-   `cmake/run_metal_kernel_registry_check.cmake` (#2798), so an omission fails
-   CI naming the kernel — `functionUsesImageAtomicScratch` does not self-detect:
-   an omission there silently drops the feeder's atomic distance writes.
+   Both are explicit hand-written lists, and both memberships are enforced —
+   `cmake/run_metal_kernel_registry_check.cmake` (#2798) for the first,
+   `cmake/run_metal_scratch_consumer_check.cmake` (#2878) for the second — so an
+   omission from either fails CI naming the kernel instead of silently
+   dispatching a 1×1×1 grid or dropping the feeder's atomic distance writes.
+   The lists are still where the fix goes.
 
 **Measured result** (same-session A/B, macOS/Metal, `IRPerfGrid --auto-profile 120`):
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -136,14 +136,42 @@ excluding `*_body.metal` include-fragments) needs an entry in
 `threadgroupSizeForFunctionName` (`metal_pipeline.cpp`) supplying its real
 `threadsPerThreadgroup`. A kernel absent from that chain falls through to the
 `MTL::Size(1, 1, 1)` fallback with no error — GL is structurally immune (it
-reads `local_size` out of the GLSL source), so this is Metal-only. Unlike the
-prose reminders elsewhere near this registry, this one is **enforced**: the
-header-checks CI workflow (via `cmake/run_header_checks_standalone.cmake`)
-and the `header-checks` / `lint` CMake targets all run
-`cmake/run_metal_kernel_registry_check.cmake`, which fails the run and
-names the kernel if a new `.metal` file has no matching entry (#2798). The
-check is pure text-scanning, so it fires on every PR — including GL-authored
-ones from hosts with no Metal toolchain.
+reads `local_size` out of the GLSL source), so this is Metal-only. This
+registry is **enforced**: the header-checks CI workflow (via
+`cmake/run_header_checks_standalone.cmake`) and the `header-checks` / `lint`
+CMake targets all run `cmake/run_metal_kernel_registry_check.cmake`, which
+fails the run and names the kernel if a new `.metal` file has no matching
+entry (#2798). The check is pure text-scanning, so it fires on every PR —
+including GL-authored ones from hosts with no Metal toolchain.
+
+### Metal image-atomic scratch consumer list
+
+`metal_pipeline.cpp` carries a second hand-written kernel list,
+`functionUsesImageAtomicScratch`. It gates the per-kernel bind of the sticky
+R32I image-atomic scratch at `kMetalImageAtomicScratchSlot` (16) — a slot that
+doubles as `kBufferIndex_RevoxelizeDetachedParams`, because the Metal 0-30
+buffer table has no free index. **Both** directions of drift are silent
+correctness bugs: a consumer missing from the list never gets the scratch bound
+(its `imageAtomicMin` writes land nowhere), and a non-consumer wrongly on the
+list gets the scratch bound over whatever it declared at slot 16 — #1619, where
+`c_revoxelize_detached`'s params UBO was clobbered and the fill read
+distance-clear words as its params.
+
+Enforced the same way as the threadgroup registry, by
+`cmake/run_metal_scratch_consumer_check.cmake` (#2878), on the same three
+entry points. The expected set is derived, not declared: a kernel is a consumer
+iff its resolved source — its own file plus the transitive
+`#include "…"` closure, which is how the `*_body.metal` fragments reach their
+wrappers — declares an `atomic_int`/`atomic_uint` parameter at that slot. The
+atomic qualifier is what separates a real consumer from `c_revoxelize_detached`'s
+`constant RevoxelizeParams&` at the same slot, so **there is no allowlist to
+maintain**; the check reads the slot number out of the
+`kMetalImageAtomicScratchSlot` constant rather than hardcoding 16.
+
+Practical upshot when adding a Metal kernel: declare the scratch and the check
+tells you to add the name; don't declare it and adding the name is what the
+check rejects. Either way the answer comes from CI, not from remembering these
+two lists exist.
 
 ### Metal AOT metallib build (opt-in, no runtime consumer)
 

--- a/engine/render/include/irreden/render/metal/metal_runtime.hpp
+++ b/engine/render/include/irreden/render/metal/metal_runtime.hpp
@@ -149,9 +149,13 @@ bool wasMetalBufferEncoded(MTL::Buffer *buffer);
 // MetalPipelineStateProvider::usesImageAtomicScratch(), resolved from the
 // explicit kernel list in metal_pipeline.cpp. A new kernel that consumes
 // the scratch MUST be added to functionUsesImageAtomicScratch there — and
-// unlike the threadgroupSizeForFunctionName map (membership enforced by
-// cmake/run_metal_kernel_registry_check.cmake, #2798), this list does not
-// self-detect.
+// like the threadgroupSizeForFunctionName map (membership enforced by
+// cmake/run_metal_kernel_registry_check.cmake, #2798), that list is checked:
+// cmake/run_metal_scratch_consumer_check.cmake (#2878) fails the build's
+// header-checks / lint targets and the header-checks CI workflow if it drifts
+// from what the kernel sources actually declare at this slot. That checker
+// reads this constant's value rather than carrying its own copy of 16, so
+// re-slotting the scratch is a one-line change here.
 constexpr std::uint32_t kMetalImageAtomicScratchSlot = 16;
 MTL::Buffer *ensureImageAtomicScratchBuffer(MTL::Texture *texture);
 MTL::Buffer *lookupImageAtomicScratchBuffer(MTL::Texture *texture);

--- a/engine/render/src/metal/metal_pipeline.cpp
+++ b/engine/render/src/metal/metal_pipeline.cpp
@@ -120,10 +120,17 @@ MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
 // kBufferIndex_RevoxelizeDetachedParams for c_revoxelize_detached (the Metal
 // 0-30 table has no free index), and an unconditional bind clobbered that
 // params UBO on every encode after the first distance-image bind (#1619: the
-// fill read distance-clear words as its params and authored nothing). Unlike
+// fill read distance-clear words as its params and authored nothing). Like
 // threadgroupSizeForFunctionName above — whose membership is enforced by
-// cmake/run_metal_kernel_registry_check.cmake (#2798) — this list does not
-// self-detect: a new kernel that consumes the scratch must be added here.
+// cmake/run_metal_kernel_registry_check.cmake (#2798) — this list is
+// hand-maintained but not un-checked:
+// cmake/run_metal_scratch_consumer_check.cmake (#2878) derives the expected
+// set from the kernels' own sources (an atomic parameter at
+// kMetalImageAtomicScratchSlot, reached through the wrapper → *_body.metal
+// include chain) and fails the same CI workflow and targets on drift in
+// either direction: a consumer missing here, or a name here that declares no
+// such parameter (the #1619 shape, since the bind would then land on
+// whatever it does declare).
 bool functionUsesImageAtomicScratch(const std::string &functionName) {
     return functionName == "c_voxel_to_trixel_stage_1" ||
            functionName == "c_voxel_to_trixel_stage_1_feeder" ||

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_feeder.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_feeder.metal
@@ -5,11 +5,12 @@
 // feederSubCap² micro-grid). The kernel name resolves to
 // c_voxel_to_trixel_stage_1_feeder (metalFunctionNameForStage keys off the file
 // stem) — it MUST be registered in metal_pipeline.cpp's threadgroupSizeForFunctionName
-// (2,3,8) and functionUsesImageAtomicScratch lists. Omission from the former
-// fails CI naming the kernel (enforced by
-// cmake/run_metal_kernel_registry_check.cmake, #2798); omission from the latter
-// is silent and drops the second dispatch's atomic distance writes. The
-// visible twin is c_voxel_to_trixel_stage_1.metal.
+// (2,3,8) and functionUsesImageAtomicScratch lists. Omission from either fails
+// CI naming the kernel — the former via
+// cmake/run_metal_kernel_registry_check.cmake (#2798), the latter via
+// cmake/run_metal_scratch_consumer_check.cmake (#2878), which is what keeps a
+// missing entry from silently dropping the second dispatch's atomic distance
+// writes. The visible twin is c_voxel_to_trixel_stage_1.metal.
 #include "ir_iso_common.metal"
 #include "ir_constants.metal"
 

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_winner_resolve.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1_winner_resolve.metal
@@ -10,10 +10,11 @@
 // c_voxel_to_trixel_stage_1_winner_resolve (metalFunctionNameForStage keys off
 // the file stem) — it MUST be registered in metal_pipeline.cpp's
 // threadgroupSizeForFunctionName (2,3,8) and functionUsesImageAtomicScratch
-// lists. Omission from the former fails CI naming the kernel (enforced by
-// cmake/run_metal_kernel_registry_check.cmake, #2798); omission from the latter
-// is silent and leaves the dispatch reading a dangling distance scratch. The
-// visible twin is c_voxel_to_trixel_stage_1.metal.
+// lists. Omission from either fails CI naming the kernel — the former via
+// cmake/run_metal_kernel_registry_check.cmake (#2798), the latter via
+// cmake/run_metal_scratch_consumer_check.cmake (#2878), which is what keeps a
+// missing entry from silently leaving the dispatch reading a dangling distance
+// scratch. The visible twin is c_voxel_to_trixel_stage_1.metal.
 #include "ir_iso_common.metal"
 #include "ir_constants.metal"
 

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -21,6 +21,12 @@
 #   - a scratch consumer absent from the list       → exit 1, names the kernel
 #   - a non-atomic decl at the scratch slot         → exit 0 (the #1619 params
 #     UBO shape must NOT be flagged — negative control)
+#   - a commented-out list entry                    → exit 1 (the runtime stops
+#     binding for it, so it must read as absent, not present)
+#   - a hand-wrapped scratch declaration            → exit 1 (the qualifier test
+#     reads the declaration window, not the attribute's line)
+#   - an atomic neighbour on the slot's line        → exit 0 (that qualifier
+#     belongs to the preceding parameter — negative control)
 #   - a listed kernel that declares no scratch      → exit 1 (reverse drift:
 #     the sticky bind would clobber its slot, #1619)
 #   - a scratch list with no bare "}" terminator    → exit 1 (EOF guard)
@@ -56,8 +62,12 @@ trap 'rm -rf "$TMPROOT"' EXIT
 # functionUsesImageAtomicScratch. Arms that inject a new kernel must register
 # it in the former — otherwise the registry check (#2798) FATALs first and the
 # arm silently tests that checker instead of the one it names.
+#
+# $4 (optional) is a list of scratch entries emitted COMMENTED OUT — the way a
+# developer disables one, rather than deleting it. bindComputeResources binds
+# off the live list, so those names must read as absent.
 write_pipeline_cpp() {
-    local root="$1" registry_names="$2" scratch_names="$3" name
+    local root="$1" registry_names="$2" scratch_names="$3" commented_names="${4:-}" name
     local out="$root/engine/render/src/metal/metal_pipeline.cpp"
     {
         echo 'namespace IRRender {'
@@ -76,6 +86,9 @@ write_pipeline_cpp() {
         echo '    return false'
         for name in $scratch_names; do
             echo "           || functionName == \"$name\""
+        done
+        for name in $commented_names; do
+            echo "        // || functionName == \"$name\""
         done
         echo '        ;'
         echo '}'
@@ -248,6 +261,74 @@ assert_contains "$alias_out" "Metal scratch-consumer check scanned 2 compute ker
     "the alias kernel was actually scanned, not skipped"
 assert_contains "$alias_out" "(1 declare the image-atomic scratch at buffer slot 16)" \
     "the alias kernel is not counted as a scratch consumer"
+
+# --- a commented-out list entry reads as absent, not present -----------------
+# bindComputeResources binds off the live list, so commenting an entry out stops
+# the bind exactly as deleting it would. A scan that harvests quoted names from
+# the raw line reads the entry as present and passes green while the consumer's
+# imageAtomicMin writes land nowhere — the forward direction, reached by two
+# slashes.
+SCRATCH_COMMENTED="$TMPROOT/scratch-commented"
+make_fixture "$SCRATCH_COMMENTED"
+write_pipeline_cpp "$SCRATCH_COMMENTED" "c_fixture_kernel" "" "c_fixture_kernel"
+scratch_commented_out=$(run_checker "$SCRATCH_COMMENTED")
+scratch_commented_rc=$?
+assert_eq "1" "$scratch_commented_rc" "commented-out scratch list entry exits 1"
+assert_contains "$scratch_commented_out" "c_fixture_kernel" \
+    "failure names the consumer whose entry was commented out"
+assert_contains "$scratch_commented_out" "absent from functionUsesImageAtomicScratch" \
+    "a commented-out entry is reported as absent, not present"
+
+# --- a hand-wrapped scratch declaration is still caught ----------------------
+# The qualifier test reads the parameter's declaration window, not the physical
+# line the slot attribute sits on. A line-scoped test reads this kernel as
+# declaring no scratch and exits 0 — the same false clean as an omission, on a
+# kernel that does declare it, reached by a line break alone. Only hand
+# authoring produces the wrap: .metal is not in irreden_collect_quality_files'
+# extension list, so no formatter can introduce or remove it.
+SCRATCH_WRAPPED="$TMPROOT/scratch-wrapped"
+make_fixture "$SCRATCH_WRAPPED"
+cat > "$SCRATCH_WRAPPED/engine/render/src/shaders/metal/c_fixture_wrapped.metal" <<'EOF'
+kernel void c_fixture_wrapped(
+    device atomic_int*
+        distanceScratch [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+write_pipeline_cpp "$SCRATCH_WRAPPED" \
+    "c_fixture_kernel c_fixture_wrapped" "c_fixture_kernel"
+scratch_wrapped_out=$(run_checker "$SCRATCH_WRAPPED")
+scratch_wrapped_rc=$?
+assert_eq "1" "$scratch_wrapped_rc" "wrapped scratch declaration makes the checker exit 1"
+assert_contains "$scratch_wrapped_out" "c_fixture_wrapped" \
+    "failure names the kernel whose declaration wrapped"
+assert_contains "$scratch_wrapped_out" "(2 declare the image-atomic scratch at buffer slot 16)" \
+    "the wrapped declaration is counted, not read as absent"
+
+# --- NEGATIVE CONTROL: an atomic neighbour sharing the slot line -------------
+# The declaration window's other half. A line-scoped qualifier test sees the
+# atomic_int belonging to the PRECEDING parameter and reads this kernel as a
+# consumer — a false positive in the #1619 direction against a kernel whose
+# slot-16 parameter is a plain params UBO. The counts pin that it was scanned
+# and correctly excluded, not skipped.
+SLOT_NEIGHBOUR="$TMPROOT/slot-neighbour"
+make_fixture "$SLOT_NEIGHBOUR"
+cat > "$SLOT_NEIGHBOUR/engine/render/src/shaders/metal/c_fixture_neighbour.metal" <<'EOF'
+struct FixtureParams { int a; };
+kernel void c_fixture_neighbour(
+    device atomic_int* other [[buffer(3)]], constant FixtureParams& params [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+write_pipeline_cpp "$SLOT_NEIGHBOUR" \
+    "c_fixture_kernel c_fixture_neighbour" "c_fixture_kernel"
+neighbour_out=$(run_checker "$SLOT_NEIGHBOUR")
+neighbour_rc=$?
+assert_eq "0" "$neighbour_rc" "an atomic neighbour on the slot line is not a consumer"
+assert_contains "$neighbour_out" "Metal scratch-consumer check scanned 2 compute kernel(s)" \
+    "the neighbour kernel was actually scanned, not skipped"
+assert_contains "$neighbour_out" "(1 declare the image-atomic scratch at buffer slot 16)" \
+    "an atomic at a different slot is not counted as a scratch declaration"
 
 # --- reverse drift: a listed kernel that declares no scratch fails -----------
 # The #1619 direction. A name on the list that does not declare the scratch

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -12,11 +12,23 @@
 # Covers:
 #   - a mutable namespace-scope global in a header  → exit 1, names the file
 #   - `constexpr` / `const` constants               → exit 0 (not state)
-#   - a clean fixture tree                          → exit 0, and the Metal
-#     kernel registry check ran (scanned 1 kernel; _body fragment excluded)
+#   - a clean fixture tree                          → exit 0, and both Metal
+#     checks ran (1 kernel scanned, _body fragment excluded as an entry point
+#     but still read through the wrapper's include chain)
 #   - an unregistered Metal compute kernel          → exit 1, names the kernel
 #   - a registry with no bare "}" terminator line   → exit 1 (EOF guard, not
 #     a silent scan past the function into unrelated string literals)
+#   - a scratch consumer absent from the list       → exit 1, names the kernel
+#   - a non-atomic decl at the scratch slot         → exit 0 (the #1619 params
+#     UBO shape must NOT be flagged — negative control)
+#   - a listed kernel that declares no scratch      → exit 1 (reverse drift:
+#     the sticky bind would clobber its slot, #1619)
+#   - a scratch list with no bare "}" terminator    → exit 1 (EOF guard)
+#   - an unresolvable `#include "…"`                → exit 1 (a dropped include
+#     would shrink a consumer's scanned source into a false clean)
+#   - no slot-attributed declaration anywhere       → exit 1 (the matcher broke;
+#     the slot is aliased and always has consumers)
+#   - an unreadable scratch-slot constant           → exit 1 (anchor guard)
 #   - a missing PROJECT_ROOT                        → exit 1 (usage guard)
 
 set -uo pipefail
@@ -38,19 +50,60 @@ fi
 TMPROOT=$(mktemp -d)
 trap 'rm -rf "$TMPROOT"' EXIT
 
+# Both Metal checks parse metal_pipeline.cpp, so the pipeline fixture is
+# parameterized: $2 is the space-separated kernel list for
+# threadgroupSizeForFunctionName, $3 the list for
+# functionUsesImageAtomicScratch. Arms that inject a new kernel must register
+# it in the former — otherwise the registry check (#2798) FATALs first and the
+# arm silently tests that checker instead of the one it names.
+write_pipeline_cpp() {
+    local root="$1" registry_names="$2" scratch_names="$3" name
+    local out="$root/engine/render/src/metal/metal_pipeline.cpp"
+    {
+        echo 'namespace IRRender {'
+        echo 'namespace {'
+        echo
+        echo 'MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {'
+        for name in $registry_names; do
+            echo "    if (functionName == \"$name\") {"
+            echo '        return MTL::Size(16, 16, 1);'
+            echo '    }'
+        done
+        echo '    return MTL::Size(1, 1, 1);'
+        echo '}'
+        echo
+        echo 'bool functionUsesImageAtomicScratch(const std::string &functionName) {'
+        echo '    return false'
+        for name in $scratch_names; do
+            echo "           || functionName == \"$name\""
+        done
+        echo '        ;'
+        echo '}'
+        echo
+        echo '}  // namespace'
+        echo '}  // namespace IRRender'
+    } > "$out"
+}
+
 # The checker only needs cmake/ to identify a tree as the repo root, plus one
-# of the globbed source roots to have headers in it. The Metal kernel registry
-# check rides the same entry point, so the fixture also carries one registered
-# kernel, one _body include-fragment (must be excluded from the scan), and a
-# registry function shaped like the real metal_pipeline.cpp one.
+# of the globbed source roots to have headers in it. Both Metal checks ride the
+# same entry point, so the fixture also carries one registered kernel, one
+# _body include-fragment, and the two registry functions shaped like the real
+# metal_pipeline.cpp ones. The scratch declaration lives in the _body fragment
+# on purpose: the fragment is excluded as a scan *entry point* (which the
+# registry check's count pins) yet must still be read through the wrapper's
+# include chain (which the scratch check's consumer count pins), and only
+# splitting them across the two files tests both properties at once.
 make_fixture() {
     local root="$1"
     mkdir -p "$root/cmake" "$root/engine/include/irreden" \
              "$root/engine/render/src/shaders/metal" \
-             "$root/engine/render/src/metal"
+             "$root/engine/render/src/metal" \
+             "$root/engine/render/include/irreden/render/metal"
     cp "$SCRIPT_DIR/cmake/ir_quality_tools.cmake" \
        "$SCRIPT_DIR/cmake/run_header_convention_checks.cmake" \
        "$SCRIPT_DIR/cmake/run_metal_kernel_registry_check.cmake" \
+       "$SCRIPT_DIR/cmake/run_metal_scratch_consumer_check.cmake" \
        "$CHECKER" "$root/cmake/"
     cat > "$root/engine/include/irreden/clean.hpp" <<'EOF'
 #pragma once
@@ -59,24 +112,24 @@ constexpr int kCleanConstant = 1;
 const char *const kCleanName = "clean";
 }
 EOF
-    echo '// fixture kernel' \
-        > "$root/engine/render/src/shaders/metal/c_fixture_kernel.metal"
-    echo '// fixture include-fragment' \
-        > "$root/engine/render/src/shaders/metal/c_fixture_kernel_body.metal"
-    cat > "$root/engine/render/src/metal/metal_pipeline.cpp" <<'EOF'
+    cat > "$root/engine/render/include/irreden/render/metal/metal_runtime.hpp" <<'EOF'
+#pragma once
 namespace IRRender {
-namespace {
-
-MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
-    if (functionName == "c_fixture_kernel") {
-        return MTL::Size(16, 16, 1);
-    }
-    return MTL::Size(1, 1, 1);
+constexpr std::uint32_t kMetalImageAtomicScratchSlot = 16;
 }
-
-}  // namespace
-}  // namespace IRRender
 EOF
+    cat > "$root/engine/render/src/shaders/metal/c_fixture_kernel.metal" <<'EOF'
+// fixture kernel
+#include "c_fixture_kernel_body.metal"
+EOF
+    cat > "$root/engine/render/src/shaders/metal/c_fixture_kernel_body.metal" <<'EOF'
+// fixture include-fragment
+kernel void IR_FIXTURE_KERNEL_NAME(
+    device atomic_int* distanceScratch [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+    write_pipeline_cpp "$root" "c_fixture_kernel" "c_fixture_kernel"
 }
 
 run_checker() {
@@ -102,6 +155,17 @@ assert_absent "$clean_out" "scanned 0 header file(s)" \
 # pins the _body include-fragment exclusion.
 assert_contains "$clean_out" "Metal kernel registry check scanned 1 compute kernel(s)" \
     "metal registry check runs on the CI path and excludes _body fragments"
+
+# Same for the scratch-consumer check (#2878). The "(1 declare" half is the
+# load-bearing one: the fixture's scratch declaration lives ONLY in the _body
+# fragment, so a count of 1 can only come from resolving the wrapper's
+# #include chain. A checker that read entry-point files alone would report 0
+# here and still exit 0, since the fixture list would then agree with an empty
+# expected set.
+assert_contains "$clean_out" "Metal scratch-consumer check scanned 1 compute kernel(s)" \
+    "metal scratch-consumer check runs on the CI path"
+assert_contains "$clean_out" "(1 declare the image-atomic scratch at buffer slot 16)" \
+    "scratch check resolves the wrapper -> _body include chain"
 
 # --- an unregistered Metal kernel fails -------------------------------------
 METAL_DIRTY="$TMPROOT/metal-dirty"
@@ -138,6 +202,163 @@ indent_rc=$?
 assert_eq "1" "$indent_rc" "indented registry (no bare \"}\" line) exits 1"
 assert_contains "$indent_out" "closing-brace terminator" \
     "EOF-without-terminator failure explains itself"
+
+# --- a scratch consumer missing from the list fails --------------------------
+# Registered in threadgroupSizeForFunctionName so the #2798 check passes and
+# this arm actually reaches the #2878 one.
+SCRATCH_MISSING="$TMPROOT/scratch-missing"
+make_fixture "$SCRATCH_MISSING"
+cat > "$SCRATCH_MISSING/engine/render/src/shaders/metal/c_fixture_consumer.metal" <<'EOF'
+kernel void c_fixture_consumer(
+    device atomic_int* distanceScratch [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+write_pipeline_cpp "$SCRATCH_MISSING" \
+    "c_fixture_kernel c_fixture_consumer" "c_fixture_kernel"
+scratch_missing_out=$(run_checker "$SCRATCH_MISSING")
+scratch_missing_rc=$?
+assert_eq "1" "$scratch_missing_rc" "unlisted scratch consumer makes the checker exit 1"
+assert_contains "$scratch_missing_out" "c_fixture_consumer" \
+    "failure names the unlisted scratch consumer"
+assert_contains "$scratch_missing_out" "absent from functionUsesImageAtomicScratch" \
+    "failure explains which direction drifted"
+
+# --- NEGATIVE CONTROL: a non-atomic declaration at the scratch slot ----------
+# c_revoxelize_detached's real shape — slot 16 as a params UBO, deliberately
+# NOT on the list (#1619). It must not be flagged, and the check must have
+# actually seen it: the kernel count rises to 2 while the consumer count stays
+# at 1. Without both halves this arm would also pass against a checker that
+# skipped the file entirely.
+SLOT_ALIAS="$TMPROOT/slot-alias"
+make_fixture "$SLOT_ALIAS"
+cat > "$SLOT_ALIAS/engine/render/src/shaders/metal/c_fixture_alias.metal" <<'EOF'
+struct FixtureParams { int a; };
+kernel void c_fixture_alias(
+    constant FixtureParams& params [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+write_pipeline_cpp "$SLOT_ALIAS" \
+    "c_fixture_kernel c_fixture_alias" "c_fixture_kernel"
+alias_out=$(run_checker "$SLOT_ALIAS")
+alias_rc=$?
+assert_eq "0" "$alias_rc" "non-atomic decl at the scratch slot is not flagged"
+assert_contains "$alias_out" "Metal scratch-consumer check scanned 2 compute kernel(s)" \
+    "the alias kernel was actually scanned, not skipped"
+assert_contains "$alias_out" "(1 declare the image-atomic scratch at buffer slot 16)" \
+    "the alias kernel is not counted as a scratch consumer"
+
+# --- reverse drift: a listed kernel that declares no scratch fails -----------
+# The #1619 direction. A name on the list that does not declare the scratch
+# gets the sticky scratch bound over whatever it does declare at that slot.
+SCRATCH_STALE="$TMPROOT/scratch-stale"
+make_fixture "$SCRATCH_STALE"
+echo 'kernel void c_fixture_plain(uint3 gid [[thread_position_in_grid]]) {}' \
+    > "$SCRATCH_STALE/engine/render/src/shaders/metal/c_fixture_plain.metal"
+write_pipeline_cpp "$SCRATCH_STALE" \
+    "c_fixture_kernel c_fixture_plain" "c_fixture_kernel c_fixture_plain"
+scratch_stale_out=$(run_checker "$SCRATCH_STALE")
+scratch_stale_rc=$?
+assert_eq "1" "$scratch_stale_rc" "listed non-consumer makes the checker exit 1"
+assert_contains "$scratch_stale_out" "c_fixture_plain" \
+    "failure names the stale list entry"
+assert_contains "$scratch_stale_out" "#1619" \
+    "failure cites the regression the reverse direction reproduces"
+assert_absent "$scratch_stale_out" "absent from functionUsesImageAtomicScratch" \
+    "reverse drift is not reported as the forward direction"
+
+# --- a scratch list without its bare "}" terminator fails --------------------
+# Same EOF guard as the registry check's: a scan that ran past the terminator
+# would sweep up unrelated quoted strings and could read a genuinely absent
+# consumer as present.
+SCRATCH_INDENTED="$TMPROOT/scratch-indented"
+make_fixture "$SCRATCH_INDENTED"
+cat > "$SCRATCH_INDENTED/engine/render/src/metal/metal_pipeline.cpp" <<'EOF'
+namespace IRRender {
+namespace {
+
+MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
+    if (functionName == "c_fixture_kernel") {
+        return MTL::Size(16, 16, 1);
+    }
+    return MTL::Size(1, 1, 1);
+}
+
+}  // namespace
+
+namespace detail {
+    bool functionUsesImageAtomicScratch(const std::string &functionName) {
+        return functionName == "c_fixture_kernel";
+    }
+}  // namespace detail
+}  // namespace IRRender
+EOF
+scratch_indent_out=$(run_checker "$SCRATCH_INDENTED")
+scratch_indent_rc=$?
+assert_eq "1" "$scratch_indent_rc" "indented scratch list (no bare \"}\" line) exits 1"
+assert_contains "$scratch_indent_out" "signature but hit EOF before its closing-brace terminator" \
+    "scratch-list EOF-without-terminator failure explains itself"
+# Both Metal checks carry that wording, so pin which one fired — the registry
+# function is well-formed in this fixture and must have passed.
+assert_contains "$scratch_indent_out" "run_metal_scratch_consumer_check.cmake" \
+    "the scratch check is what rejected the indented list"
+assert_contains "$scratch_indent_out" "Metal kernel registry check scanned" \
+    "the registry check still passed on the same fixture"
+
+# --- an unresolvable #include fails, rather than shrinking the scanned source -
+# Dropping an include silently would make a real consumer read as "declares no
+# scratch" — a false clean in the direction this check exists to close.
+BAD_INCLUDE="$TMPROOT/bad-include"
+make_fixture "$BAD_INCLUDE"
+cat > "$BAD_INCLUDE/engine/render/src/shaders/metal/c_fixture_kernel.metal" <<'EOF'
+// fixture kernel
+#include "c_fixture_kernel_missing_body.metal"
+EOF
+bad_include_out=$(run_checker "$BAD_INCLUDE")
+bad_include_rc=$?
+assert_eq "1" "$bad_include_rc" "unresolvable #include exits 1"
+assert_contains "$bad_include_out" "could not resolve #include" \
+    "unresolvable-include failure explains itself"
+assert_contains "$bad_include_out" "c_fixture_kernel_missing_body.metal" \
+    "failure names the include it could not resolve"
+
+# --- a tree where nothing matches the slot attribute fails -------------------
+# The slot is aliased and always has consumers, so zero matches means the
+# attribute spelling drifted, not that the slot went unused. Without this the
+# forward direction would read clean on an expected set the matcher can no
+# longer populate.
+NO_SLOT="$TMPROOT/no-slot"
+make_fixture "$NO_SLOT"
+cat > "$NO_SLOT/engine/render/src/shaders/metal/c_fixture_kernel_body.metal" <<'EOF'
+// fixture include-fragment with no slot-attributed parameter
+kernel void IR_FIXTURE_KERNEL_NAME(uint3 gid [[thread_position_in_grid]]) {}
+EOF
+no_slot_out=$(run_checker "$NO_SLOT")
+no_slot_rc=$?
+assert_eq "1" "$no_slot_rc" "a tree with no slot-attributed declaration exits 1"
+assert_contains "$no_slot_out" "found no [[buffer(16)]] declaration anywhere" \
+    "empty-matcher failure explains itself rather than reporting a clean scan"
+assert_contains "$no_slot_out" "spelling changed" \
+    "empty-matcher failure names the likely cause"
+
+# --- an unreadable scratch-slot constant fails ------------------------------
+# The check parses the slot number out of kMetalImageAtomicScratchSlot rather
+# than hardcoding it; a rename must be loud, not silently scanned against a
+# stale literal.
+SLOT_RENAMED="$TMPROOT/slot-renamed"
+make_fixture "$SLOT_RENAMED"
+cat > "$SLOT_RENAMED/engine/render/include/irreden/render/metal/metal_runtime.hpp" <<'EOF'
+#pragma once
+namespace IRRender {
+constexpr std::uint32_t kMetalScratchSlotRenamed = 16;
+}
+EOF
+slot_out=$(run_checker "$SLOT_RENAMED")
+slot_rc=$?
+assert_eq "1" "$slot_rc" "unreadable scratch-slot constant exits 1"
+assert_contains "$slot_out" "could not read kMetalImageAtomicScratchSlot" \
+    "slot-constant anchor failure explains itself"
 
 # --- a banned mutable global fails ------------------------------------------
 DIRTY="$TMPROOT/dirty"


### PR DESCRIPTION
## Summary
- Adds `cmake/run_metal_scratch_consumer_check.cmake` — an executed membership check for `metal_pipeline.cpp`'s `functionUsesImageAtomicScratch`, the second hand-list in that file. #2798 scoped it out because a naive slot-membership check false-positives on `c_revoxelize_detached`; the **atomic qualifier** discriminates that case structurally, so the expected set is derivable after all.
- **Checks both directions.** A consumer missing from the list never gets the scratch bound and its `imageAtomicMin` writes land nowhere; a name *on* the list that declares no atomic parameter at that slot gets the sticky scratch bound over whatever it did declare — the #1619 regression. Only the second was ever discussed and neither was checked.
- **Expected set is derived, not declared.** For each dispatchable kernel the check resolves its transitive `#include "…"` closure (the same rule `loadAndPreprocessMetalSource` applies at runtime, with the same visited-set cycle guard) — that closure is what lets the two `*_body.metal` fragments reach their five wrappers — then tests for an `atomic_int`/`atomic_uint` parameter at the scratch slot.
- **No allowlist, deliberately.** A hand-list naming a kernel the matcher already excludes would be a third hand-list inside the check written to retire the second one, and would read as load-bearing while protecting nothing. A negative-control arm pins the `c_revoxelize_detached` shape instead (see the deviation note below).
- **Slot number is parsed from `kMetalImageAtomicScratchSlot`**, not hardcoded — a rename or re-slot fails loudly rather than being scanned against a stale literal.
- Wired to all three entry points #2798 used: the header-checks CI workflow (via `run_header_checks_standalone.cmake`) and the `header-checks` / `lint` CMake targets. Pure text-scanning, so it fires on GL-authored PRs from hosts with no Metal toolchain.
- Corrects the comments in `metal_pipeline.cpp`, `metal_runtime.hpp`, and `docs/design/voxel-feeder-split.md` that said these lists "do not self-detect" — true when written, not any more. Adds the sibling section to `engine/render/CLAUDE.md` and fixes the workflow's own header, which still described itself as only the header-convention checks (it grew the registry check in #2798).

## Deviation from the issue's suggested approach

The issue's suggested approach says "allowlist `c_revoxelize_detached` with the #1619 rationale", and its acceptance criterion reads "`c_revoxelize_detached` is not flagged (allowlisted, rationale cited)". This PR delivers the **observable** criterion — it is not flagged, and the rationale is cited at the checker's own site — through structural discrimination rather than an allowlist entry, because under the atomic-qualified matcher the entry would never fire. A vacuous exclusion is worse than none: it reads as protecting something while the real property goes untested. The property is pinned by a test arm instead, and that arm is verifiably load-bearing (control below).

## Test plan
- [x] `bash scripts/fleet/tests/test_header_checks_standalone.sh` (**alone**, not via the whole-dir runner) → `48 passed, 0 failed`. Was 18 assertions on master; +30 here (21 for the checker, +9 for the nit pass). Run twice back-to-back, identical both times.
- [x] `bash scripts/fleet/tests/run_all.sh` → `124 suite(s) — 123 passed, 1 failed, 0 skipped`. The one failure is `test_cross_repo_shared_file_parity.sh` (`.github/workflows/auto-rereview.yml` DRIFTED between engine and downstream) — **pre-existing on master**, outside this diff, already filed as game #365. Isolated and confirmed by running that suite alone.
- [x] CI entry point against the real tree: `cmake -DPROJECT_ROOT="$PWD" -P cmake/run_header_checks_standalone.cmake` → exit 0, `564 header file(s)`, `Metal scratch-consumer check scanned 31 compute kernel(s) … (8 declare the image-atomic scratch at buffer slot 16)`. 8 derived = the 8 hand-list entries, exactly.
- [x] Target entry point: `fleet-build --target header-checks` → exit 0, `573 header file(s)`, same 31/8. (The 564 vs 573 split is #2889, in flight as #2892 — not this PR's; see the note below.)
- [x] `fleet-positive-control scripts/fleet/tests/test_header_checks_standalone.sh 2f6837231 --include cmake` → **MEANINGFUL**: **8** of 48 assertions fail against the pre-nit-fix head; the **40** that pass are the non-regression assertions. (40 + 8 = 48.)
- [x] `fleet-build --target IrredenEngineTest` → clean. `IrredenEngineTest` → `1502 passed`, 1 failed (`SaveTrait.InventoryIsComplete` — **#2834**, red on master, outside this diff). Count moved from 1494 because the base advanced 12 commits.
- [x] `fleet-build --target format-changed` → `11 changed file(s) examined, 0 on the quality list` (the diff is `.cmake` / `.sh` / `.md` / `.metal`; none are clang-format targets).
- [x] `bash -n` clean on the changed shell file; `git diff --check` clean.

## Acceptance evidence

| Criterion (from the issue) | Check run | Observed |
|---|---|---|
| An injected fixture kernel that declares the buffer(16) scratch but is absent from the list → CI-path run exits 1 naming it | suite arm "a scratch consumer missing from the list", which drives `cmake -DPROJECT_ROOT=… -P cmake/run_header_checks_standalone.cmake` | exit 1; `…absent from functionUsesImageAtomicScratch, so bindComputeResources never binds the scratch for it and its atomic writes land nowhere: c_fixture_consumer`. Also run against the **real** tree by injecting `c_fixture_scratch_consumer.metal` into a copy of the live shader dir → exit 1 naming it, against the live 8-entry list |
| `c_revoxelize_detached` is not flagged | clean-tree CI-path run above (it is in-tree, declares `constant RevoxelizeParams& params [[buffer(16)]]`, and is absent from the list) | exit 0; the derived count is 8, not 9 — it is scanned and not counted. Fixture twin: suite arm "non-atomic decl at the scratch slot is not flagged" asserts exit 0 **and** `scanned 2 compute kernel(s)` / `(1 declare…)`, so the arm cannot pass by the kernel being skipped |
| Clean tree exits 0; the suite's new arms pass and the untouched arms stay green | `run_all.sh`, the suite alone, both CI/target entry points | 48/48 in-suite; 123/124 suites (the 1 failure is pre-existing on master — see test plan); both entry points exit 0 |

### The negative-control arm is load-bearing, not vacuous

The `c_revoxelize_detached` criterion is the one at risk of passing for the wrong reason, so it got its own control. **Re-measured after the nit pass**, since that pass rewrote the exact qualifier test this control exercises. Replacing it with the naive slot-membership matcher #2798 rejected — and changing nothing else:

| Arm | Result |
|---|---|
| Unmodified checker (A==A baseline) | `48 passed, 0 failed` |
| Naive matcher (qualifier test removed, nothing else changed) | `44 passed, 4 failed` — red on exactly `non-atomic decl at the scratch slot is not flagged`, `the alias kernel is not counted as a scratch consumer`, `an atomic neighbour on the slot line is not a consumer`, and `an atomic at a different slot is not counted as a scratch declaration` |
| Naive matcher against the **real** tree | `9 declare…` and a hard failure naming `c_revoxelize_detached` — reproducing verbatim the false positive #2798 scoped this list out over |

### Guard coverage

Every `FATAL_ERROR` guard that is not a copy of the sibling checker's has a firing arm: the scratch-list EOF/terminator guard, the unresolvable-`#include` guard (a dropped include would shrink a real consumer's scanned source into a false clean), the "no slot-attributed declaration anywhere" guard (the matcher broke — the slot is aliased and always has consumers), and the `kMetalImageAtomicScratchSlot` anchor guard.

## Notes for reviewer
- **No screenshots.** The diff matches the visual-file glob only via `engine/render/src/metal/metal_pipeline.cpp` and `engine/render/CLAUDE.md`, and both edits are **comment/prose only** — no rendering behavior changes. `IrredenEngineTest` is the C++ control and is at its master baseline.
- **`optimize` skipped**: build/CI tooling, no system tick, render stage, shader, or math hot path.
- **Follow-up, deliberately not folded in.** While measuring this I found that `run_header_checks_standalone.cmake` calls `irreden_collect_quality_files(quality_files)` **without** `INCLUDE_RENDER_BACKENDS`, while `ir_quality_tools.cmake:106` (the `header-checks`/`lint` targets) passes it. Measured on this tree: the CI path collects **810** files and scans **564** headers; the targets collect **826** and scan **573**. The 16-file delta is exactly the render-backend set — the 9 first-party headers `.claude/rules/cpp-globals.md` §Detection says the ban "must still see", plus 7 Metal `.cpp`s. So the CI path is blind to `GLAPITrace.h`'s baselined deviation and to any new header-global under `engine/render/**/metal/`, and the shim's own comment that the two paths "cannot drift into checking different things" is false as written — the #2815 class, reopened in the CI consumer. Not folded in: it is a different rule's gate, and the fix is a one-word change with a scope decision behind it. Filed as **#2889**, in flight as **#2892** (approved, open). The 564/573 split in the test plan above is that gap, unchanged by this PR.

## Nit pass (Opus recheck)

Both nits reproduced on this tree first, then re-measured after the fix.

**1. The `metal_pipeline.cpp` list scan did not comment-strip**, so a
commented-out entry read as present while `bindComputeResources` — which reads
the live C++ — had already stopped binding the scratch for it. Comment-stripped
before the `MATCHALL`, matching what the kernel-side scan already did.

| `functionName == "c_shapes_to_trixel"` commented out | before | after |
|---|---|---|
| CI-path script | exit 0, `8 declare` | **exit 1**, names `c_shapes_to_trixel` as absent from the list |

**2. The atomic-qualifier test was line-scoped**, so a hand-wrapped declaration
was silently excluded. It now matches the parameter's *declaration window* — the
maximal run of non-delimiter characters ending at the slot attribute, which is
the declaration head regardless of wrapping. Paired control, the same probe
kernel injected into the live shader dir twice, only the line break differing:

| injected `c_fixture_probe` | before | after |
|---|---|---|
| `device atomic_int* distanceScratch [[buffer(16)]],` | exit 1, `9 declare` | exit 1, `9 declare` |
| `device atomic_int*` ⏎ `    distanceScratch [[buffer(16)]],` | **exit 0**, `8 declare` | **exit 1**, `9 declare`, names it |

The window also closes the *opposite* misread the line scan was open to, which
the review did not raise: a neighbouring parameter's `atomic_int` on a shared
line reading as this one's qualifier — a false positive in the #1619 direction.
That is the third new arm, and the positive control catches it going the wrong
way against the pre-fix code (`2 declare`, hard-failing on `c_fixture_neighbour`).

**Three suite arms, one per direction.** The negative-control arm asserts the
moving scan/declare counts, so it cannot pass by the kernel being skipped.

**Scope held at the review's boundary.** Line comments only, and the merged
sibling `run_metal_kernel_registry_check.cmake:71` carries the identical
raw-line `MATCHALL` untouched. Both are **#2899**, filed with repros — including
the measured consequence on the sibling: commenting out `c_text_to_trixel`'s
registry block leaves the checker at exit 0 while that kernel silently falls
through to the `MTL::Size(1, 1, 1)` fallback. I re-derived the affected set
rather than taking the review's citation — `fleet-rules-sweep --pattern
'string\(REGEX MATCHALL' --glob '*.cmake' cmake` returns exactly 3 hits, and the
third is an unrelated diff-hunk matcher, so these two checkers are the whole
population.

## Rebase: inherited prefix dropped

This was a native-stack child of #2868. That parent squash-merged as
`0c9eec3c8`, so the branch was still carrying its four original commits against
a master that already contained their content — which is what the merger saw as
10 conflicted files, every one duplicate #2868 content.

Resolved by dropping the prefix rather than hand-merging it:
`git rebase --onto origin/master 893047ca4`. **Zero conflicts** — the whole
conflict set was the inherited prefix. The branch is now 3 commits on
`12b8a49c8`, 11 files.

Verified master supersedes the prefix before dropping it, rather than assuming
it: `git diff 893047ca4 origin/master` restricted to the 13 files the parent's
commits touched is **insertions-only (91 lines, 0 deletions)**, and those
insertions trace to `a7680ac10` (#2838) and `e089e102c` (#2812) — master commits
the parent branch never had. No line the parent added is absent from master.

The base delta this branch had not absorbed (`0c9eec3c8..origin/master` —
#2884, #2875, #2873) touches 8 files, none of which this PR's surface reaches,
so the non-conflicting half of the rebase carries no second staleness of the
kind `2f6837231` was written to catch. Every number in the test plan above was
re-measured after this rebase, not carried over.

Closes #2878

🤖 Generated with [Claude Code](https://claude.com/claude-code)


