### PR TITLE
fleet: drop false bash-mirror sync claim from _TOKEN_ISSUE_RE (#2829)

### DIFF
--- a/scripts/fleet/fleet_branch_match.py
+++ b/scripts/fleet/fleet_branch_match.py
@@ -28,8 +28,8 @@ of the same #1425 duplicate-PR incident — workers improvised
 `claude/game-<worktree>-issue-<N>` branches the prefix-only matcher could not
 tie back to the issue, so the liveness sweep judged the live claim abandoned
 and a duplicate PR followed. The token boundaries are explicit
-(`(?:^|[-/])issue-(\\d+)(?=-|$)`) so the `fleet-claim` bash mirror can copy
-the spelling exactly.
+(`(?:^|[-/])issue-(\\d+)(?=-|$)`) — documented here since `_TOKEN_ISSUE_RE`
+below is the single source every caller imports.
 """
 
 import re
@@ -82,9 +82,10 @@ def _leading_issue(head_ref):
 
 # Word-bounded `issue-<N>` token: starts at a segment boundary (start, '/',
 # or '-') and the digits end at '-' or end-of-string, so `issue-25` does not
-# match #255 and `issue-255` does not match #25. The bash mirror in
-# `fleet-claim`'s stack-rebase auto-detect copies this spelling verbatim —
-# keep the two in sync.
+# match #255 and `issue-255` does not match #25. Single-sourced here — every
+# caller (`fleet-claim`, `fleet-reconcile-amendments`, `fleet-state-scout`,
+# `fleet_stack_base.py`) reaches this grammar through the module, and
+# `fleet-claim branch-check` is the shell entry point that shells into it.
 _TOKEN_ISSUE_RE = re.compile(r"(?:^|[-/])issue-(\d+)(?=-|$)")
 
 


### PR DESCRIPTION
## Summary
- `fleet_branch_match.py`'s module docstring and the `_TOKEN_ISSUE_RE` comment both claimed a `fleet-claim` bash-mirror sync obligation that doesn't exist — corrected both to state the grammar is single-sourced and consumed by every caller through the module.
- Comment-only, no behavior change.

## Test plan
- [x] `python3 scripts/fleet/tests/test_branch_matches_issue.py` — 41/41 passed, unchanged.
- [x] `ruff check scripts/fleet/fleet_branch_match.py` — clean.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `git grep -n "stack-rebase" -- scripts/` returns zero hits | ran post-fix | zero hits |
| `git grep -nE 'issue-\[0-9\]\|\[-/\]issue-' -- scripts/ .claude/ cmake/` still returns zero | ran post-fix | zero hits |
| `test_branch_matches_issue.py` still passes unchanged | ran post-fix | `Ran 41 tests in 0.001s / OK` |

Also fixed a second, un-cited instance of the same false claim in the module
docstring (`... so the fleet-claim bash mirror can copy the spelling exactly`)
— the issue's grep only matched `stack-rebase` literally, but this paraphrase
of the same retired mirror was in the same file.

Closes #2829

🤖 Generated with [Claude Code](https://claude.com/claude-code)
