### PR TITLE
render: resolve the Metal image-atomic scratch into trixelDistances (#2488)

### DIFF
--- a/.fleet/plans/issue-2488.md
+++ b/.fleet/plans/issue-2488.md
@@ -1,0 +1,64 @@
+## Plan: render: Metal feeder-ring depth never reaches trixelDistances — ring Hi-Z is sentinel, #2298 per-voxel cull no-ops on Metal
+
+- **Issue:** #2488
+- **Model:** opus — the approach below is fully committed and bounded, but verification is judgment-bearing (shadow-delta interpretation, reference re-bakes) and the work must run on a macOS/Metal host end to end.
+- **Date:** 2026-08-04
+
+### Scope
+
+Materialize the Metal image-atomic scratch buffer into the `trixelDistances` texture after stage 1, restoring GL parity of the distance channel — feeder ring included — so every texture-reading consumer sees feeder depth on Metal: the sun bake (`c_bake_sun_shadow_map`), `COMPUTE_VOXEL_AO`, and `COMPUTE_DISTANCE_HIZ` (which is what un-no-ops the #2298 per-voxel cull's Metal leg).
+
+### Verified current state
+
+Code-pinned (origin/master @ 34c7f7f46):
+
+- Stage 1 (visible + feeder dispatches) atomic-mins depth into the per-texture scratch **buffer** only (`writeDistanceTap`, `c_voxel_to_trixel_stage_1_body.metal:44-58`; scratch contract `metal_runtime.hpp:141-160`).
+- The only writer of the distance **texture** on Metal is stage 2's winner tap (`writeColorTap`, `c_voxel_to_trixel_stage_2_body.metal:37-62`), and it early-returns for shadow feeders (the #1740 skip, same file ~391-421). Ring texels therefore stay at the 65535 clear sentinel in the texture.
+- `c_build_distance_hiz.metal` reads the texture (`access::read`), is not a scratch consumer (`functionUsesImageAtomicScratch`, `metal_pipeline.cpp:120-129`), so the ring Hi-Z is sentinel — measured by the issue's staged probe (98.4% of feeders at sentinel Hi-Z, PR #2475 branch @ 5d2b5833) and the capture-0 table.
+- The GLSL backend has no gap: stage 1's `imageAtomicMin` writes the texture directly, ring included.
+
+**Correction to the issue's bake claim.** `c_bake_sun_shadow_map.metal` reads `trixelDistances` as a plain `texture(0)` — there is no scratch path into the bake. So deep-ring feeder depth does **not** reach the bake on Metal today either; the force-cull A/B's interior-shadow delta is explained by (a) margin-band feeders (inside the +4-iso-px `visibleIsoBounds` margin, which stage 2 fully writes) and (b) feeders winning depth elections at edge texels whose tap is then skipped — the issue's own secondary observation. The stage-2 #1740 comment's premise "Stage 1 wrote its full-res depth (the bake + AO read only trixelDistances)" is GL-authored and false on Metal. The gap is therefore wider than the Hi-Z: Metal currently loses sun shadows from off-screen casters beyond the margin band. The approach below fixes both consumers and does not depend on this correction being the whole story — wherever depth already flows, the resolve writes identical values (no-op by construction).
+
+This also settles the issue's fix-direction choice: direction 2 (a scratch-reading `c_build_distance_hiz` variant) repairs only the Hi-Z, leaves the bake's ring gap in place, and adds a scratch-consumer registration plus a diverging shader surface. Direction 1, generalized to the device layer, is committed below.
+
+### Approach
+
+One approach, no alternatives left open: a backend-neutral device primitive plus one guarded call site. No new shaders, no `functionUsesImageAtomicScratch` entry, no slot-16 alias exposure (#1619).
+
+1. **`render_device.hpp`** — add a defaulted no-op virtual (precedent: the `GpuTimestamp` family defaults in the same interface):
+   `virtual void resolveImageAtomicScratch(const Texture2D *texture) {}`
+   Semantics documented at the declaration: "make the texture's contents reflect its image-atomic state — no-op on backends whose image atomics write the texture directly (GL); a scratch→texture materialization on Metal." The OpenGL impl is untouched.
+2. **`metal_render_impl.cpp`** — override: look up the sibling scratch (`lookupImageAtomicScratchBuffer`), return if null, else encode one full-texture `copyFromBuffer(scratch, 0, width*4, totalBytes, (w,h,1), texture, 0, 0, origin(0,0))` through `createBlitEncoder` (so an active `GpuSubStageScope` samples it, #2280) — byte-for-byte the geometry the `clearTexImage` mirror blit already uses at `metal_render_impl.cpp:761-780`, in the reverse direction.
+3. **`system_voxel_to_trixel.hpp`** — call `IRRender::device()->resolveImageAtomicScratch(triangleCanvasTextures.getTextureDistances())` inside the per-canvas `voxelStage1` sub-scope, immediately after the feeder dispatch's `memoryBarrier` (~line 1745). Guard: the non-detached single-canvas cardinal branch, and ring non-empty — spelled as the direct comparison `gpuVp != visibleVp` on the two viewports the tick already computes at ~1336-1364 (the #1740 comment pins that with sun shadows off the sweep is zero and the two are equal). That guard makes the shadows-off, detached, GUI, and per-axis paths structurally resolve-free.
+4. **Whole-canvas resolve, not ring-only rects.** After stage 1, the scratch is exactly the distance state GL's texture holds at the same pipeline point: visible-domain winner texels are rewritten with identical values (stage 2's winner test IS scratch equality), never-written texels resolve sentinel→sentinel (the clear mirrors into the scratch, `metal_render_impl.cpp:777`), and the only actually-changed texels are those GL has and Metal lacks. This removes all iso→canvas-pixel rect math from the design. Encoder order is the engine-wide sequencing guarantee (the #1436 contract); stage 2 is order-independent of the blit since it re-tests depth from the scratch, not the texture.
+5. **Comment/doc maintenance in the same PR:** amend the #1740 comment in `c_voxel_to_trixel_stage_2_body.metal` (its premise becomes true on Metal via the resolve — say so); update `engine/render/CLAUDE.md`'s #1640 bullet to name the primitive as the sanctioned own-canvas materialization (distinct from the foreign-canvas resolve-then-bake rule, which stands).
+
+### Affected files
+
+- `engine/render/include/irreden/render/render_device.hpp` — new defaulted virtual
+- `engine/render/src/metal/metal_render_impl.cpp` — Metal override (blit encoder copy)
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` — guarded call after the feeder dispatch
+- `engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal` — comment amendment only
+- `engine/render/CLAUDE.md` — #1640 note
+- `test/render/gpu_compute_dispatch_test.cpp` — new headless resolve test (registered in `test/CMakeLists.txt:62` already; no build wiring needed)
+
+### Acceptance criteria
+
+1. **Headless GPU unit test (positive-fire, deterministic, macOS-runnable).** In `gpu_compute_dispatch_test.cpp` (vehicle A, `bootstrapHeadlessRenderDevice`): create an R32I texture, `bindAsImage` (pairs the scratch), seed a known pattern into the scratch via `lookupImageAtomicScratchBuffer(...)->contents()`, clear the texture to sentinel, call `resolveImageAtomicScratch`, read back, assert the pattern landed. Negative control in the same test: an identical texture without the resolve call reads back all-sentinel (proves the assert can fail). Skips cleanly when no Metal device, like the existing cases.
+2. **Scene-level positive fire (Metal, fixture exists on master).** `IRPerfGrid --mode voxel_set --no-overlay --subdivision-mode none --wave-freeze --wave-amplitude 5` at zoom 8 — the issue's own dense harness (47,835 feeders at that zoom, shadows on by default): capture master-vs-branch screenshots, `tools/img_diff` reports a non-zero pixel delta concentrated in shadow regions (off-screen casters now cast). **Byte-identity control:** the same A/B with `--no-sun-shadows` (`perf_grid/main.cpp:624`, #1812) reports **zero** differing pixels — the guard never dispatches the resolve with an empty ring.
+3. **Suite control:** `IrredenEngineTest` at 1493/1494 — `SaveTrait.InventoryIsComplete` is the pre-existing #2834 failure, not this PR's.
+4. **GL untouched:** no `opengl/` diff; the default virtual is a no-op. Normal reviewer-side `fleet:needs-linux-smoke` covers the cross-host build+run.
+5. **macOS references:** run `render-verify` on the macOS reference set; any shot whose scene has sun shadows plus off-screen casters may legitimately shift toward GL — re-bake exactly those references in the same PR, with the before/after pairs and the shadows-off control cited in the PR body.
+6. **Perf note in the PR:** `--auto-profile` pre/post on the same scene — the blit's bandwidth matches the existing every-frame `clearTexImage` blit (~4 bytes/texel), so the `voxelStage1`/`canvasClear` GPU rows are expected unchanged within noise; cite the measured rows.
+
+### Gotchas
+
+- **The resolve imports GL's depth-without-color edge texels to Metal.** Texels where a feeder won the election and stage 2 skipped its tap currently read sentinel on Metal but carry depth on GL; post-fix both backends agree. Any visible artifact there is the pre-existing, backend-agnostic #1740 margin-adequacy question — the issue routes it to the #2298 GL gate run; do not scope-creep it here.
+- **In-flight collision: PR #2475 (#2298)** touches the same tick region. It is currently parked (blocked on #2385); whichever lands second takes a trivial rebase. Behavioral interplay to note on its thread when this merges: its "byte-identical-safe on Metal, captures nothing" claim stops holding — the widened per-voxel cull will actually capture on Metal, and its Metal-side gate numbers must be re-measured on the resolved baseline. Master's chunk-occlusion cull (off by default) likewise starts seeing real ring Hi-Z on Metal — same data GL already feeds it.
+- **Use `createBlitEncoder`, never a raw `blitCommandEncoder`** — sub-stage timing attribution (#2280) rides on it.
+- **Do not add any kernel to `functionUsesImageAtomicScratch`** — there is no kernel in this design; that list and the slot-16 alias stay untouched.
+- **Guard placement:** the feeder dispatch encodes unconditionally (empty when zero feeders), so the resolve's guard must come from the CPU-side viewport comparison, not from any per-dispatch feeder count (that count is GPU-side in indirect struct 1).
+- Engine-public plan: no game-repo references anywhere in the PR (baseline isolation rule).
+
+One task, no stack — the device primitive, call site, test, and reference re-bakes land as a single PR (`Closes #2488`).
+

--- a/engine/prefabs/irreden/render/sun_shadow_constants.hpp
+++ b/engine/prefabs/irreden/render/sun_shadow_constants.hpp
@@ -117,7 +117,10 @@ inline IRMath::IsoBounds2D shadowFeederCullViewport(
 // guards is what makes that safe, not the predicate: the per-frame
 // clearTexImage mirrors the sentinel into the scratch unconditionally
 // (VOXEL_TO_TRIXEL_STAGE_1's canvasClear → metal_render_impl.cpp), so resolving
-// a ring nothing fed copies each texel's own clear value back onto itself. The
+// a ring nothing fed copies each texel's own clear value back onto itself.
+// "Unconditionally" is load-bearing and literal: that mirror *ensures* the
+// scratch rather than looking it up (#2488), so it holds on a canvas's first
+// tick too — when the clear precedes any bind that would have paired one. The
 // one caller reaches this only on the !skipSingleCanvasVoxels branch, which the
 // per-axis path already owns for the main canvas while the camera rotates — so
 // the superset costs at most one redundant blit on a SECOND (non-main,

--- a/engine/prefabs/irreden/render/sun_shadow_constants.hpp
+++ b/engine/prefabs/irreden/render/sun_shadow_constants.hpp
@@ -96,6 +96,30 @@ inline IRMath::IsoBounds2D shadowFeederCullViewport(
     );
 }
 
+// True when the shadow-feeder sweep widens @p visible into a NON-EMPTY
+// off-screen ring — i.e. when off-screen casters exist that stage 2's #1740
+// depth-only skip will strip the colour taps from.
+//
+// Quantized exactly as VOXEL_TO_TRIXEL_STAGE_1 uploads the two boxes
+// (frameData_.cullIsoMin_/cullIsoMax_ vs visibleIsoBounds_): a sweep too small
+// to cross a texel boundary yields no ring texels, so the integer compare — not
+// the float one — is the honest predicate. Empty in three states, each
+// structural rather than incidental:
+//   - sun shadows off: frameShadowFeederParams() returns sweepDistance 0 and
+//     shadowFeederIsoBounds returns `visible` unchanged;
+//   - a detached canvas: both boxes are set to the full canvas span;
+//   - residual (non-cardinal) yaw: isShadowFeederIso (ir_iso_common.glsl)
+//     short-circuits on residualYaw != 0, so the compact classifies no feeders
+//     at all and nothing reaches the feeder dispatch.
+// Exposed here rather than open-coded at the call site so the ring-empty claim
+// is testable without a GPU (test/render/sun_shadow_feeder_ring_test.cpp).
+inline bool
+shadowFeederRingNonEmpty(const IRMath::IsoBounds2D &feeder, const IRMath::IsoBounds2D &visible) {
+    return IRMath::ivec2(IRMath::floor(feeder.min_)) !=
+               IRMath::ivec2(IRMath::floor(visible.min_)) ||
+           IRMath::ivec2(IRMath::ceil(feeder.max_)) != IRMath::ivec2(IRMath::ceil(visible.max_));
+}
+
 // Sun-UV bounding box of the iso-frustum depth slab [@p depthMin, @p depthMax]
 // over @p isoBounds, with every corner ALSO offset by @p sweep (world-frame,
 // = -sunDir * sweepDistance) so off-screen casters within shadow range are

--- a/engine/prefabs/irreden/render/sun_shadow_constants.hpp
+++ b/engine/prefabs/irreden/render/sun_shadow_constants.hpp
@@ -103,14 +103,26 @@ inline IRMath::IsoBounds2D shadowFeederCullViewport(
 // Quantized exactly as VOXEL_TO_TRIXEL_STAGE_1 uploads the two boxes
 // (frameData_.cullIsoMin_/cullIsoMax_ vs visibleIsoBounds_): a sweep too small
 // to cross a texel boundary yields no ring texels, so the integer compare — not
-// the float one — is the honest predicate. Empty in three states, each
-// structural rather than incidental:
+// the float one — is the honest predicate. Above that quantization floor it is
+// empty in exactly TWO states, both structural rather than incidental:
 //   - sun shadows off: frameShadowFeederParams() returns sweepDistance 0 and
 //     shadowFeederIsoBounds returns `visible` unchanged;
-//   - a detached canvas: both boxes are set to the full canvas span;
-//   - residual (non-cardinal) yaw: isShadowFeederIso (ir_iso_common.glsl)
-//     short-circuits on residualYaw != 0, so the compact classifies no feeders
-//     at all and nothing reaches the feeder dispatch.
+//   - a detached canvas: both boxes are set to the full canvas span.
+//
+// Camera yaw is NOT a third one. Both boxes derive from the cull viewport and a
+// yaw-free sun sweep, so this returns the same answer at every yaw — while the
+// GPU's isShadowFeederIso (ir_iso_common.glsl) DOES short-circuit on
+// residualYaw != 0 and classifies zero feeders mid-rotation. The predicate is
+// therefore a superset of "a feeder was actually rastered", and the resolve it
+// guards is what makes that safe, not the predicate: the per-frame
+// clearTexImage mirrors the sentinel into the scratch unconditionally
+// (VOXEL_TO_TRIXEL_STAGE_1's canvasClear → metal_render_impl.cpp), so resolving
+// a ring nothing fed copies each texel's own clear value back onto itself. The
+// one caller reaches this only on the !skipSingleCanvasVoxels branch, which the
+// per-axis path already owns for the main canvas while the camera rotates — so
+// the superset costs at most one redundant blit on a SECOND (non-main,
+// non-detached) voxel-pool canvas, whose residualYaw_ tracks the same camera.
+//
 // Exposed here rather than open-coded at the call site so the ring-empty claim
 // is testable without a GPU (test/render/sun_shadow_feeder_ring_test.cpp).
 inline bool

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -779,11 +779,10 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                 Texture2D *distances = tex.distances_.second;
                 Texture2D *entityIds = tex.entityIds_.second;
 
-                // Bind the distance image first so its Metal atomic-scratch buffer
-                // exists before clearTexImage mirrors the clear value into it (a
-                // freshly allocated scratch is zero-initialised, which would
-                // otherwise reject every depth-matched color write on the first
-                // rotating frame).
+                // Redundant with the stage-1 image bind this loop makes before its
+                // dispatch: clearTexImage establishes the Metal atomic scratch
+                // itself, so the clear seeds the sentinel whether or not a bind has
+                // paired one yet (#2488). Removable with a rotating-path re-verify.
                 distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
                 IRRender::device()->clearTexImage(distances, 0, &kDistanceClear);
                 colors->clear(PixelDataFormat::RGBA, PixelDataType::UNSIGNED_BYTE, &kColorClear[0]);

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -782,7 +782,8 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                 // Redundant with the stage-1 image bind this loop makes before its
                 // dispatch: clearTexImage establishes the Metal atomic scratch
                 // itself, so the clear seeds the sentinel whether or not a bind has
-                // paired one yet (#2488). Removable with a rotating-path re-verify.
+                // paired one yet (#2488). Removable with a rotating-path
+                // re-verify — tracked as #2923.
                 distances->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
                 IRRender::device()->clearTexImage(distances, 0, &kDistanceClear);
                 colors->clear(PixelDataFormat::RGBA, PixelDataType::UNSIGNED_BYTE, &kColorClear[0]);

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -1334,6 +1334,10 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // Read once up front: the world path uploads it as visibleIsoBounds_
         // and the (world-only) occlusion pre-pass below reuses it.
         const IsoBounds2D visibleVp = IRRender::getCullViewport().isoViewport(kGpuMargin);
+        // Whether this canvas has an off-screen shadow-feeder ring this frame —
+        // the condition for the Metal scratch resolve after the feeder dispatch
+        // below (#2488). Resolved here because both boxes are in scope only here.
+        bool shadowFeederRing = false;
         if (canvasLocalRotation.isDetached()) {
             // Model-space canvas domain (same rationale as the chunk mask
             // above): the camera-space per-voxel cull viewport does not apply
@@ -1361,6 +1365,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             // form reads above, so the two boxes are derived consistently.
             frameData_.visibleIsoBounds_ =
                 ivec4(ivec2(IRMath::floor(visibleVp.min_)), ivec2(IRMath::ceil(visibleVp.max_)));
+            shadowFeederRing = IRPrefab::SunShadow::shadowFeederRingNonEmpty(gpuVp, visibleVp);
         }
 
         // Occlusion cull gate (#1294 chunk pre-pass + #1812 per-voxel refine, off
@@ -1740,6 +1745,30 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                     kBufferIndex_IndirectDispatchParams
                 );
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+                // #2488: on Metal both stage-1 dispatches atomic-min their depth
+                // into the texture's sibling scratch BUFFER, and the only pass
+                // that writes the distance TEXTURE — stage 2's winner tap — skips
+                // feeders (the #1740 depth-only skip). So ring texels stay at the
+                // 65535 clear sentinel in the texture, and every texture-reading
+                // consumer (BAKE_SUN_SHADOW_MAP, COMPUTE_VOXEL_AO,
+                // COMPUTE_DISTANCE_HIZ, and through it the #2298 per-voxel
+                // occlusion cull) loses the feeder ring that GL's imageAtomicMin
+                // writes straight to the texture. Materialize the scratch here to
+                // restore that parity. No-op on GL (defaulted virtual).
+                //
+                // Whole-canvas, not ring-only rects: at this point the scratch IS
+                // the distance state GL's texture holds, so visible-domain texels
+                // resolve to the identical values stage 2 is about to re-store
+                // (its winner test IS scratch equality), untouched texels resolve
+                // sentinel onto sentinel (clearTexImage mirrors the clear into the
+                // scratch), and only the texels GL has and Metal lacks change.
+                // Stage 2 is order-independent of this blit — it re-tests depth
+                // from the scratch, never from the texture.
+                if (shadowFeederRing) {
+                    IRRender::device()->resolveImageAtomicScratch(
+                        triangleCanvasTextures.getTextureDistances()
+                    );
+                }
             }
 
             // #2346 cardinal winner election — flagged (displaced-voxel) pools

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -1121,6 +1121,27 @@ parity with voxel-pool primary shapes.
   texture as a bake/compute read input. Invariant: the sun-shadow bake only
   ever reads main-canvas-layout depth sources. The underlying backend gap is
   tracked as #1640; until it lands, resolve-then-bake is mandatory.
+
+  **The own-canvas half has a primitive: `RenderDevice::resolveImageAtomicScratch`
+  (#2488).** The rule above governs reading a *foreign* canvas's distances. The
+  separate, narrower problem is a canvas's OWN distances that no pass ever
+  materialized into the texture — on Metal the atomics land in the scratch
+  buffer, so a texel the stage-2 winner tap skips stays at the 65535 clear
+  sentinel in the texture even though the scratch holds real depth. Every
+  texture-reading consumer (`c_bake_sun_shadow_map`, `COMPUTE_VOXEL_AO`,
+  `COMPUTE_DISTANCE_HIZ`) then reads a hole GL does not have. Call
+  `IRRender::device()->resolveImageAtomicScratch(texture)` after the atomic
+  passes and before the first texture reader; it is a defaulted no-op on GL
+  (whose `imageAtomicMin` writes the texture directly) and a whole-texture blit
+  on Metal. `VOXEL_TO_TRIXEL_STAGE_1` is the reference call site — after the
+  shadow-feeder dispatch, guarded on a non-empty feeder ring
+  (`IRPrefab::SunShadow::shadowFeederRingNonEmpty`).
+
+  Two boundaries worth keeping straight. It is **not** a substitute for
+  resolve-then-bake: that rule is about a foreign model-frame texture reaching a
+  bake at all, and it stands unchanged. And it needs **no**
+  `functionUsesImageAtomicScratch` entry — the resolve is a blit, not a kernel,
+  so the slot-16 alias (#1619) is untouched.
 - **Sampler and image binds are mutually exclusive per texture unit on Metal —
   the most recent bind wins (#2350/#2360; supersedes the #1812 workaround).**
   Metal flattens the sampler and image namespaces into ONE `setTexture` slot

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -1137,6 +1137,18 @@ parity with voxel-pool primary shapes.
   shadow-feeder dispatch, guarded on a non-empty feeder ring
   (`IRPrefab::SunShadow::shadowFeederRingNonEmpty`).
 
+  **What makes the whole-texture blit safe is that `clearTexImage` *ensures*
+  the scratch rather than looking it up.** A canvas clears its distance texture
+  before it ever image-binds it, so a lookup would find no scratch on the first
+  tick and skip the clear's mirror — and a freshly allocated scratch is
+  zero-filled, i.e. NEAREST depth, not the 65535 empty sentinel. The resolve
+  would then stamp a solid surface over the whole canvas for that frame (and
+  every `atomicMin` would lose against the zero, so stage 2's `scratch == depth`
+  winner tap matches nothing). Because the clear seeds it unconditionally,
+  untouched texels resolve their own clear value back onto themselves. A new
+  R32I texture that is resolved must therefore also be *cleared* through
+  `clearTexImage`, not merely bound.
+
   Two boundaries worth keeping straight. It is **not** a substitute for
   resolve-then-bake: that rule is about a foreign model-frame texture reaching a
   bake at all, and it stands unchanged. And it needs **no**

--- a/engine/render/include/irreden/render/render_device.hpp
+++ b/engine/render/include/irreden/render/render_device.hpp
@@ -80,8 +80,8 @@ class RenderDevice {
     fillBuffer(const Buffer *buffer, std::size_t sizeBytes, std::uint8_t byteValue) = 0;
     virtual void finish() = 0;
 
-    // Make @p texture's contents reflect its image-atomic state. A no-op on
-    // backends whose image atomics write the texture directly (OpenGL's
+    // Make @p texture's **level 0** contents reflect its image-atomic state. A
+    // no-op on backends whose image atomics write the texture directly (OpenGL's
     // imageAtomicMin), a scratch-buffer -> texture materialization on Metal,
     // whose atomics land in a sibling buffer instead (#1640,
     // metal/metal_runtime.hpp). Call it wherever a later pass reads the
@@ -89,6 +89,12 @@ class RenderDevice {
     // atomic pass wrote — the backends agree on the texture only after this.
     // Idempotent and value-safe: texels the atomics never touched resolve
     // their own clear value back onto themselves.
+    //
+    // Level 0 only, unlike clearTexImage's explicit @p level: the scratch is
+    // allocated per texture at its base dimensions (ensureImageAtomicScratchBuffer),
+    // so there is no per-level state to resolve. Every image-atomic texture in the
+    // engine is single-mip; a mipped one would need the scratch keyed by level
+    // first, not just a level argument here.
     virtual void resolveImageAtomicScratch(const Texture2D *) {}
 
     virtual GpuTimestampHandle createTimestampPair() {

--- a/engine/render/include/irreden/render/render_device.hpp
+++ b/engine/render/include/irreden/render/render_device.hpp
@@ -80,6 +80,17 @@ class RenderDevice {
     fillBuffer(const Buffer *buffer, std::size_t sizeBytes, std::uint8_t byteValue) = 0;
     virtual void finish() = 0;
 
+    // Make @p texture's contents reflect its image-atomic state. A no-op on
+    // backends whose image atomics write the texture directly (OpenGL's
+    // imageAtomicMin), a scratch-buffer -> texture materialization on Metal,
+    // whose atomics land in a sibling buffer instead (#1640,
+    // metal/metal_runtime.hpp). Call it wherever a later pass reads the
+    // texture through a plain sampler / access::read and must see depth an
+    // atomic pass wrote — the backends agree on the texture only after this.
+    // Idempotent and value-safe: texels the atomics never touched resolve
+    // their own clear value back onto themselves.
+    virtual void resolveImageAtomicScratch(const Texture2D *) {}
+
     virtual GpuTimestampHandle createTimestampPair() {
         return kInvalidGpuTimestampHandle;
     }

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -783,9 +783,13 @@ metalCurrentDepthPixelFormat(),
             // nothing) and resolveImageAtomicScratch blits a solid nearest-depth
             // surface over the whole texture. Ensuring the buffer here is what
             // makes this mirror unconditional, which is what both consumers of
-            // that property already assume (#2488). No extra allocation in
-            // practice: every R32Sint texture cleared here is image-bound later
-            // in the same frame anyway, so it only moves the allocation earlier.
+            // that property already assume (#2488). Canvas distance textures
+            // cleared here are image-bound later in the same frame, so the
+            // ensure only moves their allocation earlier. The exception is the
+            // per-axis resolveDepth_, cleared at (yaw-gated) allocation but
+            // image-bound only when a consumer stage is registered — a rotating
+            // creation with neither consumer pays one main-canvas-sized scratch
+            // it never binds. Bounded, one-time, torn down with the texture.
             if (pixelFormat == MTL::PixelFormatR32Sint) {
                 if (MTL::Buffer *scratch = ensureImageAtomicScratchBuffer(texture);
                     scratch != nullptr) {

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -773,8 +773,21 @@ metalCurrentDepthPixelFormat(),
 
             // Mirror the clear into the image atomic scratch buffer so atomic
             // image-min sees the same starting state as the texture itself.
+            //
+            // ensure, not lookup: bindAsImage creates the scratch lazily, and a
+            // canvas's tick clears its distance texture before it ever binds it,
+            // so a lookup finds nothing on the first tick and skips the mirror —
+            // leaving the freshly allocated scratch at its zero fill. Zero is the
+            // NEAREST depth, not the empty sentinel, so every atomicMin loses
+            // against it (stage 2's `scratch == depth` winner tap then matches
+            // nothing) and resolveImageAtomicScratch blits a solid nearest-depth
+            // surface over the whole texture. Ensuring the buffer here is what
+            // makes this mirror unconditional, which is what both consumers of
+            // that property already assume (#2488). No extra allocation in
+            // practice: every R32Sint texture cleared here is image-bound later
+            // in the same frame anyway, so it only moves the allocation earlier.
             if (pixelFormat == MTL::PixelFormatR32Sint) {
-                if (MTL::Buffer *scratch = lookupImageAtomicScratchBuffer(texture);
+                if (MTL::Buffer *scratch = ensureImageAtomicScratchBuffer(texture);
                     scratch != nullptr) {
                     auto *blit2 = createBlitEncoder(commandBuffer);
                     blit2->copyFromBuffer(clearBuf, 0, scratch, 0, totalBytes);
@@ -789,8 +802,11 @@ metalCurrentDepthPixelFormat(),
                 clearBuf->contents(),
                 static_cast<NS::UInteger>(width * bytesPerPixel)
             );
+            // Same ensure-not-lookup contract as the GPU blit path: a startup-init
+            // clear must leave the scratch holding the sentinel too, or the mirror
+            // is unconditional on only one of the two branches.
             if (pixelFormat == MTL::PixelFormatR32Sint) {
-                if (MTL::Buffer *scratch = lookupImageAtomicScratchBuffer(texture);
+                if (MTL::Buffer *scratch = ensureImageAtomicScratchBuffer(texture);
                     scratch != nullptr) {
                     std::memcpy(scratch->contents(), clearBuf->contents(), totalBytes);
                 }
@@ -802,8 +818,9 @@ metalCurrentDepthPixelFormat(),
     // image-atomic scratch back over the texture so a later sampler /
     // access::read pass sees what the atomic passes wrote. Same geometry as
     // that mirror blit, opposite direction. Textures with no paired scratch
-    // (every non-R32I format — the pairing happens in MetalTexture2DImpl's
-    // bindImage) return early, so this stays a no-op wherever it can't apply.
+    // (every non-R32I format — R32I pairs at whichever comes first, this
+    // clearTexImage or MetalTexture2DImpl's bindImage) return early, so this
+    // stays a no-op wherever it can't apply.
     void resolveImageAtomicScratch(const Texture2D *textureWrapper) override {
         if (textureWrapper == nullptr) {
             return;

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -813,6 +813,12 @@ metalCurrentDepthPixelFormat(),
         if (scratch == nullptr) {
             return;
         }
+        // No CPU fallback here, deliberately — unlike clearTexImage above, which
+        // falls back to replaceRegion/memcpy because it runs during startup init
+        // before any command buffer exists. The scratch only ever holds state a
+        // mid-frame atomic pass wrote, so a pre-beginFrame() resolve would have
+        // nothing to materialize; a future caller reaching this early return is
+        // asking at the wrong point in the frame, not hitting a missing path.
         auto *commandBuffer = metalCommandBuffer();
         if (commandBuffer == nullptr) {
             return;

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -798,6 +798,55 @@ metalCurrentDepthPixelFormat(),
         }
     }
 
+    // Reverse of the clearTexImage scratch mirror above: copy the R32I
+    // image-atomic scratch back over the texture so a later sampler /
+    // access::read pass sees what the atomic passes wrote. Same geometry as
+    // that mirror blit, opposite direction. Textures with no paired scratch
+    // (every non-R32I format — the pairing happens in MetalTexture2DImpl's
+    // bindImage) return early, so this stays a no-op wherever it can't apply.
+    void resolveImageAtomicScratch(const Texture2D *textureWrapper) override {
+        if (textureWrapper == nullptr) {
+            return;
+        }
+        auto *texture = static_cast<MTL::Texture *>(textureWrapper->getNativeTexture());
+        MTL::Buffer *scratch = lookupImageAtomicScratchBuffer(texture);
+        if (scratch == nullptr) {
+            return;
+        }
+        auto *commandBuffer = metalCommandBuffer();
+        if (commandBuffer == nullptr) {
+            return;
+        }
+        const NS::UInteger width = texture->width();
+        const NS::UInteger height = texture->height();
+        if (width == 0 || height == 0) {
+            return;
+        }
+        // Sized to match by construction: ensureImageAtomicScratchBuffer
+        // (metal_runtime.cpp) allocates width * height * sizeof(int32) for the
+        // very texture it is keyed on, and the texture's destructor releases the
+        // entry, so a live scratch always spans its whole texture.
+        const std::size_t bytesPerRow = static_cast<std::size_t>(width) * sizeof(std::int32_t);
+        const std::size_t totalBytes = bytesPerRow * static_cast<std::size_t>(height);
+
+        // createBlitEncoder, never a raw blitCommandEncoder: sub-stage timing
+        // attribution (#2280) rides on it, and this blit runs inside the
+        // caller's GpuSubStageScope.
+        auto *blit = createBlitEncoder(commandBuffer);
+        blit->copyFromBuffer(
+            scratch,
+            0,
+            static_cast<NS::UInteger>(bytesPerRow),
+            static_cast<NS::UInteger>(totalBytes),
+            MTL::Size::Make(width, height, 1),
+            texture,
+            0,
+            0,
+            MTL::Origin::Make(0, 0, 0)
+        );
+        blit->endEncoding();
+    }
+
     void fillBuffer(const Buffer *buffer, std::size_t sizeBytes, std::uint8_t byteValue) override {
         if (buffer == nullptr || sizeBytes == 0) {
             return;

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2_body.metal
@@ -398,6 +398,15 @@ kernel void IR_STAGE2_KERNEL_NAME(
     // feeder's stage-2 cost. visibleIsoBounds carries a +4-iso-px margin covering
     // the face footprint; with sun shadows off it equals cullIsoMin/Max so
     // nothing is skipped.
+    //
+    // That "stage 1 wrote its depth" premise is GL-authored, and on Metal it holds
+    // only because of #2488: stage 1's atomics land in the image-atomic scratch
+    // buffer (#1640), not the texture, and this very skip is what stops the
+    // winner tap below from ever materializing a feeder texel. The driver now
+    // calls RenderDevice::resolveImageAtomicScratch on the distance texture right
+    // after the feeder dispatch, so trixelDistances carries the ring by the time
+    // any texture reader runs. Keep the two together: dropping the resolve
+    // silently re-empties the ring for the bake, AO, and the distance Hi-Z.
     if (frameData.residualYaw == 0.0f && frameData.isDetachedCanvas < 0.5f) {
         int3 feederPos = roundHalfUp(voxelPosition.xyz);
         if (cardinalIndex != 0) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(IrredenEngineTest
   render/picking_face_normal_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp
+  render/sun_shadow_feeder_ring_test.cpp
   render/sprite_animation_test.cpp
   render/sprite_components_test.cpp
   render/sprite_render_test.cpp

--- a/test/render/gpu_compute_dispatch_test.cpp
+++ b/test/render/gpu_compute_dispatch_test.cpp
@@ -309,6 +309,152 @@ TEST_F(MetalGpuComputeDispatchTest, SecondDispatchSeesFirstDispatchDistanceWrite
                                  "nor the clear sentinel.";
 }
 
+// #2488: RenderDevice::resolveImageAtomicScratch materializes the R32I
+// image-atomic scratch buffer into the texture it mirrors, so a later
+// sampler / access::read pass sees depth the atomic passes wrote. In the
+// pipeline that is what carries the shadow-feeder ring into trixelDistances
+// on Metal; here it is exercised directly against the scratch.
+//
+// bindAsImage on an R32I texture is what PAIRS the scratch
+// (MetalTexture2DImpl::bindImage -> ensureImageAtomicScratchBuffer), so the
+// bind below is a precondition of the test, not incidental setup. The seed
+// pattern is written straight into the scratch's shared-storage contents,
+// standing in for the atomic-min writes the stage-1 dispatches perform.
+TEST_F(MetalGpuComputeDispatchTest, ResolveImageAtomicScratchLandsScratchInTexture) {
+    using namespace IRRender;
+
+    Texture2D distances{TextureKind::TEXTURE_2D, kTexDim, kTexDim, TextureFormat::R32I};
+
+    // Pair the scratch, then clear the TEXTURE to the empty sentinel.
+    //
+    // The finish() is load-bearing, not tidiness. clearTexImage ENQUEUES two
+    // blits — one into the texture, one mirroring the clear into the scratch —
+    // and the CPU seed below writes shared-storage memory immediately. Without a
+    // sync the GPU runs the mirror after the seed and overwrites the pattern
+    // with sentinels, so the resolve faithfully copies sentinels back and the
+    // assertion fails for a reason that has nothing to do with the resolve.
+    // (Production never has this hazard: there the scratch is written by the
+    // stage-1 atomics, so producer and consumer are both on the command buffer
+    // in encoder order.)
+    distances.bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::R32I);
+    const std::int32_t clearValue = kEmptyDistanceEncoded;
+    device_->clearTexImage(&distances, 0, &clearValue);
+    device_->finish();
+
+    auto *scratch =
+        lookupImageAtomicScratchBuffer(static_cast<MTL::Texture *>(distances.getNativeTexture()));
+    ASSERT_NE(scratch, nullptr) << "bindAsImage on an R32I texture must pair a scratch buffer.";
+
+    // Distinguishable from both the clear sentinel (65535) and the -1/-2
+    // readback seeds, and distinct per texel so a partial blit is visible.
+    auto *scratchTexels = static_cast<std::int32_t *>(scratch->contents());
+    for (int i = 0; i < kTexelCount; ++i) {
+        scratchTexels[i] = i;
+    }
+
+    const std::vector<std::int32_t> outSeed(kTexelCount, -1);
+    Buffer output{
+        outSeed.data(),
+        outSeed.size() * sizeof(std::int32_t),
+        BUFFER_STORAGE_NONE,
+        BufferTarget::SHADER_STORAGE,
+        kOutputBinding
+    };
+
+    device_->resolveImageAtomicScratch(&distances);
+
+    const std::string readPath = std::string(IR_TEST_GPU_SHADER_DIR) + "/c_r32i_read.glsl";
+    ShaderProgram readProgram{std::vector{ShaderStage{readPath.c_str(), ShaderType::COMPUTE}}};
+    readProgram.use();
+    distances.bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+    output.bindBase(BufferTarget::SHADER_STORAGE, kOutputBinding);
+    device_->dispatchCompute(kTexDim, kTexDim, 1);
+    device_->finish();
+
+    std::vector<std::int32_t> readback(kTexelCount, -2);
+    output.getSubData(0, readback.size() * sizeof(std::int32_t), readback.data());
+
+    std::size_t sentinelReads = 0; // the resolve never reached this texel.
+    std::size_t wrongReads = 0;    // neither the seeded value nor the sentinel.
+    for (int i = 0; i < kTexelCount; ++i) {
+        if (readback[i] == kEmptyDistanceEncoded) {
+            ++sentinelReads;
+        } else if (readback[i] != i) {
+            ++wrongReads;
+        }
+    }
+    EXPECT_EQ(sentinelReads, 0u)
+        << sentinelReads << " / " << kTexelCount
+        << " texels still read the clear sentinel — resolveImageAtomicScratch did not "
+           "materialize the scratch into the texture (#2488).";
+    EXPECT_EQ(wrongReads, 0u) << wrongReads
+                              << " texels read back neither their seeded "
+                                 "scratch value nor the clear sentinel.";
+}
+
+// Negative control for the test above, differing from it in exactly one line:
+// no resolveImageAtomicScratch call. The texture must still read back as the
+// clear sentinel despite the scratch holding the same pattern — i.e. the
+// assertion above CAN fail, and it is the resolve that makes it pass rather
+// than any incidental coupling between the scratch and the texture.
+//
+// It carries the same clear/seed finish() as its sibling for a specific reason:
+// without it the clear's mirror blit wipes the seed, and this control passes
+// because the scratch holds sentinels rather than because the resolve is
+// absent — a green control that is blind to the property it exists to pin.
+TEST_F(MetalGpuComputeDispatchTest, SeededScratchAloneDoesNotReachTheTexture) {
+    using namespace IRRender;
+
+    Texture2D distances{TextureKind::TEXTURE_2D, kTexDim, kTexDim, TextureFormat::R32I};
+
+    distances.bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::R32I);
+    const std::int32_t clearValue = kEmptyDistanceEncoded;
+    device_->clearTexImage(&distances, 0, &clearValue);
+    device_->finish();
+
+    auto *scratch =
+        lookupImageAtomicScratchBuffer(static_cast<MTL::Texture *>(distances.getNativeTexture()));
+    ASSERT_NE(scratch, nullptr) << "bindAsImage on an R32I texture must pair a scratch buffer.";
+
+    auto *scratchTexels = static_cast<std::int32_t *>(scratch->contents());
+    for (int i = 0; i < kTexelCount; ++i) {
+        scratchTexels[i] = i;
+    }
+
+    const std::vector<std::int32_t> outSeed(kTexelCount, -1);
+    Buffer output{
+        outSeed.data(),
+        outSeed.size() * sizeof(std::int32_t),
+        BUFFER_STORAGE_NONE,
+        BufferTarget::SHADER_STORAGE,
+        kOutputBinding
+    };
+
+    // No resolveImageAtomicScratch here — that is the whole control.
+
+    const std::string readPath = std::string(IR_TEST_GPU_SHADER_DIR) + "/c_r32i_read.glsl";
+    ShaderProgram readProgram{std::vector{ShaderStage{readPath.c_str(), ShaderType::COMPUTE}}};
+    readProgram.use();
+    distances.bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+    output.bindBase(BufferTarget::SHADER_STORAGE, kOutputBinding);
+    device_->dispatchCompute(kTexDim, kTexDim, 1);
+    device_->finish();
+
+    std::vector<std::int32_t> readback(kTexelCount, -2);
+    output.getSubData(0, readback.size() * sizeof(std::int32_t), readback.data());
+
+    std::size_t nonSentinel = 0;
+    for (int i = 0; i < kTexelCount; ++i) {
+        if (readback[i] != kEmptyDistanceEncoded) {
+            ++nonSentinel;
+        }
+    }
+    EXPECT_EQ(nonSentinel, 0u)
+        << nonSentinel << " / " << kTexelCount
+        << " texels read back a non-sentinel value with no resolve call — the sibling "
+           "test's assertion would pass without resolveImageAtomicScratch doing anything.";
+}
+
 } // namespace
 
 #else // other backend (e.g. Vulkan)

--- a/test/render/gpu_compute_dispatch_test.cpp
+++ b/test/render/gpu_compute_dispatch_test.cpp
@@ -315,11 +315,13 @@ TEST_F(MetalGpuComputeDispatchTest, SecondDispatchSeesFirstDispatchDistanceWrite
 // pipeline that is what carries the shadow-feeder ring into trixelDistances
 // on Metal; here it is exercised directly against the scratch.
 //
-// bindAsImage on an R32I texture is what PAIRS the scratch
-// (MetalTexture2DImpl::bindImage -> ensureImageAtomicScratchBuffer), so the
-// bind below is a precondition of the test, not incidental setup. The seed
-// pattern is written straight into the scratch's shared-storage contents,
-// standing in for the atomic-min writes the stage-1 dispatches perform.
+// An R32I texture pairs its scratch at whichever comes first, bindAsImage
+// (MetalTexture2DImpl::bindImage) or clearTexImage — both route through
+// ensureImageAtomicScratchBuffer. Binding FIRST is a precondition of this test,
+// not incidental setup: it fixes the order so the clear's mirror seeds the
+// sentinel baseline the CPU seed below then overwrites. The seed pattern is
+// written straight into the scratch's shared-storage contents, standing in for
+// the atomic-min writes the stage-1 dispatches perform.
 TEST_F(MetalGpuComputeDispatchTest, ResolveImageAtomicScratchLandsScratchInTexture) {
     using namespace IRRender;
 
@@ -453,6 +455,83 @@ TEST_F(MetalGpuComputeDispatchTest, SeededScratchAloneDoesNotReachTheTexture) {
         << nonSentinel << " / " << kTexelCount
         << " texels read back a non-sentinel value with no resolve call — the sibling "
            "test's assertion would pass without resolveImageAtomicScratch doing anything.";
+}
+
+// First-tick arm: replays the PRODUCTION order (clear -> bind -> resolve),
+// which is the reverse of the two tests above. They bind first, which pairs the
+// scratch before clearTexImage runs, so the clear's mirror establishes the
+// sentinel baseline they then assume — structurally unable to observe a canvas's
+// very first tick. The tick orders it the other way round: the per-frame clear
+// (clearCanvasAndDistances -> clearTexImage, system_voxel_to_trixel.hpp) runs
+// well before stage 1's first bindAsImage on the distance texture.
+//
+// This differs from ClearedTextureReadsBackAsClearSentinel by exactly one line —
+// the resolve call — so a failure here is attributable to the resolve reading a
+// scratch the clear never seeded, and nothing else. A freshly created scratch is
+// zero-filled (metal_runtime.cpp), and 0 encodes the NEAREST depth rather than
+// "empty", so an unseeded resolve would stamp a solid surface across the whole
+// canvas for that tick. What keeps it seeded is clearTexImage ensuring (not
+// merely looking up) the scratch, which is what makes the "mirrors the clear
+// unconditionally" claim at sun_shadow_constants.hpp hold on the first tick.
+TEST_F(MetalGpuComputeDispatchTest, ResolveOnFirstTickLeavesTheClearSentinel) {
+    using namespace IRRender;
+
+    Texture2D distances{TextureKind::TEXTURE_2D, kTexDim, kTexDim, TextureFormat::R32I};
+
+    // Production order: clear BEFORE any bindAsImage pairs a scratch.
+    const std::int32_t clearValue = kEmptyDistanceEncoded;
+    device_->clearTexImage(&distances, 0, &clearValue);
+
+    // Stage 1's first image bind on this texture. No dispatch follows it here —
+    // an atomic-min pass would only lower texels further, so the empty-canvas
+    // case is the one that isolates the clear's own baseline.
+    distances.bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::R32I);
+
+    // No finish() anywhere in this test, deliberately: unlike its two siblings
+    // there is no CPU seed to race, so every write is on the command buffer in
+    // encoder order exactly as production has it.
+    device_->resolveImageAtomicScratch(&distances);
+
+    const std::vector<std::int32_t> outSeed(kTexelCount, -1);
+    Buffer output{
+        outSeed.data(),
+        outSeed.size() * sizeof(std::int32_t),
+        BUFFER_STORAGE_NONE,
+        BufferTarget::SHADER_STORAGE,
+        kOutputBinding
+    };
+
+    const std::string readPath = std::string(IR_TEST_GPU_SHADER_DIR) + "/c_r32i_read.glsl";
+    ShaderProgram readProgram{std::vector{ShaderStage{readPath.c_str(), ShaderType::COMPUTE}}};
+    readProgram.use();
+    distances.bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+    output.bindBase(BufferTarget::SHADER_STORAGE, kOutputBinding);
+    device_->dispatchCompute(kTexDim, kTexDim, 1);
+    device_->finish();
+
+    std::vector<std::int32_t> readback(kTexelCount, -2);
+    output.getSubData(0, readback.size() * sizeof(std::int32_t), readback.data());
+
+    std::size_t zeroReads = 0;   // the unseeded-scratch symptom: nearest depth.
+    std::size_t nonSentinel = 0; // any other departure from the clear value.
+    for (int i = 0; i < kTexelCount; ++i) {
+        if (readback[i] == kEmptyDistanceEncoded) {
+            continue;
+        }
+        ++nonSentinel;
+        if (readback[i] == 0) {
+            ++zeroReads;
+        }
+    }
+    EXPECT_EQ(zeroReads, 0u)
+        << zeroReads << " / " << kTexelCount
+        << " texels read back 0 (nearest depth) after a first-tick resolve — the clear "
+           "did not seed the scratch, so the resolve blitted a zero-filled buffer over "
+           "the 65535 sentinel (#2488).";
+    EXPECT_EQ(nonSentinel, 0u)
+        << nonSentinel << " / " << kTexelCount
+        << " texels departed from the clear sentinel after a resolve with no atomic "
+           "pass in between.";
 }
 
 } // namespace

--- a/test/render/sun_shadow_feeder_ring_test.cpp
+++ b/test/render/sun_shadow_feeder_ring_test.cpp
@@ -1,0 +1,120 @@
+// Guard-predicate tests for the Metal image-atomic scratch resolve (#2488).
+//
+// VOXEL_TO_TRIXEL_STAGE_1 dispatches RenderDevice::resolveImageAtomicScratch on
+// the distance texture only when the shadow-feeder sweep produced a non-empty
+// off-screen ring. The plan-review for #2488 asked for that guard's FALSE branch
+// to be *observed* rather than asserted in prose: a pixel-level A/B with sun
+// shadows off would read zero-diff whether the guard fired or not (with an empty
+// ring the resolve is a value-identical copy), so it cannot distinguish "the
+// guard suppressed the blit" from "the blit ran and changed nothing".
+//
+// IRPrefab::SunShadow::shadowFeederRingNonEmpty is that predicate, factored out
+// of the tick so it is reachable with no GPU, no RenderManager, and no window.
+// Everything below is pure math over the two viewport boxes the tick already
+// computes.
+
+#include <gtest/gtest.h>
+
+#include <irreden/ir_math.hpp>
+#include <irreden/render/sun_shadow_constants.hpp>
+
+using IRMath::IsoBounds2D;
+using IRMath::vec2;
+using IRMath::vec3;
+using IRPrefab::SunShadow::shadowFeederRingNonEmpty;
+
+namespace {
+
+// A representative visible cull box. Deliberately NOT integer-aligned:
+// getCullViewport().isoViewport(margin) returns float bounds, and the
+// sub-texel case below depends on that being the realistic shape.
+constexpr float kVisibleMinX = 12.5f;
+constexpr float kVisibleMinY = -40.5f;
+constexpr float kVisibleMaxX = 220.5f;
+constexpr float kVisibleMaxY = 180.5f;
+
+IsoBounds2D visibleBox() {
+    return {vec2(kVisibleMinX, kVisibleMinY), vec2(kVisibleMaxX, kVisibleMaxY)};
+}
+
+// The engine's default sun: overhead with a small -X / -Y tilt. Matches
+// FrameDataSun::sunDirection_ (+Z is down, so the sun sits above).
+constexpr vec3 kSunDirection = vec3(-0.3f, -0.2f, -0.93f);
+
+} // namespace
+
+// The shadows-off state, end to end through the real derivation. Nothing here
+// hardcodes "0 means unchanged" — frameShadowFeederParams() returns a
+// default-constructed ShadowFeederParams (sweepDistance_ = 0) when
+// getSunShadowsEnabled() is false, and shadowFeederIsoBounds returns its input
+// unchanged at a non-positive sweep. So the widened box IS the visible box, and
+// the guard must read false: there is no ring, hence no feeder depth to resolve.
+TEST(SunShadowFeederRing, ShadowsOffLeavesNoRing) {
+    const IsoBounds2D visible = visibleBox();
+    const IsoBounds2D feeder = IRMath::shadowFeederIsoBounds(visible, kSunDirection, 0.0f);
+
+    EXPECT_EQ(feeder.min_, visible.min_);
+    EXPECT_EQ(feeder.max_, visible.max_);
+    EXPECT_FALSE(shadowFeederRingNonEmpty(feeder, visible));
+}
+
+// The positive control for the arm above: with shadows on at the production
+// sweep the same predicate must fire. Without this, "shadows off => false" is
+// satisfied by a predicate that is false for every input.
+TEST(SunShadowFeederRing, ProductionSweepProducesARing) {
+    const IsoBounds2D visible = visibleBox();
+    const IsoBounds2D feeder = IRMath::shadowFeederIsoBounds(
+        visible,
+        kSunDirection,
+        IRPrefab::SunShadow::kSunShadowMaxDistance
+    );
+
+    EXPECT_TRUE(shadowFeederRingNonEmpty(feeder, visible));
+}
+
+// A detached canvas takes the other branch of the tick's viewport split, which
+// assigns the full canvas span to BOTH boxes so stage 2's #1740 depth-only skip
+// stays inert. Same-box in means ring-empty out, so detached content is
+// structurally resolve-free rather than resolve-free by a separate check.
+TEST(SunShadowFeederRing, IdenticalBoundsAreRingEmpty) {
+    const IsoBounds2D canvasSpan{vec2(-512.0f, -512.0f), vec2(512.0f, 512.0f)};
+
+    EXPECT_FALSE(shadowFeederRingNonEmpty(canvasSpan, canvasSpan));
+}
+
+// The predicate is quantized to the integer iso texels the tick actually
+// uploads (frameData_.cullIsoMin_/cullIsoMax_ vs visibleIsoBounds_), NOT to the
+// float boxes. A sweep too small to cross a texel boundary widens the float box
+// while adding no ring texel for stage 2 to skip, so resolving there would blit
+// a whole canvas for nothing.
+//
+// This is the arm that discriminates the shipped predicate from the plain
+// `gpuVp != visibleVp` float comparison: the boxes below are unequal as floats
+// and equal as uploaded integers, so a float compare reads true and this reads
+// false. Both are "correct" for the ring's contents; only this one matches the
+// units the shader tests in.
+TEST(SunShadowFeederRing, SubTexelWideningIsNotARing) {
+    const IsoBounds2D visible = visibleBox();
+    const IsoBounds2D feeder{visible.min_ - vec2(0.25f, 0.25f), visible.max_};
+
+    ASSERT_NE(feeder.min_, visible.min_) << "fixture must differ as floats to be meaningful";
+    EXPECT_EQ(IRMath::ivec2(IRMath::floor(feeder.min_)), IRMath::ivec2(IRMath::floor(visible.min_)))
+        << "fixture must NOT differ as uploaded integers to be meaningful";
+    EXPECT_FALSE(shadowFeederRingNonEmpty(feeder, visible));
+}
+
+// Each edge on its own crosses a texel boundary, so no single-edge widening is
+// silently dropped by an over-narrow compare (e.g. one that only checked min_).
+TEST(SunShadowFeederRing, EachEdgeAloneIsDetected) {
+    const IsoBounds2D visible = visibleBox();
+
+    const IsoBounds2D lowX{visible.min_ - vec2(1.0f, 0.0f), visible.max_};
+    const IsoBounds2D lowY{visible.min_ - vec2(0.0f, 1.0f), visible.max_};
+    const IsoBounds2D highX{visible.min_, visible.max_ + vec2(1.0f, 0.0f)};
+    const IsoBounds2D highY{visible.min_, visible.max_ + vec2(0.0f, 1.0f)};
+
+    EXPECT_TRUE(shadowFeederRingNonEmpty(lowX, visible));
+    EXPECT_TRUE(shadowFeederRingNonEmpty(lowY, visible));
+    EXPECT_TRUE(shadowFeederRingNonEmpty(highX, visible));
+    EXPECT_TRUE(shadowFeederRingNonEmpty(highY, visible));
+}


### PR DESCRIPTION
## What

On Metal, stage 1's depth atomics land in the per-texture **image-atomic scratch buffer** (#1640), and the only pass that writes the distance **texture** — stage 2's winner tap — skips shadow feeders (the #1740 depth-only skip). Feeder-ring texels therefore stayed at the 65535 clear sentinel in `trixelDistances`, so every texture-reading consumer lost the ring that GL's `imageAtomicMin` writes straight to the texture.

Adds `RenderDevice::resolveImageAtomicScratch` — a defaulted **no-op** virtual (GL's atomics already write the texture) overridden on Metal as a whole-texture blit from the scratch, the reverse of the mirror blit `clearTexImage` already runs, through `createBlitEncoder` so sub-stage timing attribution (#2280) still sees it. `VOXEL_TO_TRIXEL_STAGE_1` calls it once per canvas immediately after the shadow-feeder dispatch, guarded on a non-empty feeder ring.

Whole-canvas rather than ring-only rects: at that point the scratch **is** the distance state GL's texture holds, so visible-domain texels resolve to values stage 2 is about to re-store (its winner test *is* scratch equality), untouched texels resolve sentinel onto sentinel, and only the texels GL has and Metal lacks change. No kernel is involved, so `functionUsesImageAtomicScratch` and the slot-16 alias (#1619) are untouched.

Closes #2488

## Plan-review binding constraints

**1 — the per-axis / rotating lane.** Answered from code, not from the guard's shape: `isShadowFeederIso` (`ir_iso_common.glsl:478`) opens with `residualYaw == 0.0 && isDetachedCanvas < 0.5`. The feeder mechanism is **cardinal-only by construction** — at any residual yaw the compact classifies zero feeders, nothing tail-appends to struct 1, and stage 2's #1740 skip is inert. So the rotating lane has no ring to lose and needs no second issue; it casts through `RESOLVE_PER_AXIS_SCREEN_DEPTH`, which writes real texture memory via `imageStore`. **This fix covers both lanes.** Measurements below corroborate: all three rotated shots sit at the environmental floor.

**2 — observing the guard's FALSE branch.** The review correctly rejected the shadows-off pixel A/B as proof: with an empty ring the resolve is a *value-identical* copy, so zero-diff holds whether or not the guard fired. The predicate is therefore factored out as `IRPrefab::SunShadow::shadowFeederRingNonEmpty` and tested directly on CPU (`test/render/sun_shadow_feeder_ring_test.cpp`, 5 cases, no GPU/RenderManager/window). The pixel control is kept as well — it is still the right safety check, just not a proof of the guard.

## Verification (macOS / Metal, `macos-debug`)

### A==A determinism floor — established first

`--wave-freeze` does **not** make every perf_grid shot deterministic on this host. Same binary, two runs, shadows on:

| shot | pose | A==A drift |
|---|---|---|
| 1 `fit_grid`, 2 `zoom1_origin`, 3 `profiler_overlay` | cardinal | **0** |
| 6 `zoom4_pan` | cardinal, panned | **0** |
| 4 `zoom1_rot`, 5 `zoom4_rot`, 7 `zoom4_rot_pan` | yaw 0.35 | 0.019 % / 0.189 % / 0.241 %, max_delta ≤ 3 |

Only shots 1/2/3/6 can carry a differential signal; 4/5/7 are floor. An earlier A/B of mine read 0.017–0.23 % on 4/5/7 and **nothing** on 6 — it was accidentally A-vs-A (uncommitted changes survived the `git checkout`), and this floor is what exposed it.

### Scene A/B — master `12b8a49c8` vs this branch

`IRPerfGrid --mode voxel_set --no-overlay --subdivision-mode none --wave-freeze --wave-amplitude 5 --zoom 8`, all runs `RESULT=CLEAN`:

| shot | shadows ON | shadows OFF (control) |
|---|---|---|
| 1 `fit_grid` | 0 | 0 |
| 2 `zoom1_origin` | 0 | 0 |
| 3 `profiler_overlay` | 0 | 0 |
| **6 `zoom4_pan`** | **15 616 px (0.4236 %), max_delta 24** | **0** |
| 4 / 5 / 7 (rotated) | within floor | within floor |

Reads exactly as designed: the one cardinal pose that is both zoomed **and** panned — i.e. the only shot with a large off-screen caster ring — moves; the cardinal shots that fit the whole grid on screen have no ring and are byte-identical; the rotated shots are structurally feeder-free; and turning sun shadows off makes the moving shot byte-identical, so the effect is ring-gated rather than a blanket behaviour change.

### What the 15 616 px are

Two spatially disjoint populations, and they partition the sign of the change exactly:

- **7 296 px (46.7 %) — the top 8 framebuffer rows** (912 px/row × 8), all *brighter*. This is the phenomenon **#2488's own "Secondary observation" already predicted**: "changed ~4 300 pixels hugging the screen edge in the cardinal panned shot (zoom4_pan)" — same shot, same band.
- **8 320 px (53.3 %) — interior diagonal streaks** (x 848-2095, y ≤ 1135), all *darker*, oriented along the sun's iso projection.

Mean luminance over the changed set: 72.97 → 70.60.

**Honest limit on the attribution.** I isolated the consumer as far as the debug overlays allow and could **not** pin the interior half: at this pose `--debug-overlay shadow` and `--debug-overlay ao` are **both byte-identical** between the two arms (0 drift on shot 6), so neither the sun-shadow nor the AO channel accounts for it. I am not going to guess which consumer does. What is established is that the delta is deterministic, ring-gated, and confined to the pose with the largest off-screen ring.

This is the class the plan's Gotchas pre-authorized — "the resolve imports GL's depth-without-color edge texels to Metal … any visible artifact there is the pre-existing, backend-agnostic #1740 margin-adequacy question; do not scope-creep it here" — so it is not addressed here.

**Specific question for the `fleet:needs-linux-smoke` GL gate**, since macOS GL is 4.1 and cannot run these 4.5 shaders: run the same command on GL and diff `zoom4_pan` against this branch's Metal capture. GL should **already** show both populations (its `imageAtomicMin` has always written the ring into the texture). If it does, this PR restored parity and the artifact is pre-existing + backend-agnostic. **If GL shows neither population, this is a Metal-only regression and the PR needs rework** — please flag rather than approve.

### macOS reference set — criterion 5

`render-verify` over **every** macOS reference set (`shape_debug`, `canvas_stress`,
`fog_demo`, `lighting`, `analytic_oracle`), run **twice**: once on this branch and
once on `origin/master` `12b8a49c8` as the pre-change control. The branch is
directly on top of that commit, so the A/B is single-variable.

| demo | master (control) | this branch | delta |
|---|---|---|---|
| shape_debug | 17/24 FAIL | 17/24 FAIL | none |
| fog_demo | 9/15 FAIL | 9/15 FAIL | none |
| lighting | 4/5 FAIL | 4/5 FAIL | none |
| analytic_oracle (shadow structural gate) | 1/1 PASS | 1/1 PASS | none |
| canvas_stress (incl. both `--debug-overlay shadow` structural gates) | 1/10 FAIL | **0/10 FAIL** | branch cleaner |

**Zero shots regress; zero references re-baked.** Every FAIL reproduces
identically on master, so those sets are stale against master independently of
this PR — `shape_debug`'s macOS references were last blessed at `dce3d1047`
(2026-07-29) and master is now six days of render work past that. Re-baking them
here would have absorbed that unrelated drift into this PR under its name. The
one verdict that differs favours the branch: master's `so3_smooth_sweep` reads
99.9998 % / max_delta 98 (a couple of pixels on a rotating SO(3) shot — the
documented per-axis run-to-run nondeterminism), the branch reads 100.0 / 0.

Verdict comparison alone is weak evidence, though, because the thresholds are
absolute: a shot master already fails says nothing about this PR either way. So
the shots were **also** compared arm-to-arm directly — same shot, same flags,
branch capture vs master capture:

```
-- compared 50 shot pair(s) across 4 demos; 0 with any non-zero delta; 0 unpaired
```

**Positive control for that zero.** `N pairs, 0 drift` is exactly the shape a
vacuous differential takes, so the same capture+compare path was pointed at the
scene that *does* have an off-screen caster ring (`IRPerfGrid --mode voxel_set
--no-overlay --subdivision-mode none --wave-freeze --wave-amplitude 5 --zoom 8`),
branch vs master:

| shot | match% | max_delta |
|---|---|---|
| 1 `fit_grid`, 2 `zoom1_origin`, 3 `profiler_overlay` (cardinal, no ring) | 100.0 | **0** |
| 4 / 5 / 7 (rotated) | 100.0 | 2 (nondeterminism floor) |
| **6 `zoom4_pan`** (cardinal + panned ⇒ large off-screen ring) | 99.7309 | **24** |

The harness detects this PR where the effect exists, so the 50 reference pairs at
`max_delta 0` is a **discriminating** zero: no reference demo poses a non-empty
shadow-feeder ring, which is precisely the guard's condition. `max_delta 24` also
independently reproduces the Scene A/B above.

### GPU cost — criterion 6

`--auto-profile 300` on the same scene, **3 runs per arm**, `profile_report.txt`
averages (never a single-frame read), all runs `RESULT=CLEAN`:

| row | master (pre) | this branch (post) | delta |
|---|---|---|---|
| `canvasClear` avg | 0.012 / 0.013 / 0.014 | 0.012 / 0.012 / 0.013 | unchanged |
| `voxelStage1` avg | 0.463 / 0.484 / 0.485 | 0.513 / 0.522 / 0.520 | **+0.041 ms** |
| `voxelStage2` avg | 1.008 / 1.072 / 1.055 | 1.147 / 1.165 / 1.149 | +0.109 ms |
| frame avg | 8.97 / 9.27 / 9.47 | 9.14 / 9.52 / 9.30 | within noise |

**The plan's criterion-6 prediction was half right, and the half it missed is the
one that shows up.** It predicted the rows unchanged within noise *on bandwidth
grounds* (~4 bytes/texel, same as the existing `clearTexImage` blit). Bandwidth
is indeed not the cost — `canvasClear`, which moves the same bytes, is flat. But
`voxelStage1` rises **+0.041 ms**, and the two arms' three-run ranges do not
overlap (pre ≤ 0.485, post ≥ 0.513), so this is not noise. +0.041 ms is one Metal
**encoder**'s fixed cost (~40 µs, the #2479 per-dispatch cost model): the resolve
is encoded inside the `voxelStage1` sub-scope and adds exactly one blit encoder.
The cost is per-encoder, not per-byte.

`voxelStage2`'s +0.109 ms is reported rather than explained: the blit is enqueued
before stage 2 and Metal timestamps are encoder-boundary samples, so some of the
blit's execution can land inside stage 2's window — a candidate mechanism, not a
measured one. The two arms also ran sequentially (the control after a full
rebuild), so thermal state differs between them.

At **frame** level — where the #2479 model says GPU cost should be gated — the
arms overlap (pre 8.97–9.47 ms, post 9.14–9.52 ms) and the change is inside
run-to-run variance.

### Tests

- `test/render/sun_shadow_feeder_ring_test.cpp` — 5 CPU cases. Shadows-off → ring empty (through the real `shadowFeederIsoBounds` derivation, not a hardcoded 0); production sweep → ring non-empty (the positive control, without which "false when shadows off" is satisfied by an always-false predicate); identical bounds (detached) → empty; **sub-texel widening → empty**, the arm that discriminates the shipped integer-quantized predicate from the plain float `gpuVp != visibleVp` the plan sketched; each edge alone → detected.
- `gpu_compute_dispatch_test.cpp` — `ResolveImageAtomicScratchLandsScratchInTexture` seeds the scratch and asserts the pattern reaches the texture, plus `SeededScratchAloneDoesNotReachTheTexture`, the negative control differing by one line (no resolve call). The control initially passed **vacuously**: `clearTexImage` *enqueues* its scratch-mirror blit, so the GPU overwrote the CPU seed and the control was reading sentinels rather than testing the absence of the resolve. Both now `device_->finish()` between clear and seed; that sync is commented at both sites as load-bearing. Production has no such hazard (scratch producer and consumer are both on the command buffer in encoder order).
- `IrredenEngineTest`: **1510 / 1511**. The single failure is `SaveTrait.InventoryIsComplete`, pre-existing on master and owned by **#2834** — master is **1502/1503** with the same one red; this PR adds **8** tests and no new failures. (Counted mechanically: branch total 1511, minus the 3 Metal cases this PR adds to `gpu_compute_dispatch_test.cpp` and the 5 in the new `sun_shadow_feeder_ring_test.cpp`. The earlier `1503/1504` master figure was one high, as the Opus recheck flagged.)
- `format-changed` clean, `header-checks` scope untouched.

## Acceptance evidence

Issue #2488's plan states six acceptance criteria; this section was missing from
the body entirely, which is why criteria 5 and 6 went ungraded (the reviewer had
to construct the table). One row per criterion, per
`.claude/skills/commit-and-push/procedures/pr-body.md`.

| Criterion | Check run | Observed |
|---|---|---|
| 1. Headless GPU unit test (positive-fire + negative control) | `fleet-run IrredenEngineTest` | `ResolveImageAtomicScratchLandsScratchInTexture` + `SeededScratchAloneDoesNotReachTheTexture` pass (`test/render/gpu_compute_dispatch_test.cpp:323-393` / `:397-458`); the control was fixed after it passed vacuously |
| 2. Scene-level positive fire + byte-identity control | `IRPerfGrid … --zoom 8`, branch vs master captures | shot 6 `zoom4_pan` max_delta **24**; shots 1-3 (no ring) max_delta **0**; shadows-off control byte-identical |
| 3. Suite control (only #2834 red) | `fleet-run IrredenEngineTest` | `1510/1511`, sole failure `SaveTrait.InventoryIsComplete` (#2834, pre-existing on master; master is `1502/1503`) |
| 4. GL untouched | `git diff origin/master...HEAD --stat` | no `opengl/` path in the diff; the virtual defaults to a no-op |
| 5. macOS references re-baked via `render-verify` | `render-verify` × **5** demos (55 checks) on **both** this branch and `origin/master` `12b8a49c8` | **zero shots affected ⇒ zero re-bakes.** All 30 FAILs reproduce identically on master — same shots, same `match%`/`max_delta`; positive control (perf_grid shot 6, `max_delta 24`) proves the zero discriminates. See §"Re-verified on the amendment" for the count correction |
| 6. Perf note (`--auto-profile` pre/post, `voxelStage1`/`canvasClear`) | `--auto-profile 300`, 3 runs per arm | `canvasClear` flat (0.013 → 0.012 ms); `voxelStage1` **+0.041 ms** — non-overlapping ranges, one Metal encoder (~40 µs, #2479), **not** the "unchanged within noise" the plan predicted; frame-level within noise |

Criterion 5 is graded **met** in the "cite zero affected shots with reasoning"
branch the criterion itself allows, not the re-bake branch — see the reasoning
and its control above.

## Notes for review

- **Review fix (comment-only, `fcc565b8b`).** The `shadowFeederRingNonEmpty`
  doc comment claimed the predicate itself returns false under residual yaw. It
  doesn't — it takes no yaw input, and both boxes derive from the cull viewport
  plus a yaw-free sun sweep, so it reads the same at every yaw; what
  short-circuits on `residualYaw != 0` is the GPU-side `isShadowFeederIso`, a
  different mechanism at a different layer. Runtime was always safe, but the
  comment credited the wrong thing. It now states the real invariant: the
  predicate is a **superset** of "a feeder was rastered", and the unconditional
  per-frame `clearTexImage` scratch mirror is what makes resolving an unfed ring
  a value-identical copy. The residual-yaw cost is scoped to what it is — at most
  one redundant blit on a *second*, non-main, non-detached voxel-pool canvas,
  since the main canvas is on the per-axis path (`skipSingleCanvasVoxels`) while
  the camera rotates. No other comment in the diff repeated the misattribution
  (checked; the stage-2 and call-site comments make no yaw claim).

- **GL is untouched** — no `opengl/` diff; the default virtual is a no-op.
- The `IR_ASSERT` I first wrote on the scratch/texture size relation was **removed**: `ensureImageAtomicScratchBuffer` sizes the scratch from the very texture it is keyed on and the texture's destructor releases the entry, so it guarded an unreachable state (the §8 "don't validate impossible scenarios" rule, and check 17 would have flagged it as an untestable guard). The coupling is stated as a comment at the site instead.
- The stage-2 `#1740` comment is amended: its "stage 1 wrote its full-res depth" premise was GL-authored and false on Metal, and now holds only *because* of this resolve. The two are noted as a pair so dropping the resolve can't silently re-empty the ring.
- `engine/render/CLAUDE.md` gains the primitive under the #1640 gotcha, with the two boundaries kept explicit: it does **not** replace resolve-then-bake (that rule is about *foreign* canvases and stands unchanged), and it needs **no** `functionUsesImageAtomicScratch` entry.
- Per the plan: when this merges, PR #2475 (#2298)'s "byte-identical-safe on Metal, captures nothing" claim stops holding — its Metal-side gate numbers need re-measuring on the resolved baseline. I'll note that on its thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Amendment — first-tick zero-scratch resolve (Opus recheck, `386445284`)

The Opus recheck found a hole no arm of the prior verification could reach, and
it was real. **Independently reproduced before fixing:** the new production-order
test arm, run against the then-head `fcc565b8b`, reports
`1024 / 1024 texels read back 0 (nearest depth)`.

**Root cause.** A canvas clears its distance texture before it ever image-binds
it (`clearCanvasAndDistances` at the top of the tick; stage 1's bind far below),
so `clearTexImage`'s scratch mirror — which only *looked up* the scratch — was
skipped on that canvas's first tick. The lazily allocated buffer stayed at its
zero fill, and zero is the NEAREST depth, not the 65535 empty sentinel: every
`atomicMin` lost against it, and the resolve blitted a solid nearest-depth
surface over the whole texture for that frame.

**Fix.** `clearTexImage` now `ensure`s the scratch in **both** branches (GPU blit
and the startup-init CPU fallback), so the mirror is genuinely unconditional —
which is what the resolve call site and `shadowFeederRingNonEmpty` already
documented it to be. Two things worth noting:

- **Allocation cost scoped (Opus final-pass nit).** The reviewer flagged a
  possible cost for "any R32Sint texture cleared but never image-bound". Two of
  the three `clearTexImage` R32Sint callers (main-canvas distances, per-axis
  `distances_`) are image-bound later in the same frame, so for them this only
  moves the allocation earlier. `resolveDepth_` is the exception: its clear runs
  at (yaw-gated) allocation and both of its image binds are stage-conditional,
  so a rotating creation with neither consumer stage registered pays one
  one-time main-canvas-sized R32I scratch (~8 MB at 1920x1080) the pre-fix code
  did not — bounded, torn down with the texture, not a correctness issue. The
  code comment is scoped accordingly.
- **The per-axis path had already hand-rolled this workaround.**
  `system_voxel_to_trixel.hpp` bound the distance image *before* clearing, with a
  comment explaining that a zero scratch "would otherwise reject every
  depth-matched color write on the first rotating frame" — the same bug, patched
  at one call site. Moving the invariant into the subsystem makes that bind
  redundant (comment updated; the removal itself is left for a change that can
  re-verify the rotating path — tracked as #2923).
- **Bonus, as the reviewer predicted:** the same zero scratch made stage 2's
  `scratch == depth` winner tap match nothing on a canvas's first tick. That
  pre-existing first-tick blank is repaired by the same change.

### Re-verified on the amendment

| Check | Result |
|---|---|
| New arm vs `fcc565b8b` (pre-fix) | **FAIL** — 1024/1024 texels read 0 |
| New arm vs `386445284` (post-fix) | **PASS** |
| `MetalGpuComputeDispatchTest.*`, each run **alone** | 5/5 OK, **0 skipped** (real Metal device) |
| `IrredenEngineTest` | **1510 / 1511**, sole failure `SaveTrait.InventoryIsComplete` (#2834) |
| `header-checks` | clean, 573 headers scanned |

**perf_grid shot-6 positive control** — `IRPerfGrid --mode voxel_set --no-overlay
--subdivision-mode none --wave-freeze --wave-amplitude 5 --zoom 8`, master
`12b8a49c8` vs this branch, both `RESULT=CLEAN`. Arm identity asserted by exe
checksum (`7ca30fdb` vs `580a4024`) so this cannot be an A-vs-A:

| shot | byte-identical | `max_delta` |
|---|---|---|
| 1 `fit_grid`, 2 `zoom1_origin`, 3 `profiler_overlay` (no ring) | YES | **0** |
| 4 `zoom1_rot`, 5 `zoom4_rot`, 7 `zoom4_rot_pan` (yaw 0.35, known floor) | no | 2 |
| **6 `zoom4_pan`** (large off-screen ring) | no | **24** |

Reproduces the original A/B exactly — shot 6 still moves by `max_delta 24`, the
no-ring shots are still byte-identical. **Steady state is unchanged**, and the
non-zero shot 6 is what keeps the zeros from being vacuous.

### Criterion-5 count correction (both reviewers' open nit)

The nit was right, and the cause is worse than an arithmetic slip: **`lighting`
was never verified.** `render-verify.py` infers the demo directory from the
target, and `IRLightingSdfBlocker` infers `lighting_sdf_blocker` — but the
directory is `lighting`, so the run died with `demo dir not found` and the "5
demos / 50 pairs" figure was really **4 demos**. 24 + 10 + 15 + 1 = exactly 50.

Re-run with the required `--demo lighting` override, all five demos, both arms:

| demo | checks | this branch | `origin/master` |
|---|---|---|---|
| shape_debug | 24 | 17 FAIL | 17 FAIL — identical shot set |
| fog_demo | 15 | 9 FAIL | 9 FAIL — identical shot set |
| canvas_stress | 10 | all PASS | — |
| analytic_oracle | 1 | all PASS | — |
| **lighting** (never previously run) | 5 | 4 FAIL | 4 FAIL — identical shots, identical `match%`/`max_delta` |
| **total** | **55** | **30 FAIL** | **30 FAIL, zero PR-attributable drift** |

The 30 pre-existing FAILs double as the coverage proof that this differential is
not vacuous: the comparator demonstrably fires on this host, and still reports
zero delta between the arms. The manifests declare 52 shots; 49 are real macOS
image comparisons (`analytic_oracle`'s shot is `structural_only`, and
canvas_stress's `floor_selfshadow_offwide` / `shadow_overlay_floor` have no
macOS reference baked), against 55 harness checks. Filed the `--demo`-inference
trap as **#2919** so the next author doesn't lose a demo to it.

### Nits

- Master suite citation corrected to **1502/1503** (counted mechanically, not
  inherited) — the delta is **+8**, not +7, since this amendment adds a test.
- `resolveImageAtomicScratch`'s doc comment now says **level 0** explicitly, and
  states why there is no `level` parameter (the scratch is keyed per texture at
  base dimensions, so there is no per-level state to resolve).
- Dropped the now-superseded claim that `bindImage` is the sole scratch-pairing
  site — `clearTexImage` pairs too, and the existing test's comment said
  otherwise.


