### PR TITLE
engine/command: query what is already bound (isButtonBound) (#2570)

### DIFF
--- a/.fleet/plans/issue-2570.md
+++ b/.fleet/plans/issue-2570.md
@@ -1,0 +1,148 @@
+## Plan: Expose command-binding query to Lua (IRCommand.isButtonBound / getRegisteredBindings)
+
+- **Issue:** #2570
+- **Model:** sonnet
+- **Date:** 2026-08-04
+
+### Scope
+
+Give creation code (C++ and Lua) a read-only query over what is already
+bound in the `CommandManager`, so ad-hoc key binds can be guarded against
+the engine's own registrations without a hand-maintained shadow list.
+Additive only: `createCommand` behavior, dedup policy, and every existing
+surface are untouched.
+
+### Verified current state
+
+All issue premises re-verified against the tree at plan time:
+
+- `CommandManager::createCommand` appends unconditionally to
+  `m_userCommands` (`engine/command/include/irreden/command/command_manager.hpp:56-72`);
+  only named+`PRESSED` binds also stamp `m_commandRegistrations`. So
+  `m_userCommands` is the authoritative scan target — it holds unnamed and
+  `RELEASED`-status rows the registration map never sees.
+- `CommandStruct<COMMAND_BUTTON>` already stores and exposes everything the
+  query needs: `getType()`, `getTriggerStatus()`, `getButton()`
+  (`engine/command/include/irreden/command/command.hpp:35-53`). No new
+  storage.
+- **Negative claim source-verified:** `fleet-rules-sweep --pattern
+  'isButtonBound|getRegisteredBindings'` → 0 matches, 3935 files swept
+  (non-zero coverage, real clean pass). No query API exists on either side.
+- All current `getCommandRegistrations()` consumers (help overlay, settings
+  menu, `buildCommandListText()`, tests) are read-only; none conflict.
+- The issue's flagged **adjacent gap is already closed**: `IRInput.Key`
+  carries the full keypad block (`KP_0`–`KP_EQUAL`,
+  `engine/script/include/irreden/script/lua_command_bindings.hpp:297-315`,
+  landed with the #2666 suite-remap work). No carve-off needed.
+- Sibling/in-flight reconciliation: #2550 (registry + generation counter)
+  and #2666 (default-binding manifests / `suiteDefaults`) are merged;
+  #2551's settings menu is in-tree. No open engine PR touches
+  `engine/command/` or `lua_command_bindings.hpp`.
+
+### Approach
+
+1. **`command_manager.hpp`** — add
+   `bool isButtonBound(IRInput::InputTypes inputType, IRInput::ButtonStatuses triggerStatus, int button) const`:
+   linear scan of `m_userCommands` matching all three of
+   `getType()` / `getTriggerStatus()` / `getButton()`. Modifier masks are
+   deliberately ignored — key-level granularity per the issue; a row with
+   `requiredModifiers`/`blockedModifiers` still counts as bound. Doc
+   comment states the cost contract: O(bindings) scan, an init/registration-time
+   guard query, not a per-tick call.
+2. **`ir_command.hpp`** — free-function wrapper
+   `inline bool isButtonBound(...)` forwarding through
+   `getCommandManager()`, matching the existing `fire` / `fireByName` /
+   `createCommand` module-API shape, so C++ creations query via the
+   `ir_command.hpp` entry point.
+3. **`lua_command_bindings.hpp`** — two entries in
+   `bindCommandFunctions`, added inside the existing idempotent-guard
+   block (the early return keys on `IRCommand.bindPrefab`; new entries ride
+   the same guard — do NOT add a second guard):
+   - `IRCommand.isButtonBound(inputType, status, button)` → boolean.
+     Casts mirror the `bindPrefab` lambda; forwards to the manager query.
+   - `IRCommand.getRegisteredBindings()` → array of
+     `{name, description, button, status, modifiers}` tables built from
+     `getCommandRegistrations()`, using the `sol::this_state` +
+     `rows.add(row)` shape `suiteDefaults` already uses. (Superset of the
+     issue's row sketch: `description` is included for full help-overlay
+     parity — it is already on `CommandRegistration`.)
+4. **Tests** — one per new public surface (per `test/CLAUDE.md`):
+   - `test/common/command_registry_test.cpp` (existing bare-`CommandManager`
+     fixture): an **unnamed** binding and a **RELEASED**-status binding are
+     both visible to `isButtonBound` (the rows `getCommandRegistrations()`
+     cannot see); the same key at an unregistered status and an unbound key
+     both return false in the same tests.
+   - `test/script/lua_command_test.cpp` (existing `LuaCommandTest`
+     fixture): register the camera suite C++-side via
+     `IRCommand::registerCameraCommands()` (registration-only, headless-safe
+     — the manifest test already does this with the same manager set), then
+     from Lua assert `IRCommand.isButtonBound(IRInput.InputType.KEY_MOUSE,
+     IRInput.ButtonStatus.PRESSED, IRInput.Key.W)` is true **and** the
+     RELEASED-W row (`MOVE_CAMERA_UP_END`,
+     `engine/prefabs/irreden/common/command_suite_registry.hpp:53`) is
+     true — proving the scan reads `m_userCommands`, not the registration
+     map — while an unbound key in the same script returns false. A
+     no-suite test on the fresh fixture asserts W is false (the "creation
+     that never registers the camera suite" acceptance arm).
+     `IRCommand.getRegisteredBindings()` coverage: row count and the
+     name/button fields of a known registration.
+5. **Docs** — `engine/command/CLAUDE.md` (§`CommandManager`: the query +
+   its cost contract) and `engine/script/CLAUDE.md` (§"Commands and
+   input": the two new API bullets).
+6. Commit `.fleet/plans/issue-2570.md` as the first commit of the
+   implementation branch, then implement; one PR, `Closes #2570`.
+
+### Affected files
+
+- `engine/command/include/irreden/command/command_manager.hpp` — add `isButtonBound` const method
+- `engine/command/include/irreden/ir_command.hpp` — free-function wrapper
+- `engine/script/include/irreden/script/lua_command_bindings.hpp` — `IRCommand.isButtonBound` + `IRCommand.getRegisteredBindings` inside `bindCommandFunctions`
+- `test/common/command_registry_test.cpp` — C++ query-surface tests
+- `test/script/lua_command_test.cpp` — Lua seam tests
+- `engine/command/CLAUDE.md`, `engine/script/CLAUDE.md` — surface docs
+- `.fleet/plans/issue-2570.md` — this plan (first commit)
+
+### Acceptance criteria
+
+All on the existing `IrredenEngineTest` target (no new fixture needed;
+build + run: `fleet-build --target IrredenEngineTest`, then filtered runs):
+
+- **Positive-fire (Lua):** `--gtest_filter='LuaCommandTest.*'` — after
+  `registerCameraCommands()`, `IRCommand.isButtonBound(KEY_MOUSE, PRESSED,
+  Key.W)` returns **true**, and `(KEY_MOUSE, RELEASED, Key.W)` returns
+  **true** (RELEASED visibility — the acceptance bullet the registration
+  map structurally cannot satisfy). False arms sit in the same tests
+  against a suite-registered manager, plus the fresh-fixture no-suite test.
+- **Positive-fire (C++):** `--gtest_filter='CommandRegistryTest.*'` — an
+  unnamed RELEASED binding flips `isButtonBound` false→true across the
+  `createCommand` call.
+- `IRCommand.getRegisteredBindings()` returns the registered rows with
+  name/description/button/status/modifiers populated.
+- **Unchanged behavior:** existing `CommandRegistryTest.*`,
+  `DefaultBindingManifestTest.*`, and `LuaCommandTest.*` suites stay green
+  (no dedup policy imposed; registration path untouched). Note when running
+  the full suite: `SaveTrait.InventoryIsComplete` is red on master (#2834)
+  — pre-existing, not this task's.
+
+### Gotchas
+
+- This is **not** a new prefab command — the five-site checklist in
+  `engine/command/CLAUDE.md` (enum / `kCommandInfo` / `Command<NAME>` /
+  `ir_command.cpp` cases / `IR_BIND_CMD`) does not apply. No
+  `CommandNames` entry, no catalog row.
+- MIDI note/CC bindings live in separate registries
+  (`m_midiNoteDeviceCommands` / `m_midiCCDeviceCommands`) and are invisible
+  to this query; passing `MIDI_NOTE` / `MIDI_CC` as `inputType` scans only
+  `m_userCommands` and returns false. Say so in the method's doc comment —
+  the guard use case (keyboard/mouse/gamepad) is what the issue asks for.
+- `command_manager.hpp` has `using namespace IRInput` at namespace scope —
+  match the file's existing type spellings.
+- `LuaCommandTest`'s member order is load-bearing (`LuaScript` declared
+  first so it destructs last) — add tests to the existing fixture, don't
+  build a new one.
+- Additive-only public surface, specified verbatim in the human-approved
+  issue body — planned low-stakes (no `human:review-plan` hold).
+- Out of scope, tracked nowhere yet by design: a modifier-mask-aware
+  overload (add only when a concrete caller needs it) and any dedup/policy
+  change in `createCommand`.
+

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -166,11 +166,28 @@ Three contract points, each deliberate:
 - **Data, not policy.** `createCommand` still appends unconditionally;
   stacking one key under different masks stays legal (existing creations do
   it on purpose). Collision policy stays with the caller.
-- **MIDI is invisible.** Note/CC bindings live in their own per-device
-  registries, so `MIDI_NOTE` / `MIDI_CC` always report false.
+- **MIDI is invisible.** Note/CC bindings are registered through
+  `registerMidiNoteCommand` / `registerMidiCCCommand` into their own
+  per-device maps, never into `m_userCommands`, so `MIDI_NOTE` / `MIDI_CC`
+  report false.
 
 Cost is an O(bindings) linear scan — an init/registration-time query, not a
 per-tick call.
+
+**The query is type-exact; the dispatcher is not.** `isButtonBound` matches on
+all three of `getType()`, status and button, but
+`executeUserKeyboardCommandsAll` — the only tick-path reader of
+`m_userCommands` — never consults `getType()`: it runs
+`IRInput::checkKeyMouseButton` over every row. So a row bound with a
+non-`KEY_MOUSE` input type would fire on the matching keyboard press while
+`isButtonBound(KEY_MOUSE, …)` calls it unbound. Latent, not live — every
+button binding in the tree registers `KEY_MOUSE` and there is no gamepad
+dispatch loop at all, so nothing misreports today. The same fact is why the
+MIDI carve-out above holds by *population* rather than by construction:
+`createCommand(MIDI_NOTE, …)` would land a button row like any other, it just
+never happens. The type check belongs to the query (it is what a `GAMEPAD`
+dispatch loop would need); the missing filter belongs to the dispatcher.
+`CommandRegistryTest.IsButtonBoundIsTypeExact` locks the query half.
 
 Two filters keep the list readable, both intentional:
 

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -107,6 +107,9 @@ Semantics worth knowing before you use it:
   only for *named PRESSED* binds — it cannot see the RELEASED
   `MOVE_CAMERA_*_END` rows. Enumerate defaults via
   `IRCommand::suiteDefaults(Suite)`, which reads the constexpr tables.
+  To ask what is bound **right now** rather than by default, use
+  `isButtonBound` (below) — it scans the live user-command list, so it
+  sees the rows the registration map filters out.
 
 Lua parity is `IRCommand.{Suite, suiteDefaults, registerSuite}` — see
 `engine/script/CLAUDE.md` §"Commands and input".
@@ -136,6 +139,38 @@ load-bearing: the pre-#2550 overlay built its text once (`if
 after the first visible frame never appeared. Bumping on a *filtered*
 registration would be equally wrong — it would turn "zero cost while hidden"
 into a per-frame rebuild.
+
+### Querying what is bound (`isButtonBound`, #2570)
+
+`isButtonBound(inputType, triggerStatus, button)` answers "is this key already
+taken" for creation code that wants to guard an ad-hoc bind against the
+engine's own registrations, instead of mirroring the engine's key list in a
+hand-maintained "reserved keys" table that drifts. Exposed on `CommandManager`,
+through `ir_command.hpp` as a free function, and to Lua as
+`IRCommand.isButtonBound`.
+
+**It scans `m_userCommands`, not the registration map** — and that choice is
+the whole design. The registry's two filters below make it structurally unable
+to back this query: an unnamed ad-hoc lambda and every non-`PRESSED` row (the
+camera suite's `MOVE_CAMERA_*_END` bindings) are never recorded there, so a
+registry-backed implementation reports "unbound" for keys that are very much
+bound. The regression locks in `test/common/command_registry_test.cpp` and
+`test/script/lua_command_test.cpp` pin exactly those rows.
+
+Three contract points, each deliberate:
+
+- **Modifier-blind.** A row with `requiredModifiers` / `blockedModifiers`
+  still counts as bound — the guard use case asks about the *key*. A
+  modifier-aware refinement would be a new overload, not a narrowing of this
+  one.
+- **Data, not policy.** `createCommand` still appends unconditionally;
+  stacking one key under different masks stays legal (existing creations do
+  it on purpose). Collision policy stays with the caller.
+- **MIDI is invisible.** Note/CC bindings live in their own per-device
+  registries, so `MIDI_NOTE` / `MIDI_CC` always report false.
+
+Cost is an O(bindings) linear scan — an init/registration-time query, not a
+per-tick call.
 
 Two filters keep the list readable, both intentional:
 

--- a/engine/command/include/irreden/command/command_manager.hpp
+++ b/engine/command/include/irreden/command/command_manager.hpp
@@ -80,6 +80,27 @@ class CommandManager {
     /// C++ or Lua, outside the regular input-driven dispatch loop.
     void fireUserCommand(CommandId id);
 
+    /// Reports whether a binding already exists for the (@p inputType,
+    /// @p triggerStatus, @p button) triple. Scans `m_userCommands`, not
+    /// `m_commandRegistrations` — the registry omits unnamed bindings and every
+    /// non-`PRESSED` one, so the camera suite's RELEASED `MOVE_CAMERA_*_END`
+    /// rows are invisible there but visible here.
+    ///
+    /// Modifier masks are deliberately ignored: a row carrying
+    /// `requiredModifiers` / `blockedModifiers` still counts as bound, so a
+    /// caller guarding an ad-hoc bind sees the key as taken whatever
+    /// combination sits behind it. Key-level granularity is the whole
+    /// contract — a modifier-aware overload can come later if a caller needs
+    /// one. This reports the *data*; collision **policy** stays with the
+    /// caller, and `createCommand` still appends unconditionally.
+    ///
+    /// MIDI note/CC bindings live in their own per-device registries and are
+    /// invisible to this scan, so `MIDI_NOTE` / `MIDI_CC` always report false.
+    ///
+    /// Cost: O(bindings) linear scan — an init/registration-time guard query,
+    /// not a per-tick call.
+    bool isButtonBound(InputTypes inputType, ButtonStatuses triggerStatus, int button) const;
+
     const std::vector<CommandRegistration> &getCommandRegistrations() const {
         return m_commandRegistrations;
     }

--- a/engine/command/include/irreden/command/command_manager.hpp
+++ b/engine/command/include/irreden/command/command_manager.hpp
@@ -94,8 +94,22 @@ class CommandManager {
     /// one. This reports the *data*; collision **policy** stays with the
     /// caller, and `createCommand` still appends unconditionally.
     ///
-    /// MIDI note/CC bindings live in their own per-device registries and are
-    /// invisible to this scan, so `MIDI_NOTE` / `MIDI_CC` always report false.
+    /// The match is *type-exact*, which is finer than what actually
+    /// dispatches: `executeUserKeyboardCommandsAll` — the only tick-path
+    /// reader of `m_userCommands` — never consults `getType()`, it runs
+    /// `IRInput::checkKeyMouseButton` over every row. A row created with a
+    /// non-`KEY_MOUSE` @p inputType would therefore fire on the matching
+    /// keyboard press while this query calls it unbound. Latent, not live:
+    /// every button binding in the tree is registered `KEY_MOUSE` and there is
+    /// no gamepad dispatch loop at all, so no row can currently misreport. The
+    /// type check stays because it is the contract a `GAMEPAD` dispatch loop
+    /// would need; the missing filter is on the dispatcher's side.
+    ///
+    /// MIDI note/CC bindings are registered through `registerMidiNoteCommand`
+    /// / `registerMidiCCCommand` into their own per-device maps, never into
+    /// `m_userCommands`, so `MIDI_NOTE` / `MIDI_CC` report false. That holds
+    /// by *population*, not by construction — `createCommand(MIDI_NOTE, …)`
+    /// would land a button row like any other — but nothing makes one.
     ///
     /// Cost: O(bindings) linear scan — an init/registration-time guard query,
     /// not a per-tick call.

--- a/engine/command/include/irreden/ir_command.hpp
+++ b/engine/command/include/irreden/ir_command.hpp
@@ -54,6 +54,22 @@ CommandId bindPrefabCommand(
     IRInput::KeyModifierMask blockedModifiers = IRInput::kModifierNone
 );
 
+/// Reports whether the (@p inputType, @p triggerStatus, @p button) triple
+/// already has a binding. Forwards to @ref CommandManager::isButtonBound —
+/// see it for the scan target, the deliberate modifier-blindness, the MIDI
+/// carve-out, and the cost contract.
+///
+/// The point of the query is to let creation code guard an ad-hoc bind
+/// against what the engine already registered, instead of mirroring the
+/// engine's key list in a hand-maintained "reserved keys" table that drifts
+/// (`.claude/rules/cpp-ecs.md` §"System-owned invariants"). No dedup policy
+/// is imposed: @ref createCommand still appends unconditionally, and stacking
+/// one key under different modifier masks stays legal.
+inline bool
+isButtonBound(IRInput::InputTypes inputType, IRInput::ButtonStatuses triggerStatus, int button) {
+    return getCommandManager().isButtonBound(inputType, triggerStatus, button);
+}
+
 /// Sentinel returned by @ref bindPrefabCommand on a name that has no
 /// `Command<NAME>` specialization. `CommandId` is `uint32_t`, so the
 /// max-value spelling lets callers distinguish a real registration

--- a/engine/command/src/command_manager.cpp
+++ b/engine/command/src/command_manager.cpp
@@ -109,6 +109,18 @@ void CommandManager::fireUserCommand(CommandId id) {
     m_userCommands[id].execute();
 }
 
+bool CommandManager::isButtonBound(
+    InputTypes inputType, ButtonStatuses triggerStatus, int button
+) const {
+    for (const CommandStruct<COMMAND_BUTTON> &command : m_userCommands) {
+        if (command.getType() == inputType && command.getTriggerStatus() == triggerStatus &&
+            command.getButton() == button) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void CommandManager::executeDeviceMidiNoteCommand(
     int device, CommandStruct<COMMAND_MIDI_NOTE> &command
 ) {

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -1470,6 +1470,31 @@ IRCommand.fireByName(CN.SCREENSHOT)
   RELEASED pair), applied at most once per row. Sugar over the same
   `IRCommand::registerBindings` primitive the C++ suites use — see
   `engine/command/CLAUDE.md` §"Default-binding manifests (#2666)".
+- `IRCommand.isButtonBound(inputType, status, button) -> boolean` (#2570) —
+  what is bound **right now**, the live counterpart to `suiteDefaults`'
+  by-default view. Scans the user-command list, so unnamed ad-hoc bindings
+  and the `RELEASED` `MOVE_CAMERA_*_END` rows are both visible — unlike
+  `getRegisteredBindings` below, which cannot see either. Lets a creation
+  guard its own key binds against the engine's registrations instead of
+  mirroring them in a hand-maintained "reserved keys" list that drifts.
+  **Modifier-blind by contract**: a row carrying required/blocked modifiers
+  still reports the key as bound. MIDI note/CC bindings live in separate
+  registries, so `MIDI_NOTE` / `MIDI_CC` always return false. It reports the
+  data only — `createCommand` still appends unconditionally and stacking one
+  key under different masks stays legal. O(bindings) scan: a
+  registration-time guard, not a per-tick call.
+- `IRCommand.getRegisteredBindings() -> {rows}` (#2570) — the help overlay's
+  rows, as `{name, description, button, status, modifiers}`. Named `PRESSED`
+  registrations only (the registry's own filter), so this is the narrower
+  view of the two.
+
+```lua
+-- Guard an ad-hoc bind against whatever the engine already took.
+local KM, BS, K = IRInput.InputType.KEY_MOUSE, IRInput.ButtonStatus, IRInput.Key
+if not IRCommand.isButtonBound(KM, BS.PRESSED, K.W) then
+    IRCommand.createCommand(KM, BS.PRESSED, K.W, function() ... end)
+end
+```
 
 ```lua
 -- Full camera controls minus Escape, with pan moved to the numpad.

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -1479,14 +1479,21 @@ IRCommand.fireByName(CN.SCREENSHOT)
   mirroring them in a hand-maintained "reserved keys" list that drifts.
   **Modifier-blind by contract**: a row carrying required/blocked modifiers
   still reports the key as bound. MIDI note/CC bindings live in separate
-  registries, so `MIDI_NOTE` / `MIDI_CC` always return false. It reports the
+  registries, so `MIDI_NOTE` / `MIDI_CC` return false. It reports the
   data only — `createCommand` still appends unconditionally and stacking one
   key under different masks stays legal. O(bindings) scan: a
-  registration-time guard, not a per-tick call.
+  registration-time guard, not a per-tick call. The match is *type-exact*,
+  which is finer than the dispatcher's — see `engine/command/CLAUDE.md`
+  §"Querying what is bound" for the (latent) divergence that also makes the
+  MIDI answer a fact about the population rather than a guarantee.
 - `IRCommand.getRegisteredBindings() -> {rows}` (#2570) — the help overlay's
-  rows, as `{name, description, button, status, modifiers}`. Named `PRESSED`
-  registrations only (the registry's own filter), so this is the narrower
-  view of the two.
+  rows, as `{name, description, button, status, requiredModifiers}`. Named
+  `PRESSED` registrations only (the registry's own filter), so this is the
+  narrower view of the two. `requiredModifiers` is spelled in full because
+  that is all `CommandRegistration` carries — there is no blocked mask on
+  this surface. The two row shapes differ on the spelling: `suiteDefaults`
+  (#2666) says `modifiers` for the same required mask, so don't infer one
+  from the other.
 
 ```lua
 -- Guard an ad-hoc bind against whatever the engine already took.

--- a/engine/script/include/irreden/script/lua_command_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_command_bindings.hpp
@@ -490,6 +490,13 @@ inline void bindCommandFunctions(LuaScript &script) {
     // The help overlay's rows, for Lua. Named PRESSED bindings only — the
     // same filter `buildCommandListText()` renders — so this is the narrower
     // view; `isButtonBound` above is the one that sees every binding.
+    //
+    // The mask field is spelled `requiredModifiers`, matching
+    // `CommandRegistration`'s own member: it carries the *required* mask only,
+    // and a bare `modifiers` would read as "the row's modifier state" when
+    // there is no blocked mask on this surface to report. The two row shapes
+    // do differ on the spelling — `suiteDefaults` says `modifiers` for the
+    // same required mask — so don't infer one from the other.
     lua["IRCommand"]["getRegisteredBindings"] = [](sol::this_state L) -> sol::table {
         sol::state_view lua_view(L);
         sol::table rows = lua_view.create_table();
@@ -500,7 +507,7 @@ inline void bindCommandFunctions(LuaScript &script) {
             row["description"] = registration.description;
             row["button"] = static_cast<lua_Integer>(registration.button);
             row["status"] = static_cast<lua_Integer>(registration.triggerStatus);
-            row["modifiers"] = static_cast<lua_Integer>(registration.requiredModifiers);
+            row["requiredModifiers"] = static_cast<lua_Integer>(registration.requiredModifiers);
             rows.add(row);
         }
         return rows;

--- a/engine/script/include/irreden/script/lua_command_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_command_bindings.hpp
@@ -472,6 +472,40 @@ inline void bindCommandFunctions(LuaScript &script) {
         IRCommand::registerBindings(IRCommand::suiteDefaults(suite), toBindingOverrides(overrides));
     };
 
+    // What is bound RIGHT NOW — the counterpart to `suiteDefaults` above,
+    // which reports what the engine *would* bind. Scans the live user-command
+    // list, so the RELEASED `MOVE_CAMERA_*_END` rows and unnamed ad-hoc
+    // bindings are both visible. Lets a creation guard its own key binds
+    // against the engine's registrations instead of mirroring them in a
+    // hand-maintained "reserved keys" list.
+    lua["IRCommand"]["isButtonBound"] =
+        [](lua_Integer inputType, lua_Integer triggerStatus, lua_Integer button) -> bool {
+        return IRCommand::isButtonBound(
+            static_cast<IRInput::InputTypes>(inputType),
+            static_cast<IRInput::ButtonStatuses>(triggerStatus),
+            static_cast<int>(button)
+        );
+    };
+
+    // The help overlay's rows, for Lua. Named PRESSED bindings only — the
+    // same filter `buildCommandListText()` renders — so this is the narrower
+    // view; `isButtonBound` above is the one that sees every binding.
+    lua["IRCommand"]["getRegisteredBindings"] = [](sol::this_state L) -> sol::table {
+        sol::state_view lua_view(L);
+        sol::table rows = lua_view.create_table();
+        for (const IRCommand::CommandRegistration &registration :
+             IRCommand::getCommandManager().getCommandRegistrations()) {
+            sol::table row = lua_view.create_table();
+            row["name"] = registration.name;
+            row["description"] = registration.description;
+            row["button"] = static_cast<lua_Integer>(registration.button);
+            row["status"] = static_cast<lua_Integer>(registration.triggerStatus);
+            row["modifiers"] = static_cast<lua_Integer>(registration.requiredModifiers);
+            rows.add(row);
+        }
+        return rows;
+    };
+
     lua["IRCommand"]["fire"] = [](lua_Integer commandId) {
         IRCommand::fire(static_cast<IRCommand::CommandId>(commandId));
     };

--- a/test/common/command_registry_test.cpp
+++ b/test/common/command_registry_test.cpp
@@ -138,6 +138,92 @@ TEST_F(CommandRegistryTest, UnnamedAndNonPressedRegistrationsAreFilteredWithoutB
     EXPECT_EQ(m_commandManager.getRegistrationGeneration(), initial);
 }
 
+// `isButtonBound` (#2570) reads `m_userCommands`, NOT the registration map —
+// so the two row classes the registry filters out (unnamed, and non-PRESSED)
+// must both be visible to it. Those arms are what discriminate a correct
+// implementation: an `isButtonBound` written over `getCommandRegistrations()`
+// is structurally unable to pass either, since neither row is ever recorded
+// there. The registry emptiness assertions below are the proof that the rows
+// really are registry-invisible, so a passing arm can't be read as the
+// registry happening to carry them.
+TEST_F(CommandRegistryTest, IsButtonBoundSeesUnnamedAndReleasedBindings) {
+    // Unnamed PRESSED: the default shape of every ad-hoc lambda binding.
+    m_commandManager.createCommand(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA, noopBody);
+    // Named RELEASED: mirrors the camera suite's MOVE_CAMERA_*_END rows.
+    m_commandManager.createCommand(
+        IRInput::KEY_MOUSE,
+        IRInput::RELEASED,
+        kTestButtonB,
+        noopBody,
+        IRInput::kModifierNone,
+        IRInput::kModifierNone,
+        "RELEASE HALF"
+    );
+
+    ASSERT_TRUE(m_commandManager.getCommandRegistrations().empty())
+        << "both bindings must be registry-invisible for this test to discriminate";
+
+    EXPECT_TRUE(m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA));
+    EXPECT_TRUE(
+        m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::RELEASED, kTestButtonB)
+    );
+
+    // The same keys at the status they were NOT bound at: the scan matches on
+    // all three of (inputType, status, button), so neither cross-matches.
+    EXPECT_FALSE(
+        m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::RELEASED, kTestButtonA)
+    );
+    EXPECT_FALSE(
+        m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonB)
+    );
+
+    // A key nothing bound, and a bound key on a different device class.
+    EXPECT_FALSE(
+        m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, IRInput::kKeyButtonF12)
+    );
+    EXPECT_FALSE(m_commandManager.isButtonBound(IRInput::GAMEPAD, IRInput::PRESSED, kTestButtonA));
+}
+
+// Modifier-blindness is the documented contract, not an oversight: a caller
+// guarding an ad-hoc bind wants "is this key taken", whatever mask sits behind
+// it. Locked so a later modifier-aware refinement has to be a deliberate
+// overload rather than a silent narrowing of this query.
+TEST_F(CommandRegistryTest, IsButtonBoundIgnoresModifierMasks) {
+    m_commandManager.createCommand(
+        IRInput::KEY_MOUSE,
+        IRInput::PRESSED,
+        kTestButtonA,
+        noopBody,
+        IRInput::kModifierControl,
+        IRInput::kModifierShift
+    );
+
+    EXPECT_TRUE(m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA));
+}
+
+// The `ir_command.hpp` free function is its own public surface — the module
+// entry point a C++ creation calls, resolving the manager through the
+// `g_commandManager` global rather than holding the instance. The fixture's
+// stack-local manager stamps that global in its ctor, so this covers the
+// forwarding path the Lua binding also rides.
+TEST_F(CommandRegistryTest, ModuleApiIsButtonBoundForwardsToTheActiveManager) {
+    EXPECT_FALSE(IRCommand::isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA));
+
+    m_commandManager.createCommand(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA, noopBody);
+
+    EXPECT_TRUE(IRCommand::isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA));
+    EXPECT_FALSE(IRCommand::isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonB));
+}
+
+// An empty manager reports nothing bound — the "in a creation that never
+// registers the camera suite it returns false" half of the acceptance
+// criteria, at the C++ level.
+TEST_F(CommandRegistryTest, IsButtonBoundIsFalseOnAFreshManager) {
+    EXPECT_FALSE(
+        m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA)
+    );
+}
+
 // Completeness: no enum value may fall back to "UNKNOWN", and every value's
 // row must sit at its own index (the table is indexed by enum value).
 TEST(CommandCatalogTest, EveryCommandNameHasANonUnknownLabel) {

--- a/test/common/command_registry_test.cpp
+++ b/test/common/command_registry_test.cpp
@@ -215,6 +215,28 @@ TEST_F(CommandRegistryTest, ModuleApiIsButtonBoundForwardsToTheActiveManager) {
     EXPECT_FALSE(IRCommand::isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonB));
 }
 
+// The type dimension, in the direction the sibling arms above don't cover: a
+// row bound under a non-`KEY_MOUSE` input type is invisible to a `KEY_MOUSE`
+// query. The `EXPECT_TRUE` is the was-seen arm — without it the `EXPECT_FALSE`
+// would also pass on a manager that never stored the row at all.
+//
+// Worth locking because it is exactly where the query and the dispatcher part
+// company: `executeUserKeyboardCommandsAll` ignores `getType()` and would fire
+// this row on a real F5 press. Nothing in the tree binds a non-`KEY_MOUSE`
+// button, so that gap is latent — but a future "simplification" that drops the
+// type check here would silently change what `isButtonBound` promises, and the
+// fix for the gap belongs on the dispatcher's side. See
+// `engine/command/CLAUDE.md` §"Querying what is bound".
+TEST_F(CommandRegistryTest, IsButtonBoundIsTypeExact) {
+    m_commandManager.createCommand(IRInput::GAMEPAD, IRInput::PRESSED, kTestButtonA, noopBody);
+
+    EXPECT_TRUE(m_commandManager.isButtonBound(IRInput::GAMEPAD, IRInput::PRESSED, kTestButtonA))
+        << "the row must exist for the negative arm below to mean anything";
+    EXPECT_FALSE(
+        m_commandManager.isButtonBound(IRInput::KEY_MOUSE, IRInput::PRESSED, kTestButtonA)
+    );
+}
+
 // An empty manager reports nothing bound — the "in a creation that never
 // registers the camera suite it returns false" half of the acceptance
 // criteria, at the C++ level.

--- a/test/script/lua_command_test.cpp
+++ b/test/script/lua_command_test.cpp
@@ -4,6 +4,8 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/script/lua_script.hpp>
 
+#include <string>
+
 namespace {
 
 // Owns the minimum slice needed to exercise the T-193 IRCommand /
@@ -421,6 +423,94 @@ TEST_F(LuaCommandTest, KeypadKeysAreNameable) {
     EXPECT_EQ(result.get<int>(3), static_cast<int>(IRInput::kKeyButtonKPEnter));
     EXPECT_EQ(result.get<int>(4), static_cast<int>(IRInput::kKeyButtonKPDecimal));
     EXPECT_EQ(result.get<int>(5), static_cast<int>(IRInput::kKeyButtonKPEqual));
+}
+
+// ---- IRCommand.isButtonBound / getRegisteredBindings (#2570) ---------------
+
+// The acceptance criterion: W is bound after the camera suite registers. The
+// RELEASED arm is the discriminator — `MOVE_CAMERA_UP_END` is
+// {KEY_MOUSE, RELEASED, W} in the manifest and is never recorded in the
+// registration map, so it is true iff the query scans the live user-command
+// list. An implementation reading `getRegisteredBindings()` fails it.
+TEST_F(LuaCommandTest, IsButtonBoundSeesCameraSuiteIncludingReleasedRows) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRCommand.registerSuite(IRCommand.Suite.CAMERA)
+        local KM = IRInput.InputType.KEY_MOUSE
+        return IRCommand.isButtonBound(KM, IRInput.ButtonStatus.PRESSED,  IRInput.Key.W),
+               IRCommand.isButtonBound(KM, IRInput.ButtonStatus.RELEASED, IRInput.Key.W),
+               IRCommand.isButtonBound(KM, IRInput.ButtonStatus.PRESSED,  IRInput.Key.ESCAPE),
+               IRCommand.isButtonBound(KM, IRInput.ButtonStatus.PRESSED,  IRInput.Key.F12),
+               IRCommand.isButtonBound(KM, IRInput.ButtonStatus.RELEASED, IRInput.Key.ESCAPE)
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_TRUE(result.get<bool>(0)) << "MOVE_CAMERA_UP_START binds PRESSED W";
+    EXPECT_TRUE(result.get<bool>(1)) << "MOVE_CAMERA_UP_END binds RELEASED W (registry-invisible)";
+    EXPECT_TRUE(result.get<bool>(2)) << "CLOSE_WINDOW binds PRESSED Escape";
+    EXPECT_FALSE(result.get<bool>(3)) << "F12 is in no suite";
+    EXPECT_FALSE(result.get<bool>(4)) << "Escape has no RELEASED half";
+}
+
+// The other half of the criterion: a creation that never registers the suite
+// sees false. The fixture builds a fresh CommandManager per test, so this is
+// the un-registered world. The trailing true arm proves the query is live
+// rather than stuck returning false — without it, a hard-coded `return false`
+// would pass this test.
+TEST_F(LuaCommandTest, IsButtonBoundIsFalseWithoutTheCameraSuite) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        local KM = IRInput.InputType.KEY_MOUSE
+        local before = IRCommand.isButtonBound(KM, IRInput.ButtonStatus.PRESSED, IRInput.Key.W)
+        IRCommand.createCommand(KM, IRInput.ButtonStatus.PRESSED, IRInput.Key.W, function() end)
+        local after = IRCommand.isButtonBound(KM, IRInput.ButtonStatus.PRESSED, IRInput.Key.W)
+        return before, after
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_FALSE(result.get<bool>(0)) << "no camera suite registered in this fixture";
+    EXPECT_TRUE(result.get<bool>(1)) << "an unnamed Lua command body still counts as bound";
+}
+
+TEST_F(LuaCommandTest, GetRegisteredBindingsReturnsTheNamedPressedRows) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRCommand.registerSuite(IRCommand.Suite.CAPTURE)
+        local rows = IRCommand.getRegisteredBindings()
+        local first = rows[1]
+        return #rows, first.name, first.description, first.button, first.status, first.modifiers
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    // Three named PRESSED rows; the camera suite's four RELEASED rows are
+    // absent by the registry's own filter, which is why `isButtonBound` above
+    // cannot be built on this surface.
+    EXPECT_EQ(result.get<int>(0), 3);
+    EXPECT_EQ(result.get<std::string>(1), IRCommand::commandNameToString(IRCommand::SCREENSHOT));
+    EXPECT_EQ(result.get<std::string>(2), IRCommand::commandDescription(IRCommand::SCREENSHOT));
+    EXPECT_EQ(result.get<int>(3), static_cast<int>(IRInput::kKeyButtonF8));
+    EXPECT_EQ(result.get<int>(4), static_cast<int>(IRInput::PRESSED));
+    EXPECT_EQ(result.get<int>(5), static_cast<int>(IRInput::kModifierNone));
+}
+
+TEST_F(LuaCommandTest, GetRegisteredBindingsIsEmptyBeforeAnyNamedRegistration) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        local KM = IRInput.InputType.KEY_MOUSE
+        IRCommand.createCommand(KM, IRInput.ButtonStatus.PRESSED, IRInput.Key.J, function() end)
+        return #IRCommand.getRegisteredBindings()
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    EXPECT_EQ(result.get<int>(), 0) << "an unnamed binding must stay out of the registry view";
 }
 
 // ---- Idempotence ----------------------------------------------------------

--- a/test/script/lua_command_test.cpp
+++ b/test/script/lua_command_test.cpp
@@ -483,7 +483,8 @@ TEST_F(LuaCommandTest, GetRegisteredBindingsReturnsTheNamedPressedRows) {
         IRCommand.registerSuite(IRCommand.Suite.CAPTURE)
         local rows = IRCommand.getRegisteredBindings()
         local first = rows[1]
-        return #rows, first.name, first.description, first.button, first.status, first.modifiers
+        return #rows, first.name, first.description, first.button, first.status,
+               first.requiredModifiers, first.modifiers == nil
         )",
         sol::script_pass_on_error
     );
@@ -497,6 +498,11 @@ TEST_F(LuaCommandTest, GetRegisteredBindingsReturnsTheNamedPressedRows) {
     EXPECT_EQ(result.get<int>(3), static_cast<int>(IRInput::kKeyButtonF8));
     EXPECT_EQ(result.get<int>(4), static_cast<int>(IRInput::PRESSED));
     EXPECT_EQ(result.get<int>(5), static_cast<int>(IRInput::kModifierNone));
+    // The mask field is the *required* mask and says so — `CommandRegistration`
+    // carries no blocked mask, so a bare `modifiers` would over-promise. The
+    // nil arm pins the spelling: without it the row could carry both and the
+    // rename would be untested.
+    EXPECT_TRUE(result.get<bool>(6)) << "the mask ships as requiredModifiers only";
 }
 
 TEST_F(LuaCommandTest, GetRegisteredBindingsIsEmptyBeforeAnyNamedRegistration) {


### PR DESCRIPTION
## Summary

- Adds `CommandManager::isButtonBound(inputType, triggerStatus, button)` — a
  read-only query over what is bound right now, so creation code can guard an
  ad-hoc key bind against the engine's own registrations instead of mirroring
  them in a hand-maintained "reserved keys" list that drifts.
- Exposed through `ir_command.hpp` as a free function and to Lua as
  `IRCommand.isButtonBound`, plus `IRCommand.getRegisteredBindings()` for the
  narrower help-overlay view.
- **It scans `m_userCommands`, not the registration map** — that choice is the
  whole design. The registry records named `PRESSED` binds only, so unnamed
  ad-hoc lambdas and every `RELEASED` row (the camera suite's
  `MOVE_CAMERA_*_END` pairs) are invisible to it; a registry-backed query
  reports "unbound" for keys that are very much bound.
- Additive only: `createCommand` still appends unconditionally, so no dedup
  policy is imposed and stacking one key under different modifier masks stays
  legal. The query is deliberately modifier-blind and MIDI-blind, both
  documented at the method.

## Test plan

- [x] `CommandRegistryTest` — 9/9 pass, run alone (`--gtest_filter='CommandRegistryTest.*'`)
- [x] `LuaCommandTest` + `LuaCommandTeardownTest` — 25/25 pass, run alone
- [x] Full `IrredenEngineTest` — **1511/1512**. The one failure is
      `SaveTrait.InventoryIsComplete`, which #2834 owns and whose own title
      records it as "red on master (C_Locked unregistered)". This diff touches
      no save/serialize path.
- [x] `header-checks` target — 573 headers scanned, 0 violations
- [x] `clang-format --dry-run --Werror` clean on all 6 touched C++ files
- [x] `cpp-lua-enums` detector (`fleet-rules-sweep`) — 12 hits in 2 files,
      exactly the documented `## Live deviations` set, coverage 81 files. No
      new deviation from the added binding.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| After the camera suite registers, `isButtonBound(KEY_MOUSE, PRESSED, W)` is true; false in a creation that never registers it | `LuaCommandTest.IsButtonBoundSeesCameraSuiteIncludingReleasedRows` / `...IsButtonBoundIsFalseWithoutTheCameraSuite` | both `[ OK ]`. True arm asserts W + Escape bound, F12 unbound; false arm asserts `before == false` **and** `after == true` once a bind lands, so a hard-coded `return false` cannot pass it |
| `RELEASED`-status bindings (`MOVE_CAMERA_*_END`) are visible to the query | same Lua test's `RELEASED, W` arm; `CommandRegistryTest.IsButtonBoundSeesUnnamedAndReleasedBindings` | both `[ OK ]`. The C++ arm `ASSERT`s the registry is empty first, so a pass can't be read as the registry happening to carry the rows |
| `createCommand` behavior unchanged, no dedup policy imposed | `CommandRegistryTest.UnnamedAndNonPressedRegistrationsAreFilteredWithoutBump`; `CommandRegistryTest.IsButtonBoundIgnoresModifierMasks`; full suite | pre-existing filter/generation tests still `[ OK ]`; modifier-blindness locked; 1510/1511 overall |

### Positive control — the design claim, measured

The plan's load-bearing claim is that a registry-backed `isButtonBound` is
*structurally* unable to satisfy the criteria. Rather than assert it, I swapped
in that naive implementation, rebuilt, and ran:

```
[  FAILED  ] CommandRegistryTest.IsButtonBoundSeesUnnamedAndReleasedBindings
[  FAILED  ] CommandRegistryTest.IsButtonBoundIgnoresModifierMasks
[  FAILED  ] CommandRegistryTest.ModuleApiIsButtonBoundForwardsToTheActiveManager
[  FAILED  ] CommandRegistryTest.IsButtonBoundIsTypeExact
[  FAILED  ] LuaCommandTest.IsButtonBoundSeesCameraSuiteIncludingReleasedRows
[  FAILED  ] LuaCommandTest.IsButtonBoundIsFalseWithoutTheCameraSuite
```

**6 of the 9 arms covering this surface go red** — including both "returns
false" tests, because their live arms can't be satisfied from the registry.
The other three stay green and should: `IsButtonBoundIsFalseOnAFreshManager`
and the two `GetRegisteredBindings` tests don't discriminate for the
scan-target claim.

Re-measured (2026-08-07) after the nit pass, since that pass added an arm:
`ModuleApiIsButtonBoundForwardsToTheActiveManager` binds an *unnamed* PRESSED
command and asserts `true`, so it is red under any registry-backed
implementation — the original "4 of 7" simply missed it. `IsButtonBoundIsTypeExact`
is the new arm; it stores a `GAMEPAD` row that the registry never records, so
its was-seen `EXPECT_TRUE` is red under the control too. The control was
reverted (`git diff` clean on `command_manager.cpp`), rebuilt, and the real
implementation re-verified green. That measurement is what makes the green run
above evidence rather than agreement.

## Notes for the reviewer

- The issue body and the `## Plan` both say `**Model:** sonnet`, but the issue
  carries the `fleet:opus` label, which is what the claim gate matches on — so
  this ran at opus. Flagging the metadata inconsistency rather than editing
  another issue's labels; no action taken.
- **Opus-recheck nits addressed** (commit `fd2542e3`): the `isButtonBound`
  doc comment and `engine/command/CLAUDE.md` now state the type asymmetry
  against `executeUserKeyboardCommandsAll` (and that the MIDI carve-out is a
  fact about the population, not a construction guarantee);
  `CommandRegistryTest.IsButtonBoundIsTypeExact` locks the query half; the Lua
  help-overlay row's mask is spelled `requiredModifiers`. The reviewer's
  under-count of the control table is corrected above.
- **Why `suiteDefaults` keeps `modifiers`.** Renaming only the new field would
  have left two sibling Lua row shapes spelling the same required mask two
  ways. Unifying them means renaming shipped Lua surface from #2666, which the
  engine API rule treats as reachable by consumers not present in this tree
  (`CLAUDE-BASELINE.md` §"Engine API removal rule") — out of scope for a nit
  pass. The divergence is stated at both sites instead.
- Module docs updated in the same commit: `engine/command/CLAUDE.md` gains a
  §"Querying what is bound" section (and the "registration map is not the
  manifest" bullet now points at it), `engine/script/CLAUDE.md` gains both Lua
  API entries plus a guard-pattern snippet.

Closes #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

