### PR TITLE
docs/rules: cpp-lua-enums — close the test/ and tools/ injection gap

### DIFF
--- a/.claude/rules/cpp-lua-enums.md
+++ b/.claude/rules/cpp-lua-enums.md
@@ -1,8 +1,8 @@
 ---
 paths:
   - "engine/script/**"
-  - "engine/**/*_lua.hpp"
-  - "engine/**/lua_*_bindings.hpp"
+  - "**/*_lua.hpp"
+  - "**/lua_*_bindings.hpp"
   - "creations/**/*.{hpp,cpp,h,cc}"
 ---
 
@@ -121,8 +121,8 @@ Why:
 ## Audit hooks
 
 Open-coded `if (s == "FOO") ... else if (s == "BAR") ...` chains in
-`engine/script/**`, `engine/**/*_lua.hpp`, or creation Lua-binding
-code are a smell. Replace them with the binding-table + enum-cast
+`engine/script/**`, any `*_lua.hpp` / `lua_*_bindings.hpp`, or creation
+Lua-binding code are a smell. Replace them with the binding-table + enum-cast
 pattern above when you touch the surrounding code. (`engine/script/**`,
 not just its `src/`: one of the deviations below lives under
 `engine/script/include/`.)
@@ -192,14 +192,26 @@ which is the whole reason the wide creations scope is justified, cannot fire.
 **It holds today** — the swept set is a strict subset of the injected set
 (81 ⊆ 141), because every binding header currently lives under
 `engine/script/include/irreden/script/`, which `engine/script/**` already
-injects. The frontmatter's `engine/**/lua_*_bindings.hpp` is **forward-looking,
-not remedial**: the hook's `**/lua_*_bindings.hpp` glob matches a binding header
-*anywhere* in the tree, so the first one placed outside `engine/script/` would
-be swept while `engine/script/**` + `engine/**/*_lua.hpp` failed to inject it.
-The entry closes that hole before it opens; it changes no counts today. Not
-widened to `engine/**/*.{hpp,cpp,h,cc}` (the sibling shape): that
-would inject a Lua-binding rule into every engine translation unit to reach a
-surface with a consistent, greppable spelling. The creations side needs the
+injects. The frontmatter's `**/*_lua.hpp` and `**/lua_*_bindings.hpp` are
+**forward-looking, not remedial**: those are the hook's own spellings, and they
+match a binding header *anywhere* in the tree, so the first one placed outside
+`engine/script/` would otherwise be swept without being injected. The entries
+close that hole before it opens; they change no counts today.
+
+**Mirror the hook's spelling, not a prefixed form of it.** These two entries
+were originally written `engine/**/…`, which closed the hole on one lane and
+left it open on every other — `test/` and `tools/` are populated top-level
+directories (two of the four search roots `irreden_collect_quality_files()`
+globs in `cmake/ir_quality_tools.cmake`), so a binding header landing in either
+was swept and never injected (#2905). A prefix added to a `**/` glob is a
+silent narrowing: it satisfies the invariant for the lane you were looking at
+and no other. When the hook says *anywhere*, `paths:` has to say *anywhere*
+too.
+
+Not widened to `engine/**/*.{hpp,cpp,h,cc}` (the sibling shape): that would
+inject a Lua-binding rule into every engine translation unit to reach a surface
+with a consistent, greppable spelling. The tree-wide entries above stay scoped
+by *filename*, which is what keeps them cheap. The creations side needs the
 blunt glob because creation binding files have no mandated name; the engine
 side does not.
 
@@ -213,10 +225,27 @@ fleet-rules-sweep --files-only --pattern '.' --glob 'engine/script/**' \
   --glob 'creations/**/lua_*.{hpp,cpp}' | sort > /tmp/detected
 # injected by paths:
 fleet-rules-sweep --files-only --pattern '.' --glob 'engine/script/**' \
-  --glob 'engine/**/*_lua.hpp' --glob 'engine/**/lua_*_bindings.hpp' \
+  --glob '**/*_lua.hpp' --glob '**/lua_*_bindings.hpp' \
   --glob 'creations/**/*.{hpp,cpp,h,cc}' | sort > /tmp/injected
 comm -23 /tmp/detected /tmp/injected      # must be empty (81 vs 141 today)
 ```
+
+An empty `comm -23` is only evidence if it *can* be non-empty — today every
+binding header sits under `engine/script/`, so the check passes on a tree that
+exercises nothing. Drive it with probes outside the previously-covered lanes
+before trusting it:
+
+```
+printf '// probe\n' > test/lua_probe_bindings.hpp
+printf '// probe\n' > tools/lua_probe2_bindings.hpp
+# re-run both commands above, then:
+comm -23 /tmp/detected /tmp/injected      # still empty: 83 detected, 143 injected
+rm -f test/lua_probe_bindings.hpp tools/lua_probe2_bindings.hpp
+```
+
+Against the pre-#2905 `engine/**`-prefixed frontmatter the same probes come
+back in `comm -23` (detected 81 → 83, injected unmoved at 141), which is what
+makes this a control rather than a re-run.
 
 A creation's `main*.cpp` is deliberately **not** in scope, `main_lua.cpp`
 included — its string compares are CLI-argv parses (three in


### PR DESCRIPTION
## Summary

- `.claude/rules/cpp-lua-enums.md` states an invariant about itself — **"`paths:`
  must cover every file the hook sweeps"** — and violated it on two lanes. The
  audit hook's globs are tree-wide (`**/*_lua.hpp`, `**/lua_*_bindings.hpp`)
  while `paths:` reached only `engine/**` and `creations/**`, so a binding header
  under `test/` or `tools/` was swept by the detector and **never injected for
  the author who wrote it**.
- `test/` and `tools/` are two of the four search roots
  `irreden_collect_quality_files()` globs (`cmake/ir_quality_tools.cmake`) — not
  hypothetical directories.
- This is the hole #2746 closed for `engine/**`, left open elsewhere. That PR
  mirrored the hook's `**/` globs in an `engine/**`-prefixed form, which
  satisfies the invariant for the lane in view and no other. Dropping the
  prefixes makes `paths:` mirror the hook's own spelling, and the file now
  records *why* a prefix added to a `**/` glob is a silent narrowing.
- Adds the **positive control the check block lacked**: an empty `comm -23` is
  only evidence if it *can* be non-empty, and today every binding header sits
  under `engine/script/`, so the committed check passed on a tree that exercised
  nothing.
- Injection-scope only — the detector's register must not move, and doesn't.

## Test plan

- [x] Reproduced the file's committed check block verbatim at base: `detected=81`,
      `injected=141`, `comm -23` empty — matches the numbers the file cites.
- [x] Pre-fix positive control: three probes (`test/lua_probe_bindings.hpp`,
      `test/probe_lua.hpp`, `tools/lua_probe2_bindings.hpp`) all came back in
      `comm -23` (detected 81 → 84, injected unmoved at 141) — the gap is real,
      not theoretical.
- [x] Post-fix, same probes: `comm -23` **empty**, injected moves with detected
      (83 → 143 on the committed two-probe form). The check discriminates.
- [x] Detector register unchanged after the change: `swept 81 file(s), 12
      match(es) in 2 file(s)`, and the two files are exactly the ones
      §"Live deviations" documents.
- [x] `simplify` §9a retired-spelling sweep: the old `engine/**/*_lua.hpp`
      spelling survived in §"Audit hooks" prose (line 124) — fixed; re-sweep
      returns 0 matches over 3944 files.
- [x] `simplify` check 19: every citation on an added line resolves **at base**
      (`cmake/ir_quality_tools.cmake`, `irreden_collect_quality_files`,
      `engine/script/`), and #2905's title matches its citing sentence.
- [x] `simplify` check 5: final newline present.
- [x] All probe files removed; `git status` clean before commit.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| 1. `paths:` covers every file the hook's globs can reach | `sed -n '2,7p' .claude/rules/cpp-lua-enums.md` | frontmatter now carries `**/*_lua.hpp` + `**/lua_*_bindings.hpp` (tree-wide, matching the hook) instead of their `engine/**`-prefixed forms |
| 2. Positive control yields an empty `comm -23`, and is recorded | probes under `test/` + `tools/`, then the file's two sweep commands | `detected=83 injected=143 comm23=0`; recipe committed into the §"Check the invariant" block with the pre-fix contrast |
| 3. Baseline reproduces; detector register unmoved | the committed check block with no probes; then the `== *"` hook | `detected=81 injected=141 comm23=0`; `swept 81 file(s) (3944 walked), 12 match(es) in 2 file(s)` — unchanged |
| 4. Prose and frontmatter agree; no re-staling census; "as of" anchors to master | read §"paths: stays wider than these globs" | invariant paragraph rewritten to describe the tree-wide entries; new §"Mirror the hook's spelling" states the narrowing rule; **no** new exact census and **no** new "as of" sha introduced |

## Notes for the reviewer

- The change is **coverage-neutral today** (81/141 unmoved with no probes) — like
  #2746's own `engine/**` entry, it closes the hole before it opens. The probes
  are what make that claim checkable rather than assertable.
- Lane check was run so the fix isn't under-scoped in the same way it's fixing:
  `cpp-ecs.md`, `cpp-ecs-smells.md`, `cpp-systems.md` carry no Detection/Audit-hooks
  block at all; `cpp-math.md`'s hook globs are a strict subset of its `paths:`;
  `cpp-globals.md` has no frontmatter. The gap was specific to this rule.
- Not widened to `engine/**/*.{hpp,cpp,h,cc}` (the sibling shape) — the new
  entries stay scoped by *filename*, which is what keeps tree-wide injection
  cheap. That reasoning is now in the file so it isn't re-litigated.

Closes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)
