### PR TITLE
engine/prefabs: setMode's canvas lifecycle covers DETACHED_REVOXELIZE (#2908)

### DIFF
--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -39,7 +39,18 @@ in `update/`.
   `rotation_mode = IRComponent.RotationMode.DETACHED` in the prefab
   table — the enum value, not the string). Mutate at runtime with
   `IRPrefab::RotationMode::setMode(entity, newMode, name, size)` —
-  allocates or destroys the canvas as needed. Non-prefab entities
+  allocates or destroys the canvas as needed. **DETACHED and
+  DETACHED_REVOXELIZE are one canvas-owning family**, spelled once as
+  `IRPrefab::RotationMode::ownsEntityCanvas(mode)` and read by both
+  lifecycle sites (`setMode` and `spawnPrefab`); a swap between them
+  keeps the canvas, and only a move to/from GRID allocates or destroys.
+  Adding a mode means classifying it there; the enum's size is
+  static-asserted in `test/ecs/rotation_mode_set_test.cpp` so a new mode
+  cannot reach one site and miss the other (#2908). `setMode`'s
+  same-mode early return is gated on the canvas
+  matching the mode, not on the mode alone, so it doubles as the
+  documented recovery for an entity `spawnPrefab` tagged headlessly
+  without allocating. Non-prefab entities
   without the component are implicitly GRID — on the render side that
   default is carried by `REBUILD_GRID_VOXELS_IMPLICIT`, the
   `Exclude<C_RotationMode>` twin a creation must register alongside

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -46,7 +46,17 @@ in `update/`.
   keeps the canvas, and only a move to/from GRID allocates or destroys.
   Adding a mode means classifying it there; the enum's size is
   static-asserted in `test/ecs/rotation_mode_set_test.cpp` so a new mode
-  cannot reach one site and miss the other (#2908). `setMode`'s
+  cannot reach one site and miss the other (#2908). That guarantee
+  covers the two **lifecycle** sites only — `PROPAGATE_CANVAS_ROTATION`
+  (`../render/systems/system_propagate_canvas_rotation.hpp`) still
+  hand-spells the two detached modes and a new mode must be added there
+  by hand. It is left off the predicate for **layering weight, not an
+  include cycle** (there is none — that header is a leaf, included only
+  by demo `main.cpp`s): `rotation_mode.hpp` pulls in
+  `render/entity_canvas.hpp` solely for `setMode`, so routing a
+  render-system header through the predicate would drag that whole chain
+  in. Splitting `ownsEntityCanvas` into a header free of the render side
+  is the clean fix if this is revisited. `setMode`'s
   same-mode early return is gated on the canvas
   matching the mode, not on the mode alone, so it doubles as the
   documented recovery for an entity `spawnPrefab` tagged headlessly

--- a/engine/prefabs/irreden/common/components/component_rotation_mode.hpp
+++ b/engine/prefabs/irreden/common/components/component_rotation_mode.hpp
@@ -39,8 +39,11 @@
 //
 // Mode is mutable at runtime via `IRPrefab::RotationMode::setMode`
 // (in `engine/prefabs/irreden/common/rotation_mode.hpp`) at a
-// re-allocation cost — switching to DETACHED allocates a new entity
-// canvas; switching to GRID destroys it. Don't mutate `mode_`
+// re-allocation cost — switching to a canvas-owning mode allocates a new
+// entity canvas; switching to GRID destroys it. DETACHED and
+// DETACHED_REVOXELIZE are one family for this purpose (the predicate is
+// `IRPrefab::RotationMode::ownsEntityCanvas`), so swapping between them
+// keeps the canvas rather than churning it. Don't mutate `mode_`
 // directly; the helper keeps `C_EntityCanvas` in sync.
 
 #include <cstdint>

--- a/engine/prefabs/irreden/common/rotation_mode.hpp
+++ b/engine/prefabs/irreden/common/rotation_mode.hpp
@@ -3,13 +3,16 @@
 
 // Prefab-scoped helpers for `C_RotationMode`. The component itself is
 // plain data; cross-entity orchestration — allocating the per-entity
-// canvas on DETACHED, destroying it on GRID — lives here so the
-// component layout stays trivial and archetype-iteration friendly.
+// canvas on the detached modes, destroying it on GRID — lives here so
+// the component layout stays trivial and archetype-iteration friendly.
 //
 // Spawn-time mode selection is handled by `IRPrefab::Prefab::spawnPrefab`
 // directly. Use `setMode` to change an already-spawned entity's mode at
 // runtime; it preserves the rest of the entity's components and pays
 // the re-allocation cost (one canvas-entity create or destroy) inline.
+//
+// Both lifecycle sites read `ownsEntityCanvas` rather than each spelling
+// out which modes own a canvas.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -23,21 +26,46 @@
 
 namespace IRPrefab::RotationMode {
 
+/// True when `mode` keeps the entity's rotation on a per-entity
+/// `C_EntityCanvas`. DETACHED and DETACHED_REVOXELIZE differ in how that
+/// canvas is *filled* — a 2D forward-scatter deform versus a per-frame
+/// re-voxelize at full-rotation cell positions — not in whether one
+/// exists. Both allocate at spawn and both must release at teardown.
+///
+/// Canvas lifecycle is decided in exactly two places — `setMode` and
+/// `IRPrefab::Prefab::spawnPrefab` — and both call this predicate rather
+/// than spelling their own mode list, so a new mode cannot be wired into
+/// one site and missed by the other. Adding a mode means classifying it
+/// here; `test/ecs/rotation_mode_set_test.cpp` static-asserts the enum's
+/// size so that stays mandatory rather than remembered. See #2908.
+inline constexpr bool ownsEntityCanvas(IRComponents::RotationMode mode) {
+    return mode == IRComponents::RotationMode::DETACHED ||
+           mode == IRComponents::RotationMode::DETACHED_REVOXELIZE;
+}
+
 /// Transition an entity to `newMode`, allocating or destroying its
 /// per-entity canvas as required.
 ///
-/// - GRID → DETACHED: allocates a child canvas via
+/// - GRID → a canvas-owning mode: allocates a child canvas via
 ///   `IRPrefab::EntityCanvas::create(canvasName, canvasSize)` and
-///   attaches `C_EntityCanvas` to `entity`. The previous canvas (if
-///   any) is left alone — re-entering DETACHED from DETACHED is a
-///   no-op rather than a re-allocation churn.
-/// - DETACHED → GRID: destroys the entity's `C_EntityCanvas` child
-///   entity (freeing its GPU textures via `onDestroy`) and removes
+///   attaches `C_EntityCanvas` to `entity`.
+/// - A canvas-owning mode → GRID: destroys the entity's `C_EntityCanvas`
+///   child entity (freeing its GPU textures via `onDestroy`) and removes
 ///   the component from `entity`.
-/// - Same mode in/out: no-op.
+/// - DETACHED ↔ DETACHED_REVOXELIZE: keeps the existing canvas. Both
+///   modes own one, so the swap is a re-tag, not a re-allocation.
+/// - Same mode in/out: a no-op **when the canvas already matches the
+///   mode**. When it does not, the call reconciles it.
 ///
-/// `canvasName` and `canvasSize` are only consulted on a GRID→DETACHED
-/// transition; pass sensible defaults otherwise.
+/// The mismatch case is load-bearing, not defensive. `spawnPrefab`
+/// deliberately tags an entity into a canvas-owning mode *without*
+/// allocating when it runs with no `RenderManager` (headless tooling,
+/// unit tests) and documents this call as the recovery once one exists.
+/// Gating the early return on the mode alone would make that recovery a
+/// no-op and strand the entity canvas-less.
+///
+/// `canvasName` and `canvasSize` are only consulted when a canvas is
+/// actually allocated; pass sensible defaults otherwise.
 inline void setMode(
     IREntity::EntityId entity,
     IRComponents::RotationMode newMode,
@@ -46,38 +74,38 @@ inline void setMode(
 ) {
     using IRComponents::C_EntityCanvas;
     using IRComponents::C_RotationMode;
-    using IRComponents::RotationMode;
 
     auto modeOpt = IREntity::getComponentOptional<C_RotationMode>(entity);
-    const RotationMode current = modeOpt ? modeOpt.value()->mode_ : RotationMode::GRID;
-    if (current == newMode) {
+    const IRComponents::RotationMode current =
+        modeOpt ? modeOpt.value()->mode_ : IRComponents::RotationMode::GRID;
+
+    auto canvasOpt = IREntity::getComponentOptional<C_EntityCanvas>(entity);
+    const bool hasCanvas = canvasOpt.has_value();
+    const bool wantsCanvas = ownsEntityCanvas(newMode);
+
+    if (current == newMode && hasCanvas == wantsCanvas) {
         return;
     }
 
-    // Exit the current mode's resources first (symmetric teardown), then enter
-    // the new mode. DETACHED owns a per-entity child canvas; GRID owns neither.
-    if (current == RotationMode::DETACHED) {
-        auto existing = IREntity::getComponentOptional<C_EntityCanvas>(entity);
-        if (existing) {
-            const IREntity::EntityId canvas = existing.value()->canvasEntity_;
-            if (canvas != IREntity::kNullEntity) {
-                IREntity::destroyEntity(canvas);
-            }
-            IREntity::removeComponent<C_EntityCanvas>(entity);
+    // Release only when leaving the canvas-owning family entirely — a
+    // DETACHED ↔ DETACHED_REVOXELIZE swap keeps the canvas it already has.
+    // Read the child id out before destroying anything; the component
+    // pointer is not held across the structural change.
+    if (hasCanvas && !wantsCanvas) {
+        const IREntity::EntityId canvas = canvasOpt.value()->canvasEntity_;
+        if (canvas != IREntity::kNullEntity) {
+            IREntity::destroyEntity(canvas);
         }
+        IREntity::removeComponent<C_EntityCanvas>(entity);
     }
 
-    if (newMode == RotationMode::DETACHED) {
+    if (wantsCanvas && !hasCanvas) {
         IR_ASSERT(
             IRRender::g_renderManager != nullptr,
-            "setMode(DETACHED) requires a live RenderManager"
+            "setMode() into a canvas-owning rotation mode requires a live RenderManager"
         );
-        auto existing = IREntity::getComponentOptional<C_EntityCanvas>(entity);
-        if (!existing) {
-            IREntity::setComponent(entity, IRPrefab::EntityCanvas::create(canvasName, canvasSize));
-        }
+        IREntity::setComponent(entity, IRPrefab::EntityCanvas::create(canvasName, canvasSize));
     }
-    // GRID: no entry work — the exit branch above already released resources.
 
     IREntity::setComponent(entity, C_RotationMode{newMode});
 }

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -4,6 +4,7 @@
 #include <irreden/asset/voxel_set_format.hpp>
 #include <irreden/common/components/component_local_transform.hpp>
 #include <irreden/common/components/component_rotation_mode.hpp>
+#include <irreden/common/rotation_mode.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_profile.hpp>
 #include <irreden/math/sdf.hpp>
@@ -279,8 +280,7 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
     // tear it down — the canvas is parented to mainFramebuffer (not the
     // spawned root), so destroying the root leaves it stranded otherwise.
     IREntity::EntityId detachedCanvasEntity = IREntity::kNullEntity;
-    if (rotationMode == IRComponents::RotationMode::DETACHED ||
-        rotationMode == IRComponents::RotationMode::DETACHED_REVOXELIZE) {
+    if (IRPrefab::RotationMode::ownsEntityCanvas(rotationMode)) {
         if (IRRender::g_renderManager != nullptr) {
             IRComponents::C_EntityCanvas wrapper =
                 IRPrefab::EntityCanvas::create(canvasName, canvasSize);

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -188,8 +188,7 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
     if (sol::optional<bool> unboundedOpt = prefab["unbounded"]; unboundedOpt) {
         unbounded = *unboundedOpt;
     }
-    if (unbounded && rotationMode != IRComponents::RotationMode::DETACHED &&
-        rotationMode != IRComponents::RotationMode::DETACHED_REVOXELIZE) {
+    if (unbounded && !IRPrefab::RotationMode::ownsEntityCanvas(rotationMode)) {
         IRE_LOG_WARN(
             "Prefab.spawn('{}'): unbounded=true has no effect with "
             "rotation_mode=IRComponent.RotationMode.GRID.",
@@ -199,8 +198,7 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
 
     IRMath::ivec2 canvasSize{0};
     std::string canvasName;
-    if (rotationMode == IRComponents::RotationMode::DETACHED ||
-        rotationMode == IRComponents::RotationMode::DETACHED_REVOXELIZE) {
+    if (IRPrefab::RotationMode::ownsEntityCanvas(rotationMode)) {
         sol::optional<sol::table> sizeOpt = prefab["canvas_size"];
         if (!sizeOpt) {
             return makeError(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(IrredenEngineTest
   ecs/modifier_types_test.cpp
   ecs/modifier_vec3_runtime_test.cpp
   ecs/propagate_transform_test.cpp
+  ecs/rotation_mode_set_test.cpp
   ecs/rotation_target_test.cpp
   ecs/sort_archetype_relational_test.cpp
   ecs/store_tie_signal_test.cpp

--- a/test/ecs/rotation_mode_set_test.cpp
+++ b/test/ecs/rotation_mode_set_test.cpp
@@ -1,0 +1,182 @@
+// Canvas-lifecycle contract of `IRPrefab::RotationMode::setMode`: DETACHED and
+// DETACHED_REVOXELIZE are one canvas-owning family, and the helper keeps
+// `C_EntityCanvas` in sync with the mode in both directions. See #2908.
+//
+// Every arm below runs headless. The one transition that cannot is
+// GRID -> a canvas-owning mode: it calls `IRPrefab::EntityCanvas::create`,
+// which `setMode` guards with `IR_ASSERT(IRRender::g_renderManager != nullptr)`.
+// That arm needs a live RenderManager and is deliberately absent rather than
+// silently skipped — the reconcile-on-mismatch behaviour it would cover is
+// pinned from the release side by `SameModeReleasesACanvas...` instead.
+
+#include <gtest/gtest.h>
+
+#include <irreden/common/components/component_rotation_mode.hpp>
+#include <irreden/common/rotation_mode.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/render/components/component_entity_canvas.hpp>
+
+#include <cstdint>
+
+namespace {
+
+using IRComponents::C_EntityCanvas;
+using IRComponents::C_RotationMode;
+using IRComponents::RotationMode;
+
+// ---- The predicate itself, and its completeness ------------------------
+
+constexpr int modeCount() {
+    return static_cast<int>(RotationMode::kLast) - static_cast<int>(RotationMode::kFirst) + 1;
+}
+
+constexpr int canvasOwningModeCount() {
+    int owning = 0;
+    for (auto raw = static_cast<std::uint8_t>(RotationMode::kFirst);
+         raw <= static_cast<std::uint8_t>(RotationMode::kLast);
+         ++raw) {
+        if (IRPrefab::RotationMode::ownsEntityCanvas(static_cast<RotationMode>(raw))) {
+            ++owning;
+        }
+    }
+    return owning;
+}
+
+// The pair is the guard, not either line alone. Counting only the owning modes
+// stays green when a mode is added and left unclassified — it is the total that
+// moves. Adding a mode must trip this and force a deliberate visit to
+// `ownsEntityCanvas`.
+static_assert(
+    modeCount() == 3,
+    "A RotationMode was added or removed. Classify it in "
+    "IRPrefab::RotationMode::ownsEntityCanvas() and update this count (#2908)."
+);
+static_assert(
+    canvasOwningModeCount() == 2,
+    "Exactly DETACHED and DETACHED_REVOXELIZE own a per-entity C_EntityCanvas."
+);
+
+TEST(RotationModeOwnsEntityCanvas, ClassifiesEachModeExplicitly) {
+    EXPECT_FALSE(IRPrefab::RotationMode::ownsEntityCanvas(RotationMode::GRID));
+    EXPECT_TRUE(IRPrefab::RotationMode::ownsEntityCanvas(RotationMode::DETACHED));
+    EXPECT_TRUE(IRPrefab::RotationMode::ownsEntityCanvas(RotationMode::DETACHED_REVOXELIZE));
+}
+
+// ---- setMode's canvas lifecycle ----------------------------------------
+
+class RotationModeSetMode : public testing::Test {
+  protected:
+    // A canvas-owning entity as it exists between frames: tagged with the
+    // mode and carrying the wrapper. `canvasEntity_` stays kNullEntity so
+    // `setMode`'s teardown skips `destroyEntity` and the arm needs no
+    // RenderManager — the assertion under test is whether the *component*
+    // is released, which is what strands the GPU textures in production.
+    static IREntity::EntityId makeCanvasBackedEntity(RotationMode mode) {
+        return IREntity::createEntity(C_RotationMode{mode}, C_EntityCanvas{});
+    }
+
+    static bool hasCanvas(IREntity::EntityId entity) {
+        return IREntity::getComponentOptional<C_EntityCanvas>(entity).has_value();
+    }
+
+    static RotationMode modeOf(IREntity::EntityId entity) {
+        return IREntity::getComponent<C_RotationMode>(entity).mode_;
+    }
+
+    IREntity::EntityManager m_entity_manager;
+};
+
+// Leaving the canvas-owning family releases the canvas for BOTH members, not
+// just DETACHED — this is the arm the family predicate exists for.
+TEST_F(RotationModeSetMode, LeavingDetachedRevoxelizeForGridReleasesTheCanvas) {
+    const IREntity::EntityId entity = makeCanvasBackedEntity(RotationMode::DETACHED_REVOXELIZE);
+    ASSERT_TRUE(hasCanvas(entity));
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::GRID);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::GRID);
+    EXPECT_FALSE(hasCanvas(entity));
+}
+
+// The paired control: the same release, entered from the other family member.
+// Without it a blanket break in the teardown path would read as a pass on the
+// arm above alone, rather than as the mode-specific gap it is.
+TEST_F(RotationModeSetMode, LeavingDetachedForGridReleasesTheCanvas) {
+    const IREntity::EntityId entity = makeCanvasBackedEntity(RotationMode::DETACHED);
+    ASSERT_TRUE(hasCanvas(entity));
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::GRID);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::GRID);
+    EXPECT_FALSE(hasCanvas(entity));
+}
+
+// A swap inside the family is a re-tag, not a re-allocation: both modes own a
+// canvas, so neither releasing nor re-creating it is correct here.
+TEST_F(RotationModeSetMode, SwitchingDetachedToDetachedRevoxelizeKeepsTheCanvas) {
+    const IREntity::EntityId entity = makeCanvasBackedEntity(RotationMode::DETACHED);
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::DETACHED_REVOXELIZE);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::DETACHED_REVOXELIZE);
+    EXPECT_TRUE(hasCanvas(entity));
+}
+
+TEST_F(RotationModeSetMode, SwitchingDetachedRevoxelizeToDetachedKeepsTheCanvas) {
+    const IREntity::EntityId entity = makeCanvasBackedEntity(RotationMode::DETACHED_REVOXELIZE);
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::DETACHED);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::DETACHED);
+    EXPECT_TRUE(hasCanvas(entity));
+}
+
+// The early return gates on the canvas matching the mode, not on the mode
+// alone. A consistent same-mode call must still take it and attempt no
+// allocation — an allocation would trip the RenderManager assert here.
+TEST_F(RotationModeSetMode, SameModeWithAMatchingCanvasIsANoOp) {
+    const IREntity::EntityId entity = makeCanvasBackedEntity(RotationMode::DETACHED_REVOXELIZE);
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::DETACHED_REVOXELIZE);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::DETACHED_REVOXELIZE);
+    EXPECT_TRUE(hasCanvas(entity));
+}
+
+TEST_F(RotationModeSetMode, SameModeOnAPlainGridEntityIsANoOp) {
+    const IREntity::EntityId entity = IREntity::createEntity(C_RotationMode{RotationMode::GRID});
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::GRID);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::GRID);
+    EXPECT_FALSE(hasCanvas(entity));
+}
+
+// Mode-matches-but-canvas-does-not is the case the early return must NOT
+// swallow: a GRID entity carrying a stray C_EntityCanvas gets reconciled
+// rather than short-circuited. This is the headlessly-reachable half of that
+// rule; its mirror (a detached-tagged entity with no canvas) is the
+// allocation path the file header notes cannot run without a RenderManager.
+TEST_F(RotationModeSetMode, SameModeReleasesACanvasTheModeDoesNotOwn) {
+    const IREntity::EntityId entity = makeCanvasBackedEntity(RotationMode::GRID);
+    ASSERT_TRUE(hasCanvas(entity));
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::GRID);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::GRID);
+    EXPECT_FALSE(hasCanvas(entity));
+}
+
+// An entity that never carried C_RotationMode is implicitly GRID, so the
+// component-less path must reach the same conclusion as the tagged one.
+TEST_F(RotationModeSetMode, ImplicitGridEntityWithAStrayCanvasIsReconciled) {
+    const IREntity::EntityId entity = IREntity::createEntity(C_EntityCanvas{});
+
+    IRPrefab::RotationMode::setMode(entity, RotationMode::GRID);
+
+    EXPECT_EQ(modeOf(entity), RotationMode::GRID);
+    EXPECT_FALSE(hasCanvas(entity));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- `IRPrefab::RotationMode::setMode` decided canvas allocate/release from `newMode == RotationMode::DETACHED`, so `DETACHED_REVOXELIZE` — which owns a `C_EntityCanvas` exactly like `DETACHED` — **leaked the canvas entity** (and its `onDestroy` GPU-texture release) when leaving the detached family, and **never allocated one** when entering it. A `DETACHED → DETACHED_REVOXELIZE` swap was the worst arm: the exit branch destroyed the canvas and the entry branch declined to rebuild it.
- The sibling lifecycle site, `spawnPrefab` (`engine/script/src/prefab_api.cpp:282-283`), already had the correct two-mode predicate. `b435a3573` (#1555) added the mode **and** widened that site in one commit; `rotation_mode.hpp` was last touched by `6ca7bbcd9`, which `git merge-base --is-ancestor` confirms **predates** it. One of two mirrors was widened.
- Rather than fix the instance, the sites now read a single `IRPrefab::RotationMode::ownsEntityCanvas(mode)` predicate, so a mode added later cannot be wired into one site and missed by the other. A `static_assert` on the enum's size makes classifying a new mode a compile error rather than something to remember.
- **Correction, second commit (`98de4eb0b`): there were three copies in `spawnPrefab`, not one.** The first commit collapsed only the canvas allocation, leaving the `canvas_size` requirement and the `unbounded`-has-no-effect warning still spelling the mode pair by hand — i.e. the fix initially demonstrated the exact problem it argues against. All three now read the predicate. Behaviour is identical on every path (each spelled the same two modes); `PrefabApi` is **37/37**.
- Second defect in the same helper: the `if (current == newMode) return;` guard tested the mode alone, which made the headless-spawn recovery that `prefab_api.cpp:288-296` documents ("a later `setMode(entity, ...)` call … picks the canvas up") a no-op for **both** detached modes. The guard now also requires the canvas to match the mode. As a side effect the RenderManager assert fires only when an allocation is genuinely needed, instead of on every entry into a detached mode.

Reachability, measured — `fleet-rules-sweep --pattern 'RotationMode::setMode' --glob '*.cpp' --glob '*.hpp' --glob '*.h' --glob '*.lua'` → **swept 982 file(s) (3953 walked), 3 matches in 3 files, all of them comments.** The helper has **no in-tree call sites**, so nothing miscompiles or crashes today: this is a public prefab API that did not do what its documentation said, plus a leak that arms the moment the first caller lands. Framing it as a live crash would have been alarmist. It also had **zero** test coverage — the only test-tree mention was a comment asserting the broken recovery.

## Test plan

- [x] `IrredenEngineTest` → **1511 / 1512**, against a pre-edit baseline of **1502 / 1503** on `12b8a49c8` — exactly **+9**, the nine new cases, nothing else moved.
- [x] Sole red in both runs is `SaveTrait.InventoryIsComplete` (**#2834**), a component-**count** assertion. Matched by name, not by count; this change registers no new component type and cannot reach it.
- [x] `header-checks` → `scanned 573 header file(s)`, rc=0.
- [x] `clang-format --dry-run --Werror` → rc=0 on all four changed C++ files.
- [x] No `glm::` / `std::` math primitives on any added line (rule sweep pattern run against the diff).

## Positive control — the fix is what the tests measure

**The obvious control is unrunnable and saying so is part of the result.** The new tests call `ownsEntityCanvas`, which does not exist on `master` (`grep -c` → 6 references), so reverting `rotation_mode.hpp` wholesale fails to *compile* rather than to *assert*. The control therefore restores only `setMode`'s **body** to master's logic and keeps the new symbol. Each case was run **alone** — a batched run would hide a non-discriminating arm behind the first failure.

| case | control (master body) | fixed |
|---|---|---|
| `LeavingDetachedRevoxelizeForGridReleasesTheCanvas` | **FAIL** | PASS |
| `SwitchingDetachedToDetachedRevoxelizeKeepsTheCanvas` | **FAIL** | PASS |
| `SwitchingDetachedRevoxelizeToDetachedKeepsTheCanvas` | **FAIL** | PASS |
| `SameModeReleasesACanvasTheModeDoesNotOwn` | **FAIL** | PASS |
| `ImplicitGridEntityWithAStrayCanvasIsReconciled` | **FAIL** | PASS |
| `LeavingDetachedForGridReleasesTheCanvas` | ok | PASS |
| `SameModeWithAMatchingCanvasIsANoOp` | ok | PASS |
| `SameModeOnAPlainGridEntityIsANoOp` | ok | PASS |
| `ClassifiesEachModeExplicitly` | ok | PASS |

**5 fail / 4 survive, and the 4 survivors are exactly the arms that do not depend on the fix** — `LeavingDetachedForGrid` is the deliberate paired control (that direction always worked, so a blanket teardown break would show up here), the two consistent same-mode calls already took the early return, and `ClassifiesEachModeExplicitly` tests the predicate the control retains. The isolation is mode-specific, not a blanket break. `rotation_mode.hpp` was restored byte-identically afterwards (`diff -q` clean) and the restored build is 9/9.

**The `static_assert` has its own control.** Temporarily adding a fourth enum value and rebuilding fails with the intended message, so the guard is not vacuous:

```
build rc=2
test/ecs/rotation_mode_set_test.cpp:55:5: error: static assertion failed due to requirement 'modeCount() == 3':
  A RotationMode was added or removed. Classify it in
  IRPrefab::RotationMode::ownsEntityCanvas() and update this count (#2908).
```

The enum was restored and rebuilt clean. Note the pairing is load-bearing: `canvasOwningModeCount() == 2` alone stays green when a mode is added and left unclassified — it is the **total** that moves, which is why both asserts are there.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Both detached modes are one canvas-owning family (enter allocates, leave destroys, swap preserves) | `IrredenEngineTest --gtest_filter=RotationModeSetMode.*`, each case alone | `LeavingDetachedRevoxelizeForGrid` PASS (control FAIL); `SwitchingDetachedToDetachedRevoxelize` + `SwitchingDetachedRevoxelizeToDetached` PASS, canvas retained (control FAIL) |
| Same-mode early return no longer defeats the documented headless recovery | same, `SameModeReleasesACanvasTheModeDoesNotOwn` + `ImplicitGridEntityWithAStrayCanvasIsReconciled` | both PASS; both **FAIL** under master's body. The three comment sites are now true, so no comment-correction fallback was needed |
| New gtest arms covering the helper for the first time, incl. the `DETACHED_REVOXELIZE → GRID` teardown headlessly | `IrredenEngineTest` | 9 cases in the new `test/ecs/rotation_mode_set_test.cpp`; the teardown arm runs headless via a `C_EntityCanvas` whose `canvasEntity_` is `kNullEntity` |
| Arms that must allocate are called out, not silently skipped | — | `GRID → a canvas-owning mode` calls `EntityCanvas::create` behind `IR_ASSERT(IRRender::g_renderManager != nullptr)` and **cannot run headlessly**. Stated in the test file header. Its rule — reconcile on mismatch — is pinned from the release side instead, which is headlessly reachable |
| Suite moves by exactly the number of added cases vs a pre-edit baseline | `./IrredenEngineTest` | **1511/1512** vs **1502/1503** = **+9**, matching the 9 added cases exactly |

## Known remaining shape-alike — disclosed, not fixed

`engine/prefabs/irreden/render/systems/system_propagate_canvas_rotation.hpp:62-63` guards on the same two modes (its own comment opens *"Both detached strategies need…"*). It is **deliberately left alone**, but the original reason given here — an include-cycle risk — was **wrong, and is corrected below** (raised by the Sonnet review, resolved by the Opus recheck, re-verified independently before this edit).

**There is no cycle.** `system_propagate_canvas_rotation.hpp` is a leaf: a tree-wide sweep (`fleet-rules-sweep`, 1358 files) finds its only `#include`rs are three demo `main.cpp` files (`canvas_stress`, `detached_probe`, `fog_demo`). No engine header includes it, so nothing reachable from `entity_canvas.hpp` can point back at it.

**The real cost is layering weight.** `common/rotation_mode.hpp` includes `render/entity_canvas.hpp` *only* because `setMode` calls `EntityCanvas::create` (line 107); `ownsEntityCanvas` is `constexpr` over the enum and needs nothing beyond `component_rotation_mode.hpp`. Routing a `render/systems/` header through the predicate would therefore drag the whole `entity_canvas.hpp` chain (`entity_trixel_canvas`, `entity_voxel_pool_canvas`, `component_voxel_pool`, …) in behind it — for a guard that is about *rotation propagation*, not canvas lifetime. That is a fair reason to leave the site alone; "include cycle" is not. If anyone revisits, the clean move is splitting the predicate into a header that does not pull in the render side.

A tree-wide sweep confirms it is the only remaining code site; the one other hit (`component_canvas_local_rotation.hpp:39`) is a comment.

## Reviewer notes

- `ownsEntityCanvas` lives in `rotation_mode.hpp`, **not** the component header — `engine/prefabs/CLAUDE.md`'s data-only rule for `components/component_*.hpp` (#2631) puts `IRPrefab::` function definitions in the sibling feature header.
- `simplify` reported one finding rather than fixing it: the `IR_ASSERT` appears on an added line, but it is master's pre-existing invariant relocated, not a new guard — and it now fires strictly *less* often. Driving it needs a live RenderManager, so it is unreachable from this suite.
- The `DETACHED ↔ DETACHED_REVOXELIZE` preserve-the-canvas behaviour was flagged here as the one judgment call worth a look. **The Opus recheck confirmed it correct**, and for a stronger reason than the GPU-allocation churn originally offered: `spawnPrefab` calls plain `EntityCanvas::create` for *both* modes (`prefab_api.cpp:283-287`), so the single canvas-creation seam takes no mode parameter — the canvas a re-create would produce is configured identically to the one already held.
- **Sibling defect filed as #2913** (not folded in): `setMode`'s canvas-release arm destroys the canvas without re-homing a pool-resident `C_VoxelSetNew`, leaving `canvasEntity_` naming a destroyed entity and `voxelStartIdx_` / `numVoxels_` indexing a dead pool. Pre-existing — master's `DETACHED → GRID` arm had the identical teardown — but this PR makes it reachable from `DETACHED_REVOXELIZE`, the mode whose canvas hosts the private pool. Nothing is live (`setMode` has zero production callers), and choosing the recovery is a design call outside this PR's "close the leak" scope.

Closes #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)


