### PR TITLE
fleet/tests: scrub ambient FLEET_PLAN_ISSUE before running dispatch-wrap suite

### DIFF
--- a/scripts/fleet/tests/test_dispatch_wrap_session.sh
+++ b/scripts/fleet/tests/test_dispatch_wrap_session.sh
@@ -22,11 +22,29 @@
 #   - cleanup: finished/no-op (clean master) clears the sidecar
 #   - planning assignment (#2197): 7th plan= arg -> FLEET_PLAN_ISSUE export;
 #     absent/bare arg stays unset; a resume releases the pre-claim instead
+#   - hermeticity (#2836): the suite is immune to an inherited FLEET_PLAN_ISSUE
+#     (every planning-assigned worker iteration exports it, so any such
+#     iteration that runs this suite — e.g. while build-verifying a
+#     scripts/fleet PR — must not see a spurious 2-assertion red)
 
 set -uo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 WRAP="$SCRIPT_DIR/fleet-dispatch-wrap"
 [[ -x "$WRAP" ]] || { echo "test setup: $WRAP not found"; exit 1; }
+
+# Hermeticity (#2836): fleet-dispatch-wrap only ever SETS FLEET_PLAN_ISSUE
+# (from its own 7th argv, when present) — it never unsets it when the arg is
+# absent. Every planning-assigned dispatch exports FLEET_PLAN_ISSUE, so this
+# suite's own process inherits it whenever it's run from inside such an
+# iteration, and T9's two absent-arg cases below would then see it leak
+# straight through into the wrap's launch. Scrub it once here, in this
+# process's own environment, before any dispatch call runs — the fix belongs
+# in the test harness, not the wrap, which has no way to distinguish "caller
+# wants no plan" from "caller's shell happens to have one lying around".
+# (Audited siblings: FLEET_ROLE_MODEL is always freshly exported by the wrap
+# itself regardless of argv, so it has no leak path; FLEET_ASSIGNED_WORKTREE
+# is not read by fleet-dispatch-wrap at all.)
+unset FLEET_PLAN_ISSUE
 
 PASS=0; FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok: $1"; }
@@ -210,6 +228,28 @@ grep -q -- '^--repo game planning-release 7 worker-1$' "$FLEET_CLAIM_LOG" \
   || bad "resume: no planning-release call: $(cat "$FLEET_CLAIM_LOG")"
 unset FLEET_CLAIM_LOG
 rm -f "$SIDECAR"
+
+# --- hermeticity regression lock (#2836) -------------------------------------
+# T9 above only proves its absent-arg cases are clean in THIS process,
+# which is already running after the setup scrub. That alone doesn't lock the
+# scrub against removal — a future edit could delete the `unset
+# FLEET_PLAN_ISSUE` above and every case here would still pass, because none
+# of them re-introduce an ambient value once the process starts. Reproduce the
+# actual bug report's repro command instead: re-invoke this whole suite as a
+# child process with FLEET_PLAN_ISSUE ambiently exported (exactly
+# `FLEET_PLAN_ISSUE=engine:9999 bash test_dispatch_wrap_session.sh`, the
+# acceptance criterion's own repro form) and assert the child still exits 0.
+# The child hits the setup scrub before its own T9 run, so this fails iff
+# that scrub regresses. FLEET_TEST_SELFCHECK guards against a second level of
+# recursion — the child must not spawn a grandchild.
+if [[ -z "${FLEET_TEST_SELFCHECK:-}" ]]; then
+    echo "T10b: suite is hermetic against an ambient FLEET_PLAN_ISSUE (#2836 repro, regression lock)"
+    if FLEET_TEST_SELFCHECK=1 FLEET_PLAN_ISSUE="engine:9999" bash "$0" >"$TMPROOT/selfcheck.log" 2>&1; then
+        ok "suite exits 0 when launched with FLEET_PLAN_ISSUE ambiently set"
+    else
+        bad "suite fails under an ambient FLEET_PLAN_ISSUE (setup scrub regressed): $(tail -5 "$TMPROOT/selfcheck.log")"
+    fi
+fi
 
 # --- in-flight false positives + resume-loop breaker (worker-2, 07-09→07-14) --
 echo "T11: scratch branch is never in-flight — sidecar cleared even when dirty"


### PR DESCRIPTION
## Summary
- `test_dispatch_wrap_session.sh` inherited an ambient `FLEET_PLAN_ISSUE` from its own calling shell (every planning-assigned worker iteration exports it), which leaked straight through into the two absent-arg cases (T9) since `fleet-dispatch-wrap` only ever *sets* the var from its own argv and never clears it when the arg is absent.
- Scrub `FLEET_PLAN_ISSUE` once in the suite's own setup, before any dispatch call runs — the fix belongs in the test harness, not the wrap.
- Added a regression-lock case (T10b) that re-invokes the whole suite as a child process with `FLEET_PLAN_ISSUE` ambiently exported (the bug report's own repro command) and asserts the child still exits 0, so a future removal of the scrub is caught automatically.
- Audited `FLEET_ROLE_MODEL` (always freshly exported by the wrap regardless of argv — no leak path) and `FLEET_ASSIGNED_WORKTREE` (not read by the wrap at all) as siblings per the issue's fix-shape guidance; neither needed a scrub.

## Test plan
- [x] `env -u FLEET_PLAN_ISSUE bash scripts/fleet/tests/test_dispatch_wrap_session.sh` — PASS: 41 FAIL: 0
- [x] `FLEET_PLAN_ISSUE=engine:2479 bash scripts/fleet/tests/test_dispatch_wrap_session.sh` (the issue's exact repro command) — PASS: 41 FAIL: 0, exit 0
- [x] Control: temporarily reverted the `unset FLEET_PLAN_ISSUE` scrub and re-ran `FLEET_PLAN_ISSUE=engine:2479 bash ... test_dispatch_wrap_session.sh` (with `FLEET_TEST_SELFCHECK=1` to avoid the new case's own recursion) — reproduced the exact pre-fix signature, `PASS: 38 FAIL: 2` with the two T9 "leak" failures; restored before committing
- Why not `fleet-positive-control` (the tool `scripts/fleet/CLAUDE.md` mandates for a new suite, "never by hand"): it cannot produce a verdict here, for two independent reasons. **(1)** Its bash tally matcher (`fleet-positive-control:167`) only accepts `summarize()`'s two spellings (`passed: N  failed: M` / `<label>: N passed, M failed`); this suite keeps its own counters and prints `PASS: N  FAIL: M`, so the run ends in `the suite printed no tally … treat this as a setup failure` (exit 2). Measured: `fleet-positive-control scripts/fleet/tests/test_dispatch_wrap_session.sh 12b8a49c8` → exit 2, while the suite itself printed `PASS: 41  FAIL: 0` two lines earlier. Filed as #2917 (41 of 92 bash suites affected). **(2)** Even past that, the tool stages `scripts/fleet` from `<ref>` and then unconditionally copies the **working-tree** suite over the staged copy (`fleet-positive-control:121-123`) — and this PR's entire diff is that one file, so no `<ref>` can yield a staged tree lacking the fix and the control would read VACUOUS. The manual line-revert above was the only control available, not a shortcut.
- [x] `bash scripts/fleet/tests/run_all.sh` — 123/124 suites pass; the one failure (`test_cross_repo_shared_file_parity.sh`, an unrelated `.github/workflows/auto-rereview.yml` engine/game drift check) reproduces identically on `origin/master` with this branch's changes stashed, confirming it predates and is unrelated to this fix

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| `FLEET_PLAN_ISSUE=engine:9999 bash ... test_dispatch_wrap_session.sh` exits 0 with all cases passing | `FLEET_PLAN_ISSUE=engine:2479 bash scripts/fleet/tests/test_dispatch_wrap_session.sh` | `PASS: 41  FAIL: 0`, exit 0 |
| `bash scripts/fleet/tests/run_all.sh` stays green | `bash scripts/fleet/tests/run_all.sh` | `test_dispatch_wrap_session.sh` reports PASS; only pre-existing, unrelated `test_cross_repo_shared_file_parity.sh` fails (reproduced on stashed/master tree) |
| The new ambient-env case fails on the pre-fix suite (positive control) | Reverted the `unset FLEET_PLAN_ISSUE` line only, re-ran the ambient repro (`fleet-positive-control` is structurally inapplicable here — see the Test plan bullet and #2917) | `PASS: 38  FAIL: 2` — exact pre-fix signature (`absent-arg plan leak`, `bare plan= leaked`); restored after |

Closes #2836

🤖 Generated with [Claude Code](https://claude.com/claude-code)
