### PR TITLE
fleet: give the scout's open-PR fetch an explicit window (#2743)

### DIFF
--- a/.fleet/plans/issue-2743.md
+++ b/.fleet/plans/issue-2743.md
@@ -1,0 +1,133 @@
+## Plan: fleet-state-scout open-PR list capped at gh's default --limit 30
+
+- **Issue:** #2743
+- **Model:** opus — one-line surface, but it changes a shared fleet-infra data source every role reads, in a subsystem with explicit GitHub-quota discipline
+- **Date:** 2026-07-31
+
+### Verified current state
+
+- `_fetch_prs_graphql` (`scripts/fleet/fleet-state-scout:263-266`) invokes `gh pr list --repo <r> --state open --json …` with no `--limit`. `gh pr list --help` documents `-L, --limit int  Maximum number of items to fetch (default 30)`.
+- Measured 2026-07-31 13:30Z: 35 open engine PRs live, 30 in `state.json` (cache 25s old). Dropped set is the 5 lowest numbers — #2393, #2475, #2585, #2607, #2608 — confirming a newest-N-by-number window, not a staleness artifact.
+- The change-detector in `fetch_prs` (`:322`) already passes `per_page=100` and its comment reasons explicitly about covering *"every open PR (REST defaults to 30)"*. The cap was closed on the detector and left open on the fetch it gates: the detector correctly observes all 35 change, then the GraphQL fetch retains 30.
+- Downstream confirmation: `enrich_inflight_pr_tasks` (`:1841`) matches on `headRefName`; #2376 projected `inflight_pr: null` / `owner: free` while open PR #2607 (head `claude/2376-implicit-grid-rotation`, `Closes #2376`, `fleet:approved`) held the finished work. The predicate would have matched — the record was absent. This pane claimed #2376 off the queue on that projection.
+- Other `repos.*.prs[]` readers inheriting the narrowing: `enrich_stackable_blocker_prs` (`:1721`), `_semantic_conflict_claimable`, the per-role slices built at `:2596`, and role-worker steps 1 / 1c.
+- Existing test harness: `scripts/fleet/tests/` (106 entries), including `test_enrich_inflight_pr_tasks.py` — the natural home for the regression check.
+
+### Scope
+
+Give `_fetch_prs_graphql` an explicit, named limit well above the plausible open-PR ceiling, **plus a truncation guard** so the silent-narrowing class cannot recur unobserved. One function, both repos (`fetch_prs` is called per repo, so engine and game are fixed by the same change).
+
+Rejected alternatives:
+- *Leave it and widen the matching predicate instead* (the #2672 / #2507 direction) — no predicate can match a record that was never fetched. Those issues remain independently valid; this is upstream of both.
+- *Migrate the open-PR list to paginated REST* — `fetch_prs`'s own comment documents why this read stays on GraphQL (it needs `reviews` + `mergeable`, which the REST list omits). Out of scope.
+- *Raise to exactly 100* — one page, but it re-creates the same silent cliff at a higher number. The guard below is what actually makes the failure loud; the limit only sets where.
+
+### Approach
+
+1. `scripts/fleet/fleet-state-scout` — add a module constant next to the other fetch tunables:
+   ```python
+   # gh pr list defaults to --limit 30 and silently truncates past it, dropping
+   # the OLDEST open PRs — exactly the long-lived stuck ones (#2743). This is the
+   # fleet's authoritative in-flight signal; every role's projection reads it.
+   OPEN_PR_FETCH_LIMIT = 200
+   ```
+2. Pass it in `_fetch_prs_graphql`: `"--limit", str(OPEN_PR_FETCH_LIMIT),`.
+3. Truncation guard — immediately after the `json.loads` succeeds, before the per-PR normalization loop:
+   ```python
+   if len(prs) >= OPEN_PR_FETCH_LIMIT:
+       log(f"gh pr list {repo}: returned {len(prs)} PRs at the "
+           f"{OPEN_PR_FETCH_LIMIT} cap — open-PR list may be truncated; "
+           f"raise OPEN_PR_FETCH_LIMIT")
+   ```
+   `>=` not `==` so it still fires if the constant is later lowered below the live set. This is the piece that converts a silent narrowing into an operator-visible one; do not drop it as "defensive noise".
+4. Regression test in `scripts/fleet/tests/test_enrich_inflight_pr_tasks.py` (or a sibling `test_fetch_prs_limit.py` if the existing file's fixtures don't reach the fetch layer): assert `_fetch_prs_graphql` passes `--limit` in its argv, and assert the #2376 shape — a task whose issue number appears in an open PR's `headRefName` gets a non-null `inflight_pr` when that PR is the 31st-or-older record.
+
+### Affected files
+
+- `scripts/fleet/fleet-state-scout` — one constant, one argv pair, one guard (~10 lines)
+- `scripts/fleet/tests/test_enrich_inflight_pr_tasks.py` (or a new sibling) — regression coverage
+
+### Acceptance criteria
+
+- **Positive-fire, and it must be run both ways:** with >30 open PRs live,
+  `python3 -c "import json,os;d=json.load(open(os.path.expanduser('~/.fleet/state/state.json')));print(len(d['repos']['engine']['prs']))"`
+  equals `gh pr list --repo jakildev/IrredenEngine --state open --limit 200 --json number --jq length` on a fresh scout tick. This assertion **FAILS on master today** (30 vs 35) — record both the pre-fix red and the post-fix green in the PR body; a post-fix-only green does not distinguish the fix from a shrunken PR set.
+- #2376-shaped unit regression passes; it fails with the `--limit` argument reverted.
+- The truncation guard fires when `OPEN_PR_FETCH_LIMIT` is temporarily set below the live open-PR count, and is silent at 200.
+- `sample_github_rate_limit`'s latched utilization shows no material regression across ~3 consecutive ticks. Expected: unchanged request count — gh pages at `min(limit, 100)` per request and stops once the result set is exhausted, so 35 open PRs cost one request at either limit; only the payload grows.
+
+### Gotchas
+
+- **Widening the list widens every consumer at once.** Roles that previously never saw #2393 / #2475 / #2585 will start seeing them. Those three carry `fleet:design-unblocked` (x2) and `fleet:needs-human` — all currently parked for reasons documented on the PRs. Expect a dispatch-pressure bump on the first post-fix tick as long-buried PRs re-enter the projections; that is the fix working, not a regression. Do **not** "fix" it by re-narrowing.
+- The projection/trigger hashes will flip once on the first tick carrying the newly-visible PRs. One-time churn, not a loop.
+- Do **not** touch `fetch_closed_fleet_queued(repo, limit=100)` or `fetch_issues_by_label`'s `per_page=30` — both are deliberate, documented windows chosen to keep the queue-ingest set byte-identical. Only the open-PR list is the unintended cap.
+- CI is Linux; this is Python within an existing harness, so no BSD/GNU portability surface — but run the touched test file, not just a macOS-local scout tick.
+
+### Sibling / in-flight reconciliation
+
+Checked all 35 open engine PRs' file lists (2026-07-31). Three touch `scripts/fleet/fleet-state-scout`: **#2709** (needs_gl_host inference from source paths), **#2657** and **#2656** (stacked-PR machinery retirement, phases 2–3). None touch `_fetch_prs_graphql` or `fetch_prs`; #2709's scout hunks are in the GL-host backstop path and it adds its own test file. No conflict expected. Single task, single PR — no stack needed.
+
+---
+
+## Plan-review refinement (opus-reviewer, pool-7, 2026-08-01) — BINDING
+
+The plan was reviewed SOUND with one binding change to the acceptance section,
+carried here so the implementer does not have to reconstruct it from the thread.
+
+The **unit** test as originally specified does not do what the plan claims:
+`enrich_inflight_pr_tasks` receives `prs[]` directly, so a fixture of 31+ PRs
+passes at **any** fetch limit — that assertion cannot go red when `--limit` is
+reverted. The only part that inverts is `assert "--limit" in argv`, which is a
+change-detector on the fix's own artifact, not a behavioural control (the trap
+#2723 was filed for).
+
+Make the fetch-layer test **behavioural** instead — stub `run_capture` with a
+fake that **honors** `--limit` the way `gh` does:
+
+```python
+_FIXTURE = [_pr(n) for n in range(1000, 1040)]   # 40 open PRs
+
+def _fake_gh(argv):
+    limit = int(argv[argv.index("--limit") + 1]) if "--limit" in argv else 30
+    return json.dumps(_FIXTURE[:limit])          # gh's newest-first truncation
+
+with patch.object(_mod, "run_capture", side_effect=_fake_gh):
+    prs = _mod._fetch_prs_graphql("jakildev/IrredenEngine")
+self.assertEqual(len(prs), 40)
+```
+
+Red on master (no `--limit` → fake returns 30), green with the fix, and it
+discriminates on *behaviour* rather than on the presence of the flag. Precedent
+for the module-load + `patch.object` shape is
+`scripts/fleet/tests/test_scout_agent_approved_fetch.py:16-20` and `:45`.
+
+Keep the `#2376`-shape enrich assertion — it is good documentation of the
+downstream harm — but state it as **coverage**, not as the control that inverts.
+
+Model stays **opus**, settling the `#2742` consolidation's open divergence.
+
+---
+
+## Implementer's note (2026-08-07) — the live control decayed before pickup
+
+Everything above is the plan as reviewed, kept verbatim. One acceptance
+criterion no longer reproduces and must not be read as a live claim:
+
+The **live** positive control ("FAILS on master today — 30 vs 35") depended on
+the engine having >30 open PRs. The merge queue drained between plan review and
+implementation: at pickup there were **16** open engine PRs and **13** game,
+both under gh's default window, so master and the fix return the same list and
+the live assertion is **vacuous today in both directions**. It is not evidence
+of anything, and a green post-fix run of it would not distinguish the fix from
+the shrunken PR set — exactly what the criterion warned about, arriving from the
+other side.
+
+The control that does invert is the **hermetic** one the plan-review refinement
+specified: `scripts/fleet/tests/test_fetch_prs_limit.py` stubs `run_capture`
+with a fake honoring `--limit` as gh does, and goes red on the pre-fix tree.
+Two further arms cover what a stub cannot: the flag is driven against the
+**real** `gh` binary (proving it is accepted in that argv position — the #2781
+hazard), and the request count is measured directly rather than via the shared
+rate-limit bucket, which concurrent fleet daemons make unusable. Evidence is in
+the PR body.
+

--- a/.fleet/plans/issue-2743.md
+++ b/.fleet/plans/issue-2743.md
@@ -131,3 +131,23 @@ hazard), and the request count is measured directly rather than via the shared
 rate-limit bucket, which concurrent fleet daemons make unusable. Evidence is in
 the PR body.
 
+### Amendment (2026-08-07, review nit) — the rate-limit arm is vacuous too
+
+The review flagged that the rate-limit criterion was demonstrated single-shot
+rather than across the ~3 ticks specified, and asked that a future rate-limit
+regression on this path not be read as pre-cleared by it. Re-measured, and the
+gap is larger than the tick count: **at today's open-PR depth the arms cannot
+differ at all**, so neither form of the criterion — single-shot or 3-tick —
+discriminates.
+
+Measured 2026-08-07 against `jakildev/IrredenEngine`, counting `POST /graphql`
+under `GH_DEBUG=api`: gh pages at 100, spending
+`ceil(min(limit, available) / 100)` requests — limits 30/100/150/200/250 cost
+1/1/2/2/3. Both real arms (no `--limit`, and `--limit 200`) return **18 PRs in
+1 request**, because 18 and 30 sit on the same side of the first page boundary.
+
+So the honest claim is a *bound*, not a clearance: the fix costs **+0 requests
+per repo per tick while the open set is under 100, and +1 above it**, capped at
+2 by the 200 limit. That bound is now measured rather than predicted from gh's
+documented paging, and it is recorded at the constant in `fleet-state-scout` —
+the site the truncation guard points an operator at when it says to raise it.

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -146,6 +146,12 @@ FETCH_SUBMIT_GAP_SECONDS = 0.25
 # semantic-conflict lanes, and the in-flight/stackable enrichers all read it,
 # and a PR outside the window contributes no projection item at all, so its
 # later label edits produce no dispatch edge (#2743).
+#
+# Raising it costs requests: gh pages at 100, so one tick spends
+# ceil(min(limit, open_count) / 100) requests per repo — measured 2026-08-07
+# at limits 30/100/150/200/250 -> 1/1/2/2/3. At 200 that is 1 request while
+# the open set is under 100 and 2 above it. The guard below tells an operator
+# to raise this constant; that is the price of doing so.
 OPEN_PR_FETCH_LIMIT = 200
 
 TERMINATE = threading.Event()

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -139,6 +139,15 @@ GH_TIMEOUT_SECONDS = 30
 FETCH_MAX_WORKERS = 2
 FETCH_SUBMIT_GAP_SECONDS = 0.25
 
+# `gh pr list` defaults to --limit 30 and truncates past it silently, keeping
+# the NEWEST 30 by number — so the oldest open PRs, exactly the long-lived
+# stalled ones, drop out first. This list is the fleet's authoritative
+# in-flight signal: every role's projection, the feedback and
+# semantic-conflict lanes, and the in-flight/stackable enrichers all read it,
+# and a PR outside the window contributes no projection item at all, so its
+# later label edits produce no dispatch edge (#2743).
+OPEN_PR_FETCH_LIMIT = 200
+
 TERMINATE = threading.Event()
 
 
@@ -260,6 +269,7 @@ def _is_pull_request(issue):
 def _fetch_prs_graphql(repo):
     out = run_capture([
         "gh", "pr", "list", "--repo", repo, "--state", "open",
+        "--limit", str(OPEN_PR_FETCH_LIMIT),
         "--json",
         # headRefOid drives the per-PR diff-cache freshness check (a changed
         # head oid invalidates the cached detail/diff). It rides the same list
@@ -274,6 +284,13 @@ def _fetch_prs_graphql(repo):
     except json.JSONDecodeError as e:
         log(f"gh pr list {repo}: bad JSON: {e}")
         return None
+    # A result sitting exactly at the cap may itself be truncated — the same
+    # silent narrowing, one window wider. `>=` rather than `==` so the warn
+    # still fires if the constant is later lowered below the live open set.
+    if len(prs) >= OPEN_PR_FETCH_LIMIT:
+        log(f"gh pr list {repo}: returned {len(prs)} PRs at the "
+            f"{OPEN_PR_FETCH_LIMIT} cap — open-PR list may be truncated; "
+            f"raise OPEN_PR_FETCH_LIMIT")
     for pr in prs:
         pr["labels"] = sorted(label["name"] for label in pr.get("labels", []))
         pr["author"] = pr.get("author", {}).get("login", "")

--- a/scripts/fleet/tests/test_fetch_prs_limit.py
+++ b/scripts/fleet/tests/test_fetch_prs_limit.py
@@ -1,0 +1,201 @@
+"""Tests for _fetch_prs_graphql's open-PR fetch window (#2743).
+
+`gh pr list` defaults to --limit 30 and truncates past it silently, keeping the
+NEWEST 30 by number. `repos.<repo>.prs[]` is the fleet's authoritative in-flight
+signal, so the truncation dropped the OLDEST open PRs — the long-lived stalled
+ones — out of every role's projection, the feedback and semantic-conflict lanes,
+and the in-flight / stackable enrichers.
+
+The control that inverts is TestOpenPrFetchWindow: it stubs run_capture with a
+fake that honors --limit the way gh does, so the fetch's own behaviour decides
+the verdict. Asserting `"--limit" in argv` would only be a change-detector on
+the fix's own artifact (the #2723 trap), and an enrich-layer fixture cannot
+discriminate at all — enrich_inflight_pr_tasks receives prs[] directly, so it
+passes at any fetch limit. TestInflightMatchPastTheDefaultWindow is therefore
+recorded as downstream-harm coverage, not as the control.
+
+Import the script via importlib because it has no .py extension.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+_REPO = "jakildev/IrredenEngine"
+
+# gh's own documented default, the value that made the truncation silent.
+_GH_DEFAULT_LIMIT = 30
+
+# Wide enough that gh's default truncates it, narrow enough to stay legible.
+_FIXTURE_COUNT = 40
+_FIRST_PR = 1000
+
+
+def _pr(n):
+    return {
+        "number": n,
+        "title": f"pr {n}",
+        "headRefName": f"claude/{n - 500}-some-task",
+        "headRefOid": f"{n:040d}",
+        "baseRefName": "master",
+        "author": {"login": "jakildev"},
+        "labels": [{"name": "fleet:approved"}],
+        "mergeable": "MERGEABLE",
+        "isDraft": False,
+        "reviews": [],
+        "updatedAt": "2026-08-07T00:00:00Z",
+        "body": "",
+    }
+
+
+_FIXTURE = [_pr(n) for n in range(_FIRST_PR, _FIRST_PR + _FIXTURE_COUNT)]
+
+
+def _fake_gh(argv, cwd=None):
+    """Stand in for `gh pr list`, modelling its ARGUMENT PARSING, not just its
+    endpoint (scripts/fleet/CLAUDE.md).
+
+    Fails closed on any argv shape it does not model, so a future rewrite of
+    the call site cannot quietly slip past the window this suite guards.
+    """
+    if argv[:3] != ["gh", "pr", "list"]:
+        raise AssertionError(f"unmodelled command: {argv!r}")
+    for required in ("--repo", "--state", "--json"):
+        if required not in argv:
+            raise AssertionError(f"gh pr list requires {required}: {argv!r}")
+
+    if "--limit" in argv:
+        raw = argv[argv.index("--limit") + 1]
+        # The real binary rejects a non-integer limit before issuing a request.
+        if not raw.lstrip("-").isdigit() or int(raw) < 1:
+            raise AssertionError(f"gh rejects --limit {raw!r}")
+        limit = int(raw)
+    else:
+        limit = _GH_DEFAULT_LIMIT
+
+    # gh returns newest-first and keeps the first `limit` — which is why the
+    # OLDEST open PRs are the ones that vanish.
+    newest_first = sorted(_FIXTURE, key=lambda pr: pr["number"], reverse=True)
+    return json.dumps(newest_first[:limit])
+
+
+class TestStubFidelity(unittest.TestCase):
+    """The stub must be able to express the bug, or every arm below is vacuous."""
+
+    def test_stub_truncates_to_ghs_default_when_limit_absent(self):
+        without = json.loads(_fake_gh(["gh", "pr", "list", "--repo", _REPO,
+                                       "--state", "open", "--json", "number"]))
+        self.assertEqual(len(without), _GH_DEFAULT_LIMIT,
+                         "stub must reproduce gh's silent default-30 truncation")
+
+    def test_stub_drops_the_oldest_prs_first(self):
+        without = json.loads(_fake_gh(["gh", "pr", "list", "--repo", _REPO,
+                                       "--state", "open", "--json", "number"]))
+        kept = {pr["number"] for pr in without}
+        oldest = _FIRST_PR
+        newest = _FIRST_PR + _FIXTURE_COUNT - 1
+        self.assertNotIn(oldest, kept, "the oldest open PR is what falls out")
+        self.assertIn(newest, kept)
+
+    def test_stub_fails_closed_on_an_unmodelled_command(self):
+        with self.assertRaises(AssertionError):
+            _fake_gh(["gh", "issue", "list", "--repo", _REPO])
+
+
+class TestOpenPrFetchWindow(unittest.TestCase):
+    """The behavioural control. Red on the pre-fix tree (30 != 40)."""
+
+    def test_fetch_returns_every_open_pr_past_ghs_default(self):
+        with patch.object(_mod, "run_capture", side_effect=_fake_gh):
+            prs = _mod._fetch_prs_graphql(_REPO)
+        self.assertEqual(
+            len(prs), _FIXTURE_COUNT,
+            f"open-PR fetch kept {len(prs)} of {_FIXTURE_COUNT} — the list is "
+            "truncated at gh's default and the oldest PRs are invisible")
+
+    def test_the_oldest_open_pr_survives_the_fetch(self):
+        # The count assertion alone would pass a fetch that returned 40 wrong
+        # records; name the PR whose disappearance is the actual harm.
+        with patch.object(_mod, "run_capture", side_effect=_fake_gh):
+            prs = _mod._fetch_prs_graphql(_REPO)
+        self.assertIn(_FIRST_PR, {pr["number"] for pr in prs},
+                      "the oldest open PR is the first one gh drops")
+
+    def test_fetch_still_sorts_ascending_by_number(self):
+        # The widened list must stay quiescent for the projection hash.
+        with patch.object(_mod, "run_capture", side_effect=_fake_gh):
+            prs = _mod._fetch_prs_graphql(_REPO)
+        numbers = [pr["number"] for pr in prs]
+        self.assertEqual(numbers, sorted(numbers))
+
+
+class TestTruncationGuard(unittest.TestCase):
+    """The guard converts a silent narrowing into an operator-visible one.
+
+    These arms name OPEN_PR_FETCH_LIMIT, which does not exist on the pre-fix
+    tree, so they error rather than fail there — they are the fix's own
+    contract, not part of the inverting control above.
+    """
+
+    def _fetch_capturing_log(self, limit):
+        seen = []
+        with patch.object(_mod, "OPEN_PR_FETCH_LIMIT", limit), \
+                patch.object(_mod, "run_capture", side_effect=_fake_gh), \
+                patch.object(_mod, "log", side_effect=seen.append):
+            prs = _mod._fetch_prs_graphql(_REPO)
+        return prs, seen
+
+    def test_guard_fires_when_the_result_reaches_the_cap(self):
+        prs, logged = self._fetch_capturing_log(5)
+        self.assertEqual(len(prs), 5)
+        self.assertTrue(
+            any("may be truncated" in m for m in logged),
+            f"a capped result must warn; logged={logged!r}")
+
+    def test_guard_is_silent_below_the_cap(self):
+        # Drive the SHIPPED constant, not a copy of it — a hardcoded 200 here
+        # would keep passing if the shipped limit were lowered under the tree's
+        # real open-PR count, which is the state the guard exists to report.
+        prs, logged = self._fetch_capturing_log(_mod.OPEN_PR_FETCH_LIMIT)
+        self.assertEqual(len(prs), _FIXTURE_COUNT)
+        self.assertFalse([m for m in logged if "may be truncated" in m],
+                         f"an untruncated result must not warn; logged={logged!r}")
+
+    def test_shipped_limit_clears_the_default_it_replaces(self):
+        self.assertGreater(_mod.OPEN_PR_FETCH_LIMIT, _GH_DEFAULT_LIMIT)
+
+
+class TestInflightMatchPastTheDefaultWindow(unittest.TestCase):
+    """Downstream-harm coverage, NOT a control.
+
+    enrich_inflight_pr_tasks takes prs[] directly, so this passes at any fetch
+    limit. It documents what the truncation cost: a task shadowed by an open PR
+    read as owner-free and claimable (#2376).
+    """
+
+    def test_task_shadowed_by_an_old_pr_is_tagged_inflight(self):
+        old_pr = _FIXTURE[0]
+        issue = old_pr["headRefName"].split("/")[1].split("-")[0]
+        state = {"repos": {"engine": {
+            "prs": [dict(p, labels=["fleet:approved"]) for p in _FIXTURE],
+            "tasks": {"open": [{"id": f"#{issue}", "issue": f"#{issue}",
+                                "owner": "free"}]},
+        }}}
+        _mod.enrich_inflight_pr_tasks(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIsNotNone(
+            task.get("inflight_pr"),
+            "a task whose issue is shadowed by an open PR must not read free")
+        self.assertEqual(task["inflight_pr"]["number"], old_pr["number"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `_fetch_prs_graphql` ran `gh pr list … --state open --json …` with **no `--limit`**. `gh` defaults to 30 and truncates past it silently, keeping the **newest 30 by number** — so the *oldest* open PRs, exactly the long-lived stalled ones, fell out of `repos.<repo>.prs[]`.
- That list is the fleet's authoritative in-flight signal. A PR outside the window contributes **no projection item at all**, so its later label edits produce no dispatch edge — a verdict stamped on an aged PR strands with no self-correction. The in-flight / stackable enrichers, the feedback and semantic-conflict lanes, and every per-role slice inherit the same narrowing.
- The change-detector one function up (`fetch_prs`) had **already** been hardened against this exact cap (`per_page=100`, with a comment reasoning about gh's default-30); the fetch it gates had not.
- Adds `OPEN_PR_FETCH_LIMIT = 200`, passes it, and warns when a result comes back sitting **at** the cap. The limit only moves the cliff; the guard is what keeps the next narrowing visible instead of silent (`>=`, not `==`, so it still fires if the constant is later lowered below the live set).

Plan lands as the first commit per #1932, carrying the plan-review refinement inline.

## ⚠️ The plan's live control decayed before pickup — read this first

The plan's headline acceptance criterion was a **live** assertion: cache count vs live count, *"FAILS on master today (30 vs 35)"*. It depended on the engine having >30 open PRs.

**The merge queue drained between plan review (2026-08-01) and implementation.** Measured at PR-open: **16** open engine PRs, **14** game — both comfortably under gh's default window, so master and this branch return the *same* list. The live assertion is **vacuous today in both directions**: it cannot go red pre-fix, and a green post-fix run would not distinguish the fix from the shrunken PR set. That is precisely the failure the criterion warned about, arriving from the other side.

I did **not** report it as green. The control that actually inverts is the hermetic one the plan review specified, plus two arms covering what a stub cannot reach. All are below.

## Test plan

- [x] `python3 scripts/fleet/tests/test_fetch_prs_limit.py` — **10/10 OK** (run alone, not via the whole-dir runner).
- [x] `bash scripts/fleet/tests/run_all.sh` — **125 suites, 124 passed, 1 failed, 0 skipped**. The one failure is `test_cross_repo_shared_file_parity.sh`, which is **master's own red, not this branch's**: it compares `.github/workflows/auto-rereview.yml` against the game repo, and this branch leaves both compared subjects byte-identical to master (`md5 707f1323…` on branch and on `origin/master`; the game copy is `d4b31ee9…`). `git diff origin/master -- .github/workflows/auto-rereview.yml scripts/fleet/classify-auto-rereview.sh` is **empty**. Repaired by game PR #366, currently merge-gated.
- [x] `ruff check scripts/` — **All checks passed!**
- [x] `fleet-positive-control scripts/fleet/tests/test_fetch_prs_limit.py origin/master` — **MEANINGFUL**, re-run after a `simplify` change to the suite.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| **Positive-fire: the control inverts against the pre-fix tree** | `fleet-positive-control … origin/master` | **MEANINGFUL — 5 of 10 fail** at `12b8a49c8`. See the honest breakdown below: **2** are behavioural inversions, **3** are errors from naming a constant that cannot exist pre-fix. |
| Cache list == live list on a fresh tick, with >30 open PRs | live vs cached counts | **Not reproducible today** — 16 open engine PRs. Vacuous in both directions; superseded by the hermetic control. See the warning section above. |
| **Real `gh` accepts `--limit` in that argv position** (a stub cannot prove this — #2781) | drove the real `_fetch_prs_graphql` against live GitHub with the constant patched to 5 | returned **5 of 16** ⇒ the real binary honored the flag. At the shipped limit: **16**, oldest `#2393` present. |
| Truncation guard fires at the cap, silent below | unit + live | unit: fires at 5, silent at the shipped limit. Live: `--limit 5` → `returned 5 PRs at the 5 cap — open-PR list may be truncated; raise OPEN_PR_FETCH_LIMIT`; shipped limit → **no warning**. |
| #2376 shape — a task shadowed by an open PR is tagged `inflight_pr` | `test_task_shadowed_by_an_old_pr_is_tagged_inflight` | passes. Recorded as **coverage, not a control**: `enrich_inflight_pr_tasks` receives `prs[]` directly, so it passes at any fetch limit and cannot discriminate. |
| Rate limit: no material regression | `GH_DEBUG=api`, counting `POST /graphql` | **Vacuous at today's queue depth — a bound, not a clearance.** Both arms (no-limit and `--limit 200`) return 18 PRs in **1 request**, because 18 and 30 sit on the same side of gh's first page boundary. Paging re-measured rather than predicted: limits 30/100/150/200/250 cost 1/1/2/2/3 requests, i.e. `ceil(min(limit, available)/100)`. So the fix costs **+0 requests per repo per tick under 100 open PRs, +1 above it**, capped at 2 by the 200 limit. See the amendment note below. |

### The positive control, broken down honestly

`fleet-positive-control` reports `5 of 10`. Those five are **not** five behavioural inversions, and the distinction matters:

| Pre-fix outcome | Count | What it is |
|---|---|---|
| **FAIL — genuine inversion** | **2** | `30 != 40` (the fetch keeps only gh's default) and `1000 not found in {1010…1039}` (the *oldest* PR is the one dropped). |
| ERROR — new symbol | 3 | `TestTruncationGuard` names `OPEN_PR_FETCH_LIMIT`, which does not exist pre-fix, so it errors rather than failing. These are the fix's own contract, not part of the control. |
| PASS — non-discriminating | 5 | 3 stub-fidelity arms + ascending-sort + the enrich coverage above. |

### Why the suite is behavioural, not an argv assertion

The plan originally specified `assert "--limit" in argv`. Plan review ruled that out as a change-detector on the fix's own artifact (the #2723 trap) and required a fake that **honors** `--limit` the way gh does. The stub therefore models gh's *argument parsing*, not just its endpoint (`scripts/fleet/CLAUDE.md`): it truncates newest-first, defaults to 30 when the flag is absent, rejects a non-integer limit, and **fails closed** on any argv shape it does not model. Three `TestStubFidelity` arms assert the stub can still express the bug — without them every other arm would be vacuous.

## Amendment (2026-08-07) — review nit on the rate-limit evidence

The review noted that the rate-limit criterion ("no material regression across
~3 consecutive ticks") was demonstrated single-shot rather than by reading the
shared latched-utilization signal across ~3 ticks, and asked that a future
rate-limit regression on this path not be assumed pre-cleared by that evidence.

Re-measured, and **the gap is wider than the tick count**: at today's open-PR
depth the two arms cannot differ at all, so neither the single-shot form nor
the specified 3-tick form discriminates. The latched-bucket read has a second,
independent problem the substitution was right to avoid — it is a *shared*
pool with no attribution, moved by every concurrent fleet daemon — but the
direct request count inherits the same vacuity here for a different reason.

What replaces the cleared-sounding claim is a measured bound: gh pages at 100,
so a tick spends `ceil(min(limit, available)/100)` requests per repo (measured
1/1/2/2/3 at limits 30/100/150/200/250). The fix therefore costs +0 requests
while the open set is under 100 and +1 above it, capped at 2 by the 200 limit.

That bound now lives **at the constant** in `fleet-state-scout`, not only here:
the truncation guard's own remediation message tells an operator to raise
`OPEN_PR_FETCH_LIMIT`, and nothing at that site said what raising it past a
multiple of 100 costs. The plan file carries the same amendment.

## Notes for reviewer

- **No screenshots / no `optimize`.** Fleet tooling — no render path, system tick, shader, or math hot path in the diff.
- **Expected on the first post-fix tick** (from the plan's Gotchas, restated because it looks like a regression): widening the list widens every consumer at once, so long-buried PRs re-enter the projections and the trigger hashes flip **once**. That is the fix working — do not "fix" it by re-narrowing. Today's open set is under the window, so the bump will be small or absent until the queue grows past 30 again.
- **Deliberately not touched, but for different reasons — and one of them is NOT sound.** `fetch_closed_fleet_queued(repo, limit=100)` is a genuinely deliberate window. `fetch_issues_by_label`'s `per_page=30` is **not**: it is the same cap one lane over, already filed as **#2856** (queued, sonnet). The plan told me to leave it alone to keep this PR scoped, which I have — but I measured it while here and posted the live instance on #2856, because the phrasing "deliberate window" undersells it. **#2743 was itself a victim of #2856:** its gates cleared 2026-08-04T23:22:57Z and it was never stamped `fleet:queued`, because at 50 open `fleet:agent-approved` issues against a 30 window it sat in the dropped-oldest tail. It reached this PR only via a direct label walk. The two defects are the same cap in the PR lane and the issue lane.
- **Sibling sweep (`simplify` check-15), reported not fixed:** the other `gh (pr|issue) list` call sites are clean — `fleet_validate_stack.py` and `fleet-claim:1426` carry `--limit 200`, `fleet-claim:1365` an explicit 30; `fleet-epic-status:184` is bare but is a `--search` with expected cardinality 1–3, not the silent-default class. No sibling hole introduced or left behind.
- **`simplify` doc-drift finding, left to the reviewer's judgement:** `scripts/fleet/CLAUDE.md` could gain a bullet stating the convention this PR establishes (*a `gh … list` whose result is counted or set-diffed carries an explicit window*). Not folded in — the plan scoped the affected files to the scout plus its test, and the in-code guard is already the anti-recurrence mechanism.

Closes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)


