### PR TITLE
render: guard extra_runs structural_only against ungated capture

### DIFF
--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -353,6 +353,46 @@ def evaluate_shots(
     return rows
 
 
+def _validate_structural_only(structural_only: set[str], shots: list[str],
+                              structural: dict[str, Any],
+                              *, pass_name: str | None = None) -> None:
+    """Reject a ``structural_only`` label that would be captured-but-ungated.
+
+    A ``structural_only`` shot is captured (so the index→reference map stays
+    aligned) but skipped by the pixel-diff, so its *only* gate is its
+    ``structural`` entry. A label with no such entry produces zero result
+    rows and the run reports PASS — captured, never checked.
+
+    Called once per **resolved pass**, the top-level manifest counting as
+    one: ``main()`` passes ``pass_name=None``, ``_parse_extra_runs`` passes
+    the pass's name. Both lanes must route through here rather than inline
+    a copy — a check written into one lane reaches only that lane, which is
+    how ``extra_runs`` (where most ``structural_only`` shots live) went
+    unguarded (#2842).
+    """
+    # Message shaping is the only thing the two lanes disagree on: a per-pass
+    # failure has to name its pass and scope 'shots' / 'structural' to it.
+    where = "" if pass_name is None else f"extra run '{pass_name}': "
+    block = "manifest 'structural_only'" if pass_name is None else "'structural_only'"
+    shots_ref = "'shots'" if pass_name is None else "this pass's 'shots'"
+    gate_scope = "" if pass_name is None else " for this pass"
+    # sorted(): a set's iteration order varies with PYTHONHASHSEED, so an
+    # unsorted walk reports a different one of several bad labels per run.
+    for label in sorted(structural_only):
+        if label not in shots:
+            raise SystemExit(
+                f"{where}{block} references unknown shot '{label}' "
+                f"(not in {shots_ref})"
+            )
+        if label not in structural:
+            raise SystemExit(
+                f"{where}shot '{label}' is 'structural_only' but has no "
+                f"'structural' gate{gate_scope} — it would be captured but "
+                f"never checked. Add a structural entry or drop it from "
+                f"structural_only."
+            )
+
+
 def _parse_extra_runs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     """Validate + normalize the optional ``extra_runs`` manifest block.
 
@@ -375,8 +415,8 @@ def _parse_extra_runs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
         per-pass overrides; each defaults to **empty**, not to the
         top-level manifest value — a pass that wants one of these gates
         must declare it itself. A per-pass ``structural_only`` label must
-        have a matching per-pass ``structural`` entry, validated the same
-        way as the top-level block.
+        have a matching per-pass ``structural`` entry — enforced by the
+        same ``_validate_structural_only`` the top-level block runs.
 
     A manifest with no ``extra_runs`` behaves exactly as before.
     """
@@ -415,24 +455,8 @@ def _parse_extra_runs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             )
         structural = entry.get("structural", {})
         structural_only = set(entry.get("structural_only", []))
-        # Same captured-but-ungated hazard the top-level structural_only
-        # block guards against: a per-pass label with no per-pass
-        # structural entry is captured, never pixel-diffed, and never
-        # structurally gated either.
-        for label in structural_only:
-            if label not in shots:
-                raise SystemExit(
-                    f"extra run '{name}': 'structural_only' references "
-                    f"unknown shot '{label}' (not in this pass's 'shots')"
-                )
-            if label not in structural:
-                raise SystemExit(
-                    f"extra run '{name}': shot '{label}' is "
-                    f"'structural_only' but has no 'structural' gate for "
-                    f"this pass — it would be captured but never checked. "
-                    f"Add a structural entry or drop it from "
-                    f"structural_only."
-                )
+        _validate_structural_only(structural_only, shots, structural,
+                                  pass_name=name)
         parsed.append({
             "name": name,
             "demo_args": demo_args,
@@ -568,20 +592,10 @@ def main(argv: list[str] | None = None) -> int:
     # index→reference alignment) but no full-frame pixel-diff and no committed
     # reference PNG. This is how an analytic-oracle scene gates the zoom regime
     # that pixel-diff excludes (epic #1766 T-4). Each must be a declared shot
-    # and must carry a structural gate, else it would be captured-but-ungated.
+    # and must carry a structural gate, else it would be captured-but-ungated —
+    # the same two arms `_parse_extra_runs` applies to each extra pass.
     structural_only: set[str] = set(manifest.get("structural_only", []))
-    for label in structural_only:
-        if label not in shot_labels:
-            raise SystemExit(
-                f"manifest 'structural_only' references unknown shot '{label}' "
-                f"(not in 'shots')"
-            )
-        if label not in structural_block:
-            raise SystemExit(
-                f"shot '{label}' is 'structural_only' but has no 'structural' "
-                f"gate — it would be captured but never checked. Add a "
-                f"structural entry or drop it from structural_only."
-            )
+    _validate_structural_only(structural_only, shot_labels, structural_block)
     # Optional second/third capture passes with their own demo args + gated
     # reference subset (e.g. canvas_stress `--only compare`). Empty for a
     # single-pass manifest, so the default path is untouched.

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -369,9 +369,14 @@ def _parse_extra_runs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
       * ``capture_offset``       — index of the first gated shot in the pass's
                                    full capture list (default 0; negative =
                                    from the tail, for end-appended shots).
-      * ``warmup`` / ``thresholds`` / ``crops`` / ``structural`` /
-        ``structural_only`` — optional per-pass overrides; each defaults to
-        the top-level manifest value.
+      * ``warmup`` / ``thresholds`` — optional per-pass overrides; each
+        falls back to the top-level manifest value when unset.
+      * ``crops`` / ``structural`` / ``structural_only`` — optional
+        per-pass overrides; each defaults to **empty**, not to the
+        top-level manifest value — a pass that wants one of these gates
+        must declare it itself. A per-pass ``structural_only`` label must
+        have a matching per-pass ``structural`` entry, validated the same
+        way as the top-level block.
 
     A manifest with no ``extra_runs`` behaves exactly as before.
     """
@@ -408,6 +413,26 @@ def _parse_extra_runs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             raise SystemExit(
                 f"extra run '{name}': 'capture_offset' must be an integer"
             )
+        structural = entry.get("structural", {})
+        structural_only = set(entry.get("structural_only", []))
+        # Same captured-but-ungated hazard the top-level structural_only
+        # block guards against: a per-pass label with no per-pass
+        # structural entry is captured, never pixel-diffed, and never
+        # structurally gated either.
+        for label in structural_only:
+            if label not in shots:
+                raise SystemExit(
+                    f"extra run '{name}': 'structural_only' references "
+                    f"unknown shot '{label}' (not in this pass's 'shots')"
+                )
+            if label not in structural:
+                raise SystemExit(
+                    f"extra run '{name}': shot '{label}' is "
+                    f"'structural_only' but has no 'structural' gate for "
+                    f"this pass — it would be captured but never checked. "
+                    f"Add a structural entry or drop it from "
+                    f"structural_only."
+                )
         parsed.append({
             "name": name,
             "demo_args": demo_args,
@@ -416,8 +441,8 @@ def _parse_extra_runs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             "warmup": entry.get("warmup"),
             "thresholds": entry.get("thresholds"),
             "crops": entry.get("crops", {}),
-            "structural": entry.get("structural", {}),
-            "structural_only": set(entry.get("structural_only", [])),
+            "structural": structural,
+            "structural_only": structural_only,
         })
     return parsed
 

--- a/scripts/tests/test_render_verify.py
+++ b/scripts/tests/test_render_verify.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 _SCRIPTS = Path(__file__).resolve().parent.parent
 # render-verify.py does a bare `import verify_common` (#2461), which resolves
@@ -48,6 +49,11 @@ _run_structural_metric = _rv._run_structural_metric
 _crop_capture_path = _rv._crop_capture_path
 _parse_extra_runs = _rv._parse_extra_runs
 _slice_capture = _rv._slice_capture
+# _validate_structural_only is deliberately NOT bound here: a module-scope
+# binding of a symbol the pre-fix tree lacks makes the whole suite
+# unimportable under the "swap in the old render-verify.py" positive control,
+# collapsing a per-test result into one ImportError. Resolved per call site
+# instead, so that control reports which arms actually discriminate.
 
 MAGENTA = (255, 0, 255)
 BLACK = (0, 0, 0)
@@ -460,6 +466,73 @@ class ParseExtraRuns(unittest.TestCase):
                     "structural_only": ["shotA"],
                 }],
             })
+
+    def test_extra_runs_delegates_to_the_shared_validator(self):
+        # #2842's fix is one validator invoked per resolved pass, not one
+        # copy per lane. An inline re-copy in _parse_extra_runs would keep
+        # every behavioural test above green while re-opening the drift, so
+        # assert the delegation itself. The manifest below is the *violating*
+        # shape: with the stub in place it must parse (proving the raise came
+        # from the patched-out helper), and an inline copy would raise here.
+        with patch.object(_rv, "_validate_structural_only") as spy:
+            _parse_extra_runs({"extra_runs": [{
+                "name": "compare",
+                "demo_args": ["--only", "compare"],
+                "shots": ["shotA"],
+                "structural_only": ["shotA"],
+            }]})
+        spy.assert_called_once()
+        self.assertEqual(spy.call_args.kwargs, {"pass_name": "compare"})
+        self.assertEqual(spy.call_args.args[0], {"shotA"})
+
+
+class ValidateStructuralOnly(unittest.TestCase):
+    """The shared two-arm guard, driven on its top-level lane (#2842).
+
+    ``main()`` is the other caller, and its lane is otherwise reachable only
+    through a full CLI run against a demo dir — these arms cover it directly.
+    The per-pass lane's arms live in ParseExtraRuns above.
+    """
+
+    def test_top_level_compliant_shape_passes(self):
+        _rv._validate_structural_only({"shotA"}, ["shotA", "shotB"],
+                                  {"shotA": [{"metric": "shadow"}]})
+
+    def test_top_level_unknown_shot_raises(self):
+        with self.assertRaises(SystemExit) as cm:
+            _rv._validate_structural_only({"nope"}, ["shotA"], {})
+        # Manifest-scoped wording: no pass name, since the top level is not
+        # an extra run. Unchanged from before the helper extraction.
+        self.assertEqual(
+            str(cm.exception),
+            "manifest 'structural_only' references unknown shot 'nope' "
+            "(not in 'shots')")
+
+    def test_top_level_missing_structural_entry_raises(self):
+        with self.assertRaises(SystemExit) as cm:
+            _rv._validate_structural_only({"shotA"}, ["shotA"], {})
+        self.assertEqual(
+            str(cm.exception),
+            "shot 'shotA' is 'structural_only' but has no 'structural' gate "
+            "— it would be captured but never checked. Add a structural "
+            "entry or drop it from structural_only.")
+
+    def test_per_pass_lane_names_the_pass(self):
+        # Same violating shape, other lane: the message must name the pass
+        # (AC 1) and scope 'shots' / the gate to it.
+        with self.assertRaises(SystemExit) as cm:
+            _rv._validate_structural_only({"shotA"}, ["shotA"], {},
+                                      pass_name="compare")
+        self.assertEqual(
+            str(cm.exception),
+            "extra run 'compare': shot 'shotA' is 'structural_only' but has "
+            "no 'structural' gate for this pass — it would be captured but "
+            "never checked. Add a structural entry or drop it from "
+            "structural_only.")
+
+    def test_empty_block_is_a_no_op(self):
+        _rv._validate_structural_only(set(), [], {})
+        _rv._validate_structural_only(set(), [], {}, pass_name="compare")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_render_verify.py
+++ b/scripts/tests/test_render_verify.py
@@ -409,6 +409,58 @@ class ParseExtraRuns(unittest.TestCase):
         with self.assertRaises(SystemExit):
             _parse_extra_runs({"extra_runs": {"name": "x"}})
 
+    # ── per-pass structural_only guard ─────────────────────────────────
+    # Mirrors the top-level 'structural_only' guard: a label with no
+    # matching 'structural' entry for the same pass would be captured,
+    # never pixel-diffed, and never structurally gated either. See #2842.
+    def test_structural_only_with_matching_structural_entry_parses(self):
+        runs = _parse_extra_runs({"extra_runs": [{
+            "name": "compare",
+            "demo_args": ["--only", "compare"],
+            "shots": ["shotA"],
+            "structural": {"shotA": [{"metric": "shadow",
+                                      "min_largest_frac": 0.8}]},
+            "structural_only": ["shotA"],
+        }]})
+        self.assertEqual(runs[0]["structural_only"], {"shotA"})
+
+    def test_structural_only_with_no_structural_entry_raises(self):
+        # Same shape as the compliant case, minus the 'structural' entry.
+        # Pre-fix this was silent (0 rows, PASS).
+        with self.assertRaises(SystemExit) as cm:
+            _parse_extra_runs({"extra_runs": [{
+                "name": "compare",
+                "demo_args": ["--only", "compare"],
+                "shots": ["shotA"],
+                "structural_only": ["shotA"],
+            }]})
+        self.assertIn("compare", str(cm.exception))
+
+    def test_structural_only_unknown_shot_raises(self):
+        with self.assertRaises(SystemExit):
+            _parse_extra_runs({"extra_runs": [{
+                "name": "compare",
+                "demo_args": ["--only", "compare"],
+                "shots": ["shotA"],
+                "structural_only": ["nope"],
+            }]})
+
+    def test_structural_only_does_not_inherit_top_level_structural(self):
+        # 'structural' is a per-pass override that defaults to empty, not
+        # to the top-level manifest value — a top-level entry for the same
+        # label must not satisfy the per-pass guard.
+        with self.assertRaises(SystemExit):
+            _parse_extra_runs({
+                "structural": {"shotA": [{"metric": "shadow",
+                                          "min_largest_frac": 0.8}]},
+                "extra_runs": [{
+                    "name": "compare",
+                    "demo_args": ["--only", "compare"],
+                    "shots": ["shotA"],
+                    "structural_only": ["shotA"],
+                }],
+            })
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `_validate_structural_only(structural_only, shots, structural, *, pass_name=None)` holds the two-arm captured-but-ungated guard and is invoked **once per resolved pass** — `main()` for the top level (`pass_name=None`), `_parse_extra_runs` for each `extra_runs` entry. Previously the check lived inline in `main()` and so reached only the top-level lane; the `extra_runs` lane — which holds 2 of the tree's 3 live `structural_only` shots — had no validation at all.
- The two lanes differ only in message shaping, which lives inside the helper. Both messages are unchanged: the top-level pair is byte-identical to `origin/master` through the real CLI (measured, below), and the per-pass pair still names its pass.
- Docstring corrected: `warmup`/`thresholds` fall back to the top-level value; `crops`/`structural`/`structural_only` default to empty and do not inherit it.
- Ten new arms in `test_render_verify.py`: four on the per-pass lane, five on the top-level lane (which had **no** unit coverage while it sat inline in `main()`), and one asserting `_parse_extra_runs` delegates to the shared helper rather than re-inlining a copy.
- The walk is sorted — a set's iteration order varies with `PYTHONHASHSEED`, so an unsorted walk named a different one of several bad labels per run.

## Test plan
- [x] `python3 -m unittest discover -p 'test_render_verify.py'` (run **alone**, from `scripts/tests/`, per the issue's caution about whole-dir runs) — **40/40 pass**.
- [x] **Positive control vs `origin/master`** (swap in master's `render-verify.py`, keep the new tests): **9 of 40 red** — 6 errors on the new helper's arms + 3 failures on the per-pass behaviour arms; 31 green.
- [x] **Positive control vs this PR's own pre-refactor commit `cf37bda4`**: **6 of 40 red** — exactly the six arms the refactor adds. The four behavioural arms from `cf37bda4` stay green, which is what makes the refactor demonstrably behaviour-preserving *and* the new arms demonstrably discriminating.
- [x] **Arm 3a byte-identity — measured, not argued.** The refactor necessarily ends `main()`'s source byte-identity with `origin/master`, so identity moved to the observable: drove the real CLI (throwaway git repo + synthetic manifest, nothing in the engine tree touched) with master's and this branch's `render-verify.py`. Both top-level arms — missing-`structural` and unknown-shot — exit 1 with **byte-identical stdout and stderr** (`diff` clean on both streams, both arms).
- [x] **Arm 3b** via the same CLI: `origin/master` sails past validation and proceeds to build (the #2842 hole); this branch exits 1 before any build with ``extra run 'probe': shot 'my_shot' is 'structural_only' but has no 'structural' gate for this pass — …``, byte-identical to `cf37bda4`'s message.
- [x] Drove **both** lanes against all 5 committed manifests — 0 errors. Population matches the issue's table exactly: analytic_oracle 1 top-level; canvas_stress 2 per-pass (`floor_selfshadow_offwide`, `shadow_overlay_floor`); fog_demo 5 passes / 0; lighting 0; shape_debug 0.
- [x] `ruff check scripts/` — clean.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1 — per-pass two-arm validation, names the pass, **via a shared helper** (issue thread's concretization) | `test_extra_runs_delegates_to_the_shared_validator` + `ValidateStructuralOnly` (5 arms) | One `_validate_structural_only`, called from `main()` and `_parse_extra_runs`. The delegation test drives the *violating* manifest with the helper patched out: it must parse, so an inline re-copy in `_parse_extra_runs` fails it — the drift the issue named is now caught by an executed arm, not by review. |
| 2 — arm 3b exits non-zero naming the pass; arm 3a unchanged | real-CLI arms 3a/3b against master, `cf37bda4`, and this branch | 3a: byte-identical stdout **and** stderr vs `origin/master`, both top-level arms. 3b: master proceeds to build, this branch exits 1 naming the pass — message byte-identical to `cf37bda4`. |
| 3 — docstring states which keys fall back vs. default empty | `_parse_extra_runs` docstring | `warmup`/`thresholds` fall back; `crops`/`structural`/`structural_only` default to empty. Runtime fallback logic untouched. |
| 4 — regression coverage, compliant shape still parses, suite run alone | `python3 -m unittest discover -p 'test_render_verify.py'` from `scripts/tests/` | `Ran 40 tests ... OK`; both positive controls above confirm non-vacuity. |
| 5 — five manifests behaviourally unchanged | both lanes driven against all 5 committed `manifest.json` files | 0 errors, no manifest edits needed. |

### Note for the re-reviewer: the control had to be repaired to stay runnable
The new symbol is resolved per call site rather than bound at module scope. A module-scope `_validate_structural_only = _rv._validate_structural_only` makes the entire suite **unimportable** against any pre-fix tree, collapsing the "swap in the old `render-verify.py`" control from a per-test result into one `ImportError` — it reports 1 failure regardless of how many arms actually discriminate. Caught by running the control, not by reading it; the reason is comment-pinned at the binding site so it isn't "tidied" back.

Closes #2842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
