### PR TITLE
jitter_probe: per-axis excursion assertion for the rotation gate (#2606)

### DIFF
--- a/.fleet/plans/issue-2606.md
+++ b/.fleet/plans/issue-2606.md
@@ -1,0 +1,83 @@
+## Plan: jitter_probe — per-axis excursion assertion for the rotation gate
+
+- **Issue:** #2606
+- **Model:** opus
+- **Date:** 2026-08-07
+
+### Scope
+
+Close the scorer-model gap #2606 measures: `jitter_probe`'s default verdict cannot express "x stays pinned while y may translate", so a smooth systematic centroid migration (the `IR_PERAXIS_OVERFLOW_DISABLE=1` defect signature, +11.13px monotone on 2026-07-28) scores clean on the axis it corrupts. Add per-axis excursion assertions (`--max-excursion-x` / `--max-excursion-y`), make the excursion check the primary rotation-gate assertion in the docs, and lock the semantics with a hermetic synthetic test plus live positive-fire runs.
+
+Out of scope: the `--max-residual` bar, the #2469 accepted-residual table, and master's residual drift at zoom 4/8 — that is **#2907**'s (see Reconciliation).
+
+### Verified current state (2026-08-07, origin/master)
+
+- `tools/jitter_probe/main.cpp` (391 lines, read in full): default verdict = `reversals==0 && maxAbsResidual<=--max-residual` on **both** axes (`main.cpp:368-370`); `--stationary` = deviation-from-frame-0 ≤ `--max-deviation` on **both** axes (`main.cpp:337`). No per-axis-independent assertion exists anywhere in the scorer, and excursion (max−min of a centroid column) is computed nowhere — the negative claim is exhaustive over the tool's single source file.
+- The defect fixture exists on master: `IR_PERAXIS_OVERFLOW_DISABLE` presence-check at `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:504`.
+- **The issue's AC2 phrase "using the same captured sequences above" is no longer satisfiable.** Those sequences were build-dir transients (`save_files/screenshots/`, wiped per the #2814 recipe) and are gone; all populations must be re-captured. Master has also drifted since 2026-07-28: **#2907** measures the same canonical probe's x residual at 0.85/1.78/2.70px (z2/z4/z8) vs the 1.50px bar — red at z4/z8 on the *residual* criterion. AC2's healthy-master leg is therefore re-anchored to fresh same-session captures (Phase 0), and the composite exit code at z4/z8 is decoupled from this task (Acceptance 3).
+- Output consumers audited (full `git grep -l jitter_probe` sweep, every hit classified): the ONLY stdout parser is `scripts/pivot-verify.py:155-157`, which regex-parses the `--stationary` summary's `x: max_deviation=…px` lines. Nothing parses the default-mode summary. All other hits are docs/comments/CMake registration (`camera_pan_pivot_test.cpp:18` and `ir_args.cpp:11` are comments).
+
+### Approach
+
+**Phase 0 — premise probe: excursion still separates the populations on today's master.** The bar the docs will publish must be derived from *current* populations, not the dead 2026-07-28 captures (#2907 proves the tree moved). On one host/backend in one session, capture with the canonical recipe (`engine/render/CLAUDE.md` §"Verifying temporal stability": wipe → sweep → 6-digit glob → `--expect-frames`), archiving each population to its own directory immediately after capture:
+
+- H2/H4/H8 — healthy voxel cylinder `--yaw-sweep`, zoom 2/4/8.
+- S4/S8 — SDF cylinder control (omit `--spin-shape-voxel`), zoom 4/8.
+- D2/D4/D8 — `IR_PERAXIS_OVERFLOW_DISABLE=1` voxel cylinder `--yaw-sweep`, zoom 2/4/8.
+
+Hand-measure per-axis excursion (max−min of the `--verbose` centroid columns) for every population. Derive the per-zoom x-bar by the committed rule: **bar(z) = the smallest half-integer ≥ 2.5 × the max healthy x excursion at that zoom (voxel and SDF both count as healthy), and it must be ≤ 0.5 × the defect x excursion at that zoom.** (2026-07-28 reference: healthy 1.26–2.83px, SDF 2.00px, defect 11.13px @ z4 → z4 bar would land at 5.0; expect the same order today.) The 2.5× margin absorbs run-to-run noise on a noise-dominated statistic; the 0.5× ceiling keeps ≥2× headroom to the defect.
+
+*Bail path:* if any zoom has no value satisfying both bounds, the premise (excursion separates healthy from defect on current master) is refuted — stop, post the full measurement table on #2606 and cross-reference it on #2907, and flag #2606 for re-plan noting the likely resolution is `Blocked by:` #2907. Do not build the dependent phases.
+
+**Phase 1 — the flags** (`tools/jitter_probe/main.cpp`):
+- Compute per-axis excursion = max−min of the centroid column over the **same valid-frame mask the fit uses**, unconditionally; append `excursion=%.2fpx` to the two default-mode axis summary lines, and the provided bars to the thresholds line.
+- Add `--max-excursion-x <px>` / `--max-excursion-y <px>`, each independently optional, gated on `parser.wasProvided(...)` (not a sentinel default). When provided, AND `excursion ≤ bar` for that axis into the default-mode SMOOTH verdict.
+- Combining either flag with `--stationary` is an argument error (exit 2, message) — prevents a silently-ignored assertion, and keeps the `--stationary` output path byte-identical for `pivot-verify.py`.
+
+**Phase 2 — hermetic semantics test** (`test/tools/jitter_probe_excursion_test.sh`, new; mirrors `ir_run_exit_code_test.sh`'s staged-fixture form): binary from `$JITTER_PROBE_BIN` else the default build path, SKIP + exit 0 with a message when absent (nothing in CI runs `test/tools/` — this is a hand/review artifact). Fixtures: an inline `python3` heredoc writes two 8-frame sequences of 48×48 binary PPMs (stb_image reads PPM — no PNG encoder needed): (A) a 12×12 white square stepping +2px/frame in x, y fixed; (B) x fixed, +2px/frame in y. Five assertions, one probe invocation each:
+1. A, default flags + `--reversal-eps 0.8` → **exit 0** — pins the blind spot (the OFF arm of the discriminating pair).
+2. A + `--max-excursion-x 5` → **exit 1** — 14px migration; the gate's positive fire.
+3. B + `--max-excursion-x 5` → **exit 0** — the issue's exact contract: x pinned while y translates 14px.
+4. B + `--max-excursion-y 5` → **exit 1** — axis independence, and proves case 3's pass is non-vacuous (same frames, mirrored assertion, opposite verdict).
+5. `--stationary --max-excursion-x 5` → **exit 2**.
+
+**Phase 3 — live acceptance runs** (re-score the archived Phase-0 populations with the built tool):
+- Cross-check the instrument: tool-printed x excursion on H4 must equal the Phase-0 hand-derived max−min to ±0.01px.
+- D4 and D8 under the canonical flags + `--max-excursion-x bar(z)` → exit 1; then an isolation run adding `--max-residual 99` → still exit 1, so the failure is attributable to the excursion criterion by construction (not caught "by accident" via another axis — the exact failure mode the issue documents).
+- H2/H4/H8 + S4/S8: printed x excursion ≤ bar(z) for every population. Composite exit codes recorded as-is: z2 expected 0; z4/z8 follow #2907's state (red today via the residual axis) — record the residuals and cross-comment them on #2907. If #2907 has landed by implementation time, expect composite 0 at all three zooms and say so.
+
+**Phase 4 — docs** (AC3):
+- `tools/jitter_probe/README.md`: usage block gains the flags; rewrite §"Accepted floors, and the model's blind spot (#2469)" — the false-negative half is closed by the excursion assertion (keep the reversal-eps history); drop the "until #2606… read excursion by hand" paragraph.
+- `engine/render/CLAUDE.md` §"Verifying temporal stability": the canonical rotation-gate recipe gains `--max-excursion-x <bar(zoom)>` with the measured per-zoom bar table (populations, values, date, host); flip the "does not fire on the `IR_PERAXIS_OVERFLOW_DISABLE=1` runtime control" bullet to its measured opposite (fires via excursion: value vs bar); replace the closing "principled fix is #2606" paragraph. Do **not** touch the #2469 accepted-residual table or `--max-residual` — #2907 owns those.
+
+### Affected files
+
+- `tools/jitter_probe/main.cpp` — excursion computation + print, two flags, verdict, stationary-combination guard
+- `tools/jitter_probe/README.md` — flags + blind-spot section rewrite
+- `engine/render/CLAUDE.md` — recipe + bar table + limitation-paragraph replacement
+- `test/tools/jitter_probe_excursion_test.sh` — new hermetic semantics test
+- `.fleet/plans/issue-2606.md` — this plan, first commit of the PR (#1932)
+
+### Acceptance criteria
+
+1. **AC1 as filed:** the per-axis flags exist and are independently usable (test cases 3/4 prove independence on identical frames).
+2. **AC2 re-anchored** (filed wording depends on dead captures + a since-drifted master, per Verified current state): D4 exits 1 with the excursion criterion attributably firing (isolation run), and every freshly captured healthy population (H2/H4/H8, S4/S8) passes the excursion criterion (printed x excursion ≤ bar(z)). z2 composite exit 0. z4/z8 composite recorded either way with residuals cross-commented on #2907.
+3. **AC3 as filed:** both docs updated as Phase 4, carrying the measured table.
+4. The synthetic test ships and passes 5/5 against the freshly built binary (run log in the PR body).
+5. `pivot-verify.py`'s parse surface is untouched by construction (`--stationary` output byte-identical; combination guard makes the new flags unreachable in that mode) — stated in the PR body.
+
+### Gotchas
+
+- `IR_PERAXIS_OVERFLOW_DISABLE` is a `getenv != nullptr` presence check — `VAR=` (empty) counts as SET. Fully `unset` it for healthy arms and verify with `env`.
+- Wipe the screenshots dir before **every** capture (exact `find … -delete` form in the CLAUDE.md block); archive each population before the next capture; `--expect-frames` must match the actual post-wipe file count. Note a live doc inconsistency: #2907/#2605 report 24-frame sweeps from `--auto-screenshot 6`, while the CLAUDE.md recipe comment says the guard should equal the auto-screenshot count and passes 6 — trust the actual file count (the guard exits 2 on a mismatch); if it is 24, fix the stale comment line in the Phase-4 docs pass.
+- `fleet-run --timeout 0` goes **before** the target token, and redirect `fleet-build` output to a file + check `$?` — piping through `grep`/`head` masks a failed build as green and a stale binary then "passes".
+- Capture all populations on ONE host/backend in one session; the published bar table names its host. The 2026-07-28 numbers are context, never controls.
+- Keep the #2907 seam clean: if #2907's PR is in flight against the same CLAUDE.md section, whoever rebases second reconciles only the shared §temporal-stability paragraphs — the two tasks change disjoint criteria.
+
+### Reconciliation (siblings / in-flight)
+
+- **#2907** (open, needs-plan): the *residual*-axis drift on the same probe — the opposite failure class, per its own "Not #2606" ruling. This plan deliberately leaves the residual criterion untouched and hands #2907 free evidence (fresh residual readings cross-commented).
+- **PR #2850 / #2479** (design-blocked): same render domain; measured digit-identical to master on this probe (#2907's ruled-out section) — no interaction.
+- **pivot-verify / #2553**: `--stationary` consumer, parse surface audited and preserved.
+- **Merged #2605** (reversal-eps recipe + limitation docs) and **#2814** (`--expect-frames`): extended, not contradicted — the limitation text #2605 added is exactly what Phase 4 replaces.
+

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -502,11 +502,14 @@ Three checks, in order:
    # reversal criterion on these probes (see "the reversal criterion" below).
    # The 6-digit glob matches full frames ONLY — ROI crops share the prefix and
    # append _<label>__crop_<crop>.png, and a 128x128 crop has no usable
-   # foreground. --expect-frames must equal the --auto-screenshot count: it is
+   # foreground. --expect-frames must equal the count the sweep ACTUALLY writes,
+   # which is the sweep's own shot-table length, NOT the --auto-screenshot value
+   # (that is the per-shot warmup): --yaw-sweep --auto-screenshot 6 emits 24
+   # frames, and the engine logs the number ("Yaw-sweep: 24 shots"). The guard is
    # the only thing that catches a widened glob, since scoring the wrong set
    # still yields a confident verdict (measured during #2469 — see
    # tools/jitter_probe/README.md §"Wipe before every capture").
-   build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 --expect-frames 6 \
+   build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 --expect-frames 24 \
        <save_files>/screenshots/screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png
    ```
 
@@ -531,20 +534,47 @@ Three checks, in order:
    Two consequences to know before you lean on this gate:
 
    - **It does not fire on the `IR_PERAXIS_OVERFLOW_DISABLE=1` runtime control.**
-     That lever now presents as a *smooth* 11.13px x-centroid migration scoring
-     `reversals=0, max_residual=0.73px` — clean on both shipped axes. No eps
-     separates the populations (the control clears at 0.6, healthy master at
-     0.8), which is why the eps was not calibrated against it.
+     That lever presented (2026-07-28) as a *smooth* 11.13px x-centroid migration
+     scoring `reversals=0, max_residual=0.73px` — clean on both shipped axes. No
+     eps separates the populations (the control clears at 0.6, healthy master at
+     0.8), which is why the eps was not calibrated against it. The conclusion
+     still holds; the 11.13px figure does not — see the re-measure below, where
+     a pivot-orbit term now dominates both arms.
    - **The hard check is the residual axis against the analytic floor.** The
      pre-#2427 defect record (residual 2.93px, Δmax 5.37 at zoom 4) fails the
      1.50px bar by ~2×, so the original multi-pixel face-pop class is still
      caught. A *systematic migration* class is not.
 
-   The principled fix — a per-axis excursion assertion, so a probe can require
-   "x stays pinned while y may translate" — is **#2606**. Until it lands, check
-   per-axis excursion by hand (`--verbose`, max-min per column) when validating
-   a change to the per-axis store, the scatter, or the camera-offset
-   decomposition; healthy master reads 1.26–2.83px on the pinned axis.
+   The per-axis assertion that expresses "x stays pinned while y may translate"
+   now ships as `jitter_probe --max-excursion-x/-y` (#2606), and every default-mode
+   run prints `excursion=` per axis, so the by-hand max-min read is gone. **But do
+   not put a bar on this probe yet — there is no separating value to put.**
+   Re-measured on macOS/Metal 2026-08-07 (24-frame sweeps, same recipe, arm
+   identity asserted per run), x excursion:
+
+   | zoom | healthy voxel | SDF control | `IR_PERAXIS_OVERFLOW_DISABLE=1` |
+   |---|---|---|---|
+   | 2 | 19.97px | — | 13.75px |
+   | 4 | 38.18px | 44.00px | 27.92px |
+   | 8 | 76.81px | 82.00px | 54.63px |
+
+   Two things changed since the 2026-07-28 table below. Excursion on this probe
+   is now ~30x larger and scales linearly with zoom — a world-space offset
+   projected to screen, present on the **SDF control too**, so it is camera-level,
+   not the per-axis store. And the defect arm reads **lower** than healthy at
+   every zoom (0.63-0.69x), so no one-sided `excursion <= bar` can separate them
+   in the intended direction.
+
+   The dominating term is the **default** pivot focus's residual orbit — #2547's
+   depth-aware `CAMERA_CENTER` derive (landed 2026-07-31, after the 2026-07-28
+   table) with the 1-iso-unit cap-entry bias that **#2641** owns and measures
+   independently (12px at zoom 4 / 22px at zoom 8 on `--pivot-verify
+   center-axis`). `pivot-verify.py` is green throughout: its *explicit*-focus
+   blocks still pin at 0.94/1.27px. `--yaw-sweep` uses the *default* focus and
+   its probe is off the viewport-center ray, so it carries a larger orbit of the
+   same family. Until #2641 lands, this probe's excursion measures the pivot, not
+   the per-axis path — so use the flags on a probe whose pivot you control, and
+   re-derive the bar here from a post-#2641 capture.
 
 **Jitter is NOT the same as cardinal byte-identity.** Confirm yaw-0 / static
 frames stay byte-identical (`img_diff`) *and* that motion is jitter-free
@@ -908,6 +938,17 @@ drift. Measured on macOS/Metal, 2026-07-28 (24-frame sweeps, one quadrant):
 | voxel cylinder, zoom 4 | 1.26px | 5 | 0.57px | 5.29px | 0 | 0.19px |
 | voxel cylinder, zoom 8 | 2.83px | 5 | 1.25px | 10.79px | 0 | 0.18px |
 | **SDF cylinder** (continuous-geometry control), zoom 4 / 8 | 2.00px | 0 | 1.43px | 4.00 / 10.00px | 0 | 0.95px |
+
+> **The excursion columns above no longer reproduce (re-measured 2026-08-07,
+> #2606).** Same recipe, same host/backend: x excursion is 19.97 / 38.18 / 76.81px
+> at zoom 2/4/8, ~30x this table. The cause is the default pivot focus's residual
+> orbit (#2547 → **#2641**), which post-dates this table and is camera-level — the
+> SDF control moved by the same order, and `pivot-verify.py`'s explicit-focus
+> blocks still pin at 0.94/1.27px. The **residual** columns are unaffected by that
+> re-measure and still reproduce at zoom 2 (0.85px); at zoom 4/8 they read
+> 1.78/2.70px against the 1.50px bar, which is **#2907**'s finding, not this one.
+> Treat the excursion columns as historical until a post-#2641 capture replaces
+> them; see §"Verifying temporal stability" for the current numbers.
 
 Three findings ground the accept, each measured rather than asserted:
 

--- a/test/tools/jitter_probe_excursion_test.sh
+++ b/test/tools/jitter_probe_excursion_test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# jitter_probe_excursion_test.sh — pin the semantics of the per-axis
+# --max-excursion-x / --max-excursion-y assertions (#2606).
+#
+# The default smooth-motion verdict models LINEAR motion, so a large but
+# perfectly smooth centroid migration fits the line and scores clean. On a probe
+# where one axis is supposed to stay PINNED while the other legitimately
+# translates, that blind spot is the whole failure mode: neither shipped
+# criterion (reversals, residual) can express "x stays pinned while y may
+# translate". These fixtures are synthetic precisely so the contract is pinned
+# independently of any render output — a live probe's populations move with the
+# tree, this does not.
+#
+# Fixtures are two 8-frame 48x48 binary-PPM sequences of a 12x12 white square:
+#   A — steps +2px/frame in x, y fixed  (14px x migration, 0px y)
+#   B — the mirror: x fixed, +2px/frame in y
+# stb_image decodes binary PPM, so no PNG encoder is needed.
+#
+# Nothing in CI runs test/tools/ (no CMakeLists, no workflow reference) — this
+# is a hand/review artifact, so it SKIPs cleanly when the binary is absent
+# rather than failing a tree that simply has not built the tool.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROBE="${JITTER_PROBE_BIN:-$REPO_ROOT/build/tools/jitter_probe/jitter_probe}"
+
+if [[ ! -x "$PROBE" ]]; then
+    echo "jitter_probe_excursion_test.sh: SKIP — no jitter_probe binary at '$PROBE'"
+    echo "  build it with: fleet-build --target jitter_probe"
+    echo "  or point JITTER_PROBE_BIN at one."
+    exit 0
+fi
+
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+python3 - "$FIXTURE_DIR" <<'PYEOF'
+import os
+import sys
+
+out = sys.argv[1]
+W = H = 48
+SQ = 12
+FRAMES = 8
+STEP = 2
+BASE = 4
+FIXED = 18
+
+
+def write_seq(name, moving_axis):
+    d = os.path.join(out, name)
+    os.makedirs(d, exist_ok=True)
+    for i in range(FRAMES):
+        moved = BASE + STEP * i
+        x0, y0 = (moved, FIXED) if moving_axis == "x" else (FIXED, moved)
+        px = bytearray(W * H * 3)
+        for y in range(y0, y0 + SQ):
+            row = y * W * 3
+            for x in range(x0, x0 + SQ):
+                o = row + x * 3
+                px[o] = px[o + 1] = px[o + 2] = 255
+        with open(os.path.join(d, "f%03d.ppm" % i), "wb") as f:
+            f.write(b"P6\n%d %d\n255\n" % (W, H))
+            f.write(bytes(px))
+
+
+write_seq("A", "x")
+write_seq("B", "y")
+PYEOF
+
+A=("$FIXTURE_DIR"/A/f*.ppm)
+B=("$FIXTURE_DIR"/B/f*.ppm)
+
+pass=0
+fail=0
+check() {
+    local label="$1" cond="$2"
+    if eval "$cond"; then
+        echo "  PASS: $label"
+        pass=$(( pass + 1 ))
+    else
+        echo "  FAIL: $label"
+        fail=$(( fail + 1 ))
+    fi
+}
+
+run_probe() {
+    # Echoes the probe's stdout to $OUT and leaves its exit code in $rc.
+    set +e
+    OUT="$("$PROBE" "$@" 2>&1)"
+    rc=$?
+    set -e
+}
+
+echo "[1] sequence A, no excursion bar: the blind spot itself — a 14px smooth"
+echo "    x migration still scores SMOOTH on the shipped criteria"
+run_probe --reversal-eps 0.8 --expect-frames 8 "${A[@]}"
+check "exit 0 (SMOOTH)" "[[ $rc -eq 0 ]]"
+check "verdict line says SMOOTH" "grep -q 'verdict=SMOOTH' <<< \"\$OUT\""
+# Without this the arm is vacuous: it would also pass on frames that never moved.
+check "the 14px x migration IS present in the frames (excursion is reported)" \
+    "grep -qE '^  x: .* excursion=14\.00px' <<< \"\$OUT\""
+
+echo "[2] sequence A + --max-excursion-x 5: the gate fires on the same frames"
+run_probe --reversal-eps 0.8 --expect-frames 8 --max-excursion-x 5 "${A[@]}"
+check "exit 1 (JITTER)" "[[ $rc -eq 1 ]]"
+check "verdict line says JITTER" "grep -q 'verdict=JITTER' <<< \"\$OUT\""
+check "thresholds line names the bar that fired" \
+    "grep -q 'max_excursion_x<=5.00px' <<< \"\$OUT\""
+
+echo "[3] sequence B + --max-excursion-x 5: x pinned while y translates 14px"
+echo "    — the contract #2606 exists for, unsayable with --stationary"
+run_probe --reversal-eps 0.8 --expect-frames 8 --max-excursion-x 5 "${B[@]}"
+check "exit 0 (SMOOTH)" "[[ $rc -eq 0 ]]"
+# Non-vacuity: the pass must be because x held, not because nothing moved.
+check "x excursion is 0.00px (pinned)" \
+    "grep -qE '^  x: .* excursion=0\.00px' <<< \"\$OUT\""
+check "y excursion is 14.00px (legitimately translating, unconstrained)" \
+    "grep -qE '^  y: .* excursion=14\.00px' <<< \"\$OUT\""
+
+echo "[4] sequence B + --max-excursion-y 5: axis independence — identical frames,"
+echo "    mirrored assertion, opposite verdict"
+run_probe --reversal-eps 0.8 --expect-frames 8 --max-excursion-y 5 "${B[@]}"
+check "exit 1 (JITTER)" "[[ $rc -eq 1 ]]"
+check "thresholds line names the y bar" \
+    "grep -q 'max_excursion_y<=5.00px' <<< \"\$OUT\""
+
+echo "[5] --stationary + an excursion bar is an argument error, not a silently"
+echo "    ignored assertion"
+run_probe --stationary --max-excursion-x 5 "${A[@]}"
+check "exit 2 (argument error)" "[[ $rc -eq 2 ]]"
+check "diagnostic explains the conflict" \
+    "grep -q 'cannot be combined with --stationary' <<< \"\$OUT\""
+
+echo "[6] --stationary alone is unchanged (pivot-verify.py parses this output)"
+run_probe --stationary --max-deviation 1.5 "${A[@]}"
+check "exit 1 (DRIFT — the square does move)" "[[ $rc -eq 1 ]]"
+check "summary still carries the max_deviation lines pivot-verify.py regexes" \
+    "grep -qE '^  x: max_deviation=[0-9.]+px' <<< \"\$OUT\""
+check "no excursion field leaked into the --stationary summary" \
+    "! grep -q 'excursion' <<< \"\$OUT\""
+
+echo
+echo "jitter_probe_excursion_test.sh: $pass passed, $fail failed"
+exit "$fail"

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -24,6 +24,8 @@ jitter_probe <frame_0.png> <frame_1.png> ... <frame_N.png>   # >=3, in capture o
     [--color R,G,B,T]    instead, foreground = pixels within T of color R,G,B
     [--reversal-eps PX]  per-frame deltas under this count as 0 (default 0.10)
     [--max-residual PX]  SMOOTH verdict requires residual <= this (default 1.50)
+    [--max-excursion-x PX]  SMOOTH also requires x excursion (max-min) <= this
+    [--max-excursion-y PX]  ... same for y; each flag is independently optional
     [--stationary]       assert the centroid does NOT move (pivot-pin check)
     [--max-deviation PX] PINNED verdict requires deviation <= this (default 1.50)
     [--verbose]          print the per-frame centroid + residual table
@@ -123,15 +125,21 @@ is a separate thing — capture the SAME pose twice and `img_diff` them (expect 
 
 ```
 jitter_probe: frames=24 (valid=24)  verdict=SMOOTH
-  x: reversals=0  max_residual=0.20px  delta_std=0.41  delta_max=1.00
-  y: reversals=0  max_residual=0.31px  delta_std=0.30  delta_max=0.51
+  x: reversals=0  max_residual=0.20px  excursion=1.26px  delta_std=0.41  delta_max=1.00
+  y: reversals=0  max_residual=0.31px  excursion=5.29px  delta_std=0.30  delta_max=0.51
+  (thresholds: reversals=0, max_residual<=1.50px)
 ```
 
 `reversals` is the count of per-frame direction flips (the jitter signature);
-`max_residual` is the worst deviation from the smooth straight-line motion.
+`max_residual` is the worst deviation from the smooth straight-line motion;
+`excursion` is how far the centroid travelled on that axis end to end (max-min).
 SMOOTH requires `reversals == 0` on both axes and `max_residual <= --max-residual`.
 A clean fix flips a JITTER verdict (high reversals, multi-px residual) to SMOOTH
 (0 reversals, sub-px residual).
+
+`excursion` is printed on every default-mode run but only *gates* when you pass
+a bar, and the `(thresholds: ...)` line lists exactly the bars in force — so a
+verdict always states what it asserted rather than leaving you to infer it.
 
 ## Accepted floors, and the model's blind spot (#2469)
 
@@ -148,18 +156,53 @@ that model is mis-specified on exactly that axis, in both directions:
   observed per-frame delta range.
 - **False negatives.** A large but *smooth* centroid migration is what the line
   fit calls correct. A known render defect (re-exposed via the engine's
-  `IR_PERAXIS_OVERFLOW_DISABLE=1` kill switch) migrates the x centroid by an
-  order of magnitude more than healthy master and still scores `reversals=0`
-  with a sub-pixel residual. Neither shipped axis fires on it.
+  `IR_PERAXIS_OVERFLOW_DISABLE=1` kill switch) migrated the x centroid by an
+  order of magnitude more than healthy master (measured 2026-07-28) and still
+  scored `reversals=0` with a sub-pixel residual. Neither shipped axis fires on
+  it. The *model gap* is real and permanent — a line fit cannot see a migration
+  it fits — and `--max-excursion-x/-y` below is the assertion that closes it.
+  The *specific defect/healthy ordering* in that measurement did not survive:
+  re-measured 2026-08-07 the kill-switch arm reads **lower** excursion than
+  healthy, because a much larger pivot-orbit term now dominates both (see the
+  bar note below).
 
 `--stationary` does not close the gap: it requires BOTH axes pinned, but on a
 yaw sweep the *other* axis legitimately translates — by more than the defect
 migrates — so `--stationary` reports DRIFT on every healthy run, including on
 the defect-free continuous-geometry control.
 
-Until **#2606** adds a per-axis excursion assertion, read per-axis excursion by
-hand from `--verbose` (max-min per centroid column) when a change touches the
-per-axis store, the scatter, or the camera-offset decomposition. Measured
-accepted floors and the full table live in
-[`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Accepted sub-pixel
-yaw-sweep centroid residual (voxel content) — #2469".
+## `--max-excursion-x` / `--max-excursion-y` — the per-axis assertion (#2606)
+
+The false-negative half above is what these close. Excursion is the peak-to-peak
+spread (max-min) of one centroid column: deliberately shape-blind, so a
+perfectly smooth migration registers at full size exactly where the line fit's
+residual reads ~0.
+
+Because each flag is independently optional, they can say the thing neither
+shipped criterion nor `--stationary` can — *this* axis is pinned, the other may
+translate:
+
+```bash
+# x must hold within 5px; y unconstrained.
+jitter_probe --reversal-eps 0.8 --expect-frames 24 --max-excursion-x 5 <frames>
+```
+
+Combining either flag with `--stationary` is an argument error (exit 2) rather
+than a silently ignored assertion — `--stationary` has its own verdict and
+output path, and that path stays byte-identical for its one stdout consumer,
+`scripts/pivot-verify.py`. Semantics are pinned by
+[`test/tools/jitter_probe_excursion_test.sh`](../../test/tools/jitter_probe_excursion_test.sh)
+against synthetic fixtures, so they do not drift with the render tree.
+
+**Picking a bar is per-probe, and the canonical rotation probe cannot carry one
+yet.** A bar is only meaningful when the axis it gates is actually pinned. On
+the canonical `--yaw-sweep` cylinder that is currently false: re-measured
+2026-08-07 on macOS/Metal, healthy x excursion is 19.97 / 38.18 / 76.81px at
+zoom 2/4/8 — dominated by the **default** pivot focus's residual orbit (#2547 →
+**#2641**), which is camera-level (the SDF control moves as far) and swamps the
+per-axis signal. The `IR_PERAXIS_OVERFLOW_DISABLE=1` arm even reads *lower* than
+healthy, so no one-sided bar separates them. Use the flags on a probe whose
+pivot you control until #2641 lands; the full table and the re-derivation note
+live in [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Verifying
+temporal stability" and §"Accepted sub-pixel yaw-sweep centroid residual (voxel
+content) — #2469".

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -16,6 +16,8 @@
 //     [--color R,G,B,T]    instead, foreground = pixels within T of color R,G,B
 //     [--reversal-eps PX]  per-frame deltas under this are treated as 0 (default 0.10)
 //     [--max-residual PX]  SMOOTH verdict requires residual <= this (default 1.50)
+//     [--max-excursion-x PX] SMOOTH verdict also requires x excursion <= this
+//     [--max-excursion-y PX] ... same for y (each independently optional)
 //     [--stationary]       assert the centroid does NOT move (pivot-pin check)
 //     [--max-deviation PX] PINNED verdict requires deviation <= this (default 1.50)
 //     [--verbose]          print the per-frame centroid + residual table
@@ -25,6 +27,16 @@
 // is clean — e.g. `shape_debug --spin-shape box --spin-shape-voxel --pan-sweep`
 // (pan jitter) or `--yaw-sweep` (rotation jitter). For a multi-shape scene pass
 // --color to lock onto one shape. Frames MUST be given in capture order.
+//
+// --max-excursion-{x,y} answer a third question, per axis: how far did the
+// centroid travel on that axis, end to end (max-min), regardless of HOW it got
+// there. The line fit is blind to a perfectly smooth systematic migration — it
+// fits it and calls the residual clean — so on a probe where one axis is
+// supposed to stay PINNED while the other legitimately translates, the shipped
+// criteria cannot express the contract and the migration scores SMOOTH (#2606).
+// Because each flag is independently optional, "x stays pinned while y may
+// translate" is exactly `--max-excursion-x <bar>` with y unconstrained, which
+// --stationary (both axes pinned) cannot say.
 //
 // --stationary answers a different question than the default line-fit: the
 // default asserts SMOOTH LINEAR motion (a sweep translates the shape without
@@ -62,10 +74,22 @@ struct Args {
     int colorR_ = 0, colorG_ = 0, colorB_ = 0, colorTol_ = 0;
     double reversalEps_ = 0.10;
     double maxResidual_ = 1.50;
+    bool hasMaxExcursionX_ = false;
+    double maxExcursionX_ = 0.0;
+    bool hasMaxExcursionY_ = false;
+    double maxExcursionY_ = 0.0;
     bool stationary_ = false;
     double maxDeviation_ = 1.50;
     bool verbose_ = false;
 };
+
+// "%.2fpx" as a string. The thresholds line lists only the bars that were
+// actually provided, so it is assembled rather than formatted in one shot.
+std::string formatPx(double px) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.2fpx", px);
+    return buf;
+}
 
 // Foreground centroid (mean x,y of matching pixels) for one frame.
 // Returns false if too few pixels match (shape off-screen / empty frame).
@@ -170,6 +194,28 @@ double maxDeviationFromFirst(
     return maxDev;
 }
 
+// Peak-to-peak spread (max-min) of the valid samples — the excursion metric.
+// Deliberately shape-blind: it says how far the centroid travelled on this axis
+// end to end and nothing about how, so a perfectly smooth migration registers at
+// full size where the line fit's residual reads ~0.
+double excursion(const std::vector<double> &v, const std::vector<bool> &valid) {
+    double lo = 0.0, hi = 0.0;
+    bool haveRef = false;
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (!valid[i])
+            continue;
+        if (!haveRef) {
+            lo = v[i];
+            hi = v[i];
+            haveRef = true;
+            continue;
+        }
+        lo = std::min(lo, v[i]);
+        hi = std::max(hi, v[i]);
+    }
+    return haveRef ? hi - lo : 0.0;
+}
+
 AxisStats analyze(
     const std::vector<double> &v,
     const std::vector<bool> &valid,
@@ -224,6 +270,16 @@ int main(int argc, char **argv) {
     parser.string("--color", "Foreground = pixels within T of color R,G,B (format: R,G,B,T)", "");
     parser.number("--reversal-eps", "Per-frame deltas under this (px) are treated as 0", 0.10f);
     parser.number("--max-residual", "SMOOTH verdict requires residual <= this (px)", 1.50f);
+    parser.number(
+        "--max-excursion-x",
+        "SMOOTH verdict also requires x excursion (max-min) <= this (px); omit to disable",
+        0.0f
+    );
+    parser.number(
+        "--max-excursion-y",
+        "SMOOTH verdict also requires y excursion (max-min) <= this (px); omit to disable",
+        0.0f
+    );
     parser.flag("--stationary", "Assert the centroid does NOT move (rotation-pivot pin check)");
     parser.number("--max-deviation", "PINNED verdict requires deviation <= this (px)", 1.50f);
     parser.flag("--verbose", "Print the per-frame centroid + residual table");
@@ -239,6 +295,12 @@ int main(int argc, char **argv) {
     args.threshold_ = parser.getInt("--threshold");
     args.reversalEps_ = parser.getFloat("--reversal-eps");
     args.maxResidual_ = parser.getFloat("--max-residual");
+    // Gate on wasProvided, not on a sentinel: 0.0 is a meaningful bar (assert the
+    // axis does not move at all), so a default value cannot double as "unset".
+    args.hasMaxExcursionX_ = parser.wasProvided("--max-excursion-x");
+    args.maxExcursionX_ = parser.getFloat("--max-excursion-x");
+    args.hasMaxExcursionY_ = parser.wasProvided("--max-excursion-y");
+    args.maxExcursionY_ = parser.getFloat("--max-excursion-y");
     args.stationary_ = parser.getFlag("--stationary");
     args.maxDeviation_ = parser.getFloat("--max-deviation");
     args.verbose_ = parser.getFlag("--verbose");
@@ -257,6 +319,22 @@ int main(int argc, char **argv) {
             std::fprintf(stderr, "jitter_probe: --color expects R,G,B,T\n");
             return 2;
         }
+    }
+
+    // --stationary takes a separate output path and verdict, so an excursion bar
+    // passed alongside it would be silently ignored — an assertion the caller
+    // believes is live but that can never fire. Reject the combination instead.
+    // (It also keeps the --stationary summary byte-identical for its one stdout
+    // parser, scripts/pivot-verify.py.)
+    if (args.stationary_ && (args.hasMaxExcursionX_ || args.hasMaxExcursionY_)) {
+        std::fprintf(
+            stderr,
+            "jitter_probe: --max-excursion-x/-y cannot be combined with --stationary "
+            "(--stationary asserts BOTH axes are pinned and uses its own verdict; the "
+            "excursion bars apply to the default smooth-motion verdict only). Drop "
+            "--stationary to assert one axis independently.\n"
+        );
+        return 2;
     }
 
     // The capture dir is never cleared between runs and VideoManager numbers
@@ -365,27 +443,45 @@ int main(int argc, char **argv) {
         }
     }
 
+    // Excursion is computed over the same valid-frame mask the fit uses, and
+    // printed unconditionally — a run that did not pass a bar still reports the
+    // number, so the by-hand reading the docs asked for stops being by hand.
+    const double excX = excursion(cx, valid);
+    const double excY = excursion(cy, valid);
+    const bool excursionOkX = !args.hasMaxExcursionX_ || excX <= args.maxExcursionX_;
+    const bool excursionOkY = !args.hasMaxExcursionY_ || excY <= args.maxExcursionY_;
+
     const bool smooth = sx.reversals_ == 0 && sy.reversals_ == 0 &&
                         sx.maxAbsResidual_ <= args.maxResidual_ &&
-                        sy.maxAbsResidual_ <= args.maxResidual_;
+                        sy.maxAbsResidual_ <= args.maxResidual_ && excursionOkX && excursionOkY;
+
+    std::string thresholds = "reversals=0, max_residual<=" + formatPx(args.maxResidual_);
+    if (args.hasMaxExcursionX_)
+        thresholds += ", max_excursion_x<=" + formatPx(args.maxExcursionX_);
+    if (args.hasMaxExcursionY_)
+        thresholds += ", max_excursion_y<=" + formatPx(args.maxExcursionY_);
 
     std::printf(
         "jitter_probe: frames=%zu (valid=%d)  verdict=%s\n"
-        "  x: reversals=%d  max_residual=%.2fpx  delta_std=%.2f  delta_max=%.2f\n"
-        "  y: reversals=%d  max_residual=%.2fpx  delta_std=%.2f  delta_max=%.2f\n"
-        "  (thresholds: reversals=0, max_residual<=%.2fpx)\n",
+        "  x: reversals=%d  max_residual=%.2fpx  excursion=%.2fpx  delta_std=%.2f  "
+        "delta_max=%.2f\n"
+        "  y: reversals=%d  max_residual=%.2fpx  excursion=%.2fpx  delta_std=%.2f  "
+        "delta_max=%.2f\n"
+        "  (thresholds: %s)\n",
         n,
         validCount,
         smooth ? "SMOOTH" : "JITTER",
         sx.reversals_,
         sx.maxAbsResidual_,
+        excX,
         sx.deltaStd_,
         sx.deltaMaxAbs_,
         sy.reversals_,
         sy.maxAbsResidual_,
+        excY,
         sy.deltaStd_,
         sy.deltaMaxAbs_,
-        args.maxResidual_
+        thresholds.c_str()
     );
     return smooth ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

`jitter_probe` gains **`--max-excursion-x` / `--max-excursion-y`** — per-axis,
each independently optional — so a probe can assert *"x stays pinned while y may
translate"*. Neither shipped criterion could say that (the line fit **fits** a
smooth migration and calls the residual clean) and `--stationary` cannot either
(it pins **both** axes). Excursion (max−min over the same valid-frame mask the
fit uses) is now printed on **every** default-mode run, so the by-hand
`--verbose` max−min read the docs prescribed is retired, and the `(thresholds:
…)` line names the bars actually in force.

**The plan's Phase-0 premise probe came back refuted, so no bar ships for the
canonical rotation gate — and that is the headline finding, not a footnote.**
Details below. Hence `Refs`, not `Closes`: #2606 stays open for the re-plan its
own plan's bail path calls for.

## Phase 0 — the premise is refuted (measured, macOS/Metal, 2026-08-07)

Eight populations, canonical recipe (`--spin-shape cylinder [--spin-shape-voxel]
--yaw-sweep --zoom Z --auto-screenshot 6`), wipe-before-each, **arm identity
asserted per run** from the engine's own log (`zoom=` as *received*, voxel flag
present iff a voxel arm) and archived before the next capture. Per-axis x
excursion:

| zoom | healthy voxel | SDF control | `IR_PERAXIS_OVERFLOW_DISABLE=1` | defect / healthy |
|---|---|---|---|---|
| 2 | 19.97px | — | 13.75px | 0.69× |
| 4 | 38.18px | 44.00px | 27.92px | 0.63× |
| 8 | 76.81px | 82.00px | 54.63px | 0.67× |

The plan's rule — `bar(z)` = smallest half-integer ≥ 2.5 × max healthy x
excursion, and ≤ 0.5 × defect x excursion — has **no satisfying value at any
zoom**, because the defect arm reads *lower* than healthy. A one-sided
`excursion <= bar` cannot separate them in the intended direction. Bail taken.

**The captures are sound, and that is verified independently:** the same runs
reproduce **#2907**'s residuals exactly — x residual 0.85 / 1.78 / 2.70px at
zoom 2/4/8, its published numbers to the digit.

**Diagnosis — the excursion signal is swamped by a camera-level pivot orbit:**

- It is **not** the per-axis/voxel store: the **SDF control moves as far or
  farther** (44.00px vs 38.18px at z4).
- It scales ~linearly with zoom (19.97 → 38.18 → 76.81), the signature of a
  world-space offset projected to screen.
- `scripts/pivot-verify.py --zoom 4` is **green, 8/8**, and its *explicit*-focus
  blocks still pin at **0.94 / 1.27px** — so the pivot machinery is sound.
  `--yaw-sweep` uses the **default** focus, and its probe is off the
  viewport-center ray.
- The default focus derive is #2547's depth-aware `CAMERA_CENTER`, landed
  **2026-07-31** — *after* the issue's 2026-07-28 baseline — whose residual
  1-iso-unit cap-entry bias **#2641** already owns and measures independently
  (12px @ z4, 22px @ z8 on `--pivot-verify center-axis`). This PR files nothing
  new: it is the same defect, seen through a different probe.

So on today's master this probe's excursion measures the *pivot*, not the
per-axis path. The bar is re-derivable from a post-#2641 capture; the docs say
exactly that rather than publishing a number that would not hold.

## Test plan

- [x] `test/tools/jitter_probe_excursion_test.sh` → **16/16 passed** against the
      built binary.
- [x] **Positive control** — same test vs. a binary compiled from
      `origin/master`'s `tools/jitter_probe/main.cpp`: **10/16 fail**. The 6 that
      pass are exactly the arms pinning *unchanged* behaviour (case 1's two
      shipped-criteria checks, case 6's whole `--stationary` path, and case 5's
      exit-2 — which master reaches via unknown-flag, so its *diagnostic* check
      correctly fails).
- [x] `scripts/pivot-verify.py --no-build --zoom 4` → `all 8 passes met their
      gate`, run **against the new binary** — the live proof the `--stationary`
      parse surface is intact.
- [x] `fleet-build --target jitter_probe` clean; `header-checks` clean;
      `format-changed` applied.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| AC1 — per-axis flags exist, independently usable | `jitter_probe_excursion_test.sh` cases 3/4 | **MET** — identical frames, mirrored assertions, opposite verdicts (exit 0 vs 1) |
| AC2 — D4 fires on the excursion criterion; healthy populations pass | Phase-0 capture, 8 populations | **NOT MET — refuted.** Defect x excursion is *below* healthy at every zoom (0.63–0.69×); no bar satisfies the plan's bounds |
| AC3 — both docs updated, carrying the measured table | `tools/jitter_probe/README.md`, `engine/render/CLAUDE.md` | **MET in substance, inverted in conclusion** — both carry the fresh table; it establishes that no bar is publishable yet, rather than making excursion the primary gate |
| AC4 — synthetic test ships and passes | `./test/tools/jitter_probe_excursion_test.sh` | **MET** — 16 checks over 6 cases, 16/16; 10/16 red on the pre-fix control |
| AC5 — `pivot-verify.py` parse surface untouched | `pivot-verify.py --no-build --zoom 4` + test case 6 | **MET** — 8/8 green against the new binary; case 6 asserts no `excursion` field leaks into the `--stationary` summary |

## Docs corrected (measured, not asserted)

- `engine/render/CLAUDE.md` §"Verifying temporal stability" — the paragraph told
  readers to expect **1.26–2.83px** on the pinned axis; master measures
  **19.97–76.81px**. Replaced with the fresh table + why no bar yet.
- The `--expect-frames` comment claimed it "must equal the `--auto-screenshot`
  count". Measured: `--yaw-sweep --auto-screenshot 6` emits **24** frames
  (`--auto-screenshot` is the per-shot warmup). The recipe's own example passed
  `--expect-frames 6`, which would have exited 2 for anyone who ran it verbatim.
  Corrected to 24.
- The 2026-07-28 accepted-floor table keeps its **residual** columns (#2907's
  lane) and gains a dated note that its **excursion** columns no longer
  reproduce. The `11.13px` bullet is dated rather than left contradicting the
  re-measure two paragraphs below.

## Not verified

- Linux/GL: macOS/Metal only. The tool is backend-agnostic (it reads PNGs), but
  the excursion population numbers are host-stamped and would need re-capture.
- Whether the overflow lane *causes* the healthy arm's extra ~10px, or merely
  correlates. The arms differ by ~10px at z4, close to the 2026-07-28 lane delta
  — but attributing that under a 28px common-mode orbit is #2641/#2907 territory,
  not this PR's.

Refs #2606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
