### PR TITLE
render-verify: resolve the demo dir by manifest target, not by name (#2919)

### DIFF
--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -64,6 +64,15 @@ Shots are mapped to screenshots by **order** (Nth shot → Nth numbered
 screenshot), so the manifest must list them in the same order the demo's
 shot table.
 
+The `"target"` field is **authoritative** for which demo directory a
+`--target` resolves to. The harness scans every
+`creations/demos/*/test/references/manifest.json`, matches on that field,
+and only falls back to inferring the directory from the target name
+(strip `IR`, snake_case) when no manifest declares it. That is what keeps
+`IRLightingSdfBlocker` → `creations/demos/lighting` reachable without
+`--demo` (#2919). A manifest that omits `target` is invisible to `--all`
+and to the lookup — always declare it.
+
 ## Running the harness
 
 One command, from the worktree root:
@@ -74,7 +83,8 @@ python3 scripts/render-verify.py --target IRShapeDebug
 
 The driver:
 
-1. Reads `creations/demos/shape_debug/test/references/manifest.json`.
+1. Resolves `IRShapeDebug` to `creations/demos/shape_debug` via the
+   declaring manifest, and reads that `manifest.json`.
 2. Detects the backend from `build/CMakeCache.txt`.
 3. Runs `fleet-build --target IRShapeDebug`.
 4. Clears `<exe_dir>/save_files/screenshots/`.
@@ -118,6 +128,36 @@ zoom2_origin                    FAIL     98.9423      214    24.12
 The diff PNG is an 8-bit-per-channel visualization of the per-byte delta,
 boosted 4x for contrast. Bright pixels = regression hotspots.
 
+## Sweeping the whole reference set
+
+```
+python3 scripts/render-verify.py --all
+```
+
+`--all` runs every demo whose manifest declares a `target` and prints one
+aggregate tally:
+
+```
+[render-verify] --all summary over 5 demo(s):
+  IRAnalyticOracle         analytic_oracle        1 checks                 PASS
+  IRCanvasStress           canvas_stress         10 checks                 PASS
+  IRFogDemo                fog_demo              15 checks                 FAIL (9 of 15)
+  IRLightingSdfBlocker     lighting               5 checks                 FAIL (4 of 5)
+  IRShapeDebug             shape_debug           24 checks                 FAIL (17 of 24)
+[render-verify] total: 55 checks across 5 demos, 30 FAIL, 0 skipped
+```
+
+**Prefer this over a hand-rolled shell loop over target names.** A loop
+reports each demo separately, so a demo that fails to start leaves no hole
+in any single number — which is how `lighting` went unverified through two
+review passes on PR #2898 (a "5-demo" sweep that actually covered 4 and
+tallied 50 instead of 55, #2919). `--all` counts a demo that produced no
+checks as **ERROR**, names it on stderr, and exits non-zero, so a shrunken
+total cannot read as a complete sweep.
+
+`--all` ignores `--target` and rejects `--demo` (which names exactly one
+directory).
+
 ## Updating references
 
 When a render change intentionally alters output (new lighting pass,
@@ -157,7 +197,10 @@ the captured PNGs.
 1. Implement `--auto-screenshot` in the demo's `main.cpp` with a shot
    table (follow `shape_debug/main.cpp`).
 2. Create `creations/demos/<demo>/test/references/manifest.json` listing
-   the shots in the same order, plus thresholds.
+   the shots in the same order, plus thresholds — and a `"target"` field
+   naming the CMake target. Without it the demo is unreachable from
+   `--all` and only resolves if its directory name happens to match the
+   inference.
 3. Build and run the demo to capture a reference set:
    `python3 scripts/render-verify.py --target IR<Demo> --update-references --force`
 4. Commit the `test/references/<backend>/` PNGs alongside the manifest.

--- a/.github/workflows/render-harness-tests.yml
+++ b/.github/workflows/render-harness-tests.yml
@@ -16,7 +16,11 @@ name: Render Harness Tests
 # a PR that breaks a subject then skips the only coverage guarding it.
 # `scripts/*` does not match across `/`, so scripts/fleet/** is excluded —
 # that tree has its own workflow. The two path lists are duplicated because
-# GitHub Actions does not support YAML anchors — keep them in sync.
+# GitHub Actions does not support YAML anchors — keep them in sync **by hand**.
+# Generalizing the sync ratchet (scripts/fleet/tests/test_fleet_tests_workflow_paths.sh,
+# #2810) across every workflow is tracked as #2929; it is pinned to
+# fleet-tests.yml until that lands, so nothing executed checks the sync here.
+# Drop this note when #2929 lands.
 #
 # The demo manifests are a subject too (#2919): test_render_verify.py's
 # CommittedManifestsResolve asserts every committed

--- a/.github/workflows/render-harness-tests.yml
+++ b/.github/workflows/render-harness-tests.yml
@@ -17,6 +17,13 @@ name: Render Harness Tests
 # `scripts/*` does not match across `/`, so scripts/fleet/** is excluded —
 # that tree has its own workflow. The two path lists are duplicated because
 # GitHub Actions does not support YAML anchors — keep them in sync.
+#
+# The demo manifests are a subject too (#2919): test_render_verify.py's
+# CommittedManifestsResolve asserts every committed
+# creations/demos/*/test/references/manifest.json declares a `target` and
+# round-trips back to its own directory, so `--all` can't silently shed a demo.
+# Adding or editing a manifest is exactly the change that breaks that guard,
+# and without the path below it is the change that skips it.
 
 on:
   push:
@@ -24,11 +31,13 @@ on:
     paths:
       - 'scripts/*.py'
       - 'scripts/tests/**'
+      - 'creations/demos/*/test/references/manifest.json'
       - '.github/workflows/render-harness-tests.yml'
   pull_request:
     paths:
       - 'scripts/*.py'
       - 'scripts/tests/**'
+      - 'creations/demos/*/test/references/manifest.json'
       - '.github/workflows/render-harness-tests.yml'
   workflow_dispatch:
 

--- a/creations/demos/CLAUDE.md
+++ b/creations/demos/CLAUDE.md
@@ -24,6 +24,12 @@ Copy the closest demo, rename targets, add
 `creations/CMakeLists.txt`. See `shape_debug/CMakeLists.txt` for the
 canonical CMake shape.
 
+A demo that joins the visual-regression harness also ships
+`test/references/manifest.json`, and that file's `"target"` field is what
+`render-verify --all` resolves the demo directory by — omit it and the demo is
+silently absent from every sweep (#2919). Schema + flow:
+[`.claude/skills/render-verify/SKILL.md`](../../.claude/skills/render-verify/SKILL.md).
+
 ## Conventions
 
 - **Self-contained.** A demo must build and run without any private

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -6,7 +6,8 @@ a committed reference-image library under
 ``creations/demos/<demo>/test/references/<backend>/<label>.png``.
 
 Workflow:
-  1. Read `manifest.json` for the target demo.
+  1. Resolve the target's demo directory from the manifest that *declares*
+     it (`"target": "IR<Demo>"`), then read that `manifest.json`.
   2. Detect the active CMake preset (linux-debug / macos-debug / windows-debug).
   3. Build the target via `fleet-build`.
   4. Clear the demo's `save_files/screenshots/` directory.
@@ -52,6 +53,14 @@ crops) over the reference set for the current backend (after explicit
 confirmation unless ``--force`` is given). It blesses the default pass and
 every ``extra_runs`` pass, so a first run on a new host bootstraps all of them.
 
+``--all`` sweeps every demo whose manifest declares a ``target``, in one run
+with one aggregate tally. That is the first-class spelling of "verify the whole
+reference set": a hand-rolled shell loop over target names reports each demo
+separately, so a demo that drops out of the sweep leaves no hole in any single
+number (#2919 — the `lighting` demo went unverified across two review passes
+that way). The ``--all`` summary lists one row per demo and counts a demo that
+failed to run as ERROR rather than as zero checks.
+
 Assumes this file lives at ``<repo>/scripts/render-verify.py``.
 """
 
@@ -72,8 +81,98 @@ REPO_ROOT = SCRIPT_DIR.parent
 RENDER_COMPARE = SCRIPT_DIR / "render-compare.py"
 
 
+# One encoding of where a demo keeps its reference set. The per-demo path, the
+# backend reference dir, and the tree-wide glob all derive from these, so a
+# layout change can't leave the glob silently matching nothing.
+REFERENCES_SUBDIR = Path("test") / "references"
+MANIFEST_NAME = "manifest.json"
+MANIFEST_GLOB = f"*/{(REFERENCES_SUBDIR / MANIFEST_NAME).as_posix()}"
+
+
+def _demos_root(worktree: Path) -> Path:
+    return worktree / "creations" / "demos"
+
+
+def _manifest_path(demo_dir: Path) -> Path:
+    return demo_dir / REFERENCES_SUBDIR / MANIFEST_NAME
+
+
+def _declared_targets(worktree: Path) -> dict[str, str]:
+    """Map each committed manifest's declared ``target`` to its demo dir name.
+
+    The manifest is the authoritative statement of which CMake target a
+    reference set gates; ``_target_to_demo_name`` is only an inference over the
+    target *name*, and the tree has a demo where the two disagree
+    (``IRLightingSdfBlocker`` lives in ``creations/demos/lighting``). Reading
+    the declaration instead of re-deriving it is what keeps that demo reachable
+    without out-of-band knowledge (#2919).
+
+    Insertion order follows the glob's sort, so ``--all`` sweeps demos in a
+    stable, filesystem-independent order.
+    """
+    demos_root = _demos_root(worktree)
+    mapping: dict[str, str] = {}
+    for path in sorted(demos_root.glob(MANIFEST_GLOB)):
+        demo = path.relative_to(demos_root).parts[0]
+        try:
+            with path.open() as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            # One malformed manifest must not make every *other* target
+            # unresolvable. If this is the manifest we actually needed,
+            # _load_manifest re-reads it and fails loudly with the same error.
+            print(f"[render-verify] warning: skipping unreadable manifest "
+                  f"{path}: {e}", file=sys.stderr)
+            continue
+        target = data.get("target")
+        if not isinstance(target, str) or not target:
+            continue
+        prev = mapping.get(target)
+        if prev is not None and prev != demo:
+            raise SystemExit(
+                f"two manifests declare target '{target}': "
+                f"creations/demos/{prev} and creations/demos/{demo} — a target "
+                f"must name exactly one reference set"
+            )
+        mapping[target] = demo
+    return mapping
+
+
+def _resolve_demo_dir(worktree: Path, target: str,
+                      explicit: str | None) -> Path:
+    """Locate the demo directory whose reference set gates ``target``.
+
+    Resolution order:
+      1. ``--demo`` — an explicit override always wins.
+      2. the manifest that declares ``"target": <target>`` (authoritative).
+      3. ``_target_to_demo_name`` inference over the target name — the
+         historical behavior, kept so a demo can still be run before its
+         manifest declares a target.
+    """
+    demos_root = _demos_root(worktree)
+    if explicit:
+        demo_dir = demos_root / explicit
+        if not demo_dir.exists():
+            raise SystemExit(f"demo dir not found: {demo_dir}")
+        return demo_dir
+
+    declared = _declared_targets(worktree).get(target)
+    if declared is not None:
+        return demos_root / declared
+
+    demo_dir = demos_root / _target_to_demo_name(target)
+    if not demo_dir.exists():
+        raise SystemExit(
+            f"no demo found for target '{target}': no manifest matching "
+            f"{demos_root}/{MANIFEST_GLOB} declares it, and the name-inferred "
+            f"fallback {demo_dir} does not exist. Pass --demo <dir> to name "
+            f"the directory explicitly."
+        )
+    return demo_dir
+
+
 def _load_manifest(demo_dir: Path) -> dict[str, Any]:
-    path = demo_dir / "test" / "references" / "manifest.json"
+    path = _manifest_path(demo_dir)
     if not path.exists():
         raise SystemExit(f"manifest not found: {path}")
     try:
@@ -539,48 +638,16 @@ def _write_references(*, captured: list[Path], shot_labels: list[str],
             print(f"[render-verify] updated {dest}")
 
 
-def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--target", default="IRShapeDebug",
-                    help="CMake target to build and run (default: IRShapeDebug).")
-    ap.add_argument("--demo", default=None,
-                    help="Demo directory name under creations/demos/ (default: "
-                         "inferred from target by stripping 'IR' prefix and "
-                         "lowercasing, so IRShapeDebug → shape_debug; override "
-                         "if the mapping doesn't hold).")
-    ap.add_argument("--build-dir", default=None,
-                    help="CMake build dir (default: <repo>/build).")
-    ap.add_argument("--warmup", type=int, default=None,
-                    help="Warmup frames before the first shot (default: 10, or "
-                         "manifest['warmup'] if set; CLI value always wins).")
-    ap.add_argument("--timeout", type=int, default=60,
-                    help="Per-run timeout in seconds (default: 60).")
-    ap.add_argument("--update-references", action="store_true",
-                    help="Overwrite the reference set with the captured shots.")
-    ap.add_argument("--force", action="store_true",
-                    help="Skip the --update-references confirmation prompt.")
-    ap.add_argument("--no-build", action="store_true",
-                    help="Skip `fleet-build`; assume the target is already built.")
-    ap.add_argument("--demo-arg", action="append", default=[], metavar="ARG",
-                    help="Extra argument passed through to the DEFAULT pass's "
-                         "demo run after --auto-screenshot (repeatable; "
-                         "manifest 'extra_runs' passes use their own declared "
-                         "demo_args). Use to prove a feature flag is output-"
-                         "neutral against the committed references — e.g. "
-                         "`--demo-arg --occlusion-cull` checks the voxel "
-                         "occlusion cull renders bit-identical to the cull-off "
-                         "baseline (#1294 child 3/3).")
-    args = ap.parse_args(argv)
+def _verify_one(*, args: argparse.Namespace, worktree: Path, build_dir: Path,
+                backend: str, target: str, demo_dir: Path) -> dict[str, Any]:
+    """Build, capture, and gate one target; return its tally.
 
-    worktree = verify_common.detect_worktree_root(Path.cwd())
-    build_dir = Path(args.build_dir) if args.build_dir else worktree / "build"
-    backend = verify_common.detect_backend(build_dir)
-
-    demo_name = args.demo or _target_to_demo_name(args.target)
-    demo_dir = worktree / "creations" / "demos" / demo_name
-    if not demo_dir.exists():
-        raise SystemExit(f"demo dir not found: {demo_dir}")
-
+    ``{target, demo, rc, checked, failed, skipped}``. ``rc`` is what a
+    single-target run exits with (0 pass, 1 fail/crash, 2 no references); the
+    counts are what ``--all`` aggregates. Everything a single-target run prints
+    is printed here — ``main`` adds output only when it is sweeping.
+    """
+    demo_name = demo_dir.name
     manifest = _load_manifest(demo_dir)
     shot_labels: list[str] = manifest["shots"]
     thresholds = manifest.get("thresholds", {})
@@ -604,8 +671,13 @@ def main(argv: list[str] | None = None) -> int:
     # CLI --warmup wins; manifest["warmup"] overrides the hardcoded default of 10.
     warmup: int = args.warmup if args.warmup is not None else manifest.get("warmup", 10)
 
+    def tally(rc: int, checked: int = 0, failed: int = 0,
+              skipped: int = 0) -> dict[str, Any]:
+        return {"target": target, "demo": demo_name, "rc": rc,
+                "checked": checked, "failed": failed, "skipped": skipped}
+
     print(
-        f"[render-verify] target={args.target} demo={demo_name} "
+        f"[render-verify] target={target} demo={demo_name} "
         f"backend={backend} warmup={warmup}"
     )
     print(f"[render-verify] {len(shot_labels)} shots: {', '.join(shot_labels)}")
@@ -615,11 +687,11 @@ def main(argv: list[str] | None = None) -> int:
               f"{', '.join(e['name'] for e in extra_runs)}")
 
     if not args.no_build:
-        verify_common.run(["fleet-build", "--target", args.target], cwd=worktree)
+        verify_common.run(["fleet-build", "--target", target], cwd=worktree)
 
-    exe = verify_common.find_exe(build_dir, args.target, demo_name)
+    exe = verify_common.find_exe(build_dir, target, demo_name)
     shots_dir = exe.parent / screenshot_subdir
-    ref_dir = demo_dir / "test" / "references" / backend
+    ref_dir = demo_dir / REFERENCES_SUBDIR / backend
     # Single-pass runs keep diffs in shots_dir/diffs (the original location,
     # cleared along with shots_dir each run). With extra_runs, each pass
     # rmtrees shots_dir on entry, so a diff written there by an earlier pass's
@@ -637,7 +709,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         if reply.strip().lower() not in ("y", "yes"):
             print("[render-verify] aborted.")
-            return 1
+            return tally(1)
 
     # ── Default pass ──────────────────────────────────────────────────────
     # `--auto-screenshot` fires `closeWindow()` after the last shot and exits
@@ -648,7 +720,7 @@ def main(argv: list[str] | None = None) -> int:
     # let it block a PASS verdict even when every shot compares clean.
     crashes: list[tuple[int, str]] = []
     crash_main = _run_capture(
-        worktree=worktree, target=args.target, shots_dir=shots_dir,
+        worktree=worktree, target=target, shots_dir=shots_dir,
         warmup=warmup, timeout=args.timeout, demo_args=args.demo_arg,
         pass_label="default")
     if crash_main is not None:
@@ -663,7 +735,7 @@ def main(argv: list[str] | None = None) -> int:
         # this is exactly how those references get blessed for the first time.
         for extra in extra_runs:
             crash = _run_capture(
-                worktree=worktree, target=args.target, shots_dir=shots_dir,
+                worktree=worktree, target=target, shots_dir=shots_dir,
                 warmup=extra["warmup"] if extra["warmup"] is not None else warmup,
                 timeout=args.timeout, demo_args=extra["demo_args"],
                 pass_label=extra["name"])
@@ -674,14 +746,14 @@ def main(argv: list[str] | None = None) -> int:
                     f"references not updated for this pass.",
                     file=sys.stderr,
                 )
-                return 1
+                return tally(1)
             all_caps = _collect_all_shots(shots_dir)
             sliced = _slice_capture(all_caps, extra["capture_offset"],
                                     len(extra["shots"]), extra["name"])
             _write_references(captured=sliced, shot_labels=extra["shots"],
                               ref_dir=ref_dir, crops_block=extra["crops"],
                               structural_only=extra["structural_only"])
-        return 0
+        return tally(0)
 
     # A reference set is only required when at least one shot is pixel-diffed.
     # An all-structural-only manifest (a pure analytic oracle) is backend-
@@ -696,7 +768,7 @@ def main(argv: list[str] | None = None) -> int:
             f"{ref_dir}. Run with --update-references to capture them.",
             file=sys.stderr,
         )
-        return 2
+        return tally(2)
 
     rows = evaluate_shots(
         captured=captured,
@@ -733,7 +805,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[render-verify] extra run '{extra['name']}': "
               f"{' '.join(extra['demo_args'])}")
         crash = _run_capture(
-            worktree=worktree, target=args.target, shots_dir=shots_dir,
+            worktree=worktree, target=target, shots_dir=shots_dir,
             warmup=extra["warmup"] if extra["warmup"] is not None else warmup,
             timeout=args.timeout, demo_args=extra["demo_args"],
             pass_label=extra["name"])
@@ -789,7 +861,7 @@ def main(argv: list[str] | None = None) -> int:
     skip_note = f" ({len(skipped)} skipped — references pending)" if skipped else ""
     if all_pass and not crashes:
         print(f"[render-verify] all {checked} checks PASS{skip_note}")
-        return 0
+        return tally(0, checked=checked, skipped=len(skipped))
 
     if not all_pass:
         print(f"[render-verify] {len(failures)} of {checked} checks FAIL{skip_note}")
@@ -803,7 +875,126 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[render-verify] demo crashed at shutdown (fleet-run exit={rc}); "
               f"failing the verify run even when shots match — see tail above.",
               file=sys.stderr)
-    return 1
+    return tally(1, checked=checked, failed=len(failures),
+                 skipped=len(skipped))
+
+
+def _print_sweep_summary(results: list[dict[str, Any]]) -> None:
+    """One row per demo plus a single aggregate tally.
+
+    The row for a demo that never produced checks says ERROR, not ``0 checks``
+    — the whole point of ``--all`` is that a demo dropping out of the sweep is
+    visible in the number, which is what a per-target shell loop cannot do
+    (#2919).
+    """
+    print()
+    print(f"[render-verify] --all summary over {len(results)} demo(s):")
+    for r in results:
+        if r["rc"] == 0:
+            verdict = "PASS"
+        elif r["checked"] == 0:
+            verdict = f"ERROR ({r.get('error') or 'exit ' + str(r['rc'])})"
+        else:
+            verdict = f"FAIL ({r['failed']} of {r['checked']})"
+        skip_note = f", {r['skipped']} skipped" if r["skipped"] else ""
+        print(f"  {r['target']:24} {r['demo']:20} "
+              f"{r['checked']:>3} checks{skip_note:16} {verdict}")
+    total = sum(r["checked"] for r in results)
+    failed = sum(r["failed"] for r in results)
+    skipped = sum(r["skipped"] for r in results)
+    errored = [r["target"] for r in results if r["rc"] != 0 and r["checked"] == 0]
+    print(f"[render-verify] total: {total} checks across {len(results)} demos, "
+          f"{failed} FAIL, {skipped} skipped")
+    if errored:
+        print(f"[render-verify] {len(errored)} demo(s) produced NO checks: "
+              f"{', '.join(errored)} — their coverage is missing from the "
+              f"total above.", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--target", default="IRShapeDebug",
+                    help="CMake target to build and run (default: IRShapeDebug).")
+    ap.add_argument("--all", action="store_true",
+                    help="Sweep every demo whose manifest declares a 'target', "
+                         "in one run with one aggregate tally. Ignores --target; "
+                         "incompatible with --demo.")
+    ap.add_argument("--demo", default=None,
+                    help="Demo directory name under creations/demos/ (default: "
+                         "the demo whose manifest declares this --target; "
+                         "falling back to the name inferred from the target by "
+                         "stripping 'IR' and snake_casing, so IRShapeDebug → "
+                         "shape_debug. Override when neither holds).")
+    ap.add_argument("--build-dir", default=None,
+                    help="CMake build dir (default: <repo>/build).")
+    ap.add_argument("--warmup", type=int, default=None,
+                    help="Warmup frames before the first shot (default: 10, or "
+                         "manifest['warmup'] if set; CLI value always wins).")
+    ap.add_argument("--timeout", type=int, default=60,
+                    help="Per-run timeout in seconds (default: 60).")
+    ap.add_argument("--update-references", action="store_true",
+                    help="Overwrite the reference set with the captured shots.")
+    ap.add_argument("--force", action="store_true",
+                    help="Skip the --update-references confirmation prompt.")
+    ap.add_argument("--no-build", action="store_true",
+                    help="Skip `fleet-build`; assume the target is already built.")
+    ap.add_argument("--demo-arg", action="append", default=[], metavar="ARG",
+                    help="Extra argument passed through to the DEFAULT pass's "
+                         "demo run after --auto-screenshot (repeatable; "
+                         "manifest 'extra_runs' passes use their own declared "
+                         "demo_args). Use to prove a feature flag is output-"
+                         "neutral against the committed references — e.g. "
+                         "`--demo-arg --occlusion-cull` checks the voxel "
+                         "occlusion cull renders bit-identical to the cull-off "
+                         "baseline (#1294 child 3/3).")
+    args = ap.parse_args(argv)
+
+    if args.all and args.demo:
+        raise SystemExit(
+            "--all sweeps every declaring manifest; --demo names one directory. "
+            "Pass one or the other."
+        )
+
+    worktree = verify_common.detect_worktree_root(Path.cwd())
+    build_dir = Path(args.build_dir) if args.build_dir else worktree / "build"
+    backend = verify_common.detect_backend(build_dir)
+
+    if not args.all:
+        demo_dir = _resolve_demo_dir(worktree, args.target, args.demo)
+        return _verify_one(args=args, worktree=worktree, build_dir=build_dir,
+                           backend=backend, target=args.target,
+                           demo_dir=demo_dir)["rc"]
+
+    declared = _declared_targets(worktree)
+    if not declared:
+        raise SystemExit(
+            f"--all found no manifest declaring a 'target' under "
+            f"{_demos_root(worktree)}/{MANIFEST_GLOB}"
+        )
+    print(f"[render-verify] --all: {len(declared)} demo(s) — "
+          f"{', '.join(declared)}")
+
+    results: list[dict[str, Any]] = []
+    for target, demo in declared.items():
+        print()
+        print("=" * 76)
+        # One broken demo must not truncate the sweep — that would silently
+        # shrink coverage, the exact failure this flag exists to make visible.
+        try:
+            results.append(_verify_one(
+                args=args, worktree=worktree, build_dir=build_dir,
+                backend=backend, target=target,
+                demo_dir=_demos_root(worktree) / demo))
+        except SystemExit as e:
+            print(f"[render-verify] {target}: {e}", file=sys.stderr)
+            results.append({"target": target, "demo": demo, "rc": 1,
+                            "checked": 0, "failed": 0, "skipped": 0,
+                            "error": str(e)})
+
+    # --update-references gates nothing, so it has no tally to summarize.
+    if not args.update_references:
+        _print_sweep_summary(results)
+    return 0 if all(r["rc"] == 0 for r in results) else 1
 
 
 def _target_to_demo_name(target: str) -> str:

--- a/scripts/tests/test_render_verify.py
+++ b/scripts/tests/test_render_verify.py
@@ -1,4 +1,5 @@
-"""Tests for render-verify.py — the ROI-crop + structural-metric gate (T-2).
+"""Tests for render-verify.py — the ROI-crop + structural-metric gate (T-2)
+and the manifest-driven demo resolution (#2919).
 
 Proves the gate wiring added in epic #1766 T-2 without a GL/Metal build:
 
@@ -11,14 +12,26 @@ Proves the gate wiring added in epic #1766 T-2 without a GL/Metal build:
   * misconfigurations (unknown shot, missing reference, un-captured crop,
     unimplemented metric, threshold-less gate) are surfaced loudly.
 
+Plus the resolution + sweep layer (#2919):
+
+  * a target is resolved from the manifest that *declares* it, so a demo
+    whose directory name doesn't match its target stays reachable;
+  * the committed tree round-trips — every manifest resolves back to its own
+    directory, so no demo can silently drop out of an --all sweep;
+  * a demo that produces no checks reads as ERROR in the sweep summary
+    rather than as a quietly smaller total.
+
 Synthetic PNGs only — no engine, no committed references. Import the
 dashed-name scripts via importlib, matching test_render_shadow_metric.py.
 """
 import importlib.machinery
 import importlib.util
+import io
+import json
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -54,6 +67,14 @@ _slice_capture = _rv._slice_capture
 # unimportable under the "swap in the old render-verify.py" positive control,
 # collapsing a per-test result into one ImportError. Resolved per call site
 # instead, so that control reports which arms actually discriminate.
+_declared_targets = _rv._declared_targets
+_resolve_demo_dir = _rv._resolve_demo_dir
+_target_to_demo_name = _rv._target_to_demo_name
+_print_sweep_summary = _rv._print_sweep_summary
+
+# The subject's own notion of the repo root, so a mis-rooted harness fails the
+# tree-level guard below rather than being papered over by a local re-derivation.
+REPO_ROOT = _rv.REPO_ROOT
 
 MAGENTA = (255, 0, 255)
 BLACK = (0, 0, 0)
@@ -533,6 +554,193 @@ class ValidateStructuralOnly(unittest.TestCase):
     def test_empty_block_is_a_no_op(self):
         _rv._validate_structural_only(set(), [], {})
         _rv._validate_structural_only(set(), [], {}, pass_name="compare")
+
+
+class DemoResolution(unittest.TestCase):
+    """Manifest-declared target -> demo dir (#2919).
+
+    The pre-fix harness inferred the directory from the target name, which is
+    wrong for any demo whose directory doesn't echo its target. These build a
+    synthetic demo tree so the cases are exercised without the real manifests.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.worktree = Path(self._tmp.name)
+        self.demos = self.worktree / "creations" / "demos"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _demo(self, name: str, target: str | None, *, raw: str | None = None):
+        d = self.demos / name
+        refs = d / "test" / "references"
+        refs.mkdir(parents=True, exist_ok=True)
+        body = raw if raw is not None else json.dumps(
+            {"demo": name, "target": target, "shots": ["s0"]})
+        (refs / "manifest.json").write_text(body)
+        return d
+
+    # ── _declared_targets ────────────────────────────────────────────────
+    def test_maps_every_declaring_manifest(self):
+        self._demo("shape_debug", "IRShapeDebug")
+        self._demo("lighting", "IRLightingSdfBlocker")
+        self.assertEqual(_declared_targets(self.worktree),
+                         {"IRLightingSdfBlocker": "lighting",
+                          "IRShapeDebug": "shape_debug"})
+
+    def test_manifest_without_target_is_ignored_not_fatal(self):
+        self._demo("legacy", None)          # "target": null
+        self._demo("lighting", "IRLightingSdfBlocker")
+        self.assertEqual(_declared_targets(self.worktree),
+                         {"IRLightingSdfBlocker": "lighting"})
+
+    def test_unreadable_manifest_is_skipped_with_a_warning(self):
+        # One malformed manifest must not make every OTHER target
+        # unresolvable — the sibling still resolves, and the skip is announced.
+        self._demo("broken", None, raw="{not json")
+        self._demo("lighting", "IRLightingSdfBlocker")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            got = _declared_targets(self.worktree)
+        self.assertEqual(got, {"IRLightingSdfBlocker": "lighting"})
+        self.assertIn("broken", err.getvalue())
+
+    def test_two_manifests_declaring_one_target_raises(self):
+        self._demo("a", "IRDup")
+        self._demo("b", "IRDup")
+        with self.assertRaises(SystemExit) as cm:
+            _declared_targets(self.worktree)
+        self.assertIn("IRDup", str(cm.exception))
+
+    # ── _resolve_demo_dir ────────────────────────────────────────────────
+    def test_declaration_beats_name_inference(self):
+        # IRLightingSdfBlocker infers `lighting_sdf_blocker`, which does not
+        # exist; the manifest says `lighting`, and the manifest wins.
+        self._demo("lighting", "IRLightingSdfBlocker")
+        self.assertEqual(_target_to_demo_name("IRLightingSdfBlocker"),
+                         "lighting_sdf_blocker")   # the inference is still wrong
+        got = _resolve_demo_dir(self.worktree, "IRLightingSdfBlocker", None)
+        self.assertEqual(got, self.demos / "lighting")
+
+    def test_matching_demo_is_unchanged(self):
+        self._demo("shape_debug", "IRShapeDebug")
+        got = _resolve_demo_dir(self.worktree, "IRShapeDebug", None)
+        self.assertEqual(got, self.demos / "shape_debug")
+
+    def test_explicit_demo_overrides_the_declaration(self):
+        self._demo("lighting", "IRLightingSdfBlocker")
+        self._demo("other", "IROther")
+        got = _resolve_demo_dir(self.worktree, "IRLightingSdfBlocker", "other")
+        self.assertEqual(got, self.demos / "other")
+
+    def test_explicit_demo_that_does_not_exist_raises(self):
+        self._demo("lighting", "IRLightingSdfBlocker")
+        with self.assertRaises(SystemExit) as cm:
+            _resolve_demo_dir(self.worktree, "IRLightingSdfBlocker", "nope")
+        self.assertIn("demo dir not found", str(cm.exception))
+
+    def test_falls_back_to_inference_when_nothing_declares_the_target(self):
+        # A demo dir that exists but whose manifest names no target still
+        # resolves the old way, so pre-declaration demos keep working.
+        self._demo("fog_demo", None)
+        got = _resolve_demo_dir(self.worktree, "IRFogDemo", None)
+        self.assertEqual(got, self.demos / "fog_demo")
+
+    def test_unknown_target_names_both_attempts(self):
+        self._demo("lighting", "IRLightingSdfBlocker")
+        with self.assertRaises(SystemExit) as cm:
+            _resolve_demo_dir(self.worktree, "IRNoSuchThing", None)
+        msg = str(cm.exception)
+        self.assertIn("manifest.json", msg)      # where it looked for a decl
+        self.assertIn("no_such_thing", msg)      # what it inferred
+        self.assertIn("--demo", msg)             # how to fix it
+
+
+class CommittedManifestsResolve(unittest.TestCase):
+    """Coverage guard against the real tree — no build, no demo run.
+
+    #2919's damage was a demo silently dropping out of a multi-target sweep.
+    The property that prevents it is that every committed manifest is
+    reachable from its own declared target with no `--demo` override, so this
+    asserts the round-trip over whatever manifests the tree currently ships
+    rather than pinning a demo list that would need editing on every addition.
+    """
+
+    def _manifests(self):
+        return sorted((REPO_ROOT / "creations" / "demos")
+                      .glob(_rv.MANIFEST_GLOB))
+
+    def test_every_committed_manifest_declares_a_target(self):
+        missing = [str(p.relative_to(REPO_ROOT)) for p in self._manifests()
+                   if not json.loads(p.read_text()).get("target")]
+        self.assertEqual(missing, [], "manifests with no 'target' are "
+                                      "unreachable from --all")
+
+    def test_every_committed_manifest_round_trips(self):
+        declared = _declared_targets(REPO_ROOT)
+        self.assertEqual(len(declared), len(self._manifests()),
+                         "a committed manifest dropped out of --all's demo set")
+        for target, demo in declared.items():
+            with self.subTest(target=target):
+                self.assertEqual(
+                    _resolve_demo_dir(REPO_ROOT, target, None),
+                    REPO_ROOT / "creations" / "demos" / demo)
+
+    def test_the_tree_still_contains_a_demo_inference_gets_wrong(self):
+        # If this ever fails because every demo dir matches its target, the
+        # inference fallback is no longer load-bearing — but the failure must
+        # be read, not silenced: it means the fixture for this bug is gone.
+        declared = _declared_targets(REPO_ROOT)
+        mismatched = {t: d for t, d in declared.items()
+                      if _target_to_demo_name(t) != d}
+        self.assertIn("IRLightingSdfBlocker", mismatched)
+        self.assertEqual(mismatched["IRLightingSdfBlocker"], "lighting")
+
+
+class SweepSummary(unittest.TestCase):
+    def _summary(self, results):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            _print_sweep_summary(results)
+        return out.getvalue(), err.getvalue()
+
+    def _row(self, target, demo, rc, checked, failed=0, skipped=0, error=None):
+        r = {"target": target, "demo": demo, "rc": rc, "checked": checked,
+             "failed": failed, "skipped": skipped}
+        if error:
+            r["error"] = error
+        return r
+
+    def test_total_sums_every_demo(self):
+        out, err = self._summary([
+            self._row("IRShapeDebug", "shape_debug", 0, 24),
+            self._row("IRLightingSdfBlocker", "lighting", 1, 5, failed=4),
+        ])
+        self.assertIn("total: 29 checks across 2 demos, 4 FAIL", out)
+        self.assertEqual(err, "")
+
+    def test_a_demo_that_produced_no_checks_reads_as_error(self):
+        # The #2919 failure mode, one level up: a demo contributing zero must
+        # not look like a demo that simply had less to check. It is named on
+        # stderr AND its row says ERROR, so a smaller total can't pass as a
+        # complete sweep.
+        out, err = self._summary([
+            self._row("IRShapeDebug", "shape_debug", 0, 24),
+            self._row("IRLightingSdfBlocker", "lighting", 1, 0,
+                      error="demo dir not found"),
+        ])
+        self.assertIn("ERROR (demo dir not found)", out)
+        self.assertIn("produced NO checks", err)
+        self.assertIn("IRLightingSdfBlocker", err)
+
+    def test_clean_sweep_says_nothing_on_stderr(self):
+        out, err = self._summary([
+            self._row("IRShapeDebug", "shape_debug", 0, 24),
+            self._row("IRFogDemo", "fog_demo", 0, 15),
+        ])
+        self.assertIn("total: 39 checks across 2 demos, 0 FAIL", out)
+        self.assertEqual(err, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `scripts/render-verify.py` resolved a demo's directory by inferring it from the CMake target name (strip `IR`, snake_case) while the demo's own `manifest.json` already declared `"target"`. Resolution now reads the declaration; the inference survives only as a fallback for a demo whose manifest declares no target, and `--demo` still overrides both.
- Adds `--all`: sweeps every demo whose manifest declares a target and prints **one aggregate tally**. A demo that produced zero checks reads as `ERROR` on its row *and* is named on stderr, so a shrunken total cannot pass as a complete sweep. `--all` is incompatible with `--demo` and ignores `--target`.
- `main()` split into `_verify_one()` (one target → tally) + a dispatcher. A `SystemExit` from one demo is caught so it cannot truncate the sweep — truncation would silently shrink coverage, the exact failure the flag exists to surface.

## Why this was more than an ergonomics nit

The per-target exit code is loud in isolation. The damage was in the loop shape people actually use — sweep every target, read the summary lines. One `demo dir not found` among demos that legitimately report FAILs does not stand out, and the missing demo leaves **no hole in any single number**. A five-demo sweep on PR #2898 verified four, tallied 50, and survived two review passes as an unresolved "count doesn't quite reconcile" nit on both.

## Test plan

- [x] `bash scripts/tests/run_all.sh` → `8 suite(s) — 8 passed, 0 failed`
- [x] `python3 scripts/tests/test_render_verify.py` run **alone** → `Ran 46 tests ... OK` (16 new)
- [x] `ruff check scripts/` → `All checks passed!`
- [x] `python3 scripts/render-verify.py --all` on `macos-debug` → `total: 55 checks across 5 demos`

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `--target IRLightingSdfBlocker` (no `--demo`) resolves `creations/demos/lighting` and runs its 5 shots | `python3 scripts/render-verify.py --target IRLightingSdfBlocker` | `target=IRLightingSdfBlocker demo=lighting backend=macos-debug` then `5 shots: zoom1_origin, zoom2_origin, zoom4_origin, zoom4_offset_3_5, zoom8_origin`. Pre-fix, same command: `demo dir not found: …/creations/demos/lighting_sdf_blocker`, rc=1 |
| Every other demo's current invocation is unchanged | resolution table over all 5 declared targets, + pre-fix control runs | 4 of 5 targets resolve to the **identical** directory pre/post-fix — only `IRLightingSdfBlocker` changes (`lighting_sdf_blocker` → `lighting`). Measured, not assumed: pre-fix `IRShapeDebug` = `17 of 24 checks FAIL`, pre-fix `IRFogDemo` = `9 of 15 checks FAIL` — identical to post-fix |
| A target with no matching manifest still fails loudly naming what it looked for | `python3 scripts/render-verify.py --target IRNoSuchThing` | `no demo found for target 'IRNoSuchThing': no manifest matching …/creations/demos/*/test/references/manifest.json declares it, and the name-inferred fallback …/creations/demos/no_such_thing does not exist. Pass --demo <dir> to name the directory explicitly.` |
| Coverage regression guard: a sweep over all five reference demos reports 55 checks, not 50 | `python3 scripts/render-verify.py --all` | `[render-verify] total: 55 checks across 5 demos, 30 FAIL, 0 skipped` — per-demo `1 / 10 / 15 / 5 / 24`. `lighting`'s 5 are the checks that were absent from the 50 |

Standing guard (no build, no demo run): `CommittedManifestsResolve` asserts every committed manifest declares a `target` and round-trips to its own directory, and that `len(declared) == len(manifests)` — so a demo cannot drop out of `--all`'s set. It asserts against whatever manifests the tree ships rather than pinning a demo list, so adding a demo doesn't require editing the test.

## Reading the 30 FAILs

They are **pre-existing macOS reference drift, not this PR**. Two independent grounds:

1. Structural — this diff changes only which directory a target resolves to plus the sweep driver. For 4 of the 5 demos the resolved path is byte-identical before and after, so the same binary is compared against the same references.
2. Measured — the pre-fix script run against the same built binaries gives the same counts (`IRShapeDebug` 17/24, `IRFogDemo` 9/15).

`lighting`'s 4 FAILs are the ones #2919's body already recorded as reproducing on `origin/master 12b8a49c8`. The red-reference condition is already owned (#2901, #1969, #2158) — not filing a duplicate, and deliberately **not** re-blessing anything here.

## Positive control — stated plainly

The 16 new unit tests **cannot** be run red-to-green against the pre-fix script: they bind `_declared_targets` / `_resolve_demo_dir` / `_print_sweep_summary` at import, so a pre-fix run dies with `AttributeError` at collection — a setup failure, not a red arm. The runnable control is the CLI A/B in the table above (pre-fix rc=1 `demo dir not found` → post-fix 5 shots), run against the identical tree.

Non-vacuity of the key test is asserted in-test rather than assumed: `test_declaration_beats_name_inference` first asserts `_target_to_demo_name("IRLightingSdfBlocker") == "lighting_sdf_blocker"` (the inference is *still* wrong), so the test cannot pass if the manifest lookup silently no-ops.

## Findings (deferred, filed as #2929)

- `.github/workflows/render-harness-tests.yml` keeps its `push` and `pull_request` path lists in sync **by hand** — its own header says so, and this PR adds a third entry to both. The existing executed ratchet, `scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` (#2810), is pinned to `fleet-tests.yml` at line 23. Generalizing it is a different workflow's test tree, so it is **filed as #2929** rather than bundled here, and the workflow's own header now names the gap and the issue in-tree — the finding no longer depends on this PR thread being read.
  - Sized while filing, on this commit: 4 of the 6 workflows carry a non-empty `paths:` list (`fleet-tests`, `header-checks`, `perf-gate`, `render-harness-tests`); all 4 hand-duplicate it across `push`/`pull_request`, all 4 are identical today, and only `fleet-tests.yml` has an executed guard.
  - Drift-injection control: deleting `creations/demos/*/test/references/manifest.json` from **only** the `pull_request` block of this workflow — leaving `push` intact — then running `scripts/fleet/tests/run_all.sh` (`124 suite(s) — 123 passed, 1 failed`) and `scripts/tests/run_all.sh` (`8 suite(s) — 8 passed`) fails **zero** assertions about the drift. `test_fleet_tests_workflow_paths.sh` passed with the asymmetry live. The single failure, `test_cross_repo_shared_file_parity.sh`, fails identically on the unmutated tree — pre-existing on master, unrelated to this PR, and filed separately. Workflow files restored (`git status` clean) after the measurement.

## Notes

- Path filter widened: the new tree-level guard's *subject* is `creations/demos/*/test/references/manifest.json`, so adding or editing a manifest — the change that breaks the guard — would have skipped the only job that runs it under the old `scripts/*.py` + `scripts/tests/**` filter. That is the #2810 shape the workflow's own header warns about.
- `creations/demos/CLAUDE.md` gained a one-line pointer: the manifest's `target` is now load-bearing and that doc never mentioned the harness.
- No screenshots: the diff touches no render code, shaders, or demo sources.

Closes #2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

