### PR TITLE
fleet: stop R7 re-arming design-unblocked on unactionable PRs (#2462)

### DIFF
--- a/.fleet/plans/issue-2462.md
+++ b/.fleet/plans/issue-2462.md
@@ -1,0 +1,188 @@
+# Plan: fleet-claim R7 re-arms fleet:design-unblocked on infra-blocked orphaned WIP PRs → opus-dispatch churn
+
+- **Issue:** #2462
+- **Model:** opus — bounded bash/python + tests once planned, but reconcile-rule
+  and label-protocol semantics need fleet-protocol judgment; not sonnet-mechanical,
+  no novel algorithm to warrant fable
+- **Date:** 2026-07-20 (planning pass); amended 2026-08-07 at implementation
+
+## The defect
+
+R7 (`reconcile_heal_design_unblock`) re-adds `fleet:design-unblocked` to a
+claimless `fleet:wip` PR whenever its backing issue is `fleet:queued` and the PR
+carries none of the three design labels. The predicate never consults whether the
+work is *actionable*, so a PR parked behind an unlanded blocker re-arms forever.
+Each re-arm routes to an opus dispatch (`fleet_task_class.feedback_pr_class` maps
+`fleet:design-unblocked` → opus) that can make zero progress.
+
+Three PRs have carried this: #2460 (issue #2260), #2393 (issue #2321), and one
+PR in a downstream repo with the same shape. #2393 alone has absorbed 7 opus
+feedback pickups.
+
+## Amendments folded in from the issue thread
+
+The 2026-07-20 plan is the base. Four later comments changed it:
+
+1. **2026-07-28 (pool-3) — add a `fleet:blocked` predicate.** Both live cases
+   have a backing issue that is *already* `fleet:blocked`; R7 gates only on
+   `fleet:queued` and never tests it. This needs no new label, no body marker,
+   and no worker action — the blocked state is already recorded by the existing
+   protocol. Folded in as step 4 below.
+2. **2026-07-31 (pool-3) — candidate fix 3 (per-PR re-heal cap) is refuted.**
+   `design-unblock-heal-persistence.json` is reset-on-success by construction
+   (`json.dump(seen, ...)` retains only keys found *this* run), so a cap built on
+   it always reads zero at the moment it would need to say "already healed once".
+   Not pursued.
+3. **2026-08-01 (pool-3) — the worker's clear is what drives the churn.**
+   Dispatch is edge-triggered on a projection hash, so leaving the label costs
+   **zero** wakes; clearing it costs one, and R7's re-add costs another. R7's
+   finding condition (`neither design label`) only reproduces *after* a clear.
+   This reclassifies the change: it is a **correctness** fix that makes a
+   worker's clear terminal, not a churn-rate fix.
+4. **2026-08-07 (pool-4) — why this never queued.** #2856's ingest window, not
+   a labelling problem. Out of scope here.
+
+## Scope
+
+Two disjoint populations, two mechanisms:
+
+| population | mechanism |
+|---|---|
+| backing issue carries `fleet:blocked` (#2393/#2321, plus the downstream pair) | R7 predicate skip — zero worker action |
+| blocked on infra with no `Blocked by:` field (#2460/#2260 behind a build wall) | explicit `fleet:awaiting-infra` park + `Parked-until: #N` |
+
+Plus a new reconcile rule **R8** that auto-un-parks when the named blocker
+closes, after which the existing R7 machinery re-surfaces the PR organically.
+Genuine #1516 stranding (no marker, unblocked issue) keeps healing exactly as
+today.
+
+## Approach
+
+1. **New label `fleet:awaiting-infra`** via the 3-file sync, one commit:
+   - `scripts/fleet/fleet-labels` catalog entry (description ≤100 chars — the
+     `--check` gate enforces it).
+   - `docs/agents/fleet-state-machine.json` node-set entry.
+   - `docs/agents/fleet-labels-reference.md` semantics + park/un-park protocol.
+
+   `./scripts/fleet/fleet-labels --check` must pass. The live label is created
+   in both repos by the normal `fleet-labels` sync on the next `fleet-up`.
+
+2. **Park protocol** (documented in `docs/agents/FLEET-FEEDBACK-HANDLING.md` and
+   the labels reference — both un-gated `docs/agents/` files; no gated
+   self-config in scope). When a worker adjudicates an orphaned `fleet:wip` PR
+   as complete-but-blocked-on-infra:
+   - remove `fleet:design-unblocked` if present + add `fleet:awaiting-infra`;
+   - append `Parked-until: #<blocker-issue>` to the **PR body** (same-repo
+     issue; last occurrence wins, so a re-park just appends);
+   - comment the rationale on the PR.
+
+   Bare removal of `fleet:design-unblocked` *without* a marker and *without* a
+   `fleet:blocked` backing issue intentionally stays re-heal-able: R7 cannot
+   distinguish a deliberate bare un-set from a crashed worker's TTL-swept claim,
+   and re-arming the latter is its job. The marker **is** the deliberate-removal
+   signal.
+
+3. **R7 + R2 exemption for `fleet:awaiting-infra`** (`scripts/fleet/fleet-claim`):
+   add it to the design-label exemption test in the R7 finding loop and to R2's
+   equivalent skip. Mirrors how `fleet:design-proposed` is already invisible to
+   both (#1663), with a comment citing #2462.
+
+4. **R7 `fleet:blocked` predicate** (the 07-28 amendment): skip the R7 finding
+   when the backing issue carries `fleet:blocked`. Under the queue-all model
+   (#1527) a blocked task legitimately keeps `fleet:queued`, so this state is
+   protocol-correct and there is by definition nothing for the worker resume
+   loop to act on.
+
+   **R2 deliberately keeps flagging it.** R2 is flag-only and dedupes into a
+   single state-drift tracker; an orphaned WIP on a blocked issue is still worth
+   a human's eye, and narrowing R2 here is beyond both the plan and the
+   amendment. Only the *auto-mutating* rule is narrowed.
+
+5. **New rule R8 (auto-un-park)** — detection in the same findings pass + an
+   apply-mode function `reconcile_unpark_infra` wired in `cmd_reconcile`:
+   - *Detection:* iterate the flat `d["prs"]` list (not `pr_by_issue` — a parked
+     PR may lack a resolvable backing-issue mapping, and `pr_by_issue` entries
+     carry no `body`). For each open PR with `fleet:awaiting-infra`:
+     - last `Parked-until: #(\d+)` in `body` parses → emit an R8 finding **with**
+       an apply action. Apply-carrying findings are skipped by
+       `reconcile_escalate_drift`'s flag-only accrual, so a long-parked PR files
+       no drift tracker.
+     - no parse → emit a **flag-only** R8 finding so the normal drift-tracker
+       accrual escalates a malformed park to a human.
+   - *Apply* (`--apply` only): verify the blocker live via `gh issue view <N>
+     --json state`. `CLOSED` → remove `fleet:awaiting-infra`. Anything else
+     (OPEN, lookup failure) → no-op; the finding recurs harmlessly.
+     **No persistence gate**: closing an issue is a deliberate durable act, and
+     the bad case (blocker reopened after un-park) self-corrects — R7 re-arms, a
+     worker re-adjudicates and re-parks.
+   - Reconcile never edits PR bodies; stale earlier `Parked-until:` lines are
+     inert because the parse takes the last occurrence.
+   - *Composition:* after un-park the PR reverts to the stranded state; R7
+     re-arms after the usual threshold; the worker resume loop adopts it. No new
+     resume machinery.
+
+6. **Tests** — extend
+   `scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh`:
+   - *Parked-invisible:* `fleet:awaiting-infra` PR with `Parked-until: #N`
+     (blocker OPEN) → no R7 and no R2 finding across ≥3 ticks; R8
+     apply-carrying finding present; no label mutation.
+   - *Un-park fires (positive-fire):* same state, blocker canned CLOSED → one
+     `--apply` tick removes `fleet:awaiting-infra` (exactly one recorded label
+     removal); then flip the PR marker-less and confirm R7 resumes and heals at
+     threshold — the full un-park → re-surface pipeline.
+   - *Malformed park:* label present, no `Parked-until:` line → flag-only R8
+     finding, no mutation.
+   - *`fleet:blocked` backing issue:* claimless `fleet:wip` PR, neither design
+     label, issue `fleet:queued` + `fleet:blocked` → no R7 across ≥3 ticks and
+     no heal, while the unblocked control on the same tick still heals.
+   - *Regression:* every existing phase stays green.
+
+## Affected files
+
+- `scripts/fleet/fleet-claim` — R7/R2 exemptions; R7 `fleet:blocked` predicate;
+  R8 detection; `reconcile_unpark_infra`; `cmd_reconcile` wiring.
+- `scripts/fleet/fleet-labels` — catalog entry.
+- `docs/agents/fleet-state-machine.json` — node-set entry.
+- `docs/agents/fleet-labels-reference.md` — label semantics + park/un-park protocol.
+- `docs/agents/FLEET-FEEDBACK-HANDLING.md` — the park branch on the
+  design-unblocked path.
+- `scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh` — new phases.
+
+## Acceptance criteria
+
+1. A parked PR (per protocol, blocker OPEN) produces **no** R7 heal and **no**
+   R2 flag across ≥ threshold `--apply` ticks.
+2. **Positive-fire:** with the blocker CLOSED, one `--apply` tick observably
+   removes `fleet:awaiting-infra`, and R7 subsequently re-heals at threshold. The
+   OFF-path quiet alone does not pass.
+3. A `fleet:queued` + `fleet:blocked` backing issue suppresses R7 across ≥
+   threshold ticks, while an unblocked control on the same ticks still heals.
+4. Genuine #1516 case (marker-less, unblocked stranded WIP) still heals at
+   threshold — existing phases unchanged and green.
+5. Malformed park escalates via the flag-only → state-drift-tracker path.
+6. `./scripts/fleet/fleet-labels --check` green; whole test file green;
+   verifiable on any host (bash/python only, no engine build).
+
+## Gotchas
+
+- The heal-persistence file resets keys absent this run — do **not** reuse it as
+  heal history; the exemption must come from the label or the issue's own state
+  (cross-host), never local state.
+- R2's exemption site is separate from R7's; miss one and a parked PR keeps
+  accruing toward state-drift trackers.
+- `gh issue edit` on a PR number is the file-wide convention for PR label edits
+  (labels share the issues endpoint) — don't switch to `gh pr edit` inside
+  `fleet-claim`.
+- Catalog description hard cap: 100 chars (`fleet-labels --check` enforces).
+- `Parked-until:` is same-repo-only in v1 (documented); the motivating
+  #2460 → #2449 case is same-repo.
+- Post-un-park there is a ~threshold-tick latency before R7 re-arms — by design
+  (reuses the tested freshly-propagating-claim protection); do not shortcut it by
+  having R8 add `fleet:design-unblocked` directly.
+- Everything the worker needs lives in `scripts/fleet/` + `docs/agents/` — do
+  **not** touch gated role/skill docs for this.
+
+## Task shape
+
+One task, one PR — no stack split. This plan file lands as the first commit of
+the implementation PR (#1932).

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -210,6 +210,41 @@ fix in Step i.)
   own host and reconcile before pushing. The authoritative handoff is the
   *pushed* PR head + the plan/comments, never the local working tree.
 
+### PARK — a `fleet:design-unblocked` PR nothing can verify (#2462)
+
+Before resuming, check whether the PR is actually *actionable on any host*. If
+the work is complete but cannot be built, run, or verified anywhere until some
+other issue lands, resuming it is a no-op that every pane repeats: R7 re-arms
+`fleet:design-unblocked` on a claimless WIP PR, so a bare label clear buys
+nothing and the PR comes straight back as an opus-tier feedback item. PR #2393
+absorbed **7** such pickups.
+
+Park it instead, in one `gh pr edit`:
+
+```
+gh pr edit <N> --remove-label "fleet:design-unblocked" --add-label "fleet:awaiting-infra"
+```
+
+then append a `Parked-until: #<blocker-issue>` line to the **PR body**
+(same-repo issue, on its own line — reconcile reads the last occurrence, so a
+re-park just appends), and comment the rationale. Keep `fleet:wip`, and release
+your claim: a parked PR is not yours to hold.
+
+Reconcile un-parks it automatically once the named blocker closes (R8), after
+which R7 re-surfaces it through this same path. Full semantics, and why an
+explicit marker is the only cross-host-correct signal:
+[`fleet-labels-reference.md`](fleet-labels-reference.md) §`fleet:awaiting-infra`.
+
+**Two cases need no park at all:**
+
+- **The backing issue already carries `fleet:blocked`.** R7 skips those outright
+  (#2462), so a plain `fleet:design-unblocked` clear is terminal — no marker, no
+  body edit. This is the common shape: the blocked state is already recorded by
+  the queue protocol.
+- **The residual is host-class-only, not blocked** (e.g. it needs a GL host and
+  you are on macOS). That is `fleet:needs-gl-host`, which the pickup filters
+  already honor — leave the PR alone and let a capable pane take it.
+
 ## AMEND vs ESCALATE (human-label paths only)
 
 For `human:needs-fix` / `human:blocker` only, choose a disposition.
@@ -653,5 +688,13 @@ mid-task design blocker and sets `fleet:design-blocked`; the
 architect responds and swaps the label to `fleet:design-unblocked`
 after updating the plan; any opus+-class worker iteration picks it
 back up via priority tier 4 above.
+
+**Infra-park cycle** (#2462): a worker resuming a `fleet:design-unblocked` PR
+finds the work complete but unverifiable on any host, swaps the label for
+`fleet:awaiting-infra` + a `Parked-until: #N` body line, and releases its claim
+→ reconcile R7/R2 skip the PR for as long as the park stands → reconcile R8
+removes the park label once #N closes → R7 re-arms `fleet:design-unblocked` at
+its usual threshold and the cycle above resumes. No worker action on the exit
+side. See the PARK section above.
 
 Address all flagged PRs before doing any other work.

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -551,6 +551,63 @@ Specifically, **never pass these via `--label` when filing**:
     are deliberately split: the PR-side label gives the projection a
     clean off-edge and the skip-lists a stable marker; the issue-side
     label is the pending-answer queue whose removal drives the cycle.
+- `fleet:awaiting-infra` — a **worker**-set park on a PR that is complete but
+  **unverifiable on any current host** (#2462). Coexists with `fleet:wip`; it is
+  a state qualifier, not a transfer of ownership.
+
+  **Why it exists, distinct from `fleet:design-blocked` and `fleet:gated`:**
+  those two name a *permission* or *judgment* wall — someone specific (architect,
+  human) must act. This one names a **sequencing** wall: the work is done and
+  correct, nothing needs deciding, and no agent of any class can verify it until
+  some other issue lands. Overloading `fleet:gated` for this is the #1990
+  label-overload thrash in reverse.
+
+  **Why it exists as a label at all**, rather than reconcile inferring the park:
+  R7 cannot distinguish a worker's deliberate removal of `fleet:design-unblocked`
+  from a crashed worker whose claim was TTL-swept — and re-arming the latter is
+  exactly R7's job. Only an *explicit, GitHub-visible* marker separates the two,
+  and only a GitHub-visible one is correct across hosts (a host-local sentinel
+  suppresses nothing on the other host). This is the same shape as the
+  `fleet:design-proposed` exemption above.
+
+  **Park protocol** (worker, on adjudicating an orphaned `fleet:wip` PR as
+  complete-but-unverifiable-on-any-host):
+
+  1. remove `fleet:design-unblocked` if present and add `fleet:awaiting-infra`;
+  2. append `Parked-until: #<blocker-issue>` to the **PR body** — on its own
+     line, starting the line. Reconcile reads the **last** occurrence, so a
+     re-park just appends and earlier lines are inert history. Trailing prose
+     after the number is fine (`Parked-until: #2449 (the fmt build wall)`
+     parses) — but only the **first** `#N` on the line is the blocker, so an
+     aside mentioning another issue is ignored rather than read as a second
+     one (the over-match that stranded a row on the sibling `Blocked by:`
+     field, #2783). **v1 is same-repo only:** a cross-repo
+     `owner/repo#N` spelling does not parse and surfaces as a malformed park
+     (flag-only → human), which is the intended loud failure, not silence;
+  3. comment the rationale on the PR.
+
+  **Un-park is automatic.** Reconcile R8 checks the named blocker each `--apply`
+  tick and removes `fleet:awaiting-infra` once that issue closes. The PR then
+  reverts to an ordinary stranded WIP, R7 re-arms `fleet:design-unblocked` after
+  its usual tick threshold, and the normal worker resume loop adopts it — there
+  is no separate resume path. Do **not** have anything add `design-unblocked`
+  directly on un-park; the threshold delay is the tested protection against
+  acting on a claim that is still propagating.
+
+  **A park with no parsable `Parked-until:` line is unrecoverable state** —
+  nothing can ever tell reconcile when it ends — so R8 emits it as a *flag-only*
+  finding that accrues to the deduped `fleet:state-drift` tracker for a human. A
+  well-formed park carries an apply action instead, which the drift accrual
+  skips, so a legitimately long park never files a tracker.
+
+  **Reconcile's R7 also skips any PR whose backing issue is `fleet:blocked`** —
+  no label or body marker needed. Under the queue-all model (#1527) a blocked
+  task legitimately keeps `fleet:queued`, and a blocked issue means there is by
+  definition nothing for a resumed worker to do. `fleet:awaiting-infra` covers
+  the disjoint case: blocked on infra with no `Blocked by:` field to record it.
+  R2 deliberately keeps flagging both (it is flag-only and dedupes into one
+  tracker, so a human retains the visibility); only the auto-mutating rule is
+  narrowed.
 - `human:owned` — a human de-queue marker on an **issue**. A human
   stamps it to take an issue out of fleet rotation; `fleet-queue-ingest`
   then never re-stamps `fleet:queued` onto it (even though it keeps

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -189,6 +189,12 @@
       "description": "Epic-steward parked this design-blocked epic-child PR; its novel question(s) ride a STEWARD PROPOSAL on the umbrella; reviewer/merger/reconcile skip until the proposal is answered"
     },
     {
+      "name": "fleet:awaiting-infra",
+      "scope": "pr",
+      "color": "fbca04",
+      "description": "Worker adjudicated this orphaned WIP PR complete-but-unverifiable-on-any-host; the PR body carries Parked-until: #N naming the infra blocker; reconcile R7/R2 skip it and R8 un-parks when that issue closes (#2462)"
+    },
+    {
       "name": "fleet:steward-proposal",
       "scope": "issue",
       "color": "fbca04",

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -155,6 +155,13 @@ quietly in the queue — visible, not claimable, not swept — until either a
 worker stacks on it or its blocker closes and the unblock pass clears the
 marker.
 
+Once such a task **does** have an open WIP PR, R7 leaves it alone too: its
+finding loop skips any backing issue carrying `fleet:blocked` (#2462). Healing
+there would re-arm `fleet:design-unblocked` toward work whose own blocker is
+still unlanded, and every re-arm costs an opus dispatch that re-derives "still
+blocked" and puts the PR straight back down. R2 still flags it — it is
+flag-only and dedupes into one tracker, so the human keeps the visibility.
+
 ## Acceptance invariants
 
 - A blocked, approved, non-skip task → `fleet:queued` + model + `fleet:blocked`;

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -2651,7 +2651,9 @@ cmd_check_stale() {
 # auto-fix + R2 flag. C2 (#1357) adds R6 (fleet:queued+human:owned flag),
 # the periodic scout spawn (see fleet-state-scout), and the deduped
 # fleet:state-drift escalation issue for flag-only drift that persists
-# across N --apply ticks.
+# across N --apply ticks. #1516 adds R7 (heal a stranded WIP's missing
+# design-unblock); #2462 narrows R7 off provably-unactionable PRs and adds
+# R8, the exit half of the fleet:awaiting-infra park it introduces.
 
 # reconcile_fs_claims_json
 #   Emit the host-local FS claim set as a JSON array, one object per claim
@@ -2980,8 +2982,14 @@ for repo in repos:
             # awaiting re-adoption.) fleet:design-proposed parks the same way:
             # the steward released its claim and re-adoption is gated on the
             # umbrella's STEWARD PROPOSAL being answered, not a free pickup
-            # decision (#1663).
-            if "fleet:design-blocked" in labs or "fleet:design-proposed" in labs:
+            # decision (#1663). fleet:awaiting-infra parks the same way: a
+            # worker adjudicated the PR complete-but-unverifiable-on-any-host
+            # and released its claim, so claimless IS the correct state and
+            # re-adoption waits on the blocker named by the body's
+            # Parked-until: line, not on a pickup decision (#2462).
+            if ("fleet:design-blocked" in labs
+                    or "fleet:design-proposed" in labs
+                    or "fleet:awaiting-infra" in labs):
                 continue
             issue_labs = d["issue_labels"].get(issue_n, set())
             if (any(l.startswith("fleet:claim-") for l in issue_labs)
@@ -3024,6 +3032,17 @@ for repo in repos:
         issue_labs = d["issue_labels"].get(issue_n, set())
         if "fleet:queued" not in issue_labs:
             continue
+        # A fleet:blocked backing issue has nothing for the worker resume loop
+        # to act on: under the queue-all model (#1527) a blocked task keeps
+        # fleet:queued, so healing here re-arms a routing signal toward work
+        # that provably cannot proceed — the PR's own blocker is unlanded. Each
+        # such re-arm costs one opus dispatch that re-derives "still blocked"
+        # and puts the PR straight back down (#2462: PR #2393 absorbed 7).
+        # R2 deliberately still flags this state — it is flag-only and dedupes
+        # into one state-drift tracker, so a human keeps the visibility; only
+        # the auto-mutating rule is narrowed.
+        if "fleet:blocked" in issue_labs:
+            continue
         # Same claimless test R2 uses — no FS claim, claim-label, or reservation.
         if (any(l.startswith("fleet:claim-") for l in issue_labs)
                 or (repo, issue_n) in fs_by_task
@@ -3036,10 +3055,18 @@ for repo in repos:
             # fleet:design-proposed exempts the PR: it IS a routing signal
             # (steward distribution, not worker resume) — healing it to
             # design-unblocked would un-park every steward proposal within
-            # a few drift ticks (#1663).
+            # a few drift ticks (#1663). fleet:awaiting-infra exempts it for
+            # the same reason: it is an explicit worker adjudication that no
+            # host can verify the PR until the blocker in its Parked-until:
+            # line lands, and R8 below un-parks it when that issue closes
+            # (#2462). This marker is the ONLY deliberate-removal signal R7
+            # honors — a bare removal of fleet:design-unblocked stays
+            # re-heal-able, because R7 cannot distinguish it from a crashed
+            # worker whose claim was TTL-swept, and re-arming that IS its job.
             if ("fleet:design-blocked" in labs
                     or "fleet:design-unblocked" in labs
-                    or "fleet:design-proposed" in labs):
+                    or "fleet:design-proposed" in labs
+                    or "fleet:awaiting-infra" in labs):
                 continue
             # Amend-snapshot guard: if a local sidecar exists and is fresh
             # (written within 2×TTL), the PR was recently claimed for amend
@@ -3060,6 +3087,61 @@ for repo in repos:
                 "queued issue, wip PR, no claim, neither design label",
                 apply={"type": "heal_design_unblock", "pr": pr["number"],
                        "repo": repo, "issue": issue_n})
+
+# ---- R8 (auto-un-park): fleet:awaiting-infra PR whose blocker has closed ----
+# The exit half of the park R7/R2 above exempt (#2462). A worker parks an
+# orphaned WIP PR it has adjudicated complete-but-unverifiable-on-any-host by
+# adding fleet:awaiting-infra and naming the blocker in a `Parked-until: #N`
+# body line. R8 watches for that blocker closing and drops the label, after
+# which the PR is an ordinary stranded WIP again and the existing R7 machinery
+# re-surfaces it — no new resume path.
+#
+# Iterates the flat prs list rather than pr_by_issue for two reasons: a parked
+# PR need not have a resolvable backing-issue mapping, and pr_by_issue entries
+# carry only number+labels (the body, which holds the marker, is dropped).
+#
+# A parsable marker yields an apply-carrying finding, which reconcile_escalate_drift
+# skips — so a legitimately long park never files a state-drift tracker. A
+# missing/malformed marker yields a FLAG-ONLY finding, so it accrues normally
+# and escalates to a human: an un-parseable park is unrecoverable state, since
+# nothing can ever tell reconcile when it ends.
+# Trailing prose after the number is TOLERATED — "Parked-until: #2449 (the fmt
+# build wall)" parses — because writing the reason inline is the shape a worker
+# actually produces, and a `$`-anchored matcher would escalate that perfectly
+# good park to a human as malformed.
+#
+# What makes the leniency safe is that exactly ONE number is taken per line (the
+# first after the marker), never every #N on it. The sibling `Blocked by:`
+# parser is the cautionary case in the other direction: it collects every ref on
+# the line, so a parenthetical aside read as an extra blocker and stranded the
+# row (#2783). Widen the trailing match, never the capture.
+#
+# The line start stays anchored so a mention inside prose is not a marker.
+PARKED_UNTIL_RE = re.compile(r"^[ \t]*Parked-until:[ \t]*#(\d+)\b",
+                             re.IGNORECASE | re.MULTILINE)
+
+for repo in repos:
+    d = repo_data[repo]
+    for pr in d["prs"]:
+        if "fleet:awaiting-infra" not in labelset(pr):
+            continue
+        # Last occurrence wins: a re-park appends a fresh line rather than
+        # rewriting the body, so earlier markers are inert history.
+        marks = PARKED_UNTIL_RE.findall(pr.get("body", "") or "")
+        if not marks:
+            add("R8", repo, pr["number"], "pr", ["pr", "label"],
+                "fleet:awaiting-infra with no parsable 'Parked-until: #N' line "
+                "in the PR body; nothing can tell reconcile when the park ends "
+                "— add the line or drop the label",
+                "flag-only (R8)")
+            continue
+        blocker = int(marks[-1])
+        add("R8", repo, pr["number"], "pr", ["pr", "label"],
+            "parked behind #%d; remove fleet:awaiting-infra once that issue "
+            "closes (R7 then re-surfaces the PR)" % blocker,
+            "awaiting-infra PR with Parked-until: #%d" % blocker,
+            apply={"type": "unpark_infra", "pr": pr["number"], "repo": repo,
+                   "blocker": blocker})
 
 for f in findings:
     print(json.dumps(f))
@@ -3144,6 +3226,9 @@ PYEOF
                 # heal_design_unblock (R7) is deliberately NOT applied here — it
                 # is persistence-gated, handled by reconcile_heal_design_unblock
                 # below so a freshly-opened WIP PR is never healed prematurely.
+                # unpark_infra (R8) is also handled below, by
+                # reconcile_unpark_infra — it needs a live per-blocker issue
+                # lookup, which does not belong in this per-line dispatch.
             esac
         done < "$findings"
     fi
@@ -3155,6 +3240,17 @@ PYEOF
     # so a fresh WIP PR mid-claim-propagation is never touched. --apply only.
     if [[ $do_apply -eq 1 ]]; then
         reconcile_heal_design_unblock "$findings" "$state_dir" "${FLEET_RECONCILE_DRIFT_TICKS:-3}"
+    fi
+
+    # ---- auto-un-park of infra-parked PRs whose blocker closed (#2462) ----
+    # R8 marks a fleet:awaiting-infra PR whose body names its blocker.
+    # reconcile_unpark_infra checks that blocker live and drops the label once
+    # it closes, handing the PR back to R7's normal re-surfacing path.
+    # --apply only. Runs after the heal so a PR un-parked this tick starts its
+    # heal accrual on the NEXT tick — it is not both un-parked and healed in
+    # one pass.
+    if [[ $do_apply -eq 1 ]]; then
+        reconcile_unpark_infra "$findings"
     fi
 
     # ---- persistence-gated, deduped escalation of unfixable drift (C2) ----
@@ -3499,6 +3595,51 @@ PYEOF
             echo "  reconcile --apply: R7 failed to re-add fleet:design-unblocked on $repo #$pr (retries next tick)" >&2
         fi
     done <<< "$healable"
+}
+
+# reconcile_unpark_infra <findings-jsonl>
+#   Apply half of R8 (#2462). Consumes R8 findings carrying an apply action
+#   (type == unpark_infra): an open PR labelled fleet:awaiting-infra whose body
+#   names its blocker in a `Parked-until: #N` line. Verifies that blocker LIVE
+#   — the reconcile issue surface is fetched filtered to label:"fleet:queued",
+#   so a blocker that has closed (or was never queued) is simply absent from it
+#   and cannot be distinguished from "still open" without asking. When the
+#   blocker is CLOSED, remove fleet:awaiting-infra: the PR reverts to an
+#   ordinary stranded WIP and R7 re-arms fleet:design-unblocked after its usual
+#   threshold, so the worker resume loop adopts it through the existing path.
+#
+#   Deliberately NOT persistence-gated, unlike the R7 heal. The heal's gate
+#   exists because its trigger state (claim labels still propagating) is
+#   routinely transient; a closed issue is a durable, deliberate act. The bad
+#   case — blocker reopened just after an un-park — self-corrects: R7 re-arms,
+#   a worker re-adjudicates and re-parks.
+#
+#   Never edits PR bodies, so a stale earlier Parked-until: line stays inert
+#   (detection takes the last occurrence). Mutates a GH label, so cmd_reconcile
+#   calls it on --apply only.
+reconcile_unpark_infra() {
+    local findings="$1"
+    local line atype repo pr blocker state
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        atype=$(reconcile_apply_field "$line" type)
+        [[ "$atype" == "unpark_infra" ]] || continue
+        repo=$(reconcile_apply_field "$line" repo)
+        pr=$(reconcile_apply_field "$line" pr)
+        blocker=$(reconcile_apply_field "$line" blocker)
+        [[ -z "$repo" || -z "$pr" || -z "$blocker" ]] && continue
+        state=$(gh issue view "$blocker" --repo "$repo" --json state \
+            --jq '.state' 2>/dev/null || true)
+        # Anything other than a confirmed CLOSED (OPEN, or a lookup failure
+        # that yields an empty string) leaves the park standing; the finding
+        # recurs next tick, so a transient API failure costs nothing.
+        [[ "$state" == "CLOSED" ]] || continue
+        if gh_release_label "$repo" "$pr" "fleet:awaiting-infra"; then
+            echo "  reconcile --apply: R8 un-parked $repo #$pr — blocker #$blocker is closed; removed fleet:awaiting-infra"
+        else
+            echo "  reconcile --apply: R8 failed to remove fleet:awaiting-infra on $repo #$pr (retries next tick)" >&2
+        fi
+    done < "$findings"
 }
 
 cmd_stack() {
@@ -4819,10 +4960,18 @@ commands:
                                         recently-applied, remove the older;
                                   R4b   queued + in-progress with no claim
                                         (any host) + no open PR → remove the
-                                        stale fleet:in-progress.
+                                        stale fleet:in-progress;
+                                  R7    stranded fleet:wip PR on a queued,
+                                        unblocked issue with neither design
+                                        label → re-add fleet:design-unblocked
+                                        (persistence-gated over N ticks);
+                                  R8    fleet:awaiting-infra PR whose body
+                                        names a now-CLOSED Parked-until: #N
+                                        blocker → remove the park label.
                                 R2 (orphaned WIP/feedback PR with no claim;
-                                fleet:design-blocked / fleet:design-proposed
-                                PRs exempt — their no-claim state is
+                                fleet:design-blocked / fleet:design-proposed /
+                                fleet:awaiting-infra PRs exempt — their
+                                no-claim state is
                                 protocol-correct) is report-only. Cross-host
                                 is flag-only by
                                 construction — never auto-releases another

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -128,6 +128,7 @@ LABELS=(
     "fleet:design-blocked|fbca04|Worker escalated for architectural input mid-task; architect should respond"
     "fleet:design-unblocked|c5def5|Architect responded; worker resumes per the architect comment + updated plan file"
     "fleet:design-proposed|fbca04|Epic-steward parked this design-blocked child; its question rides a STEWARD PROPOSAL upstream"
+    "fleet:awaiting-infra|fbca04|Complete-but-unverifiable PR parked until an infra blocker lands; body carries Parked-until: #N"
     "fleet:steward-proposal|fbca04|Umbrella has a pending STEWARD PROPOSAL; human answers inline + removes it (re-fires distribution)"
     "fleet:needs-linux-smoke|c5def5|Engine render PR awaiting Linux/OpenGL cross-host smoke validation"
     "fleet:needs-macos-smoke|c5def5|Engine render PR awaiting macOS/Metal cross-host smoke validation"

--- a/scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh
@@ -56,31 +56,58 @@ HEALPERSIST="$FLEET_STATE_DIR/design-unblock-heal-persistence.json"
 # fleet:design-proposed — an epic-steward proposal park (#1663). It must be
 # INVISIBLE to both R7 (healing it would un-park the proposal) and R2 (its
 # no-claim state is protocol-correct), across every phase below.
+#
+# #2462 adds two more standing rows, both of which must stay unhealed for the
+# whole run (phases 7-10 assert the specifics):
+#   #1000/#1050 — the fleet:awaiting-infra park. PR #1050 is claimless wip on a
+#     queued issue (so it satisfies every legacy R7 predicate) but carries the
+#     park label and a `Parked-until: #7000` body line. Invisible to R7 AND R2;
+#     visible to R8, which un-parks it once #7000 closes.
+#   #1100/#1150 — the fleet:blocked backing issue. PR #1150 is a bare claimless
+#     wip PR with NEITHER design label — the exact legacy R7 target state — but
+#     its issue is fleet:blocked, so there is nothing for a resumed worker to
+#     do. R7 must skip it; R2 deliberately still flags it.
 export ISSUES_JSON="$TMPROOT/issues.json"
 export PRS_JSON="$TMPROOT/prs.json"
 cat > "$ISSUES_JSON" <<'JSON'
 [
   {"number":800,"state":"OPEN","labels":[{"name":"fleet:queued"}]},
-  {"number":900,"state":"OPEN","labels":[{"name":"fleet:queued"}]}
+  {"number":900,"state":"OPEN","labels":[{"name":"fleet:queued"}]},
+  {"number":1000,"state":"OPEN","labels":[{"name":"fleet:queued"}]},
+  {"number":1100,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:blocked"}]}
 ]
 JSON
+
+# The #2462 rows are appended to every PR fixture so they are exercised on
+# every tick, exactly as #950 is. PARKED_PR_JSON is swapped by the later
+# phases to model park/malformed-park/un-parked without disturbing #850.
+PARKED_PR_JSON='{"number":1050,"headRefName":"claude/1000-parked-infra",
+   "body":"Closes #1000\n\nParked-until: #7000",
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:awaiting-infra"}]}'
+standing_rows() {
+    cat <<JSON
+  {"number":950,"headRefName":"claude/900-steward-proposed","body":"Closes #900",
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-proposed"}]},
+  $PARKED_PR_JSON,
+  {"number":1150,"headRefName":"claude/1100-blocked-issue","body":"Closes #1100",
+   "labels":[{"name":"fleet:wip"}]}
+JSON
+}
 wip_only_prs() {
-    cat > "$PRS_JSON" <<'JSON'
+    cat > "$PRS_JSON" <<JSON
 [
   {"number":850,"headRefName":"claude/800-stranded-wip","body":"Closes #800",
    "labels":[{"name":"fleet:wip"}]},
-  {"number":950,"headRefName":"claude/900-steward-proposed","body":"Closes #900",
-   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-proposed"}]}
+$(standing_rows)
 ]
 JSON
 }
 healed_prs() {
-    cat > "$PRS_JSON" <<'JSON'
+    cat > "$PRS_JSON" <<JSON
 [
   {"number":850,"headRefName":"claude/800-stranded-wip","body":"Closes #800",
    "labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"}]},
-  {"number":950,"headRefName":"claude/900-steward-proposed","body":"Closes #900",
-   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-proposed"}]}
+$(standing_rows)
 ]
 JSON
 }
@@ -93,6 +120,11 @@ export CREATE_LOG="$TMPROOT/create.log"; : > "$CREATE_LOG"
 export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
 export CLOSE_LOG="$TMPROOT/close.log"; : > "$CLOSE_LOG"
 export TRACKER_STATE="$TMPROOT/tracker.exists"
+# R8 blocker state: $BLOCKERS_DIR/<n> holds that issue's canned state. A blocker
+# with no file reads OPEN, so the park stands by default and a test must opt in
+# to the closed case.
+export BLOCKERS_DIR="$TMPROOT/blockers"; mkdir -p "$BLOCKERS_DIR"
+set_blocker() { printf '%s' "$2" > "$BLOCKERS_DIR/$1"; }
 cat > "$STUB_DIR/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 case "$1" in
@@ -120,6 +152,24 @@ case "$1" in
             close)
                 printf '%s\n' "$*" >> "$CLOSE_LOG"
                 rm -f "$TRACKER_STATE"
+                exit 0 ;;
+            view)
+                # R8's live blocker lookup:
+                #   gh issue view <N> --repo <r> --json state --jq '.state'
+                # Model the real argument shape rather than just the endpoint
+                # (scripts/fleet/CLAUDE.md): a call we do not emulate must FAIL,
+                # never fall through to a plausible-looking empty answer, or the
+                # suite would certify an invocation gh itself rejects (#2781).
+                _args=$(printf '%s ' "$@")
+                case "$_args" in
+                    *"--json state "*) ;;
+                    *) echo "gh stub: unmodelled 'issue view' fields: $_args" >&2; exit 64 ;;
+                esac
+                case "$_args" in
+                    *"--jq .state "*) ;;
+                    *) echo "gh stub: unmodelled 'issue view' jq: $_args" >&2; exit 64 ;;
+                esac
+                if [[ -f "$BLOCKERS_DIR/$3" ]]; then cat "$BLOCKERS_DIR/$3"; else echo "OPEN"; fi
                 exit 0 ;;
             *) exit 0 ;;
         esac ;;
@@ -155,8 +205,14 @@ PY
 }
 
 # How many times R7 has re-added fleet:design-unblocked (R2 never adds it, so a
-# grep for the add-label line uniquely counts R7 heals).
+# grep for the add-label line uniquely counts R7 heals). du_add_count is the
+# whole-run total; du_adds scopes it to one PR. Per-phase assertions use the
+# SCOPED form: the fixture carries several PRs that must each stay quiet for
+# their own reason, and a global count silently couples every phase to all of
+# them — a heal leaking from one row would then fail another row's phase with a
+# message naming the wrong PR.
 du_add_count() { grep -c 'add-label fleet:design-unblocked' "$EDIT_LOG" 2>/dev/null || true; }
+du_adds() { grep -c "^issue edit $1 .*add-label fleet:design-unblocked" "$EDIT_LOG" 2>/dev/null || true; }
 
 echo "=== Phase 1: report-only detects R7 (fix-marked) + R2 (coexists) + stays pure ==="
 run_reconcile
@@ -189,21 +245,21 @@ PY
 echo "=== Phase 2: --apply ticks accrue; freshly-opened PR NOT healed below threshold ==="
 run_reconcile --apply
 c=$(heal_count); [[ "$c" == "1" ]] && ok "apply tick 1 → heal count 1" || bad "tick 1 count=$c (want 1)"
-c=$(du_add_count); [[ "$c" == "0" ]] && ok "tick 1 below threshold → no heal (fresh-PR no-op)" || bad "tick 1 healed early (add count=$c)"
+c=$(du_adds 850); [[ "$c" == "0" ]] && ok "tick 1 below threshold → no heal (fresh-PR no-op)" || bad "tick 1 healed early (add count=$c)"
 
 # Interleave a report-only run — must not advance the heal counter or heal.
 run_reconcile
 c=$(heal_count); [[ "$c" == "1" ]] && ok "interleaved report-only leaves heal count at 1" || bad "report-only changed heal count to $c"
-c=$(du_add_count); [[ "$c" == "0" ]] && ok "interleaved report-only heals nothing" || bad "report-only healed (add count=$c)"
+c=$(du_adds 850); [[ "$c" == "0" ]] && ok "interleaved report-only heals nothing" || bad "report-only healed (add count=$c)"
 
 run_reconcile --apply
 c=$(heal_count); [[ "$c" == "2" ]] && ok "apply tick 2 → heal count 2" || bad "tick 2 count=$c (want 2)"
-c=$(du_add_count); [[ "$c" == "0" ]] && ok "tick 2 still below threshold → no heal" || bad "tick 2 healed early (add count=$c)"
+c=$(du_adds 850); [[ "$c" == "0" ]] && ok "tick 2 still below threshold → no heal" || bad "tick 2 healed early (add count=$c)"
 
 echo "=== Phase 3: threshold tick heals (re-adds fleet:design-unblocked) ==="
 run_reconcile --apply
 c=$(heal_count); [[ "$c" == "3" ]] && ok "apply tick 3 → heal count 3 (== threshold)" || bad "tick 3 count=$c (want 3)"
-c=$(du_add_count); [[ "$c" == "1" ]] && ok "tick 3 healed: added fleet:design-unblocked exactly once" || bad "tick 3 add count=$c (want 1)"
+c=$(du_adds 850); [[ "$c" == "1" ]] && ok "tick 3 healed: added fleet:design-unblocked exactly once" || bad "tick 3 add count=$c (want 1)"
 if grep -q '850' "$EDIT_LOG" && grep -q 'add-label fleet:design-unblocked' "$EDIT_LOG"; then
     ok "heal targeted PR #850 with --add-label fleet:design-unblocked"
 else
@@ -214,16 +270,16 @@ echo "=== Phase 4: idempotent — once healed (label present), R7 stops firing =
 healed_prs   # PR #850 now carries fleet:design-unblocked
 run_reconcile --apply
 c=$(heal_count); [[ "$c" == "0" ]] && ok "healed PR → R7 no longer fires; counter resets to 0" || bad "counter not reset (count=$c)"
-c=$(du_add_count); [[ "$c" == "1" ]] && ok "no further heal once the label is back (still 1 add)" || bad "re-healed an already-healed PR (add count=$c)"
+c=$(du_adds 850); [[ "$c" == "1" ]] && ok "no further heal once the label is back (still 1 add)" || bad "re-healed an already-healed PR (add count=$c)"
 
 echo "=== Phase 5: re-stranded PR re-accrues + re-heals after threshold ==="
 wip_only_prs   # label lost again (e.g. another half-executed unblock)
 run_reconcile --apply   # count 1
 run_reconcile --apply   # count 2
-c=$(du_add_count); [[ "$c" == "1" ]] && ok "re-accrual below threshold does not re-heal yet" || bad "re-healed early (add count=$c)"
+c=$(du_adds 850); [[ "$c" == "1" ]] && ok "re-accrual below threshold does not re-heal yet" || bad "re-healed early (add count=$c)"
 run_reconcile --apply   # count 3 == threshold → re-heal
 c=$(heal_count); [[ "$c" == "3" ]] && ok "re-stranded reaches threshold again (count 3)" || bad "re-accrual count=$c (want 3)"
-c=$(du_add_count); [[ "$c" == "2" ]] && ok "recurring stranded state heals again after threshold" || bad "no re-heal after recurrence (add count=$c)"
+c=$(du_adds 850); [[ "$c" == "2" ]] && ok "recurring stranded state heals again after threshold" || bad "no re-heal after recurrence (add count=$c)"
 
 echo "=== Phase 6: design-proposed PR #950 never healed across any apply tick ==="
 if grep -q '950' "$EDIT_LOG"; then
@@ -241,6 +297,161 @@ print(sum(1 for k in (s if isinstance(s, dict) else {}) if k.endswith(":950")))
 PY
 )
 [[ "$c" == "0" ]] && ok "no heal-persistence key accrued for PR #950" || bad "heal persistence tracked the design-proposed PR (#950 keys=$c)"
+
+# --- #2462: the fleet:awaiting-infra park (R8) + the fleet:blocked predicate --
+# Quiet #850 first (give it back its design-unblocked label) so it stops
+# re-heal-cycling every 3 ticks and its lines stop interleaving into the log.
+# Every assertion below is PR-scoped regardless, so this is hygiene, not a
+# dependency.
+healed_prs
+
+# remove-label edits of the park label, whole-run.
+ai_remove_count() { grep -c 'remove-label fleet:awaiting-infra' "$EDIT_LOG" 2>/dev/null || true; }
+# Any edit the apply passes made to a specific PR number.
+edits_touching() { grep -c "^issue edit $1 " "$EDIT_LOG" 2>/dev/null || true; }
+
+echo "=== Phase 7: fleet:awaiting-infra park is invisible to R7 + R2, visible to R8 ==="
+run_reconcile
+python3 - "$REPORT" <<'PY' && ok "parked PR #1050: R8 fires with an unpark_infra apply naming blocker #7000" || bad "R8 missing/misshaped for the parked PR"
+import sys, json
+r = json.load(open(sys.argv[1]))
+r8 = [f for f in r["findings"] if f["rule"] == "R8" and f["target"] == 1050]
+assert r8, f"no R8 for #1050: {[(f['rule'], f['target']) for f in r['findings']]}"
+a = (r8[0].get("apply") or {})
+assert a.get("type") == "unpark_infra", f"R8 apply wrong: {a}"
+assert a.get("blocker") == 7000, f"R8 parsed the wrong blocker: {a}"
+PY
+python3 - "$REPORT" <<'PY' && ok "parked PR #1050 invisible to R7 AND R2 (park respected on both sites)" || bad "R7/R2 fired on the parked PR #1050"
+import sys, json
+r = json.load(open(sys.argv[1]))
+hits = [f for f in r["findings"] if f["target"] == 1050 and f["rule"] in ("R2", "R7")]
+assert not hits, f"parked PR must be exempt from R7+R2, got: {hits}"
+PY
+# The park has been standing since tick 1 (blocker #7000 defaults OPEN), so the
+# whole run so far is the >=threshold-ticks evidence.
+c=$(edits_touching 1050); [[ "$c" == "0" ]] && ok "no apply tick ever edited the parked PR #1050 (blocker still open)" || bad "an apply pass edited the parked PR (edits=$c)"
+c=$(python3 - "$HEALPERSIST" <<'PY'
+import sys, json
+try:
+    s = json.load(open(sys.argv[1]))
+except Exception:
+    print(0); raise SystemExit
+print(sum(1 for k in (s if isinstance(s, dict) else {}) if k.endswith(":1050")))
+PY
+)
+[[ "$c" == "0" ]] && ok "no heal-persistence key accrued for the parked PR #1050" || bad "heal persistence tracked the parked PR (#1050 keys=$c)"
+run_reconcile --apply
+run_reconcile --apply
+run_reconcile --apply
+c=$(ai_remove_count); [[ "$c" == "0" ]] && ok "3 more apply ticks with the blocker OPEN → still no un-park" || bad "un-parked while the blocker was open (removes=$c)"
+c=$(du_adds 1050); [[ "$c" == "0" ]] && ok "park suppresses the R7 heal across threshold ticks" || bad "healed a parked PR (#1050 adds=$c, want 0)"
+
+echo "=== Phase 8: blocker closes → R8 un-parks → R7 re-surfaces the PR (positive fire) ==="
+set_blocker 7000 CLOSED
+run_reconcile --apply
+c=$(ai_remove_count); [[ "$c" == "1" ]] && ok "closed blocker → exactly one remove-label fleet:awaiting-infra" || bad "un-park did not fire exactly once (removes=$c)"
+if grep -q '^issue edit 1050 .*remove-label fleet:awaiting-infra' "$EDIT_LOG"; then
+    ok "un-park targeted PR #1050 with --remove-label fleet:awaiting-infra"
+else
+    bad "un-park edit did not target PR #1050: $(grep 'awaiting-infra' "$EDIT_LOG" || echo none)"
+fi
+c=$(du_adds 1050); [[ "$c" == "0" ]] && ok "un-park does NOT itself add design-unblocked (R7 owns re-surfacing)" || bad "R8 short-circuited R7 (#1050 adds=$c, want 0)"
+# Model the post-un-park PR: label gone, stale Parked-until line left behind
+# (reconcile never edits bodies, so the inert line must not re-park it).
+PARKED_PR_JSON='{"number":1050,"headRefName":"claude/1000-parked-infra",
+   "body":"Closes #1000\n\nParked-until: #7000",
+   "labels":[{"name":"fleet:wip"}]}'
+healed_prs
+run_reconcile --apply   # count 1
+run_reconcile --apply   # count 2
+c=$(du_adds 1050); [[ "$c" == "0" ]] && ok "un-parked PR accrues below threshold without healing" || bad "healed early after un-park (#1050 adds=$c)"
+run_reconcile --apply   # count 3 == threshold
+c=$(du_adds 1050); [[ "$c" == "1" ]] && ok "un-parked PR re-surfaces: R7 heals it at threshold" || bad "un-parked PR never re-surfaced (#1050 adds=$c, want 1)"
+if grep -q '^issue edit 1050 .*add-label fleet:design-unblocked' "$EDIT_LOG"; then
+    ok "the re-surfacing heal targeted PR #1050"
+else
+    bad "no design-unblocked add recorded for PR #1050"
+fi
+c=$(ai_remove_count); [[ "$c" == "1" ]] && ok "a stale Parked-until line with no label never re-parks or re-un-parks" || bad "stale marker drove another un-park (removes=$c)"
+
+echo "=== Phase 9: malformed park (label, no Parked-until line) is flag-only ==="
+PARKED_PR_JSON='{"number":1050,"headRefName":"claude/1000-parked-infra",
+   "body":"Closes #1000",
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:awaiting-infra"}]}'
+healed_prs
+run_reconcile
+python3 - "$REPORT" <<'PY' && ok "malformed park → flag-only R8 (accrues to the state-drift tracker)" || bad "malformed park did not produce a flag-only R8"
+import sys, json
+r = json.load(open(sys.argv[1]))
+r8 = [f for f in r["findings"] if f["rule"] == "R8" and f["target"] == 1050]
+assert r8, "no R8 finding for the malformed park"
+assert r8[0].get("apply") is None, f"malformed park must be flag-only, got: {r8[0].get('apply')}"
+PY
+before=$(ai_remove_count)
+run_reconcile --apply
+c=$(ai_remove_count); [[ "$c" == "$before" ]] && ok "malformed park is never auto-un-parked" || bad "un-parked a malformed park (removes=$c, was $before)"
+c=$(du_adds 1050); [[ "$c" == "1" ]] && ok "malformed park still suppresses the R7 heal (no heal beyond the phase-8 one)" || bad "healed a malformed park (#1050 adds=$c, want 1)"
+
+echo "=== Phase 9b: trailing prose parses, and only the FIRST #N is the blocker ==="
+# Two contracts in one fixture. A worker WILL write the reason inline, so the
+# match must not be $-anchored — but the aside here also mentions a second
+# issue, and picking that up is the exact over-match that stranded a row on the
+# sibling `Blocked by:` field (#2783). Widen the trailing match, not the capture.
+PARKED_PR_JSON='{"number":1050,"headRefName":"claude/1000-parked-infra",
+   "body":"Closes #1000\n\nParked-until: #7001 (the build wall; see also #7002)",
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:awaiting-infra"}]}'
+healed_prs
+run_reconcile
+python3 - "$REPORT" <<'PY' && ok "trailing prose parses, and the aside's #7002 is NOT taken as the blocker" || bad "Parked-until parse broke on trailing prose or over-matched the aside"
+import sys, json
+r = json.load(open(sys.argv[1]))
+r8 = [f for f in r["findings"] if f["rule"] == "R8" and f["target"] == 1050]
+assert r8, "no R8 finding at all"
+a = (r8[0].get("apply") or {})
+assert a.get("type") == "unpark_infra", f"parsed as malformed/flag-only: {r8[0]}"
+assert a.get("blocker") == 7001, f"wrong blocker parsed (over-matched the aside?): {a}"
+PY
+# The capture is one-per-line, so the aside cannot un-park the PR either:
+# #7002 is canned CLOSED, and the park must still stand on #7001 being open.
+set_blocker 7002 CLOSED
+before=$(ai_remove_count)
+run_reconcile --apply
+c=$(ai_remove_count); [[ "$c" == "$before" ]] && ok "a CLOSED issue mentioned only in the aside does not un-park" || bad "the aside's issue drove an un-park (removes=$c, was $before)"
+
+echo "=== Phase 10: fleet:blocked backing issue suppresses R7 (not R2) ==="
+# Non-vacuity: PR #1150 is a bare claimless wip PR with neither design label —
+# byte-for-byte the legacy R7 target state — so the ONLY thing standing between
+# it and a heal is its issue's fleet:blocked label. R2 flagging it is the proof
+# the row reached the rules at all.
+run_reconcile
+python3 - "$REPORT" <<'PY' && ok "blocked-issue PR #1150 IS seen (R2 still flags it) but R7 skips it" || bad "R7/R2 wrong on the blocked-issue PR"
+import sys, json
+r = json.load(open(sys.argv[1]))
+r2 = [f for f in r["findings"] if f["rule"] == "R2" and f["target"] == 1150]
+r7 = [f for f in r["findings"] if f["rule"] == "R7" and f["target"] == 1150]
+assert r2, "R2 must still flag the blocked-issue WIP PR (it is deliberately NOT narrowed)"
+assert not r7, f"R7 must skip a fleet:blocked backing issue, got: {r7}"
+PY
+c=$(edits_touching 1150); [[ "$c" == "0" ]] && ok "no apply tick across the whole run ever edited PR #1150" || bad "an apply pass edited the blocked-issue PR (edits=$c)"
+c=$(python3 - "$HEALPERSIST" <<'PY'
+import sys, json
+try:
+    s = json.load(open(sys.argv[1]))
+except Exception:
+    print(0); raise SystemExit
+print(sum(1 for k in (s if isinstance(s, dict) else {}) if k.endswith(":1150")))
+PY
+)
+[[ "$c" == "0" ]] && ok "no heal-persistence key accrued for the blocked-issue PR #1150" || bad "heal persistence tracked the blocked-issue PR (keys=$c)"
+# Control: an otherwise-identical PR on an UNBLOCKED queued issue still heals,
+# so the quiet above is the fleet:blocked predicate and not a dead fixture.
+PARKED_PR_JSON='{"number":1050,"headRefName":"claude/1000-parked-infra",
+   "body":"Closes #1000","labels":[{"name":"fleet:wip"}]}'
+wip_only_prs   # #850 stranded again: the unblocked control
+run_reconcile --apply
+run_reconcile --apply
+run_reconcile --apply
+c=$(du_adds 850); [[ "$c" -gt 2 ]] && ok "control: the unblocked twin DOES heal on the same ticks" || bad "control did not heal — the blocked-issue quiet proves nothing (#850 adds=$c, want >2)"
 
 echo
 echo "================================"


### PR DESCRIPTION
## Summary

- `reconcile` R7 re-added `fleet:design-unblocked` to any claimless `fleet:wip` PR on a `fleet:queued` issue carrying no design label. The predicate never asked whether the work could *proceed*, so a PR parked behind an unlanded blocker re-armed indefinitely — and each re-arm routes an opus dispatch (`feedback_pr_class` maps the label → opus) that makes zero progress. PR #2393 has absorbed **7**.
- **Two disjoint populations, two mechanisms.** Backing issue already `fleet:blocked` → R7 skips it outright, no marker and no worker action (the queue protocol already recorded the state). Blocked on infra with no `Blocked by:` field → the worker parks explicitly with the new **`fleet:awaiting-infra`** label + a `Parked-until: #N` PR-body line, which R7 *and* R2 exempt.
- **New rule R8 owns the exit**: it reads the marker, checks that blocker live each `--apply` tick, and drops the park label once the issue closes. The PR then reverts to an ordinary stranded WIP and the existing R7 machinery re-surfaces it — no new resume path, and the threshold delay that protects a still-propagating claim is preserved.
- A park with **no parsable marker** is unrecoverable state (nothing can ever say when it ends), so it surfaces as a *flag-only* finding that accrues to the deduped `fleet:state-drift` tracker instead of sitting silent.

### Why an explicit label, and not an inference

The issue body proposed three candidate directions; two are refuted in the thread and this PR takes neither:

- **Per-PR re-heal cap** — `design-unblock-heal-persistence.json` is reset-on-success by construction (only keys found *this* run are written back), so a cap built on it always reads zero at the exact moment it would need to say "already healed once".
- **Infer a worker's deliberate un-set from label events** — R7 cannot distinguish that from a crashed worker whose claim was TTL-swept, and re-arming the latter is precisely its job. Timestamp correlation against local state is per-host; the fleet is not.

Only an explicit, GitHub-visible marker is cross-host-correct. That is the same shape as the existing `fleet:design-proposed` exemption at the same code site (#1663), which this extends.

## Test plan

- [x] Extended `test_fleet_claim_reconcile_heal_design_unblock.sh`: **43 passed / 0 failed** (was 21 assertions; +22).
- [x] Positive control vs `origin/master` — **26 passed / 17 failed** on pre-fix code. All 17 failures land in the new phases 7–10; **zero** in the legacy phases 1–6, so the fixture additions do not perturb the existing #1516 coverage.
- [x] `bash scripts/fleet/tests/run_all.sh` — **123/124 suites pass**. The one failure, `test_cross_repo_shared_file_parity.sh`, is `.github/workflows/auto-rereview.yml` drift that reproduces on `origin/master`; this branch does not touch that file (`git diff origin/master -- .github/workflows/auto-rereview.yml` is empty) and a separate downstream PR already carries the sync.
- [x] `./scripts/fleet/fleet-labels --check` — OK, catalog and state-machine agree (56 labels), all descriptions ≤100 chars.
- [x] `ruff check scripts/` — All checks passed.
- [x] `bash -n` clean on `fleet-claim` and the suite.

Note: `fleet-positive-control` exits 2 ("printed no tally") on this suite — it predates `lib_assert.sh` and hand-rolls its own `PASS: N  FAIL: M` line, which the tool cannot parse. That is #2917, not a result of this change; the counts above are read from the suite's own summary. Migrating the suite to `lib_assert.sh` is deliberately left out of this diff so the behavior change stays reviewable.

## Acceptance evidence

| Criterion (from the `## Plan` comment) | Check run | Observed |
|---|---|---|
| Parked PR produces no R7 heal and no R2 flag across ≥ threshold `--apply` ticks | suite phase 7 | `ok: parked PR #1050 invisible to R7 AND R2`; `ok: no apply tick ever edited the parked PR #1050`; `ok: park suppresses the R7 heal across threshold ticks` |
| **Positive-fire:** blocker CLOSED → one `--apply` tick removes the label, and R7 subsequently re-heals at threshold | suite phase 8 | `ok: closed blocker → exactly one remove-label fleet:awaiting-infra`; `ok: un-parked PR re-surfaces: R7 heals it at threshold`; `ok: un-park does NOT itself add design-unblocked (R7 owns re-surfacing)` |
| Genuine #1516 case still heals at threshold; existing phases unchanged and green | suite phases 1–6 + control | 21/21 legacy assertions green on the fix, and **0** of them fail on pre-fix code (control attribution above) |
| Malformed park escalates via the flag-only → state-drift path | suite phase 9 | `ok: malformed park → flag-only R8 (accrues to the state-drift tracker)`; `ok: malformed park is never auto-un-parked` |
| *(07-28 thread amendment)* `fleet:blocked` backing issue suppresses R7, with a live control | suite phase 10 | `ok: blocked-issue PR #1150 IS seen (R2 still flags it) but R7 skips it`; `ok: control: the unblocked twin DOES heal on the same ticks` |
| `fleet-labels --check` green; whole test file green; verifiable on any host | commands above | both green; bash/python only, no engine build (run on macOS) |

The blocked-issue arm is deliberately **non-vacuous**: PR #1150 is a bare claimless `fleet:wip` PR with neither design label — byte-for-byte the legacy R7 target state — so the only thing between it and a heal is its issue's `fleet:blocked` label, and R2 still flagging it is the proof the row reached the rules at all.

## Notes for the reviewer

- **R2 is deliberately not narrowed** for either population. It is flag-only and dedupes into a single tracker, so a human keeps visibility on an orphaned WIP; only the auto-mutating rule is gated. (R2 *does* exempt `fleet:awaiting-infra`, which is an explicit park, per the plan's "miss one and a parked PR keeps accruing" gotcha.)
- **Only the first `#N` on a marker line is the blocker.** Trailing prose parses — a worker writing the reason inline is the shape that actually occurs — but widening the trailing match must not widen the capture, which is how a parenthetical aside became a second blocker on the sibling `Blocked by:` field (#2783). Phase 9b pins both halves, including that a CLOSED issue named only in the aside does not un-park.
- R8's live `gh issue view` is bounded by the `fleet-net.sh` `gh()` shadow that `fleet-claim` already sources, so it cannot hang a daemon tick.
- The `gh` stub's new `issue view` arm validates the real flag shape and exits 64 on anything it does not model, per `scripts/fleet/CLAUDE.md` (#2781).
- This does **not** change the standing "never clear `fleet:design-unblocked` to quiet the churn" guidance on its own — a bare clear is still re-heal-able by design. What changes is that on a `fleet:blocked` row a clear is now terminal, and on an infra-blocked row there is a park that sticks.

Closes #2462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
