### PR TITLE
fleet-decisions: give the untriaged backlog cue a drain threshold

### DIFF
--- a/scripts/fleet/fleet-decisions
+++ b/scripts/fleet/fleet-decisions
@@ -7,8 +7,9 @@
 # fleet:state-drift, human:review-plan holds), backlog cues
 # (fleet:coding-improvement, untriaged issues), and unread feedback-channel
 # entries. Backlog cues flip to OVERDUE past their drain thresholds
-# (coding-improvement count, feedback-marker age) — the informational cue
-# alone let the coding-improvement backlog reach 54 before its first drain.
+# (coding-improvement count, untriaged count, feedback-marker age) — the
+# informational cue alone let the coding-improvement backlog reach 54 before
+# its first drain.
 # Read-only: changes no labels, writes no state.
 #
 # Usage:
@@ -127,6 +128,7 @@ WIP_TITLE_RE = re.compile(r"\[WIP\]")
 # a full architect session, and rules sit unabsorbed while their mistakes
 # recur (the acceptance-evidence omission recurred 4x with its fix filed).
 CI_DRAIN_THRESHOLD = 12
+UNTRIAGED_DRAIN_THRESHOLD = 12
 FEEDBACK_STALE_DAYS = 14
 
 # label -> human-readable decision tag; presence on an open PR/issue means
@@ -235,9 +237,16 @@ if untriaged:
     newest = ", ".join(
         f"{repo} #{issue['number']}" for repo, issue in untriaged[:5]
     )
-    cues.append(
-        f"untriaged (no state labels): {len(untriaged)} awaiting triage — {newest}"
-    )
+    if len(untriaged) >= UNTRIAGED_DRAIN_THRESHOLD:
+        cues.append(
+            f"untriaged (no state labels): {len(untriaged)} awaiting triage — "
+            f"OVERDUE (drain threshold {UNTRIAGED_DRAIN_THRESHOLD}): {newest} — "
+            "the human-cued triage sweep (docs/agents/triage-protocol.md) is the drain"
+        )
+    else:
+        cues.append(
+            f"untriaged (no state labels): {len(untriaged)} awaiting triage — {newest}"
+        )
 if unread_roles:
     unread = (
         f"feedback channel: {len(unread_roles)} role file(s) unread "

--- a/scripts/fleet/tests/test_decisions.sh
+++ b/scripts/fleet/tests/test_decisions.sh
@@ -15,7 +15,8 @@
 #   - cues: coding-improvement count, untriaged count, unread feedback roles
 #     (file newer than .last-reviewed counts, older does not)
 #   - drain thresholds: coding-improvement cue flips to OVERDUE at >= 12
-#     open (informational below); feedback cue flips to OVERDUE when the
+#     open (informational below); untriaged cue flips to OVERDUE at >= 12
+#     awaiting (informational below); feedback cue flips to OVERDUE when the
 #     .last-reviewed marker is >= 14 days old or absent (informational when
 #     fresh) — both arms of each threshold exercised
 #   - headline decision count = merge queue + decisions
@@ -141,6 +142,7 @@ assert_absent  "$out" "fleet:coding-improvement: 1 open — OVERDUE" "1 open nev
 assert_contains "$out" "stale threshold 14d" "ancient .last-reviewed marker flips feedback cue to OVERDUE"
 assert_contains "$out" "untriaged (no state labels): 1" "untriaged cue counts label-less issue"
 assert_contains "$out" "engine #203" "untriaged cue names the issue"
+assert_absent  "$out" "untriaged (no state labels): 1 awaiting triage — OVERDUE" "1 untriaged never reads as overdue"
 assert_contains "$out" "merger" "feedback role newer than marker is unread"
 assert_absent  "$out" "role-worker" "feedback role older than marker is not unread"
 assert_contains "$out" "engine: 6 open PR(s) · 1 queued · 1 needs-plan" "status footer"
@@ -183,6 +185,48 @@ out=$(cat "$TMP/out.txt")
 assert_eq "$status" "0" "threshold run exits 0"
 assert_contains "$out" "fleet:coding-improvement: 12 open — OVERDUE" "12 open flips the cue to OVERDUE"
 assert_contains "$out" "drain threshold 12" "overdue cue names the threshold"
+
+# 11 untriaged (label-less) issues: the cue stays informational, one under
+# the drain threshold.
+python3 - "$TMP/engine-issues-untriaged-11.json" << 'PYEOF'
+import json
+import sys
+
+issues = [
+    {"number": 400 + i, "title": f"idea: untriaged {i}", "url": "u", "labels": []}
+    for i in range(11)
+]
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(issues, f)
+PYEOF
+
+status=$(GH_STUB_ENGINE_ISSUES="$TMP/engine-issues-untriaged-11.json" run_decisions --repo=engine)
+out=$(cat "$TMP/out.txt")
+assert_eq "$status" "0" "11-untriaged run exits 0"
+assert_contains "$out" "untriaged (no state labels): 11 awaiting triage — engine #400" \
+    "11 open renders informational, no OVERDUE marker"
+assert_absent  "$out" "OVERDUE" "11 untriaged never reads as overdue"
+
+# 12 untriaged issues: the cue flips to OVERDUE.
+python3 - "$TMP/engine-issues-untriaged-12.json" << 'PYEOF'
+import json
+import sys
+
+issues = [
+    {"number": 400 + i, "title": f"idea: untriaged {i}", "url": "u", "labels": []}
+    for i in range(12)
+]
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(issues, f)
+PYEOF
+
+status=$(GH_STUB_ENGINE_ISSUES="$TMP/engine-issues-untriaged-12.json" run_decisions --repo=engine)
+out=$(cat "$TMP/out.txt")
+assert_eq "$status" "0" "12-untriaged run exits 0"
+assert_contains "$out" "untriaged (no state labels): 12 awaiting triage — OVERDUE" \
+    "12 open flips the untriaged cue to OVERDUE"
+assert_contains "$out" "drain threshold 12" "overdue untriaged cue names the threshold"
+assert_contains "$out" "triage-protocol.md" "overdue untriaged cue names the drain"
 
 # Restore the ancient marker layout for any later cases.
 touch -t 202401010000 "$TMP/fleet-home/feedback/role-worker.md"


### PR DESCRIPTION
## Summary
- `fleet-decisions` gains `UNTRIAGED_DRAIN_THRESHOLD = 12`, mirroring `CI_DRAIN_THRESHOLD` — the sibling count-of-open-tickets cue. Past the threshold the untriaged cue now renders OVERDUE, naming the threshold and the drain (the human-cued triage sweep, `docs/agents/triage-protocol.md`).
- `test_decisions.sh` gains both arms (11 → informational, 12 → OVERDUE) plus an explicit "1 never reads as overdue" assertion for symmetry with the coding-improvement cue's existing coverage. Header comment block updated to mention all three thresholds.
- Header docstring's threshold enumeration corrected to include the untriaged count (previously listed only coding-improvement + feedback-marker age).

## Test plan
- [x] `bash scripts/fleet/tests/test_decisions.sh` on unmodified `origin/master` — 43 passed, 0 failed (the issue's cited "40 passing at base" predates #2884 landing a 5th PR-decision fixture on `origin/master`; measured the actual base directly rather than trusting the stale count)
- [x] `bash scripts/fleet/tests/test_decisions.sh` on this branch — 51 passed, 0 failed (+8 new assertions across the two new arms, all passing)
- [x] `ruff check scripts/` — clean
- [x] `bash scripts/fleet/tests/run_all.sh` — 123/124 suites pass; the one pre-existing failure (`test_cross_repo_shared_file_parity.sh`, a `.github/workflows/auto-rereview.yml` drift between engine and game repos) reproduces identically on unmodified `origin/master`, unrelated to this change

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. `UNTRIAGED_DRAIN_THRESHOLD` constant added, untriaged cue gains an OVERDUE arm mirroring coding-improvement's if/elif shape, value 12 | `git diff scripts/fleet/fleet-decisions` | `UNTRIAGED_DRAIN_THRESHOLD = 12` added beside `CI_DRAIN_THRESHOLD`; `if len(untriaged) >= UNTRIAGED_DRAIN_THRESHOLD: ... else: ...` |
| 2. OVERDUE text names the threshold and the drain | `fleet-decisions` output at 12 untriaged | `untriaged (no state labels): 12 awaiting triage — OVERDUE (drain threshold 12): ... — the human-cued triage sweep (docs/agents/triage-protocol.md) is the drain` |
| 3. `test_decisions.sh` gains both arms (11 informational, 12 OVERDUE); header updates; suite green | `bash scripts/fleet/tests/test_decisions.sh` | `fleet-decisions tests: 51 passed, 0 failed` (43 at base, see test plan) |
| 4. Positive control: reverting the new `>=` comparison turns the new assertions red | `fleet-positive-control scripts/fleet/tests/test_decisions.sh origin/master` | `MEANINGFUL: 3 of 51 assertions fail against origin/master (12b8a49c8)` |
| 5. Live smoke: untriaged cue prints OVERDUE at the current population | `bash scripts/fleet/tests/test_decisions.sh` (12-untriaged fixture arm; live population is currently well past 12) | `ok: 12 open flips the untriaged cue to OVERDUE` |

Closes #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)
