### PR TITLE
fleet/CI: generalize the path-list sync ratchet beyond fleet-tests.yml (#2929)

### DIFF
--- a/.github/workflows/fleet-tests.yml
+++ b/.github/workflows/fleet-tests.yml
@@ -10,21 +10,29 @@ name: Fleet Tests
 # CMake, so they have no reason to ride along with a build job anyway.
 #
 # Path-filtered to the fleet tooling surface — engine, shader, and asset
-# PRs skip this entirely (same convention as perf-gate.yml). Four suites
+# PRs skip this entirely (same convention as perf-gate.yml). Five suites
 # reach outside scripts/fleet/** for their subject under test — their
 # subjects are listed explicitly below so a PR touching only one of them
-# still runs this workflow (#2786, #2810, #2823):
+# still runs this workflow (#2786, #2810, #2823, #2929):
 #   test_format_changed_line_scoping.sh -> cmake/run_clang_format_changed.cmake
 #   test_ir_build_dir_resolution.sh     -> engine/tools/lib/concurrency_helpers.sh
 #   test_fleet_transition.sh            -> docs/agents/fleet-state-machine.json
 #   test_lint_rules_commands.py         -> .claude/rules/**, docs/agents/**
-# That last one's subjects are globs rather than single files — it checks
-# every rules/protocol doc's fenced Detection/command blocks, so a PR that
-# edits only a rules or protocol doc must still trigger this workflow;
-# without those paths the exact PR that landed a doc-ahead-of-executor
-# citation (ce2d2c57a) would not have run it (#2823). `docs/agents/**`
-# subsumes docs/agents/fleet-state-machine.json — the narrower entry stays
-# because the ratchet below asserts that subject by name.
+#   test_workflow_paths_sync.sh         -> the other path-filtered workflows
+#                                          (header-checks, perf-gate,
+#                                          render-harness-tests)
+# test_lint_rules_commands.py's subjects are globs rather than single files
+# — it checks every rules/protocol doc's fenced Detection/command blocks, so
+# a PR that edits only a rules or protocol doc must still trigger this
+# workflow; without those paths the exact PR that landed a
+# doc-ahead-of-executor citation (ce2d2c57a) would not have run it (#2823).
+# `docs/agents/**` subsumes docs/agents/fleet-state-machine.json — the
+# narrower entry stays because the ratchet below asserts that subject by
+# name. test_workflow_paths_sync.sh is the only entry whose subject set is
+# *derived* (a .github/workflows/*.yml glob) rather than a fixed file, so it
+# can grow without anyone editing this list — T4 in
+# test_workflow_paths_sync.sh is what makes that growth fail loudly instead
+# of silently un-triggering.
 # The two `paths:` blocks are duplicated because GitHub Actions has no YAML
 # anchors — keep them in sync (same note as header-checks.yml);
 # scripts/fleet/tests/test_fleet_tests_workflow_paths.sh ratchets that they do.
@@ -37,6 +45,9 @@ on:
       - '.claude/rules/**'
       - 'docs/agents/**'
       - '.github/workflows/fleet-tests.yml'
+      - '.github/workflows/header-checks.yml'
+      - '.github/workflows/perf-gate.yml'
+      - '.github/workflows/render-harness-tests.yml'
       - 'cmake/run_clang_format_changed.cmake'
       - 'engine/tools/lib/concurrency_helpers.sh'
       - 'docs/agents/fleet-state-machine.json'
@@ -46,6 +57,9 @@ on:
       - '.claude/rules/**'
       - 'docs/agents/**'
       - '.github/workflows/fleet-tests.yml'
+      - '.github/workflows/header-checks.yml'
+      - '.github/workflows/perf-gate.yml'
+      - '.github/workflows/render-harness-tests.yml'
       - 'cmake/run_clang_format_changed.cmake'
       - 'engine/tools/lib/concurrency_helpers.sh'
       - 'docs/agents/fleet-state-machine.json'

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -74,7 +74,16 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   hand-duplicated — GitHub Actions has no YAML anchors — so they drift
   independently). The list is the ratchet's whole domain: a subject absent
   from it is a subject nothing guards, however green the suite runs
-  (#2810).
+  (#2810). `OUT_OF_TREE_SUBJECTS` is `fleet-tests.yml`-scoped by design —
+  it is that one workflow's own subject-domain list, a different axis from
+  whether a workflow's `push:` and `pull_request:` blocks *agree* on
+  whatever they list. That second axis — the sync ratchet itself — is
+  **not** `fleet-tests.yml`-scoped: `tests/test_workflow_paths_sync.sh`
+  (#2929) derives the workflow population from a `.github/workflows/*.yml`
+  glob and checks every workflow that declares both blocks
+  (`header-checks.yml`, `perf-gate.yml`, `render-harness-tests.yml`, and
+  `fleet-tests.yml` today), so a new path-filtered workflow is covered the
+  moment it declares both blocks, no registration step required.
 - **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
   `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
   `summarize` exit idiom — don't re-copy the helpers into a new test.

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -82,8 +82,16 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   (#2929) derives the workflow population from a `.github/workflows/*.yml`
   glob and checks every workflow that declares both blocks
   (`header-checks.yml`, `perf-gate.yml`, `render-harness-tests.yml`, and
-  `fleet-tests.yml` today), so a new path-filtered workflow is covered the
-  moment it declares both blocks, no registration step required.
+  `fleet-tests.yml` today). Its *population* needs no registration step;
+  its *trigger* does. Those workflows live outside `scripts/fleet/**`, so
+  they are themselves out-of-tree subjects and carry entries in
+  `OUT_OF_TREE_SUBJECTS` beside the fixed-file ones — a workflow that
+  declares both blocks but is missing from `fleet-tests.yml`'s `paths:` is
+  one this suite inspects and CI never runs it for. That is the pair the
+  two ratchets have to agree on, and the derived side is the one a
+  hand-maintained list cannot follow, so `test_workflow_paths_sync.sh`'s T4
+  asserts the agreement directly off the glob: the fifth such workflow
+  fails a suite instead of silently costing itself its trigger.
 - **Bash tests source `tests/lib_assert.sh`** for the PASS/FAIL counters,
   `ok`/`bad`, `assert_eq`/`assert_contains`/`assert_absent`, and the
   `summarize` exit idiom — don't re-copy the helpers into a new test.

--- a/scripts/fleet/tests/test_fleet_tests_workflow_paths.sh
+++ b/scripts/fleet/tests/test_fleet_tests_workflow_paths.sh
@@ -2,14 +2,16 @@
 # Tests for .github/workflows/fleet-tests.yml's path filters (#2810).
 #
 # The workflow path-filters on scripts/fleet/** — the LOCATION of its
-# suites, not the SUBJECTS they test. Four suites test files that live
+# suites, not the SUBJECTS they test. Five suites test files that live
 # outside that path (test_format_changed_line_scoping.sh covers
 # cmake/run_clang_format_changed.cmake; test_ir_build_dir_resolution.sh
 # covers engine/tools/lib/concurrency_helpers.sh; test_fleet_transition.sh
 # covers docs/agents/fleet-state-machine.json; test_lint_rules_commands.py
-# covers every doc under .claude/rules/ and docs/agents/), so a PR touching
-# only one of those subjects previously got no fleet-tests run at all — the
-# only regression coverage for that subject silently never fired.
+# covers every doc under .claude/rules/ and docs/agents/;
+# test_workflow_paths_sync.sh covers the other path-filtered
+# .github/workflows/*.yml files), so a PR touching only one of those
+# subjects previously got no fleet-tests run at all — the only regression
+# coverage for that subject silently never fired.
 #
 # This is deliberately a hardcoded ratchet, not a parse of each suite's
 # variable assignments (same shape as header_global_baseline in
@@ -40,12 +42,24 @@ fi
 # not single files. `docs/agents/**` subsumes fleet-state-machine.json;
 # the narrower entry stays so the ratchet keeps naming that subject even
 # if the glob is ever tightened.
+#
+# The three .github/workflows/ entries are test_workflow_paths_sync.sh's
+# subjects (#2929). They are the first members whose population is derived
+# rather than fixed — that suite globs .github/workflows/*.yml and covers
+# whichever files declare both a push: and a pull_request: paths: block, so
+# a fifth such workflow becomes its subject with no edit here. This list
+# cannot track that on its own; T4 in test_workflow_paths_sync.sh asserts
+# the two agree, so the gap fails a suite instead of silently costing the
+# new workflow its trigger.
 OUT_OF_TREE_SUBJECTS=(
     'cmake/run_clang_format_changed.cmake'
     'engine/tools/lib/concurrency_helpers.sh'
     'docs/agents/fleet-state-machine.json'
     '.claude/rules/**'
     'docs/agents/**'
+    '.github/workflows/header-checks.yml'
+    '.github/workflows/perf-gate.yml'
+    '.github/workflows/render-harness-tests.yml'
 )
 
 # paths_block <file> <section> — the raw text of the named top-level `on:`

--- a/scripts/fleet/tests/test_workflow_paths_sync.sh
+++ b/scripts/fleet/tests/test_workflow_paths_sync.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Every path-filtered .github/workflows/*.yml hand-duplicates its paths:
+# list across the push: and pull_request: on: blocks (GitHub Actions has
+# no YAML anchors). A hand-edit that adds a path to one block and forgets
+# the other silently halves that workflow's trigger coverage, and the half
+# that goes missing is normally pull_request — the block that gates the
+# merge. #2810 built this ratchet for fleet-tests.yml only
+# (test_fleet_tests_workflow_paths.sh); this suite generalizes it to every
+# workflow in the tree.
+#
+# This is a different axis than that suite's OUT_OF_TREE_SUBJECTS ratchet.
+# OUT_OF_TREE_SUBJECTS asks "which subjects does fleet-tests.yml list at
+# all" (subject-domain completeness); this suite asks "do the two blocks
+# agree on whatever a workflow DOES list" (workflow-scope sync), for every
+# workflow, not just fleet-tests.yml. Neither subsumes the other.
+#
+# The workflow population is derived from a .github/workflows/*.yml glob,
+# not a hardcoded list — #2876 records that a hardcoded inclusion list is
+# invisible to both a green run and a positive control (both are computed
+# *from* the list, so a workflow nobody added to it is a workflow the
+# check never looks at). Deriving the population sidesteps that failure
+# mode: a new workflow is covered automatically the moment it declares
+# both blocks.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+
+# shellcheck source=lib_assert.sh
+source "$(dirname "$0")/lib_assert.sh"
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+    echo "SKIP: workflows dir not found at $WORKFLOWS_DIR" >&2
+    exit 3  # skip status — run_all.sh must not count this as a pass (#2786)
+fi
+
+# paths_list <file> <section> — the paths: list entries (one per output
+# line, "      - '<glob>'" verbatim) under the named top-level on:
+# sub-block (push or pull_request). Bounded to the paths: list itself,
+# not the whole on: sub-block: most workflows have a sibling event key
+# (workflow_dispatch:) that would stop a wider range scan, but
+# perf-gate.yml has none — its pull_request: block runs straight into the
+# top-level permissions: key, whose own sub-keys (`  contents: write`) are
+# themselves 2-space indented and would be misread as workflow content by
+# a scan keyed on indent alone. Stopping at the first line that isn't a
+# "      - " list item sidesteps that regardless of what follows.
+paths_list() {
+    local file="$1" section="$2"
+    awk -v section="$section" '
+        $0 ~ "^  " section ":" { in_section=1; next }
+        in_section && /^  [a-zA-Z_]+:/ { in_section=0 }
+        in_section && /^    paths:/ { in_paths=1; next }
+        in_section && in_paths && /^      - / { print; next }
+        in_section && in_paths { in_paths=0 }
+    ' "$file"
+}
+
+# is_covered <file> — true when the workflow declares both push: and
+# pull_request: paths: lists (the sync check applies to it at all). A
+# workflow with no paths: filter at all (auto-rereview.yml, quality.yml)
+# or only one of the two blocks is out of scope, not a violation.
+is_covered() {
+    local file="$1"
+    [[ -n "$(paths_list "$file" push)" && -n "$(paths_list "$file" pull_request)" ]]
+}
+
+# paths_diff <file> — empty when a covered workflow's push and
+# pull_request lists carry the same entries; the unified diff otherwise.
+# Order-independent (sorted before compare) — a re-sort of an identical
+# set is not drift, only an added/removed/changed entry is.
+paths_diff() {
+    local file="$1" push_sorted pr_sorted
+    push_sorted=$(paths_list "$file" push | sort)
+    pr_sorted=$(paths_list "$file" pull_request | sort)
+    [[ "$push_sorted" == "$pr_sorted" ]] && return 0
+    diff <(printf '%s\n' "$push_sorted") <(printf '%s\n' "$pr_sorted")
+}
+
+# first_pr_entry_line <file> — the line number (in <file>) of the first
+# paths: entry inside the pull_request: block specifically. Targeting by
+# line number (rather than by matching the entry's text) is what keeps
+# this correct when push and pull_request are in sync: every entry's text
+# occurs twice in the file (once per block), so a text match would risk
+# deleting the push occurrence instead of the pull_request one.
+first_pr_entry_line() {
+    local file="$1"
+    awk '
+        /^  pull_request:/ { in_section=1; next }
+        in_section && /^  [a-zA-Z_]+:/ { in_section=0 }
+        in_section && /^    paths:/ { in_paths=1; next }
+        in_section && in_paths && /^      - / { print NR; exit }
+    ' "$file"
+}
+
+mapfile -t all_workflows < <(find "$WORKFLOWS_DIR" -maxdepth 1 -name '*.yml' -type f | sort)
+
+covered_workflows=()
+for f in "${all_workflows[@]}"; do
+    is_covered "$f" && covered_workflows+=("$f")
+done
+
+echo "T0: coverage — derived workflow set is non-empty"
+if [[ ${#all_workflows[@]} -eq 0 ]]; then
+    bad "found zero workflow files under $WORKFLOWS_DIR — glob is broken"
+else
+    ok "found ${#all_workflows[@]} workflow file(s) total, ${#covered_workflows[@]} declare both push: and pull_request: paths: lists"
+fi
+if [[ ${#covered_workflows[@]} -eq 0 ]]; then
+    bad "zero workflows are covered — nothing below would ever be asserted"
+fi
+
+echo "T1: every covered workflow's push: and pull_request: paths: lists match"
+for f in "${covered_workflows[@]}"; do
+    name=$(basename "$f")
+    d=$(paths_diff "$f")
+    assert_eq "$d" "" "$name: push/pull_request paths: lists in sync"
+done
+
+echo "T2: positive control — deleting one pull_request path reports that workflow, per-workflow"
+MUTATED=$(mktemp -d -t workflow-paths-sync-control.XXXXXX)
+trap 'rm -rf "$MUTATED"' EXIT
+for f in "${covered_workflows[@]}"; do
+    name=$(basename "$f")
+    lineno=$(first_pr_entry_line "$f")
+    if [[ -z "$lineno" ]]; then
+        bad "$name: control setup failed — could not locate a pull_request paths: entry to delete"
+        continue
+    fi
+    entry=$(sed -n "${lineno}p" "$f")
+    dst="$MUTATED/$name"
+    awk -v skip="$lineno" 'NR==skip{next} {print}' "$f" > "$dst"
+
+    d=$(paths_diff "$dst")
+    assert_contains "$d" "$entry" \
+        "$name: control fires — deleting a pull_request entry is reported as drift"
+done
+
+summarize "workflow push/pull_request paths: sync"

--- a/scripts/fleet/tests/test_workflow_paths_sync.sh
+++ b/scripts/fleet/tests/test_workflow_paths_sync.sh
@@ -137,4 +137,68 @@ for f in "${covered_workflows[@]}"; do
         "$name: control fires — deleting a pull_request entry is reported as drift"
 done
 
+echo "T4: fleet-tests.yml triggers on every workflow this suite covers"
+# T1/T2 only run when CI runs this suite at all, and the only thing that
+# runs it is fleet-tests.yml — whose paths: filter keys on scripts/fleet/**,
+# the LOCATION of this file, not the workflows it inspects. So a covered
+# workflow absent from that filter is a workflow this suite silently never
+# checks: editing only header-checks.yml triggers no fleet-tests run, and
+# the push/pull_request drift this suite exists to catch ships green. That
+# is #2810's failure mode one level up, and it applies to this suite's own
+# subjects.
+#
+# Asserted from the derived covered set rather than a hardcoded list, so a
+# fifth workflow that declares both blocks fails here the moment it lands
+# instead of quietly costing itself its trigger. The mirror registry is
+# OUT_OF_TREE_SUBJECTS in test_fleet_tests_workflow_paths.sh.
+FLEET_TESTS_WORKFLOW="$WORKFLOWS_DIR/fleet-tests.yml"
+
+# missing_triggers <fleet-tests.yml> — one "<block> <path>" line per (block,
+# covered workflow) pair whose repo-relative path is absent from that block's
+# paths: list. Empty output means every covered workflow actually triggers
+# this suite. Pure check, no ok/bad — callers decide what output means.
+missing_triggers() {
+    local file="$1" block entries wf name
+    for block in push pull_request; do
+        entries=$(paths_list "$file" "$block")
+        for wf in "${covered_workflows[@]}"; do
+            name=$(basename "$wf")
+            printf '%s' "$entries" | grep -qF -- ".github/workflows/$name" \
+                || echo "$block .github/workflows/$name"
+        done
+    done
+}
+
+if [[ ! -f "$FLEET_TESTS_WORKFLOW" ]]; then
+    bad "fleet-tests.yml not found at $FLEET_TESTS_WORKFLOW — cannot verify this suite is ever triggered"
+else
+    real_missing_triggers=$(missing_triggers "$FLEET_TESTS_WORKFLOW")
+    assert_eq "$real_missing_triggers" "" \
+        "fleet-tests.yml paths: covers every covered workflow, in both blocks"
+
+    echo "T5: positive control — dropping a covered workflow from fleet-tests.yml paths: is reported"
+fi
+# Indexing [0] under set -u aborts on an empty array, and an empty covered
+# set is a real state (T0 reports it) rather than an impossible one.
+if [[ -f "$FLEET_TESTS_WORKFLOW" ]] && (( ${#covered_workflows[@]} > 0 )); then
+    control_target=$(basename "${covered_workflows[0]}")
+    CTL="$MUTATED/fleet-tests-trigger-control.yml"
+    grep -vF ".github/workflows/$control_target" "$FLEET_TESTS_WORKFLOW" > "$CTL"
+
+    ctl_missing=$(missing_triggers "$CTL")
+    assert_contains "$ctl_missing" "push .github/workflows/$control_target" \
+        "control fires: dropped workflow reported missing from push"
+    assert_contains "$ctl_missing" "pull_request .github/workflows/$control_target" \
+        "control fires: dropped workflow reported missing from pull_request"
+    # Isolate the control to the one dropped entry — looping the whole tail
+    # keeps that isolation complete as the covered set grows, where a
+    # single-index assert would leave every later workflow unexercised.
+    if (( ${#covered_workflows[@]} > 1 )); then
+        for wf in "${covered_workflows[@]:1}"; do
+            assert_absent "$ctl_missing" ".github/workflows/$(basename "$wf")" \
+                "control isolation: untouched $(basename "$wf") is not reported missing"
+        done
+    fi
+fi
+
 summarize "workflow push/pull_request paths: sync"


### PR DESCRIPTION
## Summary
- Generalizes the push:/pull_request: `paths:` sync ratchet (#2810 built it for `fleet-tests.yml` only) to every workflow in `.github/workflows/`, via a new `scripts/fleet/tests/test_workflow_paths_sync.sh` that derives its workflow population from a glob rather than a hardcoded list.
- Wires the workflows that suite covers into `fleet-tests.yml`'s own `paths:` filter and `OUT_OF_TREE_SUBJECTS`, so CI actually runs the suite for them, and adds T4/T5 asserting the two stay in agreement off the glob.
- Updates `scripts/fleet/CLAUDE.md`'s authoring bullet to describe the sync ratchet as tree-wide, distinct from `OUT_OF_TREE_SUBJECTS` (a different axis), and to state that the sync suite's *population* needs no registration step while its *trigger* does.

## Test plan
- [x] `bash scripts/fleet/tests/test_workflow_paths_sync.sh` — 15/15 assertions pass (coverage + real-file sync + per-workflow drift control + trigger agreement + per-workflow trigger-drop control).
- [x] `bash scripts/fleet/tests/test_fleet_tests_workflow_paths.sh` — 11/11 assertions pass (up from 6/6: the 3 new out-of-tree subjects added here extend T2's isolation loop, and master's #2872 has since added 2 more — `.claude/rules/**`, `docs/agents/**` — which extend it again; see "Rebase reconciliation" below).
- [x] `bash scripts/fleet/tests/run_all.sh` — 126 suites, 125 passed; the one failure (`test_cross_repo_shared_file_parity.sh`) is a pre-existing, unrelated master failure (tracked downstream).
- [x] Control arm for the trigger fix: restore the pre-fix `fleet-tests.yml` (`git checkout HEAD -- .github/workflows/fleet-tests.yml`) and re-run the suite — T4 fails, naming all three workflows missing from **both** blocks (6 pairs). See "Trigger-gap control" below.
- [x] Empty-population guard: ran the suite against a synthetic repo whose only workflow declares no `paths:` — T0/T4 report clean assertion failures and exit 1, no `set -u` unbound-variable crash on `${covered_workflows[0]}`.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Suite derives workflow set from `.github/workflows/*.yml` glob (no hardcoded list), asserts push/pull_request `paths:` identical for every workflow declaring both | `bash test_workflow_paths_sync.sh` | `T0: ok: found 6 workflow file(s) total, 4 declare both push: and pull_request: paths: lists` / `T1: ok:` ×4 (all covered workflows in sync) |
| Positive control fires per-workflow, including the 3 previously-unguarded workflows | same run | `T2: ok: header-checks.yml: control fires...`, `ok: perf-gate.yml: ...`, `ok: render-harness-tests.yml: ...`, `ok: fleet-tests.yml: ...` — each from an isolated temp-copy mutation of that one workflow |
| Coverage arm: derived set is non-empty, size reported | same run | `T0: ok: found 6 workflow file(s) total, 4 declare both...` |
| CI actually runs this suite for every workflow it covers | same run | `T4: ok: fleet-tests.yml paths: covers every covered workflow, in both blocks` |
| That trigger check has its own per-workflow positive control | same run | `T5: ok: control fires...` ×2 (push + pull_request) + 3 isolation asserts on the untouched workflows |
| `test_fleet_tests_workflow_paths.sh` subject-coverage assertions unchanged in kind, extended by the 3 new subjects | `bash scripts/fleet/tests/run_all.sh` | `PASS  test_fleet_tests_workflow_paths.sh` (11/11) |
| `run_all.sh` no worse than master | same run | `126 suite(s) — 125 passed, 1 failed, 0 skipped` / `failed: test_cross_repo_shared_file_parity.sh` (pre-existing, unrelated) |
| `scripts/fleet/CLAUDE.md` authoring rule names the generalized check | (diff) | `scripts/fleet/CLAUDE.md` bullet updated in this PR — see diff |
| PR #2925's interim note in `render-harness-tests.yml` deleted in the same PR | n/a | **Not done** — PR #2925 (which added the note) is still open/unmerged as of this writing; the note doesn't exist in this branch's base. Will be removed as a follow-up once #2925 lands (either a small amend here if still open, or a trivial cleanup PR). |

## Trigger-gap control (the needs-fix fix)

`test_workflow_paths_sync.sh` lives in `scripts/fleet/tests/`, but its
subjects are workflow files. `fleet-tests.yml` — the only thing that runs it —
path-filtered on `scripts/fleet/**` plus its own filename, so a PR editing
only `header-checks.yml` / `perf-gate.yml` / `render-harness-tests.yml`
triggered no run, and the push/pull_request drift the suite exists to catch
would ship green. That is #2810's own failure mode (filter keyed on a suite's
LOCATION, not its SUBJECTS) reappearing against the new suite's own subjects.

Against the pre-fix workflow, with the amended suite:

```
T4: fleet-tests.yml triggers on every workflow this suite covers
  FAIL: fleet-tests.yml paths: covers every covered workflow, in both blocks
        expected:
        actual:   push .github/workflows/header-checks.yml
push .github/workflows/perf-gate.yml
push .github/workflows/render-harness-tests.yml
pull_request .github/workflows/header-checks.yml
pull_request .github/workflows/perf-gate.yml
pull_request .github/workflows/render-harness-tests.yml
```

Note this control cannot be expressed through `fleet-positive-control`: that
tool stages `scripts/fleet/` at a ref via `git archive`, and the defect lives
in `.github/workflows/`, outside what it stages.

Why T4 exists rather than the two list edits alone: `OUT_OF_TREE_SUBJECTS` is
hand-maintained, while this suite's subject population is *derived* from a
glob and grows on its own. The fifth workflow to declare both blocks would
re-open the identical hole with no edit anywhere for a reviewer to catch. T4
asserts the derived set and the filter agree, so that growth fails a suite
instead of silently costing the new workflow its trigger.

## Rebase reconciliation (semantic-conflict resolution)

Rebased onto current `master` (`a9459315b`). The conflict the merger reported was
in `.github/workflows/fleet-tests.yml` against master's `ad5159ec3` (#2872), which
edited the same `paths:` blocks and `OUT_OF_TREE_SUBJECTS` list this PR
generalizes. Resolved by keeping **both** sides: master's two new doc-glob
subjects (`.claude/rules/**`, `docs/agents/**`) and this PR's three workflow
subjects all appear in `OUT_OF_TREE_SUBJECTS` and in both `paths:` blocks — the
lists are supersets, not competing rewrites, so neither side's trigger coverage
is lost.

Two evidence numbers above moved as a direct result, and neither reflects a
change in this PR's own behaviour:

- `test_fleet_tests_workflow_paths.sh`: **9/9 → 11/11**. T2's control-isolation
  loop iterates `OUT_OF_TREE_SUBJECTS`; master's #2872 added 2 entries, so the
  loop emits 2 more asserts. Re-measured, not derived.
- `run_all.sh`: **125/124 → 126/125**. Master's `a9459315b` (#2892) added
  `test_header_checks_standalone.sh`, one new suite. Same single pre-existing
  failure (`test_cross_repo_shared_file_parity.sh`), unchanged.

All numbers above were re-measured on the pushed tree (`308a4dfe4`), not carried
over from the pre-rebase run.

Closes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

