### PR TITLE
build/cmake: fix header-global matcher formatter-defeatability (#2916)

### DIFF
--- a/.claude/rules/cpp-globals.md
+++ b/.claude/rules/cpp-globals.md
@@ -123,6 +123,12 @@ Two precision notes, both measured against the tree:
   also banned. Only `inline const T *const p` is a program constant. A `*`
   inside a template argument (`std::array<const char *, N>`) belongs to the
   type argument, not the declarator, and does not make the object a pointer.
+- A candidate whose terminator (`;` / `=` / `{`) wraps onto a continuation
+  line — what the repo's own 100-col clang-format does to a long `inline`
+  declaration — is joined with the following lines (bounded lookahead) before
+  the reject chain runs. Scanning only the head line as the executor
+  originally did made the ban formatter-defeatable: `format`ting a violation
+  could turn a `FLAGGED` result into a clean pass with no other change (#2916).
 
 Keep the executor and this file in sync — a detection spec nothing runs
 drifts silently (see #2727).

--- a/cmake/run_header_convention_checks.cmake
+++ b/cmake/run_header_convention_checks.cmake
@@ -78,61 +78,95 @@ foreach(file_path IN LISTS QUALITY_FILES)
     if(NOT is_baselined)
         # CMake's regex engine has no lookahead, so the rule's negative
         # assertions are applied as per-line rejects below rather than inline.
-        file(STRINGS "${normalized_file_path}" candidate_lines REGEX "^[ \t]*(inline|extern)[ \t]")
-        foreach(line IN LISTS candidate_lines)
-            # `extern "C" {` — a linkage block, not a variable.
-            if(line MATCHES "^[ \t]*extern[ \t]+\"")
-                continue()
-            endif()
-            # Declaration head only — everything before the initializer or
-            # terminator. A whole-line scan would read a trailing comment's
-            # "const" as a qualifier and pass real globals as clean.
-            string(REGEX REPLACE "[=;{].*$" "" decl_head "${line}")
-            # `constexpr` always makes the declared object itself a constant.
-            if(decl_head MATCHES "(^|[ \t])constexpr[ \t]")
-                continue()
-            endif()
-            # Strip template argument lists before looking for a pointer
-            # declarator — a `*` inside `<...>` belongs to a type argument
-            # (`std::array<const char *, N>`), not to the declared object.
-            # Repeated to unwrap nesting; CMake has no loop-until-stable.
-            set(decl_core "${decl_head}")
-            foreach(unused_pass RANGE 3)
-                string(REGEX REPLACE "<[^<>]*>" "" decl_core "${decl_core}")
-            endforeach()
-            if(decl_core MATCHES "\\*")
-                # A pointer declaration is a program constant only when BOTH
-                # ends are const: `const T *const p`. A leading `const` alone
-                # freezes the pointee (`const T *p` is a mutable pointer —
-                # reseatable state), and a trailing `const` alone freezes the
-                # pointer to still-mutable data. Either way it is unowned
-                # process state, which is what this ban is about.
-                if(decl_core MATCHES "(^|[ \t])const[ \t]" AND
-                   decl_core MATCHES "\\*[ \t]*const([ \t]|$)")
+        #
+        # Read every line unfiltered (not REGEX-filtered) so a candidate whose
+        # terminator wraps onto a continuation line — exactly what the repo's
+        # own 100-col clang-format produces on a long `inline` declaration —
+        # can be joined back into one line before the reject chain runs.
+        # `file(STRINGS ... REGEX ...)` would have already discarded that
+        # continuation line, since it doesn't itself start with
+        # `inline`/`extern`.
+        file(STRINGS "${normalized_file_path}" all_lines)
+        list(LENGTH all_lines total_line_count)
+        if(total_line_count GREATER 0)
+            math(EXPR last_line_index "${total_line_count} - 1")
+            foreach(line_index RANGE ${last_line_index})
+                list(GET all_lines ${line_index} candidate_head)
+                if(NOT candidate_head MATCHES "^[ \t]*(inline|extern)[ \t]")
                     continue()
                 endif()
-            elseif(decl_core MATCHES "(^|[ \t])const[ \t]")
-                # Non-pointer `const` (incl. `extern const`, `inline static
-                # const`) and `const T &` references are program constants.
-                continue()
-            endif()
-            # A `(` before the initializer means a function declaration, which
-            # is what the rule's `[^(]*` guard drops.
-            if(line MATCHES "^[^;={]*\\(")
-                continue()
-            endif()
-            if(line MATCHES "(^|[ \t])void[ \t]")
-                continue()
-            endif()
-            if(NOT line MATCHES "[;={]")
-                continue()
-            endif()
-            string(STRIP "${line}" stripped_line)
-            # Escape the source line's `;` — CMake lists are `;`-delimited, so
-            # an unescaped one splits the entry and emits a blank bullet.
-            string(REPLACE ";" "\\;" stripped_line "${stripped_line}")
-            list(APPEND header_global_failures "${normalized_file_path}: ${stripped_line}")
-        endforeach()
+
+                # Join continuation lines onto the head until a terminator
+                # appears. Bounded lookahead so a candidate that never
+                # terminates (or a runaway match) can't scan the rest of the
+                # file; a real declaration wrap is one or two lines.
+                set(max_join_lookahead_lines 10)
+                set(line "${candidate_head}")
+                set(join_index ${line_index})
+                set(join_steps 0)
+                while(NOT line MATCHES "[;={]" AND join_steps LESS ${max_join_lookahead_lines} AND join_index LESS ${last_line_index})
+                    math(EXPR join_index "${join_index} + 1")
+                    list(GET all_lines ${join_index} next_line)
+                    string(APPEND line " ${next_line}")
+                    math(EXPR join_steps "${join_steps} + 1")
+                endwhile()
+
+                # `extern "C" {` — a linkage block, not a variable.
+                if(line MATCHES "^[ \t]*extern[ \t]+\"")
+                    continue()
+                endif()
+                # Declaration head only — everything before the initializer or
+                # terminator. A whole-line scan would read a trailing comment's
+                # "const" as a qualifier and pass real globals as clean.
+                string(REGEX REPLACE "[=;{].*$" "" decl_head "${line}")
+                # `constexpr` always makes the declared object itself a constant.
+                if(decl_head MATCHES "(^|[ \t])constexpr[ \t]")
+                    continue()
+                endif()
+                # Strip template argument lists before looking for a pointer
+                # declarator — a `*` inside `<...>` belongs to a type argument
+                # (`std::array<const char *, N>`), not to the declared object.
+                # Repeated to unwrap nesting; CMake has no loop-until-stable.
+                set(decl_core "${decl_head}")
+                foreach(unused_pass RANGE 3)
+                    string(REGEX REPLACE "<[^<>]*>" "" decl_core "${decl_core}")
+                endforeach()
+                if(decl_core MATCHES "\\*")
+                    # A pointer declaration is a program constant only when BOTH
+                    # ends are const: `const T *const p`. A leading `const` alone
+                    # freezes the pointee (`const T *p` is a mutable pointer —
+                    # reseatable state), and a trailing `const` alone freezes the
+                    # pointer to still-mutable data. Either way it is unowned
+                    # process state, which is what this ban is about.
+                    if(decl_core MATCHES "(^|[ \t])const[ \t]" AND
+                       decl_core MATCHES "\\*[ \t]*const([ \t]|$)")
+                        continue()
+                    endif()
+                elseif(decl_core MATCHES "(^|[ \t])const[ \t]")
+                    # Non-pointer `const` (incl. `extern const`, `inline static
+                    # const`) and `const T &` references are program constants.
+                    continue()
+                endif()
+                # A `(` before the initializer means a function declaration, which
+                # is what the rule's `[^(]*` guard drops. (No separate `void`
+                # reject: `inline void f() {}` is already caught here, and
+                # `inline void *g_x = ...;` is a banned mutable pointer, not an
+                # exemption.)
+                if(line MATCHES "^[^;={]*\\(")
+                    continue()
+                endif()
+                # Safety net: the bounded join above may not have found a
+                # terminator (genuinely multi-line signature, or EOF).
+                if(NOT line MATCHES "[;={]")
+                    continue()
+                endif()
+                string(STRIP "${line}" stripped_line)
+                # Escape the source line's `;` — CMake lists are `;`-delimited, so
+                # an unescaped one splits the entry and emits a blank bullet.
+                string(REPLACE ";" "\\;" stripped_line "${stripped_line}")
+                list(APPEND header_global_failures "${normalized_file_path}: ${stripped_line}")
+            endforeach()
+        endif()
     endif()
 endforeach()
 

--- a/cmake/run_header_convention_checks.cmake
+++ b/cmake/run_header_convention_checks.cmake
@@ -29,6 +29,89 @@ set(feature_detail_namespace_failures "")
 set(header_global_failures "")
 set(file_count 0)
 
+# Runs the header-global reject chain against one already-joined declaration
+# line and appends to `header_global_failures` (outer scope — macros don't
+# get their own) when it survives every exemption. A macro rather than a
+# function because the reject chain is a sequence of early-outs; CMake
+# functions can't mutate the caller's list without an explicit PARENT_SCOPE
+# round-trip, so the chain is expressed as `should_flag` guards instead of
+# `continue()`/`return()`.
+macro(irreden_process_header_global_candidate line_text)
+    set(candidate_line "${line_text}")
+    set(should_flag TRUE)
+
+    # `extern "C" {` — a linkage block, not a variable.
+    if(candidate_line MATCHES "^[ \t]*extern[ \t]+\"")
+        set(should_flag FALSE)
+    endif()
+
+    if(should_flag)
+        # Declaration head only — everything before the initializer or
+        # terminator. A whole-line scan would read a trailing comment's
+        # "const" as a qualifier and pass real globals as clean.
+        string(REGEX REPLACE "[=;{].*$" "" decl_head "${candidate_line}")
+        # `constexpr` always makes the declared object itself a constant.
+        if(decl_head MATCHES "(^|[ \t])constexpr[ \t]")
+            set(should_flag FALSE)
+        endif()
+    endif()
+
+    if(should_flag)
+        # Strip template argument lists before looking for a pointer
+        # declarator — a `*` inside `<...>` belongs to a type argument
+        # (`std::array<const char *, N>`), not to the declared object.
+        # Repeated to unwrap nesting; CMake has no loop-until-stable.
+        set(decl_core "${decl_head}")
+        foreach(unused_pass RANGE 3)
+            string(REGEX REPLACE "<[^<>]*>" "" decl_core "${decl_core}")
+        endforeach()
+        if(decl_core MATCHES "\\*")
+            # A pointer declaration is a program constant only when BOTH
+            # ends are const: `const T *const p`. A leading `const` alone
+            # freezes the pointee (`const T *p` is a mutable pointer —
+            # reseatable state), and a trailing `const` alone freezes the
+            # pointer to still-mutable data. Either way it is unowned
+            # process state, which is what this ban is about.
+            if(decl_core MATCHES "(^|[ \t])const[ \t]" AND
+               decl_core MATCHES "\\*[ \t]*const([ \t]|$)")
+                set(should_flag FALSE)
+            endif()
+        elseif(decl_core MATCHES "(^|[ \t])const[ \t]")
+            # Non-pointer `const` (incl. `extern const`, `inline static
+            # const`) and `const T &` references are program constants.
+            set(should_flag FALSE)
+        endif()
+    endif()
+
+    if(should_flag)
+        # A `(` before the initializer means a function declaration, which
+        # is what the rule's `[^(]*` guard drops. (No separate `void`
+        # reject: `inline void f() {}` is already caught here, and
+        # `inline void *g_x = ...;` is a banned mutable pointer, not an
+        # exemption.)
+        if(candidate_line MATCHES "^[^;={]*\\(")
+            set(should_flag FALSE)
+        endif()
+    endif()
+
+    if(should_flag)
+        # Safety net: a candidate flushed with no terminator at all (should
+        # not happen — callers only flush on a matched terminator — kept as
+        # a defensive guard against a future call site that doesn't).
+        if(NOT candidate_line MATCHES "[;={]")
+            set(should_flag FALSE)
+        endif()
+    endif()
+
+    if(should_flag)
+        string(STRIP "${candidate_line}" stripped_line)
+        # Escape the source line's `;` — CMake lists are `;`-delimited, so
+        # an unescaped one splits the entry and emits a blank bullet.
+        string(REPLACE ";" "\\;" stripped_line "${stripped_line}")
+        list(APPEND header_global_failures "${normalized_file_path}: ${stripped_line}")
+    endif()
+endmacro()
+
 foreach(file_path IN LISTS QUALITY_FILES)
     file(TO_CMAKE_PATH "${file_path}" normalized_file_path)
     if(normalized_file_path MATCHES "/(build|_deps|third_party)/")
@@ -77,7 +160,8 @@ foreach(file_path IN LISTS QUALITY_FILES)
 
     if(NOT is_baselined)
         # CMake's regex engine has no lookahead, so the rule's negative
-        # assertions are applied as per-line rejects below rather than inline.
+        # assertions are applied as per-line rejects in
+        # irreden_process_header_global_candidate() rather than inline.
         #
         # Read every line unfiltered (not REGEX-filtered) so a candidate whose
         # terminator wraps onto a continuation line — exactly what the repo's
@@ -86,87 +170,65 @@ foreach(file_path IN LISTS QUALITY_FILES)
         # `file(STRINGS ... REGEX ...)` would have already discarded that
         # continuation line, since it doesn't itself start with
         # `inline`/`extern`.
+        #
+        # Single forward pass over the lines, not index-by-index `list(GET)`
+        # — that call is a linear scan of the list per invocation, so an
+        # index loop over an n-line file costs O(n^2) overall, dominated by
+        # whichever header in the tree has the most lines. `join_pending`/
+        # `join_buffer` below carry the in-progress join instead of
+        # re-deriving the next index.
         file(STRINGS "${normalized_file_path}" all_lines)
-        list(LENGTH all_lines total_line_count)
-        if(total_line_count GREATER 0)
-            math(EXPR last_line_index "${total_line_count} - 1")
-            foreach(line_index RANGE ${last_line_index})
-                list(GET all_lines ${line_index} candidate_head)
-                if(NOT candidate_head MATCHES "^[ \t]*(inline|extern)[ \t]")
-                    continue()
-                endif()
 
-                # Join continuation lines onto the head until a terminator
-                # appears. Bounded lookahead so a candidate that never
-                # terminates (or a runaway match) can't scan the rest of the
-                # file; a real declaration wrap is one or two lines.
-                set(max_join_lookahead_lines 10)
-                set(line "${candidate_head}")
-                set(join_index ${line_index})
+        set(join_pending FALSE)
+        set(join_buffer "")
+        set(join_steps 0)
+        # Bounded lookahead so a candidate that never terminates (or a
+        # runaway match) can't scan the rest of the file; a real declaration
+        # wrap is one or two lines.
+        set(max_join_lookahead_lines 10)
+
+        foreach(raw_line IN LISTS all_lines)
+            # Strip a trailing line comment before it can reach either the
+            # terminator test or the function-declaration guard inside the
+            # macro — a `(` inside explanatory comment text on a wrapped
+            # declaration's head line otherwise reads as a function
+            # signature and the declaration silently exempts itself.
+            string(REGEX REPLACE "//.*$" "" stripped_raw_line "${raw_line}")
+
+            if(join_pending)
+                string(APPEND join_buffer " ${stripped_raw_line}")
+                math(EXPR join_steps "${join_steps} + 1")
+                if(join_buffer MATCHES "[;={]")
+                    irreden_process_header_global_candidate("${join_buffer}")
+                    set(join_pending FALSE)
+                    set(join_buffer "")
+                    set(join_steps 0)
+                elseif(join_steps GREATER_EQUAL max_join_lookahead_lines)
+                    # Lookahead exhausted with no terminator (genuinely
+                    # multi-line signature, or EOF next) — drop the
+                    # candidate rather than flag on partial text.
+                    set(join_pending FALSE)
+                    set(join_buffer "")
+                    set(join_steps 0)
+                endif()
+                continue()
+            endif()
+
+            if(NOT stripped_raw_line MATCHES "^[ \t]*(inline|extern)[ \t]")
+                continue()
+            endif()
+
+            if(stripped_raw_line MATCHES "[;={]")
+                irreden_process_header_global_candidate("${stripped_raw_line}")
+            else()
+                set(join_pending TRUE)
+                set(join_buffer "${stripped_raw_line}")
                 set(join_steps 0)
-                while(NOT line MATCHES "[;={]" AND join_steps LESS ${max_join_lookahead_lines} AND join_index LESS ${last_line_index})
-                    math(EXPR join_index "${join_index} + 1")
-                    list(GET all_lines ${join_index} next_line)
-                    string(APPEND line " ${next_line}")
-                    math(EXPR join_steps "${join_steps} + 1")
-                endwhile()
-
-                # `extern "C" {` — a linkage block, not a variable.
-                if(line MATCHES "^[ \t]*extern[ \t]+\"")
-                    continue()
-                endif()
-                # Declaration head only — everything before the initializer or
-                # terminator. A whole-line scan would read a trailing comment's
-                # "const" as a qualifier and pass real globals as clean.
-                string(REGEX REPLACE "[=;{].*$" "" decl_head "${line}")
-                # `constexpr` always makes the declared object itself a constant.
-                if(decl_head MATCHES "(^|[ \t])constexpr[ \t]")
-                    continue()
-                endif()
-                # Strip template argument lists before looking for a pointer
-                # declarator — a `*` inside `<...>` belongs to a type argument
-                # (`std::array<const char *, N>`), not to the declared object.
-                # Repeated to unwrap nesting; CMake has no loop-until-stable.
-                set(decl_core "${decl_head}")
-                foreach(unused_pass RANGE 3)
-                    string(REGEX REPLACE "<[^<>]*>" "" decl_core "${decl_core}")
-                endforeach()
-                if(decl_core MATCHES "\\*")
-                    # A pointer declaration is a program constant only when BOTH
-                    # ends are const: `const T *const p`. A leading `const` alone
-                    # freezes the pointee (`const T *p` is a mutable pointer —
-                    # reseatable state), and a trailing `const` alone freezes the
-                    # pointer to still-mutable data. Either way it is unowned
-                    # process state, which is what this ban is about.
-                    if(decl_core MATCHES "(^|[ \t])const[ \t]" AND
-                       decl_core MATCHES "\\*[ \t]*const([ \t]|$)")
-                        continue()
-                    endif()
-                elseif(decl_core MATCHES "(^|[ \t])const[ \t]")
-                    # Non-pointer `const` (incl. `extern const`, `inline static
-                    # const`) and `const T &` references are program constants.
-                    continue()
-                endif()
-                # A `(` before the initializer means a function declaration, which
-                # is what the rule's `[^(]*` guard drops. (No separate `void`
-                # reject: `inline void f() {}` is already caught here, and
-                # `inline void *g_x = ...;` is a banned mutable pointer, not an
-                # exemption.)
-                if(line MATCHES "^[^;={]*\\(")
-                    continue()
-                endif()
-                # Safety net: the bounded join above may not have found a
-                # terminator (genuinely multi-line signature, or EOF).
-                if(NOT line MATCHES "[;={]")
-                    continue()
-                endif()
-                string(STRIP "${line}" stripped_line)
-                # Escape the source line's `;` — CMake lists are `;`-delimited, so
-                # an unescaped one splits the entry and emits a blank bullet.
-                string(REPLACE ";" "\\;" stripped_line "${stripped_line}")
-                list(APPEND header_global_failures "${normalized_file_path}: ${stripped_line}")
-            endforeach()
-        endif()
+            endif()
+        endforeach()
+        # A join still pending here ran out of lines (EOF) before finding a
+        # terminator or hitting the lookahead bound — same drop as the
+        # bounded-exhaustion case above, nothing left to flush.
     endif()
 endforeach()
 

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -37,6 +37,13 @@
 #     the slot is aliased and always has consumers)
 #   - an unreadable scratch-slot constant           → exit 1 (anchor guard)
 #   - a missing PROJECT_ROOT                        → exit 1 (usage guard)
+#   - `inline void *g_x = ...;`                     → exit 1 (#2916: the old
+#     undocumented `void` reject exempted this mutable pointer)
+#   - `inline void f() {}`                          → exit 0 (already caught
+#     by the function-declaration guard; the `void` reject was redundant)
+#   - a declaration whose terminator wraps onto a    → exit 1 (#2916: the
+#     continuation line, as clang-format's 100-col     formatter-defeat case
+#     wrap produces                                    — see #2916 for repro)
 
 set -uo pipefail
 
@@ -495,6 +502,55 @@ assert_contains "$backend_out" "metal_probe.hpp" "failure names the metal header
 assert_contains "$backend_out" "g_metalBackendGlobal" "failure names the metal declaration"
 assert_contains "$backend_out" "gl_probe.h" "failure names the gl_wrap header"
 assert_contains "$backend_out" "g_glWrapBackendGlobal" "failure names the gl_wrap declaration"
+
+# --- a void-pointer global fails (#2916 Defect 2: the old undocumented
+# `void` reject exempted this mutable, unowned pointer) ---------------------
+VOIDPTR="$TMPROOT/voidptr"
+make_fixture "$VOIDPTR"
+cat > "$VOIDPTR/engine/include/irreden/voidptr.hpp" <<'EOF'
+#pragma once
+namespace IRFixture {
+inline void *g_metalDevice = nullptr;
+}
+EOF
+voidptr_out=$(run_checker "$VOIDPTR")
+voidptr_rc=$?
+assert_eq "1" "$voidptr_rc" "void-pointer header global makes the checker exit 1"
+assert_contains "$voidptr_out" "g_metalDevice" \
+    "failure names the void-pointer declaration"
+
+# --- a void function still passes (the deleted `void` reject was redundant
+# for this case — the function-declaration guard already catches it) -------
+VOIDFN="$TMPROOT/voidfn"
+make_fixture "$VOIDFN"
+cat > "$VOIDFN/engine/include/irreden/voidfn.hpp" <<'EOF'
+#pragma once
+namespace IRFixture {
+inline void doThing() {}
+}
+EOF
+voidfn_out=$(run_checker "$VOIDFN")
+voidfn_rc=$?
+assert_eq "0" "$voidfn_rc" "void function still passes without the void reject"
+
+# --- a declaration whose terminator wraps onto a continuation line fails
+# (#2916 Defect 1: the formatter-defeat case — the repo's own 100-col
+# clang-format wraps a long `inline` declaration exactly like this) ---------
+WRAPPED="$TMPROOT/wrapped"
+make_fixture "$WRAPPED"
+cat > "$WRAPPED/engine/include/irreden/wrapped.hpp" <<'EOF'
+#pragma once
+#include <unordered_map>
+namespace IRFixture {
+inline std::unordered_map<int, int>
+    g_wrappedRegistry;
+}
+EOF
+wrapped_out=$(run_checker "$WRAPPED")
+wrapped_rc=$?
+assert_eq "1" "$wrapped_rc" "wrapped-declaration header global makes the checker exit 1"
+assert_contains "$wrapped_out" "g_wrappedRegistry" \
+    "failure names the wrapped declaration"
 
 # --- usage guard ------------------------------------------------------------
 noroot_out=$(cmake -P "$CHECKER" 2>&1)

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -41,9 +41,13 @@
 #     undocumented `void` reject exempted this mutable pointer)
 #   - `inline void f() {}`                          → exit 0 (already caught
 #     by the function-declaration guard; the `void` reject was redundant)
-#   - a declaration whose terminator wraps onto a    → exit 1 (#2916: the
-#     continuation line, as clang-format's 100-col     formatter-defeat case
-#     wrap produces                                    — see #2916 for repro)
+#   - a wrapped declaration terminator              → exit 1 (#2916: the
+#     formatter-defeat case the repo's own 100-col clang-format produces)
+#   - `inline const T *const p`                     → exit 0 (both ends const
+#     is a program constant, and the arm pins that the header entered the scan
+#     rather than passing by skipping the candidate gate)
+#   - `inline const T *p` / `inline T *const p`     → exit 1 (single-sided
+#     const is still unowned mutable state — #2726's `g_activeShots` shape)
 
 set -uo pipefail
 
@@ -551,6 +555,54 @@ wrapped_rc=$?
 assert_eq "1" "$wrapped_rc" "wrapped-declaration header global makes the checker exit 1"
 assert_contains "$wrapped_out" "g_wrappedRegistry" \
     "failure names the wrapped declaration"
+
+# --- a both-ends-const pointer is a program constant and stays exempt -------
+REALCONST="$TMPROOT/realconst"
+make_fixture "$REALCONST"
+cat > "$REALCONST/engine/include/irreden/realconst.hpp" <<'EOF'
+#pragma once
+namespace IRFixture {
+inline const char *const g_realConstName = "ok";
+}
+EOF
+realconst_out=$(run_checker "$REALCONST")
+realconst_rc=$?
+assert_eq "0" "$realconst_rc" "both-ends-const pointer stays exempt"
+
+# A header the scan never reached exits 0 too, so the count is what makes the
+# exemption a measurement, not just an exit code: the clean fixture scans 2
+# (clean.hpp plus the render-backend metal_runtime.hpp, in scope since #2889
+# widened the collector to INCLUDE_RENDER_BACKENDS), so this fixture must
+# scan 3. Both numbers are measured against make_fixture — re-measure them if
+# it grows a header, rather than assuming the delta.
+assert_contains "$realconst_out" "scanned 3 header file(s)" \
+    "the exempt header entered the scan rather than skipping the candidate gate"
+
+# --- single-sided const on a pointer is still a banned global ---------------
+# Both halves live in one header so the two failures prove the scan read this
+# file — which is what makes the third assertion (the both-ends form is NOT
+# named) evidence about the reject chain rather than about a skipped file.
+# This is the shape that hid a real `g_activeShots` violation through an entire
+# hand-grep pass (#2726), and .claude/rules/cpp-globals.md calls it out by name.
+HALFCONST="$TMPROOT/halfconst"
+make_fixture "$HALFCONST"
+cat > "$HALFCONST/engine/include/irreden/halfconst.hpp" <<'EOF'
+#pragma once
+namespace IRFixture {
+inline const char *const g_bothEndsConst = "ok";
+inline const char *g_pointeeConstOnly = "reseatable";
+inline char *const g_handleConstOnly = nullptr;
+}
+EOF
+halfconst_out=$(run_checker "$HALFCONST")
+halfconst_rc=$?
+assert_eq "1" "$halfconst_rc" "single-sided-const pointer globals exit 1"
+assert_contains "$halfconst_out" "g_pointeeConstOnly" \
+    "leading const alone leaves a reseatable pointer, still flagged"
+assert_contains "$halfconst_out" "g_handleConstOnly" \
+    "trailing const alone freezes the handle, not the data, still flagged"
+assert_absent "$halfconst_out" "g_bothEndsConst" \
+    "both-ends-const in that same scanned header is exempt"
 
 # --- usage guard ------------------------------------------------------------
 noroot_out=$(cmake -P "$CHECKER" 2>&1)

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -48,6 +48,9 @@
 #     rather than passing by skipping the candidate gate)
 #   - `inline const T *p` / `inline T *const p`     → exit 1 (single-sided
 #     const is still unowned mutable state — #2726's `g_activeShots` shape)
+#   - a wrapped declaration whose head line carries a trailing comment with
+#     a paren in it                                 → exit 1 (the comment's
+#     `(` must not read as a function-declaration guard hit)
 
 set -uo pipefail
 
@@ -603,6 +606,29 @@ assert_contains "$halfconst_out" "g_handleConstOnly" \
     "trailing const alone freezes the handle, not the data, still flagged"
 assert_absent "$halfconst_out" "g_bothEndsConst" \
     "both-ends-const in that same scanned header is exempt"
+
+# --- a paren inside a trailing comment on a wrapped head line still flags ---
+# The join buffer used to carry the raw head line verbatim, so a `(` inside
+# `// registry (id -> slot)` on the head of a wrapped declaration satisfied
+# the function-declaration guard and the global silently exempted itself.
+# Comments are now stripped before either the terminator test or the guard
+# see it.
+PARENCOMMENT="$TMPROOT/parencomment"
+make_fixture "$PARENCOMMENT"
+cat > "$PARENCOMMENT/engine/include/irreden/parencomment.hpp" <<'EOF'
+#pragma once
+#include <unordered_map>
+namespace IRFixture {
+inline std::unordered_map<int, int>  // registry (id -> slot)
+    g_parenCommentRegistry;
+}
+EOF
+parencomment_out=$(run_checker "$PARENCOMMENT")
+parencomment_rc=$?
+assert_eq "1" "$parencomment_rc" \
+    "a paren inside a wrapped head line's trailing comment does not exempt the global"
+assert_contains "$parencomment_out" "g_parenCommentRegistry" \
+    "failure names the paren-comment-wrapped declaration"
 
 # --- usage guard ------------------------------------------------------------
 noroot_out=$(cmake -P "$CHECKER" 2>&1)


### PR DESCRIPTION
## Summary
- Fixed the header-global matcher's reject chain so it no longer silently passes a declaration whose terminator wraps onto a continuation line (the formatter-defeat case: clang-format's 100-col wrap could turn a `FLAGGED` violation into a clean pass with no other change).
- Deleted the undocumented `void` reject, which exempted `inline void *g_x = ...;` — a mutable, unowned namespace-scope pointer, exactly the state kind the ban exists for. The branch was redundant for its stated purpose: `inline void f() {}` is already caught by the function-declaration guard.
- Added a precision note to `.claude/rules/cpp-globals.md` documenting the wrap-join behavior, keeping the doc's allowance list in sync with the executor.
- Landed the issue's five discrimination probes (plus a real clang-format wrap case) as a committed fixture in `scripts/fleet/tests/test_header_checks_standalone.sh`, including the `d_realconst` both-ends-const exemption and both previously-untested single-sided-const spellings (`const T *p`, `T *const p` — #2726's `g_activeShots` shape).

## Test plan
- [x] `cmake --build build --target header-checks` — scanned all 574 in-scope headers, 0 header-global failures (zero new flags vs master's tree). Re-run post-rebase; the standalone CI entry point (`cmake -DPROJECT_ROOT=. -P cmake/run_header_checks_standalone.cmake`) reports the same 574/0, so the two paths still agree on scope.
- [x] `bash scripts/fleet/tests/test_header_checks_standalone.sh` — **64/64** assertions pass, including the 5 new probes and the 6 both-ends-const assertions added for criterion 6. (Was 26/26 pre-rebase; master's suite has grown since this branch forked, and the rebase merged master's `#2889` render-backend arm alongside these.)
- [x] `fleet-positive-control scripts/fleet/tests/test_header_checks_standalone.sh origin/master --include cmake` — MEANINGFUL: **4 of 64** assertions fail against pre-fix `origin/master` (`a9459315b`), confirming the suite actually detects the bug (not vacuous). All 4 are in the `voidptr` / `wrapped` arms; no legacy assertion changed verdict, and master's `#2889` render-backend arm passes as a non-regression assertion. Re-run after the rebase.
- [x] **Naive-implementation control** (the axis `fleet-positive-control` cannot cover — the both-ends-const branch predates this fix, so the new arms correctly pass against pre-fix master). Weakened the reject chain's two-condition both-ends test to the naive `decl_core MATCHES "const"` — the design this executor rejects — and re-ran: **61 passed / 3 failed, all 3 in the new `halfconst` arm, zero legacy failures.** Re-measured on the rebased suite rather than rescaled from the pre-rebase 23/3; tree reverted afterwards (`git diff HEAD` empty). That is what makes "these arms are load-bearing" a measurement rather than a claim.
- [x] Manual repro of the issue's five probes (`a_plain`, `b_voidptr`, `c_wrapped`, `d_realconst`, `e_voidfn`) against the fixed executor — all match the issue's "fixed" column.
- [x] Manual repro of the real clang-format wrap arm (117-column `inline std::unordered_map<...>` wrapped at col 100 by `clang-format --style=file`) — now FLAGGED.
- [x] `fleet-build --target format-changed` — no formattable sources in this diff (cmake/bash/markdown only).
- [x] `bash scripts/fleet/tests/run_all.sh` — **124/125** suites pass; the one failure (`test_cross_repo_shared_file_parity.sh`, an unrelated `auto-rereview.yml` engine/game drift) is pre-existing on master, not introduced by this change.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. `c_wrapped.hpp` / clang-format arm-B FLAGGED; `a_plain.hpp` stays FLAGGED | manual repro + `test_header_checks_standalone.sh` "wrapped-declaration" case | `c_wrapped rc=1`; real clang-format wrap arm `rc=1`; `a_plain rc=1` |
| 2. `b_voidptr.hpp` FLAGGED | manual repro + `test_header_checks_standalone.sh` "void-pointer" case | `b_voidptr rc=1`, failure names `g_metalDevice` |
| 3. `d_realconst.hpp` / `e_voidfn.hpp` still pass | manual repro + `test_header_checks_standalone.sh` "void function" case | `d_realconst rc=0`; `e_voidfn rc=0` |
| 4. Zero new flags across the 574 in-scope headers | `cmake --build build --target header-checks` **and** the standalone CI entry point | Both report "Header convention checks scanned 574 header file(s); 0 file(s) baselined for header-global violations" |
| 5. `cpp-globals.md` §Detection allowance list matches the executor's reject chain | manual diff review | `void` removed from both; new precision note documents the wrap-join behavior |
| 6. The five probes land as a committed fixture | `scripts/fleet/tests/test_header_checks_standalone.sh` | 11 new assertions (voidptr ×2, voidfn ×1, wrapped ×2, `realconst` ×2, `halfconst` ×4). `d_realconst` now has a fixture that provably reaches the matcher: the `realconst` arm pins `scanned 3 header file(s)` (the clean fixture alone scans 2), and the `halfconst` arm flags both single-sided spellings from the same header so the both-ends form's absence is evidence about the reject chain, not a skipped file |

## Amend note (Opus recheck nits addressed)

The Opus recheck (2026-08-08T23:03) approved with two non-blocking nits on
`bf9caa9eb`. Addressed both:

- **O(n²) join scan.** The index-by-index `list(GET all_lines ${line_index})`
  walk is a linear scan per call, so an n-line file cost O(n²) overall —
  measured 5.5s tree-wide on this host pre-fix (1.67s on the review's cited
  4864-line vendored header alone), 6.35s in the recheck's own measurement.
  Rewritten as a single forward pass (`join_pending`/`join_buffer` state
  machine instead of re-deriving the next index); same terminator and
  10-line lookahead-bound semantics, ~0.8s tree-wide after the fix.
- **Paren-in-comment false-clean.** `inline std::unordered_map<int, int>  //
  registry (id -> slot)` followed by the continuation line read the
  comment's `(` as a function-declaration guard hit and silently exempted
  the global. Trailing `//` comments are now stripped from every raw line
  before either the terminator test or the guard sees it. New `parencomment`
  fixture arm asserts the wrap+paren-comment shape still exits 1.

### Verification (re-run on `d980bb8d4`)

- `bash scripts/fleet/tests/test_header_checks_standalone.sh` — **66/66**
  (was 64/64; +2 for the `parencomment` arm).
- `cmake -DPROJECT_ROOT=. -P cmake/run_header_checks_standalone.cmake` (CI
  entry point) — **574 headers scanned, 0 violations**, ~0.8s (was ~5.5s on
  `bf9caa9eb`'s O(n²) walk on this host).
- **Positive control** (`fleet-positive-control … origin/master --include cmake`)
  — MEANINGFUL: **6 of 66** fail against pre-fix `origin/master` (`5a1fdc9ec`).
  Attributed: `voidptr` ×2, `wrapped` ×2 (the original #2916 defects) +
  `parencomment` ×2 (this amend's fix). Zero legacy assertions changed
  verdict.
- **Naive-implementation control** — re-ran (weakened the both-ends-const
  test to naive `decl_core MATCHES "const"`, reverted after): **63 passed /
  3 failed, all 3 in `halfconst`, zero legacy failures.** Tree confirmed
  clean afterward (`git diff` empty against this commit).
- `bash scripts/fleet/tests/run_all.sh` — **124/125**, sole failure
  `test_cross_repo_shared_file_parity.sh`, the pre-existing cross-repo drift
  on master, unrelated to this change.
- No C++ sources in this diff (cmake/bash only) — `format-changed` has
  nothing to check.

## Rebase note (semantic conflict resolved)

Rebased onto `a9459315b` to clear `fleet:semantic-conflict`. The conflict was in `scripts/fleet/tests/test_header_checks_standalone.sh`: master's `#2889` render-backend arm and this PR's `voidptr`/`voidfn`/`wrapped` arms were appended at the same insertion point. Both sides' arms are kept, master's first so its "the same global" comment keeps its referent (the `DIRTY` arm above it).

One arm needed a real fix, not just a textual merge: `#2889` widened the collector to `INCLUDE_RENDER_BACKENDS`, which pulls `make_fixture`'s `metal_runtime.hpp` into scope, so the clean fixture now scans **2** headers rather than 1. The `realconst` arm pinned the old baseline (`scanned 2`) and went red on a correct merge. Re-measured the baseline directly and updated the arm to `scanned 3`, plus the comment that asserted the old number. The arm's mechanism is unchanged — baseline +1 still proves the exempt header entered the scan.

All measurements above were re-run on the rebased tree.

Closes #2916

🤖 Generated with [Claude Code](https://claude.com/claude-code)



