### PR TITLE
fleet: un-gate the stale-conflict cleanup from fleet:approved

### DIFF
--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -727,11 +727,13 @@ for pr in data.get("prs", []):
     # a concurrent second merger pass may succeed and push but not remove the
     # failed first pass's label. Detect before the general skip_re check so
     # MERGEABLE PRs with no real conflict bypass the skip-labels verdict and
-    # get label cleanup instead. Guard: no other skip labels present, PR is
-    # approved, and GitHub reports MERGEABLE (conflict is provably resolved).
+    # get label cleanup instead. Guard: no other skip labels present and
+    # GitHub reports MERGEABLE (conflict is provably resolved). Deliberately
+    # NOT guarded on `approved` — the merger strips fleet:approved in the same
+    # step it adds fleet:semantic-conflict, so gating on it would make this
+    # verdict unreachable in exactly the state it exists to clear (#2874).
     has_stale_conflict = (
         "fleet:semantic-conflict" in labels
-        and approved
         and mergeable == "MERGEABLE"
         and not any(skip_re.search(l) for l in labels if l != "fleet:semantic-conflict")
     )
@@ -741,17 +743,18 @@ for pr in data.get("prs", []):
     # cleanup rather than parking it (why nothing else ever clears it:
     # cleanup_stale_base_park, #2764).
     #
-    # Deliberately NOT guarded on `approved` or on other skip labels, unlike
-    # the stale-conflict case above — do not "unify" the two predicates
-    # (#2840). Those guards mean "don't touch a PR another agent owns", which
-    # is correct for every lane that does branch work; this verdict does none.
-    # It removes one retired label whose discharge base == master already
+    # Deliberately NOT guarded on other skip labels either, unlike the
+    # stale-conflict case above (which still requires no other skip label
+    # present) — do not "unify" the two predicates (#2840). The skip-label
+    # guard means "don't touch a PR another agent owns", which is correct
+    # for every lane that does branch work; this verdict does none. It
+    # removes one retired label whose discharge base == master already
     # proves, independent of who owns the branch, and a PR that is genuinely
     # parked keeps its real park label and routes to skip-labels next tick.
-    # The guards also defeat each other here: the merger strips fleet:approved
-    # at the same moment it adds fleet:semantic-conflict, and that label leads
-    # SKIP_LABEL_RE — so a conflicted retargeted child fails both at once and
-    # lands on skip-labels, which no lane revisits.
+    # A skip-label guard would also defeat this verdict outright:
+    # fleet:semantic-conflict leads SKIP_LABEL_RE, so a conflicted retargeted
+    # child carrying both labels would fail the guard and land on skip-labels,
+    # which no lane revisits.
     stack_park = {"fleet:needs-base-update", "fleet:awaiting-base"} & set(labels)
     has_stale_base_park = bool(stack_park) and base == "master"
     if has_stale_conflict:

--- a/scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
@@ -11,8 +11,12 @@
 # iteration on a branch that has no real conflict.
 #
 # The fix: fleet-rebase's triage detects fleet:semantic-conflict on a
-# MERGEABLE PR (no other skip labels, approved) and emits a "stale-conflict"
-# verdict that routes to cleanup_stale_conflict() instead of skip-labels.
+# MERGEABLE PR (no other skip labels) and emits a "stale-conflict" verdict
+# that routes to cleanup_stale_conflict() instead of skip-labels. The
+# predicate is deliberately NOT guarded on fleet:approved — the sole minter
+# of fleet:semantic-conflict strips fleet:approved in the same step it adds
+# the conflict label, so an approved guard would make this verdict unreachable
+# in exactly the state it exists to clear (#2874).
 #
 #   T1: MERGEABLE + fleet:semantic-conflict + fleet:approved → cleanup fires
 #       (dry-run: logs "would remove").
@@ -22,6 +26,11 @@
 #       not cleaned (WIP guard takes precedence).
 #   T4: fleet:semantic-conflict absent, MERGEABLE → normal llm-other path,
 #       no cleanup triggered.
+#   T5: MERGEABLE + fleet:semantic-conflict + fleet:merger-cooldown, NO
+#       fleet:approved → cleanup fires. This is the real #1654 end-state (the
+#       merger strips fleet:approved in the same step it adds the conflict
+#       label), and the one arm an approved guard routes to skip-labels
+#       instead — the regression lock for #2874.
 #
 # All run --auto --dry-run: the stale-conflict cleanup logs its intent but
 # does not call gh (which is gated behind DRY_RUN=0).
@@ -152,6 +161,21 @@ write_slice '[{
 T4=$(run_rebase)
 assert_absent "$T4" "would remove" \
     "T4 no stale label -> no cleanup"
+
+# === T5: real #1654 end-state — MERGEABLE + semantic-conflict + =============
+# === merger-cooldown, NO fleet:approved -> cleanup fires (#2874) ============
+echo "T5: MERGEABLE + semantic-conflict + merger-cooldown, no approved -> cleanup fires"
+write_slice '[{
+  "repo":"engine","number":304,
+  "headRefName":"feat-race","baseRefName":"master",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:semantic-conflict","fleet:merger-cooldown"]
+}]'
+T5=$(run_rebase)
+assert_contains "$T5" "would remove" \
+    "T5 cleanup fires on the real fail-then-succeed end-state with no fleet:approved (#2874)"
+assert_absent   "$T5" "llm_remaining=1" \
+    "T5 stale-conflict cleanup does not count toward LLM_REMAINING"
 
 # --- Summary ------------------------------------------------------------------
 summarize "fleet-rebase stale-conflict cleanup tests"


### PR DESCRIPTION
## Summary

- `fleet-rebase`'s `has_stale_conflict` required `fleet:approved`, but the sole
  minter of `fleet:semantic-conflict` strips `fleet:approved` in the same step it
  adds the conflict label, and no automated lane restores it while the conflict
  label is live. The `stale-conflict` verdict was therefore unreachable in exactly
  the state it exists to clear, so `cleanup_stale_conflict()` — the #1654 fix — has
  never fired since it landed 2026-06-12.
- Drops **only** the `approved` term. `mergeable == "MERGEABLE"` is the real proof
  the conflict is resolved, and `cleanup_stale_conflict()` already live-reverifies
  OPEN + MERGEABLE + label-still-present before touching anything. The skip-label
  term stays — T3 covers it and it is not implicated in the unreachability.
- Mirrors #2847, which un-gated the sibling `cleanup_stale_base_park` one
  file-region below. Both neighbouring rationale comments are reconciled: they
  still described `approved` as a live guard.

## Test plan

- [x] `bash scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh` —
      **9 passed, 0 failed** (T1–T4 unchanged, new T5).
- [x] **Positive control**: the suite run against the pre-fix `origin/master`
      (`12b8a49c8`) fails **1** assertion; the **8** that still pass are the
      non-regression assertions. (8 + 1 = 9, the full suite.) Run via
      `fleet-positive-control`, which reported `MEANINGFUL`.
- [x] `bash scripts/fleet/tests/run_all.sh` — 124 suites, **123 passed, 1 failed**.
      The single failure is `test_cross_repo_shared_file_parity.sh`, which
      reproduces unchanged on `origin/master` at `12b8a49c8` (a comment-only
      shared-workflow drift already filed downstream). It touches no file in this
      diff. No second suite failed.
- [x] `ruff check scripts/` — `All checks passed!`

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| `has_stale_conflict` no longer requires `fleet:approved` | `git diff origin/master -- scripts/fleet/fleet-rebase` | the `and approved` term is deleted from the predicate; `approved` remains bound at `:725` for the `attempt` / `merge-candidate` verdicts |
| Test gains an arm for the real end-state (`semantic-conflict` + `merger-cooldown`, MERGEABLE, **no** `approved`) → cleanup fires | `bash scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh` | `ok: T5 cleanup fires on the real fail-then-succeed end-state with no fleet:approved (#2874)` |
| …and that arm fails on the pre-fix tree (verdict `skip-labels`, no "would remove") | `fleet-positive-control scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh origin/master` | `FAIL: T5 …` / `expected to find: would remove` / log line shows `attempted=0 cleared=0 merged=0 llm_remaining=0` → `MEANINGFUL: 1 of 9` |
| T1–T4 still pass; T3's skip-label precedence unchanged | same suite run | `ok: T1 …` ×3, `ok: T2 …` ×2, `ok: T3 fleet:wip + stale-conflict not cleaned (WIP guard wins)`, `ok: T4 …` |
| `run_all.sh` green | `bash scripts/fleet/tests/run_all.sh` | `124 suite(s) — 123 passed, 1 failed, 0 skipped`; sole failure pre-existing on master (see Test plan) |

## Note for the reviewer — lane-widening check

`scripts/fleet/CLAUDE.md` requires checking claim-namespace overlap "whenever a
lane is added or its label set widened", and this widens the stale-conflict lane.
`fleet:resolving-` is **not** in `SKIP_LABEL_RE` (0 occurrences in the file), so a
PR that worker step-1c holds a `fleet:resolving-*` lock on is no longer excluded
from tier-0 cleanup.

Assessed as benign and deliberately left alone: the #2423 hazard is two panes
force-pushing one head branch, and `cleanup_stale_conflict()` does no branch work
— it is two `gh pr edit --remove-label` calls. Both lanes also converge on the
same action (remove the stale label), and the worker's own step-`b''` MERGEABLE
re-check clears it identically, so the worst case is a redundant remove-label on
an already-absent label. Adding `fleet:resolving-` to `SKIP_LABEL_RE` would change
behaviour for the `attempt` and `merge-candidate` verdicts too, which is outside
this issue's scope.

Closes #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
