### PR TITLE
engine: warn when --auto-screenshot arms no capture system (#2941)

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -40,8 +40,8 @@ void warnIfAutoScreenshotNeverArmed() {
         IRE_LOG_WARN(
             "--auto-screenshot was provided but no capture system is registered; "
             "this creation will render indefinitely and never exit. The creation "
-            "must call IRVideo::createAutoScreenshotSystem before gameLoop() "
-            "(see engine/video/CLAUDE.md)."
+            "must call IRVideo::createAutoScreenshotSystem (or createGuiTestSystem "
+            "for the GUI-test path) before gameLoop() (see engine/video/CLAUDE.md)."
         );
     }
 }

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -2,6 +2,7 @@
 
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_script.hpp>
+#include <irreden/ir_video.hpp>
 #include <irreden/render/voxel_pool_config.hpp>
 #include <irreden/input/systems/system_entity_hover_detect.hpp>
 
@@ -32,6 +33,17 @@ void applyPreInitLuaConfig(const char *configFile) {
 
 void clearEntityEventHandlers() {
     IRSystem::getEntityEventHandlers().clear();
+}
+
+void warnIfAutoScreenshotNeverArmed() {
+    if (args().wasProvided("--auto-screenshot") && !IRVideo::isAutoCaptureActive()) {
+        IRE_LOG_WARN(
+            "--auto-screenshot was provided but no capture system is registered; "
+            "this creation will render indefinitely and never exit. The creation "
+            "must call IRVideo::createAutoScreenshotSystem before gameLoop() "
+            "(see engine/video/CLAUDE.md)."
+        );
+    }
 }
 
 } // namespace IREngine::detail

--- a/engine/include/irreden/ir_engine.hpp
+++ b/engine/include/irreden/ir_engine.hpp
@@ -63,6 +63,14 @@ void applyPreInitLuaConfig(const char *configFile);
 // this deterministic clear prevents.
 void clearEntityEventHandlers();
 
+// Warns when --auto-screenshot was provided but no creation registered a
+// capture system, so the run would otherwise render indefinitely with no
+// diagnostic (#2941). Out-of-line in engine.cpp for the same reason as
+// clearEntityEventHandlers: the check reads IRVideo::isAutoCaptureActive(),
+// and inlining it would put ir_video.hpp in this header's include graph —
+// widening every includer of ir_engine.hpp to buy one log line.
+void warnIfAutoScreenshotNeverArmed();
+
 } // namespace detail
 
 // The process-global engine argument parser, pre-loaded with the engine-common
@@ -128,6 +136,7 @@ inline int entityCountOverride() {
 // process-exit destructor unrefs into nothing (#2572). Order matters: after
 // the reset the VM is gone and the unref is the crash itself.
 inline void gameLoop() {
+    detail::warnIfAutoScreenshotNeverArmed();
     getWorld().gameLoop();
     detail::clearEntityEventHandlers();
     g_world.reset();

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -98,9 +98,11 @@ callback** (`IREngine::registerLuaBindings`) must read the warmup count
 *inside that callback* instead — the callback fires from
 `World::setupLuaBindings` partway through `IREngine::init`, so a step-1 read
 placed after `init` returns lands after the pipeline is already built. The
-failure is silent and total: the `warmupFrames > 0` guard sees 0, no capture
-system is ever created, nothing calls `IRWindow::closeWindow()`, and the run
-hangs to the harness timeout with no screenshot and no error (#2502). A
+failure is total: the `warmupFrames > 0` guard sees 0, no capture system is
+ever created, nothing calls `IRWindow::closeWindow()`, and the run hangs to
+the harness timeout with no screenshot (#2502). It is no longer *silent* —
+`IREngine::gameLoop()` warns when `--auto-screenshot` was provided and
+nothing armed a capture (#2941), so the hang is greppable instead of mute. A
 creation that instead builds its pipeline in `main()` after `init` (the
 step-1–3 order above) is unaffected.
 

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -138,7 +138,8 @@ template <std::size_t LabelSize = 40> struct IndexedSweepShots {
     }
 };
 
-/// True once @c createAutoScreenshotSystem has been called this run — i.e. the
+/// True once either capture-system creator (@c createAutoScreenshotSystem or
+/// @c createGuiTestSystem) has been called this run — i.e. the
 /// process is doing a headless auto-screenshot capture. @c World reads this to
 /// switch the UPDATE loop to a deterministic fixed step (one tick per render
 /// frame) so per-tick animation (AUTO_SPIN, etc.) advances reproducibly during

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -55,8 +55,9 @@ struct CyclingState {
     bool screenshotPending_ = false;
 };
 
-// Set true the first time createAutoScreenshotSystem runs this process, i.e. a
-// headless --auto-screenshot capture is active. Read by World via
+// Set true the first time either capture-system creator
+// (createAutoScreenshotSystem or createGuiTestSystem) runs this process,
+// i.e. a headless --auto-screenshot capture is active. Read by World via
 // isAutoCaptureActive() to switch the UPDATE loop to a deterministic fixed
 // step. Process-lifetime flag; capture is one-shot per process.
 bool g_autoCaptureActive = false;


### PR DESCRIPTION
## Summary
- `IREngine::gameLoop()` now warns at entry when `--auto-screenshot` was provided but no creation armed a capture system, turning a silent infinite hang into a greppable diagnostic.
- The check is declared in `IREngine::detail` and defined out-of-line in `engine.cpp` (the `clearEntityEventHandlers` precedent), so `ir_video.hpp` stays out of the public header's include graph.
- Corrected `engine/video/CLAUDE.md`, which asserted this failure "is silent and total" — this change falsifies the *silent* half.

## Test plan
- [x] `fleet-build --target IRCreationDefault` and `--target IRLuaPerfGrid` — both exit 0.
- [x] `fleet-build --target header-checks` — exit 0, 573 headers scanned, 0 header-global violations.
- [x] `fleet-build --target format-changed` — exit 0, formatted 2 files, no content change.
- [x] All four acceptance arms run on this host (macOS/Metal arm64); table below.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Positive-fire: exactly one warning naming the flag and the unarmed capture | `fleet-run --timeout 20 IRCreationDefault --auto-screenshot 10` | 314 log lines; `grep -c 'no capture system is registered'` = **1**, at line 304 — `[warning] --auto-screenshot was provided but no capture system is registered; this creation will render indefinitely and never exit.` Emitted *before* the loop blocks. 0 `AutoScreenshot n/` lines, 0 `Saved screenshot`. |
| Negative control: no warning, **and** still exits clean with 2 screenshots | `fleet-run --timeout 0 IRLuaPerfGrid --auto-screenshot 10` | warning count **0**; `AutoScreenshot n/N` count **2** — `AutoScreenshot 1/2: fit_grid` and `AutoScreenshot 2/2: zoom1_origin`; `ir-run: RESULT=CLEAN exe=IRLuaPerfGrid exit=0`. Both halves reported, so the arm cannot pass vacuously. |
| Interactive run (flag absent) emits no warning | `fleet-run --timeout 15 IRCreationDefault` (reaped at 22 s) | warning count **0** over 314 lines — the same line count as the positive arm, and both lines that bracket the warn site there are present (`commands.lua` load = the line immediately before it; `C_ResolvedFields` registration = immediately after). The run reached and passed the call site, so the absence is real discrimination rather than a truncated log. |
| `ir_engine.hpp`'s include graph is not widened | `grep -n '^#include' engine/include/irreden/ir_engine.hpp` | Unchanged at 6 includes (`ir_args`, `world`, `filesystem`, `functional`, `string`, `vector`). The only `ir_video` occurrence in the header is inside a comment (line 69). |

## Notes for reviewer

**The plan review's binding constraint is applied, but its cited spelling does not reproduce — I measured both.** The review justified using `wasProvided("--auto-screenshot")` over `autoScreenshotWarmupFrames() > 0` with "`--auto-screenshot 0` is an accepted command line that returns 0 from a provided flag". It is not: `OPTIONAL_INT` consumes a space-separated token **only when it parses as a positive integer** (`engine/ir_args.cpp:308-321`), so `0` is left for the loop and lands in the positional handler —

```
$ fleet-run --timeout 15 IRLuaPerfGrid --auto-screenshot 0
Unexpected positional argument: 0
ir-run: RESULT=CRASH exe=IRLuaPerfGrid exit=2
```

The hole is real, just via the **inline** spelling, which the same branch takes verbatim (`--auto-screenshot=0`). Measured on `IRLuaPerfGrid`, whose own arming gate is `g_autoWarmupFrames > 0` (`main_lua.cpp:490`), so nothing arms and the run hangs:

| `--auto-screenshot=0` on IRLuaPerfGrid | Observed |
|---|---|
| parse errors | 0 (330 log lines) |
| warning emitted by this change | **1** |
| `AutoScreenshot n/N` lines | 0 — capture never armed |
| `Clean shutdown complete` | 0 — this is the hang |

So the constraint earns its keep on all 30 demos, not just the three capture-less ones; `autoScreenshotWarmupFrames() > 0` would have been silent on exactly this run. The conclusion the review reached was right — only the spelling it cited was wrong.

**Unrelated harness observation — recorded, deliberately not filed.** `fleet-run --timeout N` did not reap the hung positive-fire demo: it was alive at 6 min under `--timeout 20`, and a clean re-run at `--timeout 10` also failed to reap and emitted **no `ir-run: RESULT` line** (the arms that do exit print `RESULT=CLEAN` / `RESULT=CRASH`). The issue body's own repro shows `Terminated: 15` from that watchdog, so it is not caused by this diff — the change adds one log line before the loop.

I am **not** filing this as a defect, because I could not establish a mechanism and the second observation is confounded two ways: the harness killed my shell at 3 min, and `ir-run` execs behind an `ir-acquire gpu` lock whose wait may sit outside the measured timeout. A defect filed on that evidence would be noise. Routed to `~/.fleet/feedback/pool-1.md` instead, which is the channel for exactly this. Flagging here only so a reviewer reproducing the positive arm on macOS is not surprised by a demo that outlives its timeout — kill it by PID.

Closes #2941

🤖 Generated with [Claude Code](https://claude.com/claude-code)
