### PR TITLE
scripts/fleet: derive --help header slices from content, not line numbers

### DIFF
--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -87,7 +87,7 @@ for arg in "$@"; do
         --wait)         WAIT_FOR_IDLE=1 ;;
         --summary)      WANT_SUMMARY=1 ;;
         -h|--help)
-            sed -n '2,57p' "$0"
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0"
             exit 0
             ;;
         *) echo "fleet-down: unknown argument '$arg'" >&2; exit 2 ;;

--- a/scripts/fleet/fleet-heartbeat
+++ b/scripts/fleet/fleet-heartbeat
@@ -45,7 +45,7 @@ fi
 
 case "$1" in
     -h|--help)
-        sed -n '28,34p' "$0"
+        awk '/^# Usage:/ {f=1} f {if (/^#/) {print; next} else exit}' "$0"
         exit 0
         ;;
 esac

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -57,7 +57,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            sed -n '2,26p' "$0"
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0"
             exit 0
             ;;
         *)

--- a/scripts/fleet/fleet-pr-amend-push
+++ b/scripts/fleet/fleet-pr-amend-push
@@ -41,7 +41,7 @@ set -euo pipefail
 if [[ $# -gt 0 ]]; then
     case "$1" in
         -h|--help)
-            sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)

--- a/scripts/fleet/fleet-pr-checkout-detached
+++ b/scripts/fleet/fleet-pr-checkout-detached
@@ -58,7 +58,7 @@ fi
 # pr-number (and rejected by the integer check below).
 case "$1" in
     -h|--help)
-        sed -n '2,52p' "$0" | sed 's/^# \{0,1\}//'
+        awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
         exit 0
         ;;
 esac

--- a/scripts/fleet/fleet-pr-claim-feedback
+++ b/scripts/fleet/fleet-pr-claim-feedback
@@ -68,7 +68,7 @@ fi
 # Help first so `--help` isn't mis-parsed as the positional pr-number.
 case "$1" in
     -h|--help)
-        sed -n '2,59p' "$0" | sed 's/^# \{0,1\}//'
+        awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
         exit 0
         ;;
 esac

--- a/scripts/fleet/fleet-pr-clear-feedback-labels
+++ b/scripts/fleet/fleet-pr-clear-feedback-labels
@@ -59,7 +59,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         --)

--- a/scripts/fleet/fleet-review-verdict
+++ b/scripts/fleet/fleet-review-verdict
@@ -106,7 +106,7 @@ while [[ $# -gt 0 ]]; do
             repo_slug="${1#--repo=}"; shift ;;
         --dry-run) dry_run=1; shift ;;
         -h|--help)
-            sed -n '2,61p' "$0" | sed 's/^# \{0,1\}//'
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
             exit 0 ;;
         --) shift; break ;;
         -*)

--- a/scripts/fleet/fleet-transition
+++ b/scripts/fleet/fleet-transition
@@ -97,7 +97,7 @@ while [[ $# -gt 0 ]]; do
             repo_slug="${1#--repo=}"; shift ;;
         --dry-run) dry_run=1; shift ;;
         -h|--help)
-            sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
             exit 0 ;;
         --) shift; break ;;
         -*)

--- a/scripts/fleet/fleet-worktree-busy-branches
+++ b/scripts/fleet/fleet-worktree-busy-branches
@@ -49,9 +49,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            # Update the sed range here when adding/removing lines in the
-            # comment header above (lines 2-34 today).
-            sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'
+            awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)


### PR DESCRIPTION
## Summary
- Replaced hardcoded `sed -n 'N,Mp' "$0"` header slices with the content-derived `awk 'NR==1{next}/^#/{print;next}{exit}' "$0"` form (established by #2847/#2772/#2852) in 10 `scripts/fleet/*` `--help` handlers.
- `fleet-heartbeat`'s range doesn't start at line 1 (skips a rationale block), so it anchors on `/^# Usage:/` instead of a hardcoded start line.
- Deleted the now-false "update the sed range here" maintenance comment in `fleet-worktree-busy-branches`.

## Test plan
- [x] `bash -n` on all 10 touched scripts — syntax OK.
- [x] `fleet-rules-sweep --pattern "sed -n '[0-9]+,[0-9]+p' \"\$0\"" --glob '*' scripts/fleet` — exit 1, 0 matches, 202 files swept (real clean pass).
- [x] `bash scripts/fleet/fleet-pr-checkout-detached --help | grep -c 'set -euo'` — `0` (was `1` pre-fix, the #2433 leak).
- [x] `bash scripts/fleet/fleet-pr-clear-feedback-labels --help | grep -c '2  usage error'` — `1` (exit-code table no longer truncated).
- [x] Positive control (all 10 scripts): appended 2 sentinel `#` lines at the true header end in a scratch copy — post-fix `--help` gains exactly 2 lines for all 10; re-ran the same test against `origin/master`'s pre-fix versions — 0 lines gained for all 10 (the fixed sed ranges don't track header content).
- [x] `bash scripts/fleet/tests/run_all.sh` — 124 suites, 123 passed, 1 failed (`test_cross_repo_shared_file_parity.sh`, pre-existing on `origin/master`, unrelated — filed as game #368, do not re-file).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Tree-wide sweep returns no matches, coverage reported | `fleet-rules-sweep --pattern "sed -n '[0-9]+,[0-9]+p' \"\$0\"" --glob '*' scripts/fleet` | `swept 202 file(s) (202 walked in scope), 0 match(es)`, exit 1 |
| Each of 10 scripts: `--help` exits 0, last header line appears, no code leak | per-script `--help` runs | all exit 0; each ends on its own true last header comment line; `fleet-pr-checkout-detached --help \| grep -c 'set -euo'` = `0` |
| `fleet-pr-clear-feedback-labels --help` contains exit-code table | `... --help \| grep -c '2  usage error'` | `1` |
| Positive control per script | sentinel-line append, pre-fix vs post-fix diff | post-fix: +2 lines for all 10; pre-fix (origin/master): +0 lines for all 10 |
| `run_all.sh` stays green | `bash scripts/fleet/tests/run_all.sh` | 123/124 passed — matches the documented pre-existing master baseline (1 known unrelated failure) |

Closes #2885

🤖 Generated with [Claude Code](https://claude.com/claude-code)