### PR TITLE
fleet: needs-windows-smoke missing from merger skip set and fleet-rebase SKIP_LABEL_RE (#2888)

### DIFF
--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -134,7 +134,7 @@ rearm_llm() {
 #
 # Single source: the python triage below reads this via
 # FLEET_REBASE_SKIP_RE and the pre-push re-verify greps it directly.
-SKIP_LABEL_RE='fleet:semantic-conflict|fleet:wip|human:wip|fleet:needs-fix|human:needs-fix|human:blocker|human:re-review|fleet:design-blocked|fleet:amending-|fleet:blocker|fleet:needs-info|fleet:fork-of-other-pr|fleet:needs-linux-smoke|fleet:needs-macos-smoke'
+SKIP_LABEL_RE='fleet:semantic-conflict|fleet:wip|human:wip|fleet:needs-fix|human:needs-fix|human:blocker|human:re-review|fleet:design-blocked|fleet:amending-|fleet:blocker|fleet:needs-info|fleet:fork-of-other-pr|fleet:needs-linux-smoke|fleet:needs-macos-smoke|fleet:needs-windows-smoke'
 export FLEET_REBASE_SKIP_RE="$SKIP_LABEL_RE"
 
 # Auto-merge lane gates. MERGE_LABEL_ALLOW_RE is the benign-label allowlist:

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -2078,10 +2078,11 @@ def _merger_action_signal(labels, mergeable, base_ref):
     fired, toggled its cooldown, re-fired itself on the next scout tick.
     Observed live 2026-05-09 burning ~$2/10min on idle state.
 
-    `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` are also
-    skip signals — the merger isn't the agent that resolves those;
-    a smoke-runner clears them. Including them as merger candidates
-    just makes the merger fire repeatedly to find nothing to do.
+    `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` /
+    `fleet:needs-windows-smoke` are also skip signals — the merger
+    isn't the agent that resolves those; a smoke-runner clears them.
+    Including them as merger candidates just makes the merger fire
+    repeatedly to find nothing to do.
 
     `fleet:human-deferred` is intentionally NOT skipped. It marks a PR
     whose *human-review feedback* was deferred to a follow-up issue
@@ -2120,7 +2121,7 @@ def _merger_action_signal(labels, mergeable, base_ref):
         # design-blocked; design-unblock re-surfaces it (#1664).
         "fleet:design-proposed",
         "fleet:needs-info", "fleet:needs-linux-smoke",
-        "fleet:needs-macos-smoke",
+        "fleet:needs-macos-smoke", "fleet:needs-windows-smoke",
         # Blocked on a gated self-config edit no agent can push. The
         # conflict itself is in the gated file, so the merger can never
         # resolve or merge it — skip unconditionally (human-only). This is

--- a/scripts/fleet/tests/test_fleet_rebase_smoke_skip_labels.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_smoke_skip_labels.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Tests that fleet-rebase's SKIP_LABEL_RE treats all three cross-host smoke
+# labels identically (issue #2888).
+#
+# #2804 widened the scout's _SMOKE_PENDING_LABELS from two smoke labels to
+# three (adding fleet:needs-windows-smoke), but SKIP_LABEL_RE here was a
+# hand-listed consumer left at two. A stacked PR (base != master) carrying
+# only fleet:approved + fleet:needs-windows-smoke fell through to the
+# "attempt" verdict — tier-0 would mechanically rebase and force-push it,
+# invalidating the pending smoke verification the label exists to protect
+# (fleet-rebase:124's own stated rationale for skipping smoke-pending PRs).
+#
+#   T1: base != master, fleet:needs-linux-smoke   -> skip-labels (control)
+#   T2: base != master, fleet:needs-macos-smoke   -> skip-labels (control)
+#   T3: base != master, fleet:needs-windows-smoke -> skip-labels (the fix;
+#       pre-fix this PR fell through to "attempt" and force-pushed the
+#       branch out from under the pending Windows smoke run)
+#   T4: no smoke label -> the normal "attempt" path is unchanged
+#
+# All run --auto --dry-run: attempt_pr's git push happens against a local
+# bare remote in the sandbox, so a "clean rebase onto" or "attempted=1" line
+# is proof branch work was attempted, not just logged.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REBASE="$SCRIPT_DIR/fleet-rebase"
+
+if [[ ! -x "$REBASE" ]]; then
+    echo "test setup: fleet-rebase not executable at $REBASE" >&2
+    exit 1
+fi
+
+source "$(dirname "$0")/lib_assert.sh"
+
+TMPROOT=""
+
+cleanup() {
+    if [[ -n "$TMPROOT" && -d "$TMPROOT" ]]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+# --- Sandbox ------------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT"
+export FLEET_STATE_DIR="$TMPROOT/.fleet/state"
+export FLEET_REBASE_SCRATCH="$TMPROOT/.fleet/rebase-scratch"
+mkdir -p "$FLEET_STATE_DIR/projections" "$TMPROOT/bin" "$TMPROOT/log"
+
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+REMOTE="$TMPROOT/remote.git"
+ENGINE="$TMPROOT/src/IrredenEngine"
+
+git init --bare -b master "$REMOTE" >/dev/null 2>&1
+
+AUTH="$TMPROOT/auth"
+git clone "$REMOTE" "$AUTH" -q
+git -C "$AUTH" config commit.gpgsign false
+echo init > "$AUTH/readme.txt"
+git -C "$AUTH" add readme.txt
+git -C "$AUTH" commit -q -m "init"
+git -C "$AUTH" push origin master -q
+
+# feat-parent: the upstream base a stacked child would rebase onto.
+git -C "$AUTH" checkout -b feat-parent master -q
+echo "parent work" > "$AUTH/parent.txt"
+git -C "$AUTH" add parent.txt
+git -C "$AUTH" commit -q -m "parent commit"
+git -C "$AUTH" push origin feat-parent -q
+
+# feat-child: already up to date with feat-parent, so a real rebase attempt
+# would push cleanly (proving branch work was attempted, not just skipped).
+git -C "$AUTH" checkout -b feat-child feat-parent -q
+echo "child work" > "$AUTH/child.txt"
+git -C "$AUTH" add child.txt
+git -C "$AUTH" commit -q -m "child commit"
+git -C "$AUTH" push origin feat-child -q
+
+git clone "$REMOTE" "$ENGINE" -q
+git -C "$ENGINE" config commit.gpgsign false
+
+# Minimal stub gh: silent success on everything.
+cat > "$TMPROOT/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+chmod +x "$TMPROOT/bin/gh"
+export PATH="$TMPROOT/bin:$PATH"
+
+write_slice() {
+    printf '{"prs": %s}\n' "$1" > "$FLEET_STATE_DIR/projections/merger.json"
+}
+
+run_rebase() {
+    "$REBASE" --auto --dry-run 2>&1 || true
+}
+
+# === T1: fleet:needs-linux-smoke -> skip-labels (control) ====================
+echo "T1: base != master, fleet:needs-linux-smoke -> skip-labels"
+write_slice '[{
+  "repo":"engine","number":500,
+  "headRefName":"feat-child","baseRefName":"feat-parent",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:needs-linux-smoke"]
+}]'
+T1=$(run_rebase)
+assert_absent "$T1" "clean rebase onto" \
+    "T1 needs-linux-smoke blocks branch work"
+assert_absent "$T1" "attempted=1" \
+    "T1 needs-linux-smoke does not reach the attempt path"
+
+# === T2: fleet:needs-macos-smoke -> skip-labels (control) ====================
+echo "T2: base != master, fleet:needs-macos-smoke -> skip-labels"
+write_slice '[{
+  "repo":"engine","number":501,
+  "headRefName":"feat-child","baseRefName":"feat-parent",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:needs-macos-smoke"]
+}]'
+T2=$(run_rebase)
+assert_absent "$T2" "clean rebase onto" \
+    "T2 needs-macos-smoke blocks branch work"
+assert_absent "$T2" "attempted=1" \
+    "T2 needs-macos-smoke does not reach the attempt path"
+
+# === T3: fleet:needs-windows-smoke -> skip-labels (the #2888 fix) ============
+echo "T3: base != master, fleet:needs-windows-smoke -> skip-labels"
+write_slice '[{
+  "repo":"engine","number":502,
+  "headRefName":"feat-child","baseRefName":"feat-parent",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:needs-windows-smoke"]
+}]'
+T3=$(run_rebase)
+assert_absent "$T3" "clean rebase onto" \
+    "T3 needs-windows-smoke blocks branch work — the orphaned label from #2888"
+assert_absent "$T3" "attempted=1" \
+    "T3 needs-windows-smoke does not reach the attempt path"
+
+# === T4: no smoke label -> the normal attempt path is unchanged ==============
+echo "T4: base != master, no smoke label -> attempt (unchanged)"
+write_slice '[{
+  "repo":"engine","number":503,
+  "headRefName":"feat-child","baseRefName":"feat-parent",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved"]
+}]'
+T4=$(run_rebase)
+assert_contains "$T4" "attempted=1" \
+    "T4 an ordinary stacked PR still reaches the attempt path"
+
+# --- Summary ------------------------------------------------------------------
+summarize "fleet-rebase smoke-label skip parity tests"

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -133,6 +133,17 @@ class SkipLabelsRemovedFromProjection(unittest.TestCase):
         ])])
         self.assertEqual(_hash(empty), _hash(with_smoke))
 
+    def test_needs_windows_smoke_dropped(self):
+        # #2888: fleet:needs-windows-smoke was the orphaned third smoke
+        # label — must behave identically to linux/macos, not leak through
+        # as a merge-ready wake.
+        empty = _state([])
+        with_smoke = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:needs-windows-smoke",
+        ])])
+        self.assertEqual(_hash(empty), _hash(with_smoke),
+                         "needs-windows-smoke PRs should be invisible to merger")
+
     def test_wip_dropped(self):
         empty = _state([])
         with_wip = _state([_pr(101, labels=[


### PR DESCRIPTION
## Summary

`#2804` widened the scout's `_SMOKE_PENDING_LABELS` from two smoke labels
to three (adding `fleet:needs-windows-smoke`), but two hand-listed
consumer sets were left at two:

1. `fleet-state-scout`'s `_merger_action_signal` skip set
2. `fleet-rebase`'s `SKIP_LABEL_RE`

Both are documented as skip signals specifically because a smoke-pending
PR shouldn't be touched by the merger or by tier-0's mechanical rebase —
but `fleet:needs-windows-smoke` alone slipped through both:

- **Merger projection:** an `approved` + `needs-windows-smoke` PR
  projected `merge-ready`, waking the merger to find nothing to do
  (the exact wasted-wake failure the linux/macos entries exist to
  prevent).
- **fleet-rebase:** a **stacked** (`base != master`) PR carrying only
  those two labels fell through triage to the `attempt` verdict —
  mechanically rebasing and force-pushing a branch a pending Windows
  smoke run needs to stay put on.

## Changes

- `scripts/fleet/fleet-state-scout`: added `fleet:needs-windows-smoke`
  to `_merger_action_signal`'s skip set; docstring now names all three
  smoke labels.
- `scripts/fleet/fleet-rebase`: added `fleet:needs-windows-smoke` to
  `SKIP_LABEL_RE`.
- `scripts/fleet/tests/test_merger_projection.py`: added
  `test_needs_windows_smoke_dropped`, mirroring the existing
  linux/macos arms.
- `scripts/fleet/tests/test_fleet_rebase_smoke_skip_labels.sh` (new):
  four-arm test exercising `fleet-rebase`'s triage directly against a
  stacked (`base != master`) PR — linux/macos controls plus the
  windows arm, and an unlabeled control confirming the ordinary
  `attempt` path is unchanged.

## Verification

- New suite (`test_fleet_rebase_smoke_skip_labels.sh`): 7/7 pass on
  the fixed tree. **Positive control**: reverting just the
  `SKIP_LABEL_RE` addition fails the windows arm with `attempted=1`
  (real branch work — `git push` against the sandbox remote
  succeeded), confirming the test is meaningful, not vacuous.
- `python3 scripts/fleet/tests/test_merger_projection.py`: 34/34 pass.
- `bash scripts/fleet/tests/run_all.sh`: 125/126 suites pass. The sole
  failure, `test_cross_repo_shared_file_parity.sh`, is a pre-existing
  master-red baseline (comment-only `auto-rereview.yml` drift between
  repos, filed as game #368) — unrelated to this diff.
- `ruff check` clean on the touched Python file.

Closes #2888
