### PR TITLE
docs: disambiguate deferred IREntity::destroyEntity from the eager method (#2951)

### DIFF
--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -89,8 +89,32 @@ deferred API:
 - `stageStructuralChange(fn)` — queue an arbitrary `void()` mutation (the
   non-templated staging entry point the Lua `IREntity.deferredCreate` binding
   uses to marshal runtime-typed component attachment).
+- `destroyEntity(id)` — **the `IREntity::` free function** (not the eager
+  `EntityManager::` method of the same name): delegates to
+  `markEntityForDeletion`, so the entity stays fully live until
+  `destroyMarkedEntities` drains the mark list. See the note below.
 - `flushStructuralChanges()` — apply queued changes at a safe point (the
   frame boundary in most pipelines).
+
+> **`destroyEntity` names two functions with opposite timing.** The bare
+> spelling resolves to whichever one is in scope, so decide deliberately:
+>
+> | Spelling | Timing | Callable from |
+> |---|---|---|
+> | `IREntity::destroyEntity(id)` — free function | **Deferred.** Delegates to `markEntityForDeletion`; the entity is only *marked*, and stays fully queryable until `destroyMarkedEntities` runs | main thread or a `PARALLEL_FOR` worker (routes to the caller's staging slot) |
+> | `IREntity::getEntityManager().destroyEntity(id)` — manager method | **Eager.** Tears the entity down in place; runs the pre-destroy hooks and asserts on a dead id | main thread only |
+>
+> Creations reach the engine through the `ir_*.hpp` entry points
+> (`engine/CLAUDE.md` §"Module include discipline"), so the one a creation
+> writes is the **deferred** free function. Probing the id in the same tick
+> therefore still reports it alive — `entityExists` `true`, `hasComponent`
+> `true`, `getComponentOptional` returning a value. That is the
+> marked-but-not-yet-drained state working as designed, not the stale-record
+> corruption described in §"Record lookup". When the entity must be gone before
+> the next statement, call the manager method explicitly.
+>
+> Unqualified `destroyEntity` elsewhere in this file means the eager manager
+> method.
 
 ### Per-worker buffers + thread safety (T-225)
 
@@ -135,7 +159,10 @@ misuse only in debug builds):
 - `setComponent<C>(id, value)` — use `setComponentDeferred` instead
 - `removeComponent<C>(id)` — use `removeComponentDeferred` instead
 - `removeComponentById(id, componentId)`
-- `destroyEntity(id)` — use `markEntityForDeletion` instead
+- `EntityManager::destroyEntity(id)` — the **eager** teardown. Use
+  `markEntityForDeletion`, or the `IREntity::destroyEntity` free function that
+  wraps it, instead. Note the two spellings differ in semantics, not just in
+  reachability — see §"Deferred structural changes"
 - `setComponents(id, ...)` (multi-component overloads)
 - `insertNewComponent<C>(id, value)`
 - `createEntityBatch(...)` / `createEntitiesBatch(...)` — batch paths do not


### PR DESCRIPTION
## Summary
- `engine/entity/CLAUDE.md` listed `destroyEntity(id)` under **"Eager mutation APIs"** with the advice *"use `markEntityForDeletion` instead"*. That describes `EntityManager::destroyEntity` — but the spelling a creation writes is the `IREntity::` free function, which **already** delegates to `markEntityForDeletion` and is therefore deferred. The advice was a no-op for the function most readers hold, and the framing told them it was eager.
- The two sections also disagreed: §"Deferred structural changes" enumerated the deferred API without `destroyEntity`, so a reader checking both concluded "the deferred set does not include destroy" — wrong, and lifetime-shaped.
- Fix: name the manager method explicitly in the eager list, add the free function to the deferred list, and state the split once in a table covering **timing** and **calling thread** for both spellings.

## Test plan
- [x] `rg -n "destroyEntity" engine/entity/CLAUDE.md` — eager-list entry now reads `EntityManager::destroyEntity(id)`; deferred-list entry names the `IREntity::` free function.
- [x] `rg -n "markEntityForDeletion" engine/entity/src/ir_entity.cpp` — free function still delegates (AC4 guard against the doc being "fixed" to match behaviour that later changes).
- [x] Verified in code, not assumed: `EntityManager::markEntityForDeletion` (`entity_manager.cpp:140-148`) routes through `workerSlotForCurrentThread()` with no main-thread assert, so the free function is worker-callable; `EntityManager::destroyEntity` (`entity_manager.cpp:151+`) validates before firing pre-destroy hooks.
- [x] All 3 `§"..."` citations added by this diff resolve **at `origin/master`** (not just the worktree): `§"Module include discipline"` → `engine/CLAUDE.md:5`, `§"Deferred structural changes"` → `engine/entity/CLAUDE.md:79`, `§"Record lookup"` → `:159`.
- [x] All 6 cited symbols verified present in **code** (`.hpp`/`.cpp`), not only in the doc.
- [x] Docs-only diff — no build required; no C++, shader, or Python touched.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| 1. Eager-API list no longer implies the `IREntity::` free function is eager; names the manager method explicitly | `rg -n "EntityManager::destroyEntity\(id\)" engine/entity/CLAUDE.md` | `162:- \`EntityManager::destroyEntity(id)\` — the **eager** teardown. Use` |
| 2. File states the eager/deferred split for this name in one place; a reader can answer "is `IREntity::destroyEntity` deferred?" from the doc alone | `rg -n 'names two functions with opposite timing' engine/entity/CLAUDE.md` | `99:> **\`destroyEntity\` names two functions with opposite timing.**` — followed by a 2-row table giving timing + calling thread for each spelling |
| 3. Deferred section lists `destroyEntity` (free function), so the two sections agree | `rg -n '^- \`destroyEntity\(id\)\`' engine/entity/CLAUDE.md` | `92:- \`destroyEntity(id)\` — **the \`IREntity::\` free function** (not the eager …` |
| 4. Claim checked against the tree, not assumed | `rg -n "markEntityForDeletion" engine/entity/src/ir_entity.cpp` | `12:    getEntityManager().markEntityForDeletion(entity);` |

**Note on AC3's section name:** the issue calls it §"Deferred entity operations"; the actual heading is §"Deferred structural changes" (`engine/entity/CLAUDE.md:79`). Same section — recording the discrepancy rather than silently reinterpreting the criterion.

## Findings (deferred, not folded in)
`EntityHandle` (`engine/entity/include/irreden/entity/entity_handle.hpp:74-80`) exposes the same eager/deferred split through a third route — `destroy()` calls the eager `destroyEntity`, `destroyDeferred()` calls `markEntityForDeletion`. Those spellings are unambiguous, so this PR's claim ("`destroyEntity` names two functions") stays accurate. Not folded in: this `CLAUDE.md` never introduces `EntityHandle` at all, so a bare mention would dangle a new topic. Flagging for a reviewer's call on whether the doc should cover the handle API separately.

Closes #2951

🤖 Generated with [Claude Code](https://claude.com/claude-code)