### PR TITLE
render/cmake: strip comments before Metal registry MATCHALL scans (#2899)

### DIFF
--- a/cmake/run_metal_kernel_registry_check.cmake
+++ b/cmake/run_metal_kernel_registry_check.cmake
@@ -75,7 +75,7 @@ foreach(line IN LISTS pipeline_lines)
     # forward direction this check exists to close. Handle both line (//) and
     # block (/* ... */) comments; the sibling scratch-consumer checker applies
     # the identical strip for the identical reason (#2899).
-    string(REGEX REPLACE "/\\*.*\\*/" "" line "${line}")
+    string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" line "${line}")
     string(REGEX REPLACE "//.*" "" line "${line}")
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)

--- a/cmake/run_metal_kernel_registry_check.cmake
+++ b/cmake/run_metal_kernel_registry_check.cmake
@@ -56,6 +56,7 @@ set(in_registry FALSE)
 set(found_registry FALSE)
 set(found_terminator FALSE)
 set(registered_kernels "")
+set(in_block_comment FALSE)
 foreach(line IN LISTS pipeline_lines)
     if(NOT in_registry)
         if(line MATCHES "MTL::Size[ \t]+threadgroupSizeForFunctionName\\(")
@@ -72,11 +73,30 @@ foreach(line IN LISTS pipeline_lines)
     # reaches the compiled binary, so the kernel it named silently falls
     # through to the MTL::Size(1, 1, 1) fallback while this check reads the
     # dead line and still sees it "registered" -- a false clean in the exact
-    # forward direction this check exists to close. Handle both line (//) and
-    # block (/* ... */) comments; the sibling scratch-consumer checker applies
-    # the identical strip for the identical reason (#2899).
+    # forward direction this check exists to close. Handle line (//) and BOTH
+    # block-comment shapes -- same-line /* ... */ and a block that spans
+    # multiple lines (the registry's real entries are multi-line `if`
+    # conditions, so a block comment disabling one spans lines too); the
+    # sibling scratch-consumer checker applies the identical strip for the
+    # identical reason (#2899).
+    if(in_block_comment)
+        if(line MATCHES "\\*/")
+            # Strip through the FIRST "*/" only -- CMake's regex engine has no
+            # lazy quantifier, so this reuses the same non-greedy-emulation
+            # trick as the same-line block-comment strip below rather than a
+            # greedy ".*\\*/" that would run past this "*/" to a later one.
+            string(REGEX REPLACE "^([^*]|\\*+[^*/])*\\*+/" "" line "${line}")
+            set(in_block_comment FALSE)
+        else()
+            set(line "")
+        endif()
+    endif()
     string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" line "${line}")
     string(REGEX REPLACE "//.*" "" line "${line}")
+    if(line MATCHES "/\\*")
+        string(REGEX REPLACE "/\\*.*$" "" line "${line}")
+        set(in_block_comment TRUE)
+    endif()
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)
         string(REPLACE "\"" "" bare_name "${quoted_name}")

--- a/cmake/run_metal_kernel_registry_check.cmake
+++ b/cmake/run_metal_kernel_registry_check.cmake
@@ -68,6 +68,15 @@ foreach(line IN LISTS pipeline_lines)
         set(found_terminator TRUE)
         break()
     endif()
+    # Strip comments before harvesting names. A commented-out entry never
+    # reaches the compiled binary, so the kernel it named silently falls
+    # through to the MTL::Size(1, 1, 1) fallback while this check reads the
+    # dead line and still sees it "registered" -- a false clean in the exact
+    # forward direction this check exists to close. Handle both line (//) and
+    # block (/* ... */) comments; the sibling scratch-consumer checker applies
+    # the identical strip for the identical reason (#2899).
+    string(REGEX REPLACE "/\\*.*\\*/" "" line "${line}")
+    string(REGEX REPLACE "//.*" "" line "${line}")
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)
         string(REPLACE "\"" "" bare_name "${quoted_name}")

--- a/cmake/run_metal_scratch_consumer_check.cmake
+++ b/cmake/run_metal_scratch_consumer_check.cmake
@@ -197,6 +197,7 @@ set(in_list FALSE)
 set(found_list FALSE)
 set(found_terminator FALSE)
 set(listed_consumers "")
+set(in_block_comment FALSE)
 foreach(line IN LISTS pipeline_lines)
     if(NOT in_list)
         if(line MATCHES "bool[ \t]+functionUsesImageAtomicScratch\\(")
@@ -214,11 +215,29 @@ foreach(line IN LISTS pipeline_lines)
     # bindComputeResources is concerned, so reading it as present is a false
     # clean in the forward direction: the consumer stops getting the scratch
     # bound, its imageAtomicMin writes land nowhere, and this check stays green.
-    # Handles both line (//) and block (/* ... */) comments; the sibling
-    # run_metal_kernel_registry_check.cmake's identical scan applies the same
-    # two-form strip (#2899).
+    # Handles line (//) and BOTH block-comment shapes -- same-line /* ... */
+    # and a block that spans multiple lines (disabling a run of consecutive
+    # entries is the natural reason to reach for a block comment here, and
+    # that spans lines); the sibling run_metal_kernel_registry_check.cmake's
+    # identical scan applies the same strip (#2899).
+    if(in_block_comment)
+        if(line MATCHES "\\*/")
+            # Strip through the FIRST "*/" only -- CMake's regex engine has no
+            # lazy quantifier, so this reuses the same non-greedy-emulation
+            # trick as the same-line block-comment strip below rather than a
+            # greedy ".*\\*/" that would run past this "*/" to a later one.
+            string(REGEX REPLACE "^([^*]|\\*+[^*/])*\\*+/" "" line "${line}")
+            set(in_block_comment FALSE)
+        else()
+            set(line "")
+        endif()
+    endif()
     string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" line "${line}")
     string(REGEX REPLACE "//.*" "" line "${line}")
+    if(line MATCHES "/\\*")
+        string(REGEX REPLACE "/\\*.*$" "" line "${line}")
+        set(in_block_comment TRUE)
+    endif()
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)
         string(REPLACE "\"" "" bare_name "${quoted_name}")

--- a/cmake/run_metal_scratch_consumer_check.cmake
+++ b/cmake/run_metal_scratch_consumer_check.cmake
@@ -217,7 +217,7 @@ foreach(line IN LISTS pipeline_lines)
     # Handles both line (//) and block (/* ... */) comments; the sibling
     # run_metal_kernel_registry_check.cmake's identical scan applies the same
     # two-form strip (#2899).
-    string(REGEX REPLACE "/\\*.*\\*/" "" line "${line}")
+    string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" line "${line}")
     string(REGEX REPLACE "//.*" "" line "${line}")
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)

--- a/cmake/run_metal_scratch_consumer_check.cmake
+++ b/cmake/run_metal_scratch_consumer_check.cmake
@@ -214,10 +214,10 @@ foreach(line IN LISTS pipeline_lines)
     # bindComputeResources is concerned, so reading it as present is a false
     # clean in the forward direction: the consumer stops getting the scratch
     # bound, its imageAtomicMin writes land nowhere, and this check stays green.
-    # Scope: line comments only. A `/* ... */` around an entry still reads as
-    # present, and the sibling run_metal_kernel_registry_check.cmake's identical
-    # scan strips neither form. Both are #2899 -- fixing one comment form in one
-    # of the two checkers here would leave the pair asymmetric for no gain.
+    # Handles both line (//) and block (/* ... */) comments; the sibling
+    # run_metal_kernel_registry_check.cmake's identical scan applies the same
+    # two-form strip (#2899).
+    string(REGEX REPLACE "/\\*.*\\*/" "" line "${line}")
     string(REGEX REPLACE "//.*" "" line "${line}")
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -17,13 +17,17 @@
 #     checks ran (1 kernel scanned, _body fragment excluded as an entry point
 #     but still read through the wrapper's include chain)
 #   - an unregistered Metal compute kernel          → exit 1, names the kernel
+#   - a line- or block-commented registry entry     → exit 1, names the kernel
+#     (a commented-out entry never reaches the compiled binary, so it must
+#     read as absent, not present — both comment forms, #2899)
 #   - a registry with no bare "}" terminator line   → exit 1 (EOF guard, not
 #     a silent scan past the function into unrelated string literals)
 #   - a scratch consumer absent from the list       → exit 1, names the kernel
 #   - a non-atomic decl at the scratch slot         → exit 0 (the #1619 params
 #     UBO shape must NOT be flagged — negative control)
-#   - a commented-out list entry                    → exit 1 (the runtime stops
-#     binding for it, so it must read as absent, not present)
+#   - a line- or block-commented list entry         → exit 1 (the runtime stops
+#     binding for it, so it must read as absent, not present — both comment
+#     forms, #2899)
 #   - a hand-wrapped scratch declaration            → exit 1 (the qualifier test
 #     reads the declaration window, not the attribute's line)
 #   - an atomic neighbour on the slot's line        → exit 0 (that qualifier
@@ -64,11 +68,17 @@ trap 'rm -rf "$TMPROOT"' EXIT
 # it in the former — otherwise the registry check (#2798) FATALs first and the
 # arm silently tests that checker instead of the one it names.
 #
-# $4 (optional) is a list of scratch entries emitted COMMENTED OUT — the way a
-# developer disables one, rather than deleting it. bindComputeResources binds
-# off the live list, so those names must read as absent.
+# $4 (optional) is a list of scratch entries emitted LINE-COMMENTED OUT (//) —
+# the way a developer disables one, rather than deleting it. bindComputeResources
+# binds off the live list, so those names must read as absent. $5 is the same
+# but BLOCK-COMMENTED (/* ... */) — the sibling comment form #2899 closes. $6
+# and $7 are the registry-side twins: kernel names whose
+# threadgroupSizeForFunctionName entry is emitted commented out, line-style and
+# block-style respectively.
 write_pipeline_cpp() {
-    local root="$1" registry_names="$2" scratch_names="$3" commented_names="${4:-}" name
+    local root="$1" registry_names="$2" scratch_names="$3" commented_names="${4:-}" \
+          commented_names_block="${5:-}" registry_commented_names="${6:-}" \
+          registry_commented_names_block="${7:-}" name
     local out="$root/engine/render/src/metal/metal_pipeline.cpp"
     {
         echo 'namespace IRRender {'
@@ -80,6 +90,12 @@ write_pipeline_cpp() {
             echo '        return MTL::Size(16, 16, 1);'
             echo '    }'
         done
+        for name in $registry_commented_names; do
+            echo "    // if (functionName == \"$name\") { return MTL::Size(16, 16, 1); }"
+        done
+        for name in $registry_commented_names_block; do
+            echo "    /* if (functionName == \"$name\") { return MTL::Size(16, 16, 1); } */"
+        done
         echo '    return MTL::Size(1, 1, 1);'
         echo '}'
         echo
@@ -90,6 +106,9 @@ write_pipeline_cpp() {
         done
         for name in $commented_names; do
             echo "        // || functionName == \"$name\""
+        done
+        for name in $commented_names_block; do
+            echo "        /* || functionName == \"$name\" */"
         done
         echo '        ;'
         echo '}'
@@ -194,6 +213,39 @@ assert_contains "$metal_out" "c_unregistered_kernel" \
 assert_absent "$metal_out" "c_fixture_kernel" \
     "registered kernel is not flagged as missing"
 
+# --- a line-commented (//) registry entry reads as absent, not present -------
+# A kernel absent from threadgroupSizeForFunctionName silently falls through to
+# the MTL::Size(1, 1, 1) fallback -- no assert, no log, no build error -- so a
+# commented-out entry must fail exactly like an omitted one.
+REGISTRY_COMMENTED="$TMPROOT/registry-commented"
+make_fixture "$REGISTRY_COMMENTED"
+echo '// registry-commented fixture kernel' \
+    > "$REGISTRY_COMMENTED/engine/render/src/shaders/metal/c_registry_commented.metal"
+write_pipeline_cpp "$REGISTRY_COMMENTED" "c_fixture_kernel" "c_fixture_kernel" "" "" \
+    "c_registry_commented"
+registry_commented_out=$(run_checker "$REGISTRY_COMMENTED")
+registry_commented_rc=$?
+assert_eq "1" "$registry_commented_rc" "line-commented-out registry entry exits 1"
+assert_contains "$registry_commented_out" "c_registry_commented" \
+    "failure names the kernel whose registry entry was commented out"
+assert_contains "$registry_commented_out" "no entry in" \
+    "a commented-out registry entry is reported as absent, not present"
+
+# --- a block-commented (/* */) registry entry reads as absent, not present ---
+REGISTRY_COMMENTED_BLOCK="$TMPROOT/registry-commented-block"
+make_fixture "$REGISTRY_COMMENTED_BLOCK"
+echo '// registry-commented-block fixture kernel' \
+    > "$REGISTRY_COMMENTED_BLOCK/engine/render/src/shaders/metal/c_registry_commented_block.metal"
+write_pipeline_cpp "$REGISTRY_COMMENTED_BLOCK" "c_fixture_kernel" "c_fixture_kernel" "" "" "" \
+    "c_registry_commented_block"
+registry_commented_block_out=$(run_checker "$REGISTRY_COMMENTED_BLOCK")
+registry_commented_block_rc=$?
+assert_eq "1" "$registry_commented_block_rc" "block-commented-out registry entry exits 1"
+assert_contains "$registry_commented_block_out" "c_registry_commented_block" \
+    "failure names the kernel whose registry entry was block-commented out"
+assert_contains "$registry_commented_block_out" "no entry in" \
+    "a block-commented registry entry is reported as absent, not present"
+
 # --- a registry without its bare "}" terminator fails, not false-cleans ------
 # The function-body scan ends on a line that is exactly "}"; if the function
 # is ever indented (namespace style change, moved into a block), the scan
@@ -279,6 +331,20 @@ assert_contains "$scratch_commented_out" "c_fixture_kernel" \
     "failure names the consumer whose entry was commented out"
 assert_contains "$scratch_commented_out" "absent from functionUsesImageAtomicScratch" \
     "a commented-out entry is reported as absent, not present"
+
+# --- a block-commented (/* */) list entry reads as absent, not present -------
+# The line-comment form above is fixed by #2886; this is the other comment
+# shape a developer reaches for to disable an entry (#2899).
+SCRATCH_COMMENTED_BLOCK="$TMPROOT/scratch-commented-block"
+make_fixture "$SCRATCH_COMMENTED_BLOCK"
+write_pipeline_cpp "$SCRATCH_COMMENTED_BLOCK" "c_fixture_kernel" "" "" "c_fixture_kernel"
+scratch_commented_block_out=$(run_checker "$SCRATCH_COMMENTED_BLOCK")
+scratch_commented_block_rc=$?
+assert_eq "1" "$scratch_commented_block_rc" "block-commented-out scratch list entry exits 1"
+assert_contains "$scratch_commented_block_out" "c_fixture_kernel" \
+    "failure names the consumer whose entry was block-commented out"
+assert_contains "$scratch_commented_block_out" "absent from functionUsesImageAtomicScratch" \
+    "a block-commented entry is reported as absent, not present"
 
 # --- a hand-wrapped scratch declaration is still caught ----------------------
 # The qualifier test reads the parameter's declaration window, not the physical

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -20,6 +20,9 @@
 #   - a line- or block-commented registry entry     → exit 1, names the kernel
 #     (a commented-out entry never reaches the compiled binary, so it must
 #     read as absent, not present — both comment forms, #2899)
+#   - a MULTI-LINE block-commented registry entry    → exit 1 (the registry's
+#     real entries are multi-line `if` conditions, so disabling one wraps
+#     several lines, not one — a same-line-only strip false-cleans this shape)
 #   - a registry with no bare "}" terminator line   → exit 1 (EOF guard, not
 #     a silent scan past the function into unrelated string literals)
 #   - a scratch consumer absent from the list       → exit 1, names the kernel
@@ -28,6 +31,9 @@
 #   - a line- or block-commented list entry         → exit 1 (the runtime stops
 #     binding for it, so it must read as absent, not present — both comment
 #     forms, #2899)
+#   - a MULTI-LINE block-commented list entry        → exit 1 (disabling a run
+#     of consecutive entries is the natural reason to reach for a block
+#     comment here, and that spans lines)
 #   - a hand-wrapped scratch declaration            → exit 1 (the qualifier test
 #     reads the declaration window, not the attribute's line)
 #   - an atomic neighbour on the slot's line        → exit 0 (that qualifier
@@ -246,6 +252,48 @@ assert_contains "$registry_commented_block_out" "c_registry_commented_block" \
 assert_contains "$registry_commented_block_out" "no entry in" \
     "a block-commented registry entry is reported as absent, not present"
 
+# --- a MULTI-LINE block-commented registry entry reads as absent -------------
+# The real registry's entries are multi-line `if` conditions
+# (metal_pipeline.cpp), so disabling one wraps the block comment across
+# several lines -- the shape write_pipeline_cpp's per-name single-line echo
+# can't express, hence the direct fixture write. A same-line-only strip reads
+# every interior line as still live (Opus recheck on #2959).
+REGISTRY_COMMENTED_BLOCK_MULTILINE="$TMPROOT/registry-commented-block-multiline"
+make_fixture "$REGISTRY_COMMENTED_BLOCK_MULTILINE"
+echo '// registry-commented-block-multiline fixture kernel' \
+    > "$REGISTRY_COMMENTED_BLOCK_MULTILINE/engine/render/src/shaders/metal/c_registry_commented_multiline.metal"
+cat > "$REGISTRY_COMMENTED_BLOCK_MULTILINE/engine/render/src/metal/metal_pipeline.cpp" <<'EOF'
+namespace IRRender {
+namespace {
+
+MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
+    if (functionName == "c_fixture_kernel") {
+        return MTL::Size(16, 16, 1);
+    }
+    /* if (functionName == "c_registry_commented_multiline") {
+        return MTL::Size(16, 16, 1);
+    } */
+    return MTL::Size(1, 1, 1);
+}
+
+bool functionUsesImageAtomicScratch(const std::string &functionName) {
+    return false
+           || functionName == "c_fixture_kernel"
+        ;
+}
+
+}  // namespace
+}  // namespace IRRender
+EOF
+registry_commented_block_multiline_out=$(run_checker "$REGISTRY_COMMENTED_BLOCK_MULTILINE")
+registry_commented_block_multiline_rc=$?
+assert_eq "1" "$registry_commented_block_multiline_rc" \
+    "multi-line block-commented-out registry entry exits 1"
+assert_contains "$registry_commented_block_multiline_out" "c_registry_commented_multiline" \
+    "failure names the kernel whose registry entry was multi-line block-commented out"
+assert_contains "$registry_commented_block_multiline_out" "no entry in" \
+    "a multi-line block-commented registry entry is reported as absent, not present"
+
 # --- a registry without its bare "}" terminator fails, not false-cleans ------
 # The function-body scan ends on a line that is exactly "}"; if the function
 # is ever indented (namespace style change, moved into a block), the scan
@@ -345,6 +393,54 @@ assert_contains "$scratch_commented_block_out" "c_fixture_kernel" \
     "failure names the consumer whose entry was block-commented out"
 assert_contains "$scratch_commented_block_out" "absent from functionUsesImageAtomicScratch" \
     "a block-commented entry is reported as absent, not present"
+
+# --- a MULTI-LINE block-commented list entry reads as absent -----------------
+# Disabling a run of consecutive entries at once is the natural reason to
+# reach for a block comment in this list, and that spans lines -- the shape
+# write_pipeline_cpp's per-name single-line echo can't express, hence the
+# direct fixture write (Opus recheck on #2959).
+SCRATCH_COMMENTED_BLOCK_MULTILINE="$TMPROOT/scratch-commented-block-multiline"
+make_fixture "$SCRATCH_COMMENTED_BLOCK_MULTILINE"
+cat > "$SCRATCH_COMMENTED_BLOCK_MULTILINE/engine/render/src/shaders/metal/c_scratch_commented_multiline.metal" <<'EOF'
+kernel void c_scratch_commented_multiline(
+    device atomic_int* distanceScratch [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+cat > "$SCRATCH_COMMENTED_BLOCK_MULTILINE/engine/render/src/metal/metal_pipeline.cpp" <<'EOF'
+namespace IRRender {
+namespace {
+
+MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
+    if (functionName == "c_fixture_kernel") {
+        return MTL::Size(16, 16, 1);
+    }
+    if (functionName == "c_scratch_commented_multiline") {
+        return MTL::Size(16, 16, 1);
+    }
+    return MTL::Size(1, 1, 1);
+}
+
+bool functionUsesImageAtomicScratch(const std::string &functionName) {
+    return false
+           || functionName == "c_fixture_kernel"
+        /*
+        || functionName == "c_scratch_commented_multiline"
+        */
+        ;
+}
+
+}  // namespace
+}  // namespace IRRender
+EOF
+scratch_commented_block_multiline_out=$(run_checker "$SCRATCH_COMMENTED_BLOCK_MULTILINE")
+scratch_commented_block_multiline_rc=$?
+assert_eq "1" "$scratch_commented_block_multiline_rc" \
+    "multi-line block-commented-out scratch list entry exits 1"
+assert_contains "$scratch_commented_block_multiline_out" "c_scratch_commented_multiline" \
+    "failure names the consumer whose entry was multi-line block-commented out"
+assert_contains "$scratch_commented_block_multiline_out" "absent from functionUsesImageAtomicScratch" \
+    "a multi-line block-commented entry is reported as absent, not present"
 
 # --- a hand-wrapped scratch declaration is still caught ----------------------
 # The qualifier test reads the parameter's declaration window, not the physical


### PR DESCRIPTION
## Summary
- `run_metal_kernel_registry_check.cmake` gets its first comment strip (previously none) — a commented-out registry entry read as present, so a disabled kernel silently fell through to `MTL::Size(1, 1, 1)` with no signal.
- `run_metal_scratch_consumer_check.cmake` gains `/* ... */` block-comment stripping alongside the `//` strip #2886 added, so the pair now handles both comment forms symmetrically.
- Extended `test_header_checks_standalone.sh`'s `write_pipeline_cpp` fixture helper (new optional `$5`–`$7` params) rather than adding a parallel fixture, and added the three missing firing arms.

**Update (Opus recheck):** the block-comment strip above only handled a
`/* ... */` that opens and closes on the same physical line. The registry's
real entries are multi-line `if` conditions, so disabling one — or disabling
a run of consecutive scratch-list entries — means wrapping the block comment
across several lines, which the same-line-only strip read as still live (the
opener has no closer on its line, and interior lines carry neither
delimiter). Both checkers now carry an `in_block_comment` flag across the
per-line scan: an interior line is blanked outright, and the closing line is
stripped through its first `*/` using the same non-greedy-emulation regex
trick the same-line strip already relies on (CMake's regex engine has no
lazy quantifier). Two new direct-write fixture arms cover the multi-line
shape for both checkers (the per-name single-line `echo` in
`write_pipeline_cpp` can't express a comment spanning lines).

## Test plan
- [x] `bash scripts/fleet/tests/test_header_checks_standalone.sh` — 68 passed, 0 failed (62 prior + 6 new assertions across the 2 new multi-line arms)
- [x] `cmake -DPROJECT_ROOT="$PWD" -P cmake/run_header_checks_standalone.cmake` against the real tree — exit 0, `31 compute kernel(s)` / `8 declare`, unchanged from before the fix
- [x] `fleet-build --target header-checks` — clean

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Registry checker strips comments; both checkers handle `/* ... */` and `//`, same-line AND multi-line | `git diff` review of both `.cmake` files | both files now run a stateful `in_block_comment` carry-over strip, then the same-line `/\*([^*]\|\*+[^*/])*\*+/` strip, then `//.*`, before the `MATCHALL` |
| Suite gains a firing arm per checker per comment shape | `bash scripts/fleet/tests/test_header_checks_standalone.sh` | new arms: "multi-line block-commented-out registry entry exits 1", "multi-line block-commented-out scratch list entry exits 1" — all pass, 68/68 total |
| Reproduced the exact multi-line leak the Opus recheck cited, against the fixed checkers | `cmake -P` against the reviewer's 5-line repro (`c_multi_a`/`c_multi_b` in a 2-line block comment, `c_single` same-line, `c_line` `//`, `c_live` unquoted) | only `c_live` harvested — the multi-line pair, the same-line block comment, and the line comment all strip correctly |
| `fleet-positive-control ... <pre-fix-sha> --include cmake` reports MEANINGFUL | `fleet-positive-control scripts/fleet/tests/test_header_checks_standalone.sh 8bb9ea133e9c443926d044a4da4b7ca9aa69c318 --include cmake` | `MEANINGFUL: 6 of 68 assertions fail against 8bb9ea133e9c443926d044a4da4b7ca9aa69c318 (8bb9ea133)` — the 6 new assertions fail on the pre-fix commit, the 62 prior ones are unaffected |
| Clean tree unchanged: CI-path script exits 0 at `31 compute kernel(s)` / `8 declare` | `cmake -DPROJECT_ROOT="$PWD" -P cmake/run_header_checks_standalone.cmake` | `Metal kernel registry check scanned 31 compute kernel(s)` / `Metal scratch-consumer check scanned 31 compute kernel(s) ... (8 declare the image-atomic scratch at buffer slot 16)` |
| `fleet-build --target header-checks` (real CI target, not just the standalone script) | `fleet-build --target header-checks` | clean, same scan counts as above |

Closes #2899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

