### PR TITLE
fleet: back the empty-exit backoff with a claim marker, not wall-clock (#2698)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -4920,6 +4920,14 @@ _stamp_dispatch_outcome() {
 # a full task's work while acquiring nothing — it already held the lock from
 # the prior iteration — and would otherwise record empty.
 #
+# The release arms carry a coupling worth knowing before you edit a role's
+# shutdown sequence: they are productive signals only because a starved
+# iteration never reaches one. `role-worker.md` exits a no-pick at step 3,
+# well before step 12's `release-worktree`. Making any shutdown step
+# unconditional would stamp every no-pick as productive and quietly kill the
+# backoff a second time — the same defect this marker exists to fix, arriving
+# through a role doc instead of through a heuristic.
+#
 # Deliberately EXCLUDED, because they act on *other* agents' state and would
 # make a starved iteration look productive:
 #   cleanup   — the sanctioned zero-pick move, so this is the common case

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -4354,6 +4354,7 @@ fi
 # `--repo <owner/repo>` scoped after their name. Exact/prefix token match (not
 # substring) so a --stackable-on <url> value containing "repo" isn't misflagged.
 _subcmd="${1:-}"
+_subsubcmd="${2:-}"   # `molecule <sub>` — read back by the outcome stamp below
 if [[ "$_subcmd" != "cleanup" && "$_subcmd" != "reconcile" ]]; then
     for _arg in "$@"; do
         if [[ "$_arg" == "--repo" || "$_arg" == --repo=* ]]; then
@@ -4880,5 +4881,71 @@ USAGE
         echo "fleet-claim: unknown command '$1'" >&2
         echo "run 'fleet-claim help' for usage." >&2
         exit 2
+        ;;
+esac
+
+# --- Dispatch-outcome marker (#2698) ---------------------------------------
+#
+# The dispatcher's empty-exit backoff needs to know whether a finished
+# iteration actually did work; wall-clock duration cannot tell it (rationale
+# at the EMPTY_EXIT_SECONDS config block in fleet-dispatcher).
+#
+# fleet-claim IS the enforced mutex: it is the only sanctioned way to take a
+# fleet lock, so stamping here covers every claim path *structurally*,
+# rather than as a prose obligation in a role doc that an early-exit path
+# can skip. fleet-dispatch-wrap exports FLEET_CLAIM_FLAG (pane-keyed, the
+# same shape as FLEET_THROTTLE_FLAG) and clears it at dispatch start;
+# fleet-dispatcher reads it back once the pane returns to a shell.
+#
+# Two properties this placement buys:
+#   - Success-only. `set -euo pipefail` aborts the script the moment a cmd_*
+#     returns non-zero, so a *losing* claim never reaches here and a starved
+#     pane that tried and lost still records empty.
+#   - Release-early-safe. The marker is a separate artifact from
+#     $CLAIMS_DIR, which __remove_claim is the only thing that touches, so an
+#     iteration that claims, works, and releases before exiting still reads
+#     claimed. That is the case duration and a claim-liveness probe both get
+#     wrong.
+_stamp_dispatch_outcome() {
+    [[ -n "${FLEET_CLAIM_FLAG:-}" ]] || return 0
+    # Best-effort throughout: a read-only or full $HOME must never turn a
+    # successful claim into a failed one just because bookkeeping failed.
+    mkdir -p "$(dirname "$FLEET_CLAIM_FLAG")" 2>/dev/null || return 0
+    : > "$FLEET_CLAIM_FLAG" 2>/dev/null || true
+    return 0
+}
+
+# Enumerated from the live `case` block above, not from memory. Acquire arms
+# AND release arms: a step-0.5 reservation resume (or a molecule resume) does
+# a full task's work while acquiring nothing — it already held the lock from
+# the prior iteration — and would otherwise record empty.
+#
+# Deliberately EXCLUDED, because they act on *other* agents' state and would
+# make a starved iteration look productive:
+#   cleanup   — the sanctioned zero-pick move, so this is the common case
+#   reconcile, clear-all, reset-sweep-host-claims — fleet-wide sweeps
+# Also excluded: every read-only arm (claim-base, check, list, host,
+# branch-check, find-stackable-blockers, stack-base, stack-pr-state,
+# check-stale, reservation-of, worktree-for-task, list-reservations,
+# reservation-role, molecule list|show) and `reclaim`, a removed stub.
+#
+# planning-claim/-release are included deliberately: the dispatcher takes the
+# pre-claim itself (#2197) with FLEET_CLAIM_FLAG unset, so the stamp is a
+# no-op there, but a planning iteration that posts its plan and releases is
+# productive and should say so on its own rather than resting solely on the
+# dispatch record's plan_issue backstop.
+case "$_subcmd" in
+    claim|stack|reserve|\
+    review-claim|resolving-claim|amending-claim|steward-claim|planning-claim|\
+    release|release-stack|release-worktree|\
+    review-release|resolving-release|amending-release|steward-release|planning-release)
+        _stamp_dispatch_outcome
+        ;;
+    molecule)
+        # `resume` is a query that legitimately returns nothing — only the
+        # arms that record progress on a held stack count as work.
+        case "$_subsubcmd" in
+            advance|complete) _stamp_dispatch_outcome ;;
+        esac
         ;;
 esac

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -61,6 +61,7 @@ unset _plan_arg
 # config change in one place propagates to both scripts.
 STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
 RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
+CLAIM_FLAG_DIR="$STATE_DIR/dispatch-claimed"   # keep in sync with fleet-dispatcher
 
 # Install-symlink freshness (#2262): a tool/role-cmd merged WHILE the fleet is
 # running only reaches ~/bin when install.sh re-links — otherwise it's
@@ -127,6 +128,20 @@ unset _tag
 mkdir -p "$RATE_LIMIT_DIR"
 export FLEET_THROTTLE_FLAG="$RATE_LIMIT_DIR/$PANE_KEY.throttle-seen"
 rm -f "$FLEET_THROTTLE_FLAG"
+
+# Dispatch-outcome marker (#2698). fleet-claim touches this whenever the
+# iteration takes or releases a fleet lock — i.e. whenever it did productive
+# work — and fleet-dispatcher reads it back in cleanup_stale_dispatches to
+# decide claimed-vs-empty for the empty-exit streak.
+#
+# Cleared HERE, at dispatch start, and NOT at the end like the throttle flag:
+# the dispatcher only folds the outcome once the pane has returned to a shell,
+# which is after this script exits, so the marker has to outlive it. A stale
+# marker from this pane's previous dispatch would mask a genuine no-pick,
+# which is exactly the failure the backoff exists to catch.
+mkdir -p "$CLAIM_FLAG_DIR"
+export FLEET_CLAIM_FLAG="$CLAIM_FLAG_DIR/$PANE_KEY"
+rm -f "$FLEET_CLAIM_FLAG"
 
 # --- Session-id persistence + interrupted-session resume (dispatched roles) ---
 #

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1071,11 +1071,37 @@ record_dispatch_outcome() {
     fi
 }
 
+# Decide claimed-vs-empty for one completed dispatch from its record file.
+# Prints `yes`, `no`, or empty for "unknown" (a legacy record, see below).
+# Split out of cleanup_stale_dispatches so the decision is reachable from the
+# --derive-outcome hook: the fold path itself needs tmux and a live pane, so
+# without this seam the planning and legacy arms would ship untested.
+derive_dispatch_outcome() {
+    local file="$1" pane="$2" marker plan_issue claim_flag
+    # `claim_marker` is only present on records written by this version of the
+    # dispatcher. Its absence means the pane was launched by the previous
+    # version, whose wrapper never exported FLEET_CLAIM_FLAG, so the marker
+    # would read a spurious "no" — report unknown and let the caller fall back
+    # to the old duration heuristic. Self-clearing after one dispatch cycle.
+    marker=$(sed -n 's/.*"claim_marker":\([0-9]*\).*/\1/p' "$file" | head -n 1)
+    [[ -n "$marker" ]] || return 0
+    # A planning dispatch is productive by assignment: the dispatcher took its
+    # planning-claim pre-launch (#2197), where the pane's FLEET_CLAIM_FLAG did
+    # not yet exist to be stamped.
+    plan_issue=$(sed -n 's/.*"plan_issue":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
+    claim_flag="$CLAIM_FLAG_DIR/$(pane_id_to_key "$pane")"
+    if [[ -f "$claim_flag" || -n "$plan_issue" ]]; then
+        printf 'yes\n'
+    else
+        printf 'no\n'
+    fi
+}
+
 cleanup_stale_dispatches() {
     if [[ ! -d "$DISPATCH_DIR" ]]; then
         return
     fi
-    local file role pane dispatched_epoch class plan_issue marker claim_flag claimed
+    local file role pane dispatched_epoch class claimed
     for file in "$DISPATCH_DIR"/*.json; do
         [[ -e "$file" ]] || continue
         role=$(sed -n 's/.*"role":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
@@ -1093,28 +1119,8 @@ cleanup_stale_dispatches() {
         # recorded before the process exits — unlike a post-exit claim probe,
         # which reads empty for an iteration that released early, and unlike
         # wall-clock, which cannot tell a claim from a diligent no-pick.
-        #
-        # `claim_marker` is only present on records written by this version of
-        # the dispatcher. Its absence means the pane was launched by the
-        # previous version, whose wrapper never exported FLEET_CLAIM_FLAG, so
-        # the marker would read a spurious "no" — those fold on the old
-        # duration heuristic instead. Self-clearing after one dispatch cycle;
-        # same shape as the dispatched_epoch legacy guard below.
-        marker=$(sed -n 's/.*"claim_marker":\([0-9]*\).*/\1/p' "$file" | head -n 1)
-        claim_flag="$CLAIM_FLAG_DIR/$(pane_id_to_key "$pane")"
-        claimed=""
-        if [[ -n "$marker" ]]; then
-            # A planning dispatch is productive by assignment: the dispatcher
-            # took its planning-claim pre-launch (#2197), where the pane's
-            # FLEET_CLAIM_FLAG did not exist to be stamped.
-            plan_issue=$(sed -n 's/.*"plan_issue":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
-            if [[ -f "$claim_flag" || -n "$plan_issue" ]]; then
-                claimed=yes
-            else
-                claimed=no
-            fi
-        fi
-        rm -f "$claim_flag"
+        claimed=$(derive_dispatch_outcome "$file" "$pane")
+        rm -f "$CLAIM_FLAG_DIR/$(pane_id_to_key "$pane")"
         # Fold the just-finished dispatch into the role's empty-exit streak.
         # Legacy records (pre-upgrade, no dispatched_epoch) skip this silently.
         dispatched_epoch=$(sed -n 's/.*"dispatched_epoch":\([0-9]*\).*/\1/p' "$file" | head -n 1)
@@ -2660,6 +2666,25 @@ case "${1:-}" in
             exit 2
         fi
         record_dispatch_outcome "$_ro_role" "$_ro_duration" "$_ro_class" "$_ro_claimed"
+        exit 0
+        ;;
+    --derive-outcome)
+        # Test/debug: print the claimed-vs-empty verdict for one dispatch
+        # record — `yes`, `no`, or empty for a legacy record with no
+        # claim_marker (which folds on the duration heuristic instead). Reads
+        # the marker under FLEET_STATE_DIR, so tests drive it against a
+        # scratch dir.
+        #
+        #   --derive-outcome <record-file> <pane-id>
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --derive-outcome <record-file> <pane-id>" >&2
+            exit 2
+        fi
+        if [[ ! -f "$2" ]]; then
+            echo "fleet-dispatcher --derive-outcome: no such record file: $2" >&2
+            exit 2
+        fi
+        derive_dispatch_outcome "$2" "$3"
         exit 0
         ;;
     --empty-streak-check)

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -444,14 +444,10 @@ fi
 #
 # "Claimed nothing" is a signal, not an inference (#2698). fleet-claim stamps a
 # pane-keyed marker on every acquire/release arm, so the answer is recorded
-# before the iteration exits. It originally *was* an inference — a return to the
-# shell in under EMPTY_EXIT_SECONDS — and that is why the mechanism sat dead for
-# the worker role for 15 days: a worker that walks both queues and correctly
-# declines also runs for minutes, so it landed in the long-run branch and RESET
-# the streak. The backoff could never engage for the one failure mode it was
-# written to bound. Duration cannot separate worked from walked-and-declined,
-# and raising the threshold does not help — the two occupy the same band, and
-# the band moves whenever a role doc's mandated walk changes.
+# before the iteration exits. Duration cannot separate worked from
+# walked-and-declined: a worker that walks both queues and correctly declines
+# also runs for minutes. Raising the threshold does not help — the two occupy
+# the same band, and the band moves whenever a role doc's mandated walk changes.
 #
 # EMPTY_EXIT_SECONDS survives as the fallback for dispatches whose outcome is
 # unknown (records written before this landed, and the roles below) and as a

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -435,17 +435,49 @@ fi
 # Observed on the native-Windows host with a stale boot trigger the scout
 # never re-armed (its projection had gone empty for this host's class).
 #
-# The fix: treat a dispatch that returns to a shell in under EMPTY_EXIT_SECONDS
-# as "claimed nothing" (a genuine claim runs for minutes — build / test / PR).
-# Count consecutive empty exits per role; once the streak reaches
-# EMPTY_STREAK_CAP, consume the trigger after the tick's probe dispatches (all
-# idle panes for the role) instead of retaining it. The scout re-arms on the
-# next real projection change, and a genuine long-running claim resets the
-# streak (cleanup_stale_dispatches). Net: at most one wasted probe-fan-out per
-# armed trigger instead of an unbounded loop.
+# The fix: count consecutive dispatches that claimed nothing, per (role, class);
+# once the streak reaches EMPTY_STREAK_CAP, consume the trigger after the tick's
+# probe dispatches (all idle panes for the role) instead of retaining it. The
+# scout re-arms on the next real projection change, and a dispatch that claimed
+# work resets the streak (cleanup_stale_dispatches). Net: at most one wasted
+# probe-fan-out per armed trigger instead of an unbounded loop.
+#
+# "Claimed nothing" is a signal, not an inference (#2698). fleet-claim stamps a
+# pane-keyed marker on every acquire/release arm, so the answer is recorded
+# before the iteration exits. It originally *was* an inference — a return to the
+# shell in under EMPTY_EXIT_SECONDS — and that is why the mechanism sat dead for
+# the worker role for 15 days: a worker that walks both queues and correctly
+# declines also runs for minutes, so it landed in the long-run branch and RESET
+# the streak. The backoff could never engage for the one failure mode it was
+# written to bound. Duration cannot separate worked from walked-and-declined,
+# and raising the threshold does not help — the two occupy the same band, and
+# the band moves whenever a role doc's mandated walk changes.
+#
+# EMPTY_EXIT_SECONDS survives as the fallback for dispatches whose outcome is
+# unknown (records written before this landed, and the roles below) and as a
+# test knob; the stale-boot-trigger case it was built for is now covered by the
+# marker, since a pane that never claims stamps nothing however fast it exits.
+#
+# Roles for which duration is STILL the right proxy. The marker assumes a
+# role's productive work goes through fleet-claim — true for everything that
+# claims from a queue: worker (claim/reserve/release), the reviewers and
+# smoke-worker (review-claim), the epic steward (steward-claim). The merger is
+# the deliberate exception: it does not consult or take fleet-claim locks at
+# all (`role-merger.md` — `--force-with-lease` is its concurrency control), so
+# under the marker it would stamp nothing on a *successful* merge run and
+# stand its own lane down after EMPTY_STREAK_CAP productive dispatches.
+#
+# Duration stays sound for exactly these roles, for the mirror of the reason it
+# broke elsewhere: it failed for the worker because that role doc mandates a
+# multi-minute queue walk before a legitimate decline. A role with no such walk
+# still exits fast when idle and runs long when busy.
+NO_CLAIM_FABRIC_ROLES="${FLEET_DISPATCHER_NO_CLAIM_FABRIC_ROLES:-merger}"
 EMPTY_EXIT_SECONDS="${FLEET_DISPATCHER_EMPTY_EXIT_SECONDS:-60}"
 EMPTY_STREAK_CAP="${FLEET_DISPATCHER_EMPTY_STREAK_CAP:-3}"
 EMPTY_STREAK_DIR="$STATE_DIR/empty-streak"
+# Where fleet-dispatch-wrap exports FLEET_CLAIM_FLAG and fleet-claim stamps a
+# pane's productive-work marker (#2698). Keep in sync with fleet-dispatch-wrap.
+CLAIM_FLAG_DIR="$STATE_DIR/dispatch-claimed"
 # Validate-and-clamp both overrides the same way BOOT_FANOUT_WINDOW_SECONDS is
 # guarded above — a non-numeric value would emit arithmetic errors every tick
 # or kill the daemon under `set -u`.
@@ -883,7 +915,11 @@ write_dispatch_record() {
     epoch=$(date +%s)   # read back by cleanup_stale_dispatches for the empty-exit streak
     [[ -n "$plan_issue" ]] && extra=$(printf ',"plan_issue":"%s"' "$plan_issue")
     mkdir -p "$DISPATCH_DIR"
-    printf '{"role":"%s","pane":"%s","class":"%s","dispatched_at":"%s","dispatched_epoch":%s%s}\n' \
+    # claim_marker:1 asserts this dispatch's wrapper exports FLEET_CLAIM_FLAG,
+    # so cleanup_stale_dispatches may trust the marker's absence as "claimed
+    # nothing" (#2698). Records without it predate the change and fold on the
+    # old duration heuristic.
+    printf '{"role":"%s","pane":"%s","class":"%s","dispatched_at":"%s","dispatched_epoch":%s,"claim_marker":1%s}\n' \
         "$role" "$pane_id" "$class" "$ts" "$epoch" "$extra" >"$(dispatch_record "$pane_id")"
 }
 
@@ -896,6 +932,19 @@ class_of_model() {
         "$SONNET_MODEL") echo "sonnet" ;;
         *)               echo "opus" ;;
     esac
+}
+
+# The model class a dispatch of $1 is stamped and counted under: the class this
+# tick elected when the role is class-routed, else the class of the role's
+# static default model.
+#
+# Single source of truth on purpose. The write site (write_dispatch_record) and
+# the empty-exit consume site (dispatch_role) must agree with what the fold
+# site reads back out of the record, or the streak is written under one key and
+# read under another — a counter that never reaches the cap, which is #2698's
+# own failure mode reintroduced one level down.
+dispatch_class_key() {
+    printf '%s\n' "${DISPATCH_CLASS:-$(class_of_model "${ROLE_MODEL[$1]:-sonnet}")}"
 }
 
 # Count in-flight dispatches of a model class across ALL panes/roles. A
@@ -942,45 +991,83 @@ count_recent_active_for_class() {
 }
 
 # --- Empty-exit streak bookkeeping -----------------------------------------
-# Per-role counter of consecutive dispatches that returned to a shell without
-# claiming work (see the EMPTY_EXIT_SECONDS config block). One small file per
-# role under $EMPTY_STREAK_DIR holding a non-negative integer.
+# Per-(role, class) counter of consecutive dispatches that returned to a shell
+# without claiming work (see the EMPTY_EXIT_SECONDS config block). One small
+# file per counter under $EMPTY_STREAK_DIR holding a non-negative integer.
+#
+# The class qualifier (#2698) keeps one class's real work from clearing
+# another's starvation streak: on a mixed fleet a busy sonnet lane would
+# otherwise reset the counter a structurally-starved opus/macOS lane is
+# accumulating, so the cap was effectively unreachable.
+#
+# The counter is already per-HOST by construction — EMPTY_STREAK_DIR hangs off
+# STATE_DIR ($HOME/.fleet/state by default) and each host runs its own
+# dispatcher daemon against its own $HOME — so no host component is needed.
+# (The issue body's "one counter is shared by every host" is not accurate; if
+# state dirs are ever shared, `fleet-claim host` is the canonical host tag.)
+#
+# Pre-#2698 files use the bare `<role>` name. They are stale artifacts, not
+# something to migrate: the counter is ephemeral by design and a missing file
+# already reads 0.
 
 empty_streak_file() {
-    printf '%s\n' "$EMPTY_STREAK_DIR/$1"
+    # $1 = role, $2 = model class. Roles that aren't class-routed (and the
+    # unqualified test hooks) collapse to `all`.
+    printf '%s\n' "$EMPTY_STREAK_DIR/$1__${2:-all}"
 }
 
 read_empty_streak() {
     local f n
-    f=$(empty_streak_file "$1")
+    f=$(empty_streak_file "$1" "${2:-}")
     n=$(cat "$f" 2>/dev/null || printf '0')
     [[ "$n" =~ ^[0-9]+$ ]] || n=0
     printf '%s\n' "$n"
 }
 
-# 0 (true) when the role's streak has reached the cap — caller should consume
-# the trigger rather than retain it.
+# 0 (true) when the (role, class) streak has reached the cap — caller should
+# consume the trigger rather than retain it.
 empty_streak_over_cap() {
     local n
-    n=$(read_empty_streak "$1")
+    n=$(read_empty_streak "$1" "${2:-}")
     (( n >= EMPTY_STREAK_CAP ))
 }
 
 reset_empty_streak() {
-    rm -f "$(empty_streak_file "$1")"
+    rm -f "$(empty_streak_file "$1" "${2:-}")"
 }
 
-# Fold one completed dispatch's wall-clock duration into the role's streak: a
-# fast exit (no claim) bumps it, a long-running one (real work) resets it.
+# Fold one completed dispatch into its (role, class) streak.
+#
+# $4 is the verdict derived from the claim marker fleet-claim stamps
+# (`yes`/`no`); empty means "unknown", which only happens for the legacy
+# positional test hook and for dispatch records written before this change
+# landed, and falls back to the original wall-clock heuristic.
+#
+# Duration is NOT consulted once the verdict is known — see the
+# EMPTY_EXIT_SECONDS config block above for why it cannot be.
+#
 # Shared by cleanup_stale_dispatches and the --record-outcome test hook.
 record_dispatch_outcome() {
-    local role="$1" duration="$2"
+    local role="$1" duration="$2" class="${3:-}" claimed="${4:-}" empty=""
     [[ "$duration" =~ ^[0-9]+$ ]] || return 0
-    if (( duration < EMPTY_EXIT_SECONDS )); then
+    # A role outside the claim fabric never stamps the marker, so its verdict
+    # carries no information — discard it and fall back to duration, which is
+    # still valid for those roles (see NO_CLAIM_FABRIC_ROLES).
+    case " $NO_CLAIM_FABRIC_ROLES " in
+        *" $role "*) claimed="" ;;
+    esac
+    case "$claimed" in
+        yes) empty="" ;;
+        no)  empty=1 ;;
+        # Unknown: pre-#2698 record or the legacy two-arg hook.
+        *)   if (( duration < EMPTY_EXIT_SECONDS )); then empty=1; fi ;;
+    esac
+    if [[ -n "$empty" ]]; then
         mkdir -p "$EMPTY_STREAK_DIR"
-        printf '%s\n' "$(( $(read_empty_streak "$role") + 1 ))" > "$(empty_streak_file "$role")"
+        printf '%s\n' "$(( $(read_empty_streak "$role" "$class") + 1 ))" \
+            > "$(empty_streak_file "$role" "$class")"
     else
-        reset_empty_streak "$role"
+        reset_empty_streak "$role" "$class"
     fi
 }
 
@@ -988,7 +1075,7 @@ cleanup_stale_dispatches() {
     if [[ ! -d "$DISPATCH_DIR" ]]; then
         return
     fi
-    local file role pane dispatched_epoch
+    local file role pane dispatched_epoch class plan_issue marker claim_flag claimed
     for file in "$DISPATCH_DIR"/*.json; do
         [[ -e "$file" ]] || continue
         role=$(sed -n 's/.*"role":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
@@ -1000,13 +1087,42 @@ cleanup_stale_dispatches() {
         if pane_is_occupied "$pane"; then
             continue
         fi
+        class=$(sed -n 's/.*"class":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
+        # Did this iteration do productive work? fleet-claim stamps the
+        # pane-keyed marker on every acquire/release arm, so the answer is
+        # recorded before the process exits — unlike a post-exit claim probe,
+        # which reads empty for an iteration that released early, and unlike
+        # wall-clock, which cannot tell a claim from a diligent no-pick.
+        #
+        # `claim_marker` is only present on records written by this version of
+        # the dispatcher. Its absence means the pane was launched by the
+        # previous version, whose wrapper never exported FLEET_CLAIM_FLAG, so
+        # the marker would read a spurious "no" — those fold on the old
+        # duration heuristic instead. Self-clearing after one dispatch cycle;
+        # same shape as the dispatched_epoch legacy guard below.
+        marker=$(sed -n 's/.*"claim_marker":\([0-9]*\).*/\1/p' "$file" | head -n 1)
+        claim_flag="$CLAIM_FLAG_DIR/$(pane_id_to_key "$pane")"
+        claimed=""
+        if [[ -n "$marker" ]]; then
+            # A planning dispatch is productive by assignment: the dispatcher
+            # took its planning-claim pre-launch (#2197), where the pane's
+            # FLEET_CLAIM_FLAG did not exist to be stamped.
+            plan_issue=$(sed -n 's/.*"plan_issue":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
+            if [[ -f "$claim_flag" || -n "$plan_issue" ]]; then
+                claimed=yes
+            else
+                claimed=no
+            fi
+        fi
+        rm -f "$claim_flag"
         # Fold the just-finished dispatch into the role's empty-exit streak.
         # Legacy records (pre-upgrade, no dispatched_epoch) skip this silently.
         dispatched_epoch=$(sed -n 's/.*"dispatched_epoch":\([0-9]*\).*/\1/p' "$file" | head -n 1)
         if [[ -n "$dispatched_epoch" ]]; then
-            record_dispatch_outcome "$role" "$(( $(date +%s) - dispatched_epoch ))"
+            record_dispatch_outcome "$role" "$(( $(date +%s) - dispatched_epoch ))" \
+                "$class" "$claimed"
         fi
-        log "dispatch for $role on $pane completed (pane returned to shell)"
+        log "dispatch for $role on $pane completed (pane returned to shell${claimed:+, outcome=$claimed})"
         rm -f "$file"
     done
 }
@@ -1922,8 +2038,7 @@ dispatch_role() {
             fi
             continue
         fi
-        write_dispatch_record "$role" "$pane_id" \
-            "${DISPATCH_CLASS:-$(class_of_model "${ROLE_MODEL[$role]:-sonnet}")}" "$plan_arg"
+        write_dispatch_record "$role" "$pane_id" "$(dispatch_class_key "$role")" "$plan_arg"
         LAST_DISPATCH_EPOCH=$now_epoch
         dispatched=$((dispatched + 1))
     done <<< "$idle_panes"
@@ -1942,10 +2057,12 @@ dispatch_role() {
     # genuine projection change; a real long-running claim resets the streak in
     # cleanup_stale_dispatches. Guarded on dispatched>0 so a tick that sent
     # nothing leaves the existing min-gap/retry semantics untouched.
-    if (( dispatched > 0 )) && empty_streak_over_cap "$role"; then
+    local _streak_class
+    _streak_class=$(dispatch_class_key "$role")
+    if (( dispatched > 0 )) && empty_streak_over_cap "$role" "$_streak_class"; then
         rm -f "$trigger_file"
-        reset_empty_streak "$role"
-        log "$role: ${EMPTY_STREAK_CAP} consecutive fast exits (<${EMPTY_EXIT_SECONDS}s, no claim) — standing down; scout re-arms on new work"
+        reset_empty_streak "$role" "$_streak_class"
+        log "$role: ${EMPTY_STREAK_CAP} consecutive dispatches claimed nothing (class=$_streak_class) — standing down; scout re-arms on new work"
         return
     fi
 
@@ -2507,34 +2624,70 @@ case "${1:-}" in
         exit 0
         ;;
     --record-outcome)
-        # Test/debug: fold one dispatch outcome into a role's empty-exit
-        # streak. <duration> is the dispatch's wall-clock seconds; under
-        # EMPTY_EXIT_SECONDS bumps the streak, at/over it resets. Honors
-        # FLEET_DISPATCHER_EMPTY_EXIT_SECONDS / _EMPTY_STREAK_CAP and writes
-        # under FLEET_STATE_DIR, so tests drive it against a scratch dir.
+        # Test/debug: fold one dispatch outcome into a (role, class) empty-exit
+        # streak. Honors FLEET_DISPATCHER_EMPTY_EXIT_SECONDS / _EMPTY_STREAK_CAP
+        # and writes under FLEET_STATE_DIR, so tests drive it against a scratch
+        # dir.
+        #
+        #   --record-outcome <role> <duration> [--class=<c>] [--claimed=yes|no]
+        #
+        # --claimed is the production signal (#2698): yes resets the streak, no
+        # increments it, and <duration> is not consulted. Omitting it keeps the
+        # original two-arg behavior — under EMPTY_EXIT_SECONDS bumps, at/over
+        # resets — which is what the pre-#2698 fixtures exercise.
         if [[ -z "${2:-}" || -z "${3:-}" ]]; then
-            echo "usage: fleet-dispatcher --record-outcome <role> <duration-seconds>" >&2
+            echo "usage: fleet-dispatcher --record-outcome <role> <duration-seconds> [--class=<c>] [--claimed=yes|no]" >&2
             exit 2
         fi
         if ! [[ "$3" =~ ^[0-9]+$ ]]; then
             echo "fleet-dispatcher --record-outcome: <duration-seconds> must be a non-negative integer (got: $3)" >&2
             exit 2
         fi
-        record_dispatch_outcome "$2" "$3"
+        _ro_role="$2"; _ro_duration="$3"; _ro_class=""; _ro_claimed=""
+        shift 3
+        for _ro_arg in "$@"; do
+            case "$_ro_arg" in
+                --class=*)   _ro_class="${_ro_arg#--class=}" ;;
+                --claimed=*) _ro_claimed="${_ro_arg#--claimed=}" ;;
+                *)
+                    echo "fleet-dispatcher --record-outcome: unknown argument '$_ro_arg'" >&2
+                    exit 2
+                    ;;
+            esac
+        done
+        if [[ -n "$_ro_claimed" && "$_ro_claimed" != "yes" && "$_ro_claimed" != "no" ]]; then
+            echo "fleet-dispatcher --record-outcome: --claimed must be 'yes' or 'no' (got: $_ro_claimed)" >&2
+            exit 2
+        fi
+        record_dispatch_outcome "$_ro_role" "$_ro_duration" "$_ro_class" "$_ro_claimed"
         exit 0
         ;;
     --empty-streak-check)
         # Test/debug: print `over` (streak >= cap → consume the trigger) or
-        # `under` (still retain) for a role, plus the current count. Reads the
-        # streak files under FLEET_STATE_DIR seeded by --record-outcome.
+        # `under` (still retain) for a (role, class), plus the current count.
+        # Reads the streak files under FLEET_STATE_DIR seeded by
+        # --record-outcome. Omitting --class reads the `all` counter.
+        #
+        #   --empty-streak-check <role> [--class=<c>]
         if [[ -z "${2:-}" ]]; then
-            echo "usage: fleet-dispatcher --empty-streak-check <role>" >&2
+            echo "usage: fleet-dispatcher --empty-streak-check <role> [--class=<c>]" >&2
             exit 2
         fi
-        if empty_streak_over_cap "$2"; then
-            echo "over $(read_empty_streak "$2")"
+        _esc_role="$2"; _esc_class=""
+        shift 2
+        for _esc_arg in "$@"; do
+            case "$_esc_arg" in
+                --class=*) _esc_class="${_esc_arg#--class=}" ;;
+                *)
+                    echo "fleet-dispatcher --empty-streak-check: unknown argument '$_esc_arg'" >&2
+                    exit 2
+                    ;;
+            esac
+        done
+        if empty_streak_over_cap "$_esc_role" "$_esc_class"; then
+            echo "over $(read_empty_streak "$_esc_role" "$_esc_class")"
         else
-            echo "under $(read_empty_streak "$2")"
+            echo "under $(read_empty_streak "$_esc_role" "$_esc_class")"
         fi
         exit 0
         ;;

--- a/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
+++ b/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
@@ -237,42 +237,54 @@ echo "T12: the verdict derived from a dispatch record"
 # The fold path itself needs tmux and a live pane; --derive-outcome exposes
 # just the decision. Without it the planning and legacy arms below would ship
 # on inspection alone.
-S=$(mktemp -d "$TMPROOT/s.XXXXXX")
-mkdir -p "$S/dispatch-claimed"
-rec="$S/pane-9.json"
-new_record() { printf '%s\n' "$1" > "$rec"; }
-BASE='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1,"claim_marker":1}'
-PLAN='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1,"claim_marker":1,"plan_issue":"engine:2698"}'
-LEGACY='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1}'
+#
+# Probe for the hook by inspecting the subject rather than by invoking it:
+# fleet-dispatcher falls through to main() on an argument it doesn't
+# recognize, so a blind call against an older subject starts the DAEMON LOOP
+# and hangs the run forever. That is exactly what a positive control does
+# (it stages the pre-fix ref), so the guard is what makes this suite
+# controllable at all. A missing hook is a genuine failure, not a skip.
+if ! grep -q -- '--derive-outcome)' "$DISPATCHER"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: --derive-outcome hook absent from the subject (5 assertions not run)"
+else
+    S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+    mkdir -p "$S/dispatch-claimed"
+    rec="$S/pane-9.json"
+    BASE='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1,"claim_marker":1}'
+    PLAN='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1,"claim_marker":1,"plan_issue":"engine:2698"}'
+    LEGACY='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1}'
 
-new_record "$BASE"
-rm -f "$S/dispatch-claimed/pane-9"
-assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "no" \
-    "no marker on disk -> empty (the diligent no-pick)"
-: > "$S/dispatch-claimed/pane-9"
-assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "yes" \
-    "marker present -> claimed"
-# The pane key is derived from the pane id, so another pane's marker must not
-# be read as this one's.
-rm -f "$S/dispatch-claimed/pane-9"; : > "$S/dispatch-claimed/pane-8"
-assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "no" \
-    "a different pane's marker is not borrowed"
-# A planning assignment is productive even though the pane never stamped:
-# the dispatcher took the planning-claim pre-launch (#2197).
-new_record "$PLAN"
-rm -f "$S/dispatch-claimed/pane-9"
-assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "yes" \
-    "plan_issue with no marker -> claimed (pre-claimed planning assignment)"
-# A record from before this change has no claim_marker; its pane's wrapper
-# never exported the flag, so the verdict is unknown, not empty.
-new_record "$LEGACY"
-rm -f "$S/dispatch-claimed/pane-9"
-assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "" \
-    "legacy record -> unknown (falls back to the duration heuristic)"
-# ...and unknown really does route to duration, not to a silent increment.
-S2=$(mktemp -d "$TMPROOT/s.XXXXXX")
-disp "$S2" --record-outcome worker 300 --class=opus
-assert_eq "$(disp "$S2" --empty-streak-check worker --class=opus)" "under 0" \
+    printf '%s\n' "$BASE" > "$rec"
+    rm -f "$S/dispatch-claimed/pane-9"
+    assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "no" \
+        "no marker on disk -> empty (the diligent no-pick)"
+    : > "$S/dispatch-claimed/pane-9"
+    assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "yes" \
+        "marker present -> claimed"
+    # The pane key is derived from the pane id, so another pane's marker must
+    # not be read as this one's.
+    rm -f "$S/dispatch-claimed/pane-9"; : > "$S/dispatch-claimed/pane-8"
+    assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "no" \
+        "a different pane's marker is not borrowed"
+    # A planning assignment is productive even though the pane never stamped:
+    # the dispatcher took the planning-claim pre-launch (#2197).
+    printf '%s\n' "$PLAN" > "$rec"
+    rm -f "$S/dispatch-claimed/pane-9"
+    assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "yes" \
+        "plan_issue with no marker -> claimed (pre-claimed planning assignment)"
+    # A record from before this change has no claim_marker; its pane's wrapper
+    # never exported the flag, so the verdict is unknown, not empty.
+    printf '%s\n' "$LEGACY" > "$rec"
+    rm -f "$S/dispatch-claimed/pane-9"
+    assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "" \
+        "legacy record -> unknown (falls back to the duration heuristic)"
+fi
+# Unknown really does route to duration, not to a silent increment. Outside the
+# hook guard: it runs through --record-outcome, which every version has.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 300 --class=opus
+assert_eq "$(disp "$S" --empty-streak-check worker --class=opus)" "under 0" \
     "unknown + long duration resets, exactly as before this change"
 
 echo "T13: --claimed / --class argument validation"

--- a/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
+++ b/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
@@ -107,8 +107,19 @@ assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "30s >= thr(10s) 
 echo "T6: a non-integer / garbage streak file is treated as 0, not a crash"
 S=$(mktemp -d "$TMPROOT/s.XXXXXX")
 mkdir -p "$S/empty-streak"
-printf 'not-a-number\n' > "$S/empty-streak/worker"
+# Must be the QUALIFIED name (#2698): the unqualified hook reads `worker__all`,
+# so seeding the bare pre-#2698 `worker` would make this assertion pass by
+# reading a missing file rather than by surviving the garbage it means to test.
+printf 'not-a-number\n' > "$S/empty-streak/worker__all"
 assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "corrupt streak file reads as 0"
+
+echo "T6b: a pre-#2698 unqualified streak file is inert, not adopted"
+# The old bare-`<role>` files are documented as stale artifacts. A stale 99
+# must not stand a healthy lane down on the first tick after the upgrade.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+mkdir -p "$S/empty-streak"
+printf '99\n' > "$S/empty-streak/worker"
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "legacy unqualified streak file ignored"
 
 echo "T7: argument validation"
 if disp "$TMPROOT" --record-outcome worker >/dev/null 2>&1; then
@@ -126,6 +137,125 @@ if disp "$TMPROOT" --empty-streak-check >/dev/null 2>&1; then
 else
     PASS=$((PASS + 1)); echo "  ok: --empty-streak-check missing role exits non-zero"
 fi
+
+echo "T8: --claimed is authoritative; duration is not consulted (#2698)"
+# The defect: a worker that walks both queues and correctly declines runs for
+# minutes, so the old duration branch RESET the streak — the backoff could
+# never engage for the one failure mode it was written to bound. On master the
+# first assertion below reads `under 0`.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 300 --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 1" \
+    "long no-pick (300s, claimed=no) increments"
+disp "$S" --record-outcome worker 300 --claimed=no
+disp "$S" --record-outcome worker 300 --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check worker)" "over 3" \
+    "three long no-picks reach the cap"
+disp "$S" --record-outcome worker 300 --claimed=yes
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" \
+    "a real claim resets, however long it took"
+# Regression guard for the original stale-boot-trigger case: a fast exit that
+# claimed nothing still increments — now because it claimed nothing.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 5 --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 1" \
+    "sub-threshold exit with no claim still increments"
+# A short REAL claim resets — duration must not override an affirmative claim.
+disp "$S" --record-outcome worker 5 --claimed=yes
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" \
+    "sub-threshold exit that claimed resets"
+
+echo "T9: streaks are per-(role, class) — one class cannot clear another's"
+# A busy sonnet lane must not reset the streak a structurally-starved
+# opus/macOS lane is accumulating.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 300 --class=opus --claimed=no
+disp "$S" --record-outcome worker 300 --class=opus --claimed=no
+disp "$S" --record-outcome worker 300 --class=opus --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check worker --class=opus)" "over 3" \
+    "opus lane tripped"
+assert_eq "$(disp "$S" --empty-streak-check worker --class=sonnet)" "under 0" \
+    "sonnet lane untouched"
+# The reset is also class-scoped.
+disp "$S" --record-outcome worker 300 --class=sonnet --claimed=yes
+assert_eq "$(disp "$S" --empty-streak-check worker --class=opus)" "over 3" \
+    "a sonnet claim does not clear the opus streak"
+# ...and the unqualified counter is a third, independent one.
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" \
+    "unqualified (all) counter independent of both classes"
+
+echo "T10: the merger keeps the duration heuristic (it is outside the claim fabric)"
+# AC 7, tested against what the merger actually does in production rather than
+# against a hypothetical verdict. role-merger.md is explicit that the merger
+# never takes a fleet-claim lock (--force-with-lease is its concurrency
+# control), so it stamps no marker even on a fully successful merge run. Left
+# on the marker signal it would read `empty` every time and stand its own lane
+# down after EMPTY_STREAK_CAP *productive* dispatches — the same
+# strictly-worse-than-today regression the plan review caught for the reviewer
+# and steward lanes, one role further along.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome merger 300 --class=sonnet --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check merger --class=sonnet)" "under 0" \
+    "a long, productive merger run resets (verdict discarded, duration wins)"
+# ...and it still stands down on genuine fast idle exits, exactly as before.
+disp "$S" --record-outcome merger 1 --class=sonnet --claimed=no
+disp "$S" --record-outcome merger 1 --class=sonnet --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check merger --class=sonnet)" "under 2" "2 < cap(3) -> retain"
+disp "$S" --record-outcome merger 1 --class=sonnet --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check merger --class=sonnet)" "over 3" \
+    "merger stands down after 3 fast exits, exactly as before"
+# The exemption is scoped: a claim-fabric role at the same duration increments.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 300 --class=sonnet --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check worker --class=sonnet)" "under 1" \
+    "the exemption does not leak to the worker"
+# And it is overridable, so a future non-claiming role needs no code change.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+FLEET_DISPATCHER_NO_CLAIM_FABRIC_ROLES="merger triage" \
+    disp "$S" --record-outcome triage 300 --claimed=no
+assert_eq "$(disp "$S" --empty-streak-check triage)" "under 0" \
+    "NO_CLAIM_FABRIC_ROLES is overridable"
+
+echo "T11: every role family that can stand down is covered"
+# Binding constraint from plan review: the reviewer and steward lanes claim via
+# `review-claim` / `steward-claim`, arms the plan's stamping set originally
+# omitted. If a productive reviewer dispatch recorded `empty`, the reviewer
+# lane would stand down after EMPTY_STREAK_CAP *productive* dispatches — a
+# strictly-worse-than-today regression. These assert the fold treats them like
+# any other role once the claim signal says `yes`.
+for role in sonnet-reviewer opus-reviewer epic-steward smoke-worker; do
+    S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+    disp "$S" --record-outcome "$role" 300 --claimed=no
+    disp "$S" --record-outcome "$role" 300 --claimed=no
+    assert_eq "$(disp "$S" --empty-streak-check "$role")" "under 2" "$role: no-picks accumulate"
+    disp "$S" --record-outcome "$role" 300 --claimed=yes
+    assert_eq "$(disp "$S" --empty-streak-check "$role")" "under 0" \
+        "$role: a productive claim+release dispatch resets (does NOT stand the lane down)"
+done
+
+echo "T12: --claimed / --class argument validation"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+if disp "$S" --record-outcome worker 300 --claimed=maybe >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: --claimed=maybe should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: --claimed with a non-yes/no value exits non-zero"
+fi
+if disp "$S" --record-outcome worker 300 --bogus >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: unknown --record-outcome argument should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: unknown --record-outcome argument exits non-zero"
+fi
+if disp "$S" --empty-streak-check worker --bogus >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: unknown --empty-streak-check argument should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: unknown --empty-streak-check argument exits non-zero"
+fi
+# An empty `--claimed=` must not be read as an affirmative claim; it falls back
+# to the duration heuristic like an omitted flag (dual-spelling arm discipline).
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 300 --claimed=
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" \
+    "--claimed= (empty) falls back to the duration heuristic"
 
 echo
 echo "passed: $PASS  failed: $FAIL"

--- a/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
+++ b/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
@@ -217,12 +217,11 @@ assert_eq "$(disp "$S" --empty-streak-check triage)" "under 0" \
     "NO_CLAIM_FABRIC_ROLES is overridable"
 
 echo "T11: every role family that can stand down is covered"
-# Binding constraint from plan review: the reviewer and steward lanes claim via
-# `review-claim` / `steward-claim`, arms the plan's stamping set originally
-# omitted. If a productive reviewer dispatch recorded `empty`, the reviewer
-# lane would stand down after EMPTY_STREAK_CAP *productive* dispatches — a
-# strictly-worse-than-today regression. These assert the fold treats them like
-# any other role once the claim signal says `yes`.
+# The reviewer and steward lanes claim via `review-claim` / `steward-claim`, so
+# they belong in the stamping set (#2698). If a productive reviewer dispatch
+# recorded `empty`, the reviewer lane would stand down after EMPTY_STREAK_CAP
+# *productive* dispatches — a strictly-worse-than-today regression. These assert
+# the fold treats them like any other role once the claim signal says `yes`.
 for role in sonnet-reviewer opus-reviewer epic-steward smoke-worker; do
     S=$(mktemp -d "$TMPROOT/s.XXXXXX")
     disp "$S" --record-outcome "$role" 300 --claimed=no

--- a/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
+++ b/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
@@ -233,7 +233,49 @@ for role in sonnet-reviewer opus-reviewer epic-steward smoke-worker; do
         "$role: a productive claim+release dispatch resets (does NOT stand the lane down)"
 done
 
-echo "T12: --claimed / --class argument validation"
+echo "T12: the verdict derived from a dispatch record"
+# The fold path itself needs tmux and a live pane; --derive-outcome exposes
+# just the decision. Without it the planning and legacy arms below would ship
+# on inspection alone.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+mkdir -p "$S/dispatch-claimed"
+rec="$S/pane-9.json"
+new_record() { printf '%s\n' "$1" > "$rec"; }
+BASE='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1,"claim_marker":1}'
+PLAN='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1,"claim_marker":1,"plan_issue":"engine:2698"}'
+LEGACY='{"role":"worker","pane":"%9","class":"opus","dispatched_at":"x","dispatched_epoch":1}'
+
+new_record "$BASE"
+rm -f "$S/dispatch-claimed/pane-9"
+assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "no" \
+    "no marker on disk -> empty (the diligent no-pick)"
+: > "$S/dispatch-claimed/pane-9"
+assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "yes" \
+    "marker present -> claimed"
+# The pane key is derived from the pane id, so another pane's marker must not
+# be read as this one's.
+rm -f "$S/dispatch-claimed/pane-9"; : > "$S/dispatch-claimed/pane-8"
+assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "no" \
+    "a different pane's marker is not borrowed"
+# A planning assignment is productive even though the pane never stamped:
+# the dispatcher took the planning-claim pre-launch (#2197).
+new_record "$PLAN"
+rm -f "$S/dispatch-claimed/pane-9"
+assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "yes" \
+    "plan_issue with no marker -> claimed (pre-claimed planning assignment)"
+# A record from before this change has no claim_marker; its pane's wrapper
+# never exported the flag, so the verdict is unknown, not empty.
+new_record "$LEGACY"
+rm -f "$S/dispatch-claimed/pane-9"
+assert_eq "$(disp "$S" --derive-outcome "$rec" '%9')" "" \
+    "legacy record -> unknown (falls back to the duration heuristic)"
+# ...and unknown really does route to duration, not to a silent increment.
+S2=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S2" --record-outcome worker 300 --class=opus
+assert_eq "$(disp "$S2" --empty-streak-check worker --class=opus)" "under 0" \
+    "unknown + long duration resets, exactly as before this change"
+
+echo "T13: --claimed / --class argument validation"
 S=$(mktemp -d "$TMPROOT/s.XXXXXX")
 if disp "$S" --record-outcome worker 300 --claimed=maybe >/dev/null 2>&1; then
     FAIL=$((FAIL + 1)); echo "  FAIL: --claimed=maybe should exit non-zero"

--- a/scripts/fleet/tests/test_fleet_claim_dispatch_marker.sh
+++ b/scripts/fleet/tests/test_fleet_claim_dispatch_marker.sh
@@ -4,9 +4,8 @@
 # fleet-dispatch-wrap exports FLEET_CLAIM_FLAG (pane-keyed) and clears it at
 # dispatch start; fleet-claim touches it on every arm that takes or releases a
 # fleet lock; fleet-dispatcher reads it back once the pane returns to a shell
-# and folds claimed-vs-empty into the empty-exit backoff streak. It replaces a
-# wall-clock heuristic that could not tell a real claim from a diligent
-# no-pick, which left the backoff dead for the worker role for 15 days.
+# and folds claimed-vs-empty into the empty-exit backoff streak. A wall-clock
+# heuristic cannot tell a real claim from a diligent no-pick; the marker can.
 #
 # The properties that matter, and why each is here rather than left to a live
 # observation:

--- a/scripts/fleet/tests/test_fleet_claim_dispatch_marker.sh
+++ b/scripts/fleet/tests/test_fleet_claim_dispatch_marker.sh
@@ -115,6 +115,20 @@ rm -f "$FLAG"   # simulate the next dispatch's start-of-run clear
 claim_run "$S" release-worktree pool-7 >/dev/null 2>&1
 assert_stamped "release-worktree alone stamps (resume-without-acquire case)"
 
+echo "T3b: each release arm stamps, not just the one T2/T3 happened to use"
+# Coverage gap this closes: T2/T3 drive `release-worktree`, and passing there
+# says nothing about `release` / `release-stack` — different case arms with
+# different cmd_* bodies, any of which could exit before reaching the stamp.
+# Both are driven on state they do NOT hold, which is also the weaker case: a
+# no-op release still stamps, so the arms are reached unconditionally.
+for arm in "release 999999" "release-stack no-such-agent"; do
+    S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+    rm -f "$FLAG"
+    # shellcheck disable=SC2086
+    claim_run "$S" $arm >/dev/null 2>&1
+    assert_stamped "release arm stamps: $arm"
+done
+
 echo "T4: read-only arms do not stamp"
 S=$(mktemp -d "$TMPROOT/s.XXXXXX")
 for arm in "reservation-of pool-7" "list" "list-reservations" "worktree-for-task 4242"; do

--- a/scripts/fleet/tests/test_fleet_claim_dispatch_marker.sh
+++ b/scripts/fleet/tests/test_fleet_claim_dispatch_marker.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's dispatch-outcome marker (#2698).
+#
+# fleet-dispatch-wrap exports FLEET_CLAIM_FLAG (pane-keyed) and clears it at
+# dispatch start; fleet-claim touches it on every arm that takes or releases a
+# fleet lock; fleet-dispatcher reads it back once the pane returns to a shell
+# and folds claimed-vs-empty into the empty-exit backoff streak. It replaces a
+# wall-clock heuristic that could not tell a real claim from a diligent
+# no-pick, which left the backoff dead for the worker role for 15 days.
+#
+# The properties that matter, and why each is here rather than left to a live
+# observation:
+#
+#   - RELEASE-EARLY SAFE. The lock discipline is acquire-late/release-early, so
+#     a productive iteration has usually released by the time it exits. Any
+#     signal derived from live claim state reads `empty` for it. The marker is
+#     a separate artifact from $CLAIMS_DIR, so it survives the release — that
+#     is the assertion the prior plan's refuted claim-liveness design failed.
+#   - SUCCESS-ONLY. A pane that tried to claim and lost did no work.
+#   - `cleanup` EXCLUDED. It sweeps other agents' stale locks and is the
+#     sanctioned zero-pick move, so stamping there would make every starved
+#     iteration look productive and inarguably invert the fix.
+#   - NO-OP OFF-DISPATCH. Interactive/architect use has no FLEET_CLAIM_FLAG.
+#
+# Hermetic: only GitHub-free arms are driven (reserve / release-worktree /
+# reservation-of / molecule / cleanup-on-empty), against scratch
+# FLEET_CLAIMS_DIR + FLEET_STATE_DIR.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$(dirname "$0")/lib_assert.sh"
+
+CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -e "$CLAIM" ]]; then
+    echo "SKIP: missing $CLAIM" >&2
+    exit 3
+fi
+
+TMPROOT=""
+cleanup_tmp() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup_tmp EXIT
+TMPROOT=$(mktemp -d)
+
+# fleet-claim keeps state in THREE dirs, each with its own override. Setting
+# only FLEET_CLAIMS_DIR looks hermetic and is not: `reserve` writes to
+# RESERVATIONS_DIR and `molecule` reads MOLECULES_DIR, so a partial override
+# silently mutates the live fleet — an early draft of this suite left a real
+# `pool-7` reservation behind, which a real pool-7 pane would have resumed at
+# step 0.5. Override all three, and assert it below.
+HERMETIC_DIRS=(claims molecules reservations)
+FLAG=""
+claim_run() {
+    # usage: claim_run <scratch> <args...>
+    local scratch="$1"; shift
+    FLAG="$scratch/dispatch-claimed/pane-7"
+    FLEET_CLAIMS_DIR="$scratch/claims" \
+    FLEET_MOLECULES_DIR="$scratch/molecules" \
+    FLEET_RESERVATIONS_DIR="$scratch/reservations" \
+    FLEET_STATE_DIR="$scratch/state" \
+    FLEET_CLAIM_FLAG="$FLAG" \
+        "$CLAIM" "$@"
+}
+
+# Same, with no FLEET_CLAIM_FLAG in the environment (interactive use).
+claim_run_undispatched() {
+    local scratch="$1"; shift
+    FLEET_CLAIMS_DIR="$scratch/claims" \
+    FLEET_MOLECULES_DIR="$scratch/molecules" \
+    FLEET_RESERVATIONS_DIR="$scratch/reservations" \
+    FLEET_STATE_DIR="$scratch/state" \
+        env -u FLEET_CLAIM_FLAG "$CLAIM" "$@"
+}
+
+# Fingerprint the live dirs so the run can prove it never touched them.
+live_fingerprint() {
+    local d
+    for d in "${HERMETIC_DIRS[@]}"; do
+        printf '%s:' "$d"
+        ls -1 "$HOME/.fleet/$d" 2>/dev/null | sort | tr '\n' ','
+        printf '\n'
+    done
+}
+LIVE_BEFORE=$(live_fingerprint)
+
+assert_stamped() {
+    if [[ -f "$FLAG" ]]; then ok "$1"; else bad "$1"; echo "        no marker at: $FLAG"; fi
+}
+assert_not_stamped() {
+    if [[ -f "$FLAG" ]]; then bad "$1"; echo "        unexpected marker at: $FLAG"; else ok "$1"; fi
+}
+
+echo "T1: an acquire arm stamps the marker"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+claim_run "$S" reserve 4242 pool-7 >/dev/null 2>&1
+assert_stamped "reserve stamps"
+
+echo "T2: the marker survives the release (acquire-late / release-early)"
+# This is AC 1: an iteration that claims, works, and releases before exiting
+# must still read `claimed`. A claim-liveness probe reads empty here, and
+# wall-clock cannot distinguish it from a no-pick that ran just as long.
+claim_run "$S" release-worktree pool-7 >/dev/null 2>&1
+assert_stamped "marker outlives release-worktree"
+assert_eq "$(claim_run "$S" reservation-of pool-7 2>/dev/null)" "" \
+    "…and the reservation really is gone (the marker is not just a stale lock)"
+
+echo "T3: a release arm stamps on its own"
+# Load-bearing for the step-0.5 reservation resume and the molecule resume: a
+# full task's work while acquiring nothing, because the lock was taken in a
+# prior iteration. Without the release arms those iterations record `empty`.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+claim_run "$S" reserve 4243 pool-7 >/dev/null 2>&1
+rm -f "$FLAG"   # simulate the next dispatch's start-of-run clear
+claim_run "$S" release-worktree pool-7 >/dev/null 2>&1
+assert_stamped "release-worktree alone stamps (resume-without-acquire case)"
+
+echo "T4: read-only arms do not stamp"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+for arm in "reservation-of pool-7" "list" "list-reservations" "worktree-for-task 4242"; do
+    rm -f "$FLAG"
+    # shellcheck disable=SC2086
+    claim_run "$S" $arm >/dev/null 2>&1
+    assert_not_stamped "read-only arm does not stamp: $arm"
+done
+
+echo "T5: cleanup is excluded — the sanctioned zero-pick move stays empty"
+# AC 5. Run against an empty claims dir so the sweep completes locally with
+# nothing to do (and no network), which is exactly a starved iteration's call.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+mkdir -p "$S/claims"
+rm -f "$FLAG"
+claim_run "$S" cleanup >/dev/null 2>&1
+rc=$?
+assert_eq "$rc" "0" "cleanup on an empty claims dir succeeds (so the check below is not vacuous)"
+assert_not_stamped "cleanup does not stamp"
+
+echo "T6: failure does not stamp (success-only)"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+rm -f "$FLAG"
+claim_run "$S" reserve >/dev/null 2>&1
+assert_not_stamped "reserve with missing args does not stamp"
+# The one that matters: a pane that CONTENDED for a lock and lost did no work,
+# and must still record empty. `set -euo pipefail` aborts before the stamp.
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+claim_run "$S" reserve 4245 pool-7 >/dev/null 2>&1   # first one wins
+rm -f "$FLAG"
+claim_run "$S" reserve 4246 pool-7 >/dev/null 2>&1   # second contends and loses
+rc=$?
+assert_eq "$rc" "1" "a contended reserve really does fail (so the check below is not vacuous)"
+assert_not_stamped "a lost lock acquisition does not stamp"
+
+echo "T7: no marker path in the environment is a no-op, not an error"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+claim_run_undispatched "$S" reserve 4244 pool-7 >/dev/null 2>&1
+rc=$?
+assert_eq "$rc" "0" "reserve still succeeds with FLEET_CLAIM_FLAG unset (interactive use)"
+
+echo "T8: molecule — progress arms stamp, the resume query does not"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+rm -f "$FLAG"
+claim_run "$S" molecule resume pool-7 >/dev/null 2>&1
+assert_not_stamped "molecule resume (a query that legitimately returns nothing) does not stamp"
+
+echo "T9: fidelity — every lock arm in the live case block is in the stamping set"
+# The executable form of the plan-review finding: the stamping set was written
+# from memory and omitted review-claim / steward-claim, which would have stood
+# the reviewer and steward lanes down after EMPTY_STREAK_CAP *productive*
+# dispatches. Enumerate from the source instead of trusting a hand list, so a
+# newly added lock arm fails here rather than silently dropping out.
+#
+# The dispatch case arms are indented four spaces; the trailing stamp block is
+# everything after the `_stamp_dispatch_outcome()` definition.
+stamp_block=$(sed -n '/^_stamp_dispatch_outcome()/,$p' "$CLAIM")
+lock_arms=$(grep -oE '^    (claim|release|stack|release-stack|reserve|release-worktree|[a-z-]+-(claim|release))\)' "$CLAIM" \
+    | tr -d ' )' | sort -u)
+# 8 acquire (claim, stack, reserve, {review,resolving,amending,steward,planning}-claim)
+# + 8 release (release, release-stack, release-worktree, {review,resolving,
+# amending,steward,planning}-release).
+assert_eq "$(printf '%s\n' "$lock_arms" | grep -c .)" "16" \
+    "enumerated the expected number of lock arms (update this suite when one is added)"
+missing=""
+while read -r arm; do
+    [[ -n "$arm" ]] || continue
+    printf '%s' "$stamp_block" | grep -qE "(^|[|\\\\ ])${arm}\)?([|\\\\]|\$| )" \
+        || missing="${missing:+$missing }$arm"
+done <<< "$lock_arms"
+assert_eq "$missing" "" "every acquire/release arm appears in the stamping set"
+
+# And the exclusions are deliberate, not omissions.
+for excluded in cleanup reconcile clear-all reset-sweep-host-claims; do
+    assert_absent "$(printf '%s' "$stamp_block" | grep -E "^ +${excluded}\)" || true)" \
+        "$excluded)" "$excluded is NOT in the stamping set"
+done
+
+echo "T10: the marker path agrees across the three scripts that share it"
+# scripts/fleet/CLAUDE.md: an inlined duplicate ships with a drift guard, or
+# the duplication is pure cost. CLAIM_FLAG_DIR is spelled independently in
+# fleet-dispatch-wrap (which exports FLEET_CLAIM_FLAG) and fleet-dispatcher
+# (which reads the marker back). If the two ever disagree, the wrapper clears
+# and the agent stamps one path while the dispatcher reads another — every
+# dispatch would then record `empty` and every lane would stand down after
+# EMPTY_STREAK_CAP productive dispatches, silently.
+wrap_dir=$(grep -E '^CLAIM_FLAG_DIR=' "$SCRIPT_DIR/fleet-dispatch-wrap" | head -n 1 | sed 's/[[:space:]]*#.*//')
+disp_dir=$(grep -E '^CLAIM_FLAG_DIR=' "$SCRIPT_DIR/fleet-dispatcher" | head -n 1 | sed 's/[[:space:]]*#.*//')
+assert_eq "$wrap_dir" "$disp_dir" "CLAIM_FLAG_DIR agrees between fleet-dispatch-wrap and fleet-dispatcher"
+assert_contains "$wrap_dir" 'CLAIM_FLAG_DIR="$STATE_DIR/dispatch-claimed"' \
+    "…and is the expected STATE_DIR-relative path (not an absolute or \$HOME-relative spelling)"
+# The wrapper must key the marker by PANE_KEY, which is what the dispatcher
+# reconstructs via pane_id_to_key when folding the outcome.
+assert_contains "$(grep -E 'export FLEET_CLAIM_FLAG=' "$SCRIPT_DIR/fleet-dispatch-wrap")" \
+    '$CLAIM_FLAG_DIR/$PANE_KEY' "the wrapper keys the marker by PANE_KEY"
+
+echo "T11: the suite itself stayed hermetic"
+# Not a formality. fleet-claim has three state dirs behind three separate
+# overrides; miss one and the suite mutates the live fleet while every
+# assertion still passes. This is the check that fails instead.
+assert_eq "$(live_fingerprint)" "$LIVE_BEFORE" \
+    "live ~/.fleet claims/molecules/reservations unchanged by this run"
+
+summarize "fleet-claim dispatch-marker tests"


### PR DESCRIPTION
## Summary

`fleet-dispatcher`'s empty-exit backoff inferred "claimed nothing" from a dispatch's **wall-clock duration**. A worker that walks both queues per `role-worker.md` and *correctly* declines takes minutes, so it landed in the long-run branch and **reset** the streak. The backoff could never engage for the one failure mode it was written to bound, and had not fired for the worker role since 2026-07-15.

- **The signal is now recorded, not inferred.** `fleet-claim` stamps a pane-keyed marker on every arm that takes or releases a fleet lock; `fleet-dispatch-wrap` exports and clears it per dispatch (beside the existing `FLEET_THROTTLE_FLAG`); the dispatcher reads it back when the pane returns to a shell. Because `fleet-claim` *is* the enforced mutex, coverage is structural rather than a prose obligation a role doc could skip — and because the marker is a separate artifact from `$CLAIMS_DIR`, it survives the acquire-late/release-early discipline that defeats any claim-liveness probe.
- **The streak is keyed per `(role, class)`**, so a busy sonnet lane no longer clears the starvation streak a starved opus lane is accumulating.
- `EMPTY_EXIT_SECONDS` is retained for dispatches whose outcome is unknown (records predating this change) and as a test knob.

## Deviations from the plan — both measured, please review

**1. The merger would have been a regression, and neither the plan nor its review caught it.** The plan states non-worker roles "go through their own acquire arms", listing `merger` first. Enumerating the live `case` block shows the merger takes **no `fleet-claim` locks at all** — `role-merger.md` is explicit that `--force-with-lease` is its concurrency control. Left on the marker signal it would stamp nothing on a *successful* merge run and stand its own lane down after `EMPTY_STREAK_CAP` **productive** dispatches — the same "strictly worse than today" outcome the plan review caught for the reviewer and steward lanes, one role further along. `NO_CLAIM_FABRIC_ROLES` (default `merger`) keeps duration for exactly those roles, which is sound for the mirror of the reason it broke elsewhere: duration failed for the worker because its role doc mandates a multi-minute walk before a legitimate decline, and a role with no such walk still exits fast when idle.

**2. Unclassed roles key on their resolved class, not the plan's literal `<role>__all`.** Both the fold site and the consume site derive the qualifier from one expression (`dispatch_class_key`), so they agree by construction; inventing a second normalization rule for unclassed roles is how the two sides come to disagree — which would write the streak under one key and read it under another, reproducing #2698 one level down. `__all` is still the real default for the unqualified test hooks. Behavior is unchanged either way (AC 7).

**Binding constraints from plan review, all three applied.** The stamping set is enumerated from the live `case` block — 8 acquire + 8 release arms, including the `review-claim`/`review-release` and `steward-claim`/`steward-release` the plan omitted, and `planning-claim`/`planning-release` decided deliberately rather than by omission. `T11` covers a reviewer-family arm per constraint 2. Enumeration is now **executable** (`T9`), so a newly added lock arm fails the suite rather than silently dropping out — it caught my own hand-count error while writing it.

## Test plan

- [x] `test_dispatcher_empty_exit_backoff.sh` — **49 passed, 0 failed** (extended, not replaced; was 16).
- [x] `test_fleet_claim_dispatch_marker.sh` — **27 passed, 0 failed** (new).
- [x] **Positive control**, dispatcher suite vs pre-fix `origin/master` (`a9459315b`): **15 of 45** assertions fail. `MEANINGFUL`.
- [x] **Positive control**, marker suite vs the same ref: **6 of 25** fail. `MEANINGFUL`.
- [x] Full fleet suite `run_all.sh` — **125 of 126 suites pass**. The sole failure, `test_cross_repo_shared_file_parity.sh`, is **pre-existing**: verified by stashing this branch's diff and re-running it on a clean tree (`rc=1` there too).
- [x] **Phase 0 (the plan's mandated live signal proof), run in a real dispatched pane** — against the actual wrapper-derived path `~/.fleet/state/dispatch-claimed/pane-3`: read-only arm → no marker; acquire → stamped; **release → still stamped**. No bail condition hit. Live `~/.fleet` state unchanged.
- [x] `bash -n` clean on all three modified scripts.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| AC1 — a dispatch that claims *and releases* before completing records `claimed` | marker suite `T2`/`T3` | `marker outlives release-worktree`; `release-worktree alone stamps (resume-without-acquire case)` |
| AC2 — `--claimed=no` increments at 300s, `--claimed=yes` resets | dispatcher `T8` | `long no-pick (300s, claimed=no) increments`; `a real claim resets, however long it took` |
| AC3 — sub-60s with no claim still increments | dispatcher `T8` | `sub-threshold exit with no claim still increments` |
| AC4 — a `plan_issue` record with no marker records `claimed` | dispatcher `T12` | `plan_issue with no marker -> claimed (pre-claimed planning assignment)` |
| AC5 — `cleanup` alone does not stamp | marker suite `T5` | `cleanup does not stamp`, paired with `cleanup on an empty claims dir succeeds` so the check is not vacuous |
| AC6 — `worker__opus` reaching the cap does not stand down `worker__sonnet` | dispatcher `T9` | `opus lane tripped`; `sonnet lane untouched`; `a sonnet claim does not clear the opus streak` |
| AC7 — unclassed roles (`merger`) behave exactly as today | dispatcher `T10` | `a long, productive merger run resets (verdict discarded, duration wins)`; `merger stands down after 3 fast exits, exactly as before` |

The plan's old AC5 (observe a live `standing down` line) is deliberately **not** gated here — it was demoted to a post-merge manual observation by the re-plan, and the plan review agreed. Watch `~/.fleet/logs/dispatcher.log` for the first `worker` stand-down since 2026-07-15.

## Findings deferred

- **The merger has no productivity signal at all.** It is exempted here so this PR cannot regress it, but that leaves its backoff on the same duration proxy — correct today only because the merger has no mandated walk. Worth a follow-up if the merger ever grows one.
- **`fleet-dispatcher` falls through to `main()` on an unrecognized argument**, so a stray flag starts the daemon loop rather than erroring. This bit the positive control here (hung until killed) and is guarded around in the suite; the dispatcher itself still has no `*)` usage arm. Pre-existing, out of scope.
- **The release arms are productive signals only by a prose coupling.** A starved iteration never reaches one — `role-worker.md` exits a no-pick at step 3, before step 12's `release-worktree` — so "released a lock" implies "did work" *today*. Making any shutdown step unconditional would stamp every no-pick as productive and kill this backoff a second time, arriving through a role doc instead of a heuristic. Noted at the stamping-set site; a structural fix (stamp only when a release actually released something) needs per-arm return values the central stamp cannot see.
- **`fleet-claim` has three independent state-dir overrides** (`FLEET_CLAIMS_DIR`, `FLEET_MOLECULES_DIR`, `FLEET_RESERVATIONS_DIR`). Setting only the first looks hermetic and is not — an early draft of the new suite left a real `pool-7` reservation in live `~/.fleet` (found, released, and now guarded by `T11`'s fingerprint assertion). Any future `fleet-claim` test is exposed to the same trap.

Closes #2698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
