### PR TITLE
fleet: per-kind wake suppression for the union worker lane (#2700)

### DIFF
--- a/.fleet/plans/issue-2700.md
+++ b/.fleet/plans/issue-2700.md
@@ -1,0 +1,238 @@
+# Plan: per-kind trigger suppression for the union worker lane (rev 2)
+
+- **Issue:** #2700
+- **Model:** opus
+- **Date:** 2026-08-08
+
+Rev 2, superseding the 2026-07-31 plan per the plan-review bounce. Everything
+the review marked keep-verbatim carries forward. Three deltas: the Phase 2 fire
+rule is now the membership test, picked deliberately; verification of the
+review's item 3 shows that rule **requires a dispatcher-side amendment** (new
+Phase 3); and a fact both prior passes missed forces an explicit role allowlist.
+
+## Scope
+
+Make the transition-to-nothing-to-do suppression in `update_role_trigger`
+**per sub-lane with a new-item membership test**, scoped to the `worker` role
+by explicit allowlist — plus **one amendment to the dispatcher's steady-state
+trigger consumption**, which the verification below shows is load-bearing for
+the membership rule, not optional hardening. Rev 1 scoped this to "the wake
+predicate only"; that scope is not honestly achievable with the rule that
+covers the dominant wake class, because today's queue drainage is *pumped by*
+the claim-churn wakes this issue removes. The dispatcher change is the
+replacement pump.
+
+Still out of scope: `project_worker`'s item-level filtering (#2114 / #2287 /
+#1726 — all correct as-is), the empty-exit backoff itself (#2698, unchanged and
+still wanted as the spin bound), and the `fleet_task_class` claimable gate
+(#2696, unchanged).
+
+**One task, one PR.** Splitting the scout rule from the dispatcher retention
+would ship a throughput regression in the gap between them (see Phase 3
+rationale) — they land together.
+
+## Verified current state (source-read at `a9459315b`)
+
+- `update_role_trigger` — `fleet-state-scout:2690`; whole-projection
+  suppression `if not projection:` at 2724; `touch()` at 2730; seen file is a
+  bare 16-hex `stable_hash` (:1199, sha256 of sorted JSON, truncated).
+- `project_worker` — :1922, registered in `PROJECTORS` (:2391). Emits four
+  `kind`s: `task` `{kind, repo, id, blocked_by}` (:1935), `needs_plan` (:1957),
+  `pr` `{…, labels: sorted(labels & _WORKER_RELEVANT_LABELS)}` (:1983),
+  `semantic_conflict` (:1989). All items are dicts carrying `kind`.
+- Trigger loop at :3037; `queue-manager` / `queue-manager-ingest` branch to
+  inline bare-hash compares before the `elif update_role_trigger(...)` at :3132
+  — untouched by this change.
+- Slicers write `projections/<role>.json` every tick **regardless of
+  suppression** (:3136-3145), so the dispatcher's resolver always reads a fresh
+  claimable set. This is what makes Phase 3 sound.
+- **Correction to the issue's AC-3 premise:** opus-reviewer items are NOT all
+  kind-less — `project_opus_reviewer` emits kind-less PR items *and*
+  `{kind: "plan_review"}` issue items (:2035). `epic_steward` items all carry
+  kinds (:2369-2386). Only sonnet-reviewer, merger, and smoke-worker are
+  kind-free. So "bucket by item shape, single-lane roles reduce to one bucket"
+  is false for two roles: shape-keyed bucketing would silently change
+  opus-reviewer and epic-steward suppression semantics. Hence the allowlist.
+- **Dispatcher trigger lifecycle** (`fleet-dispatcher`):
+  - Defer paths that KEEP the trigger: role at concurrency cap (:1613), no idle
+    pane, resolver defer (:1720), class saturated (:1763), min-gap
+    (:1958-1963), other classes queued (:1988), zero dispatched (:1999).
+  - CONSUME paths: empty-exit backoff (:1946, #2698) and **steady-state success
+    (:1994) — `dispatched > 0`, past boot window, no other class queued — which
+    consumes even when the claimable count exceeds this tick's launches** (the
+    "headroom is filled" comment above it is wrong in exactly this case; the
+    fan-out loop also exits on idle-pane exhaustion).
+  - Periodic worker safety rearm (:2151-2196, `PERIODIC_REARM_INTERVAL_SECONDS`
+    = 300, :397): re-arms only when no trigger is pending AND **zero workers are
+    active** (:2179) AND the resolver would dispatch a concrete class (:1518).
+
+## The fire rule: membership test, and why
+
+**Fire iff some kind's new item set contains an item absent from that kind's old
+set.** Item identity = `stable_hash(item)` over the whole projector dict.
+Per-kind state stored as the fmt-2 seen payload (Phase 2).
+
+- Pure removal — a task claimed, a feedback label cleared, a `fleet:resolving-*`
+  claim dropping a conflict item, a merge closing an issue — is suppressed
+  **even when the lane stays non-empty**. This is the dominant wake class and
+  the issue's central case; rev 1's non-empty rule missed it entirely.
+- A modification (a task's `blocked_by` going `#2385` → `(none)`, a PR's verdict
+  label swapping) hashes as remove+add ⇒ the new item is absent from the old set
+  ⇒ fires. Unblocking and re-verdicts are genuinely new work.
+- The rejected alternative — keep rev 1's cheaper non-empty rule and narrow the
+  scope to drain-to-zero wakes — is honest but keeps the highest-frequency wake
+  source (task claims against a ~30-item lane) at ~100% of today's rate. With
+  each wake fanning out to every idle pane, the membership payload (~1 KB of
+  hashes for a ~50-item projection) is cheap against that; rejected.
+
+A false-positive direction note: any projector field change fires (the item
+re-hashes). That is the safe direction — over-firing costs one no-pick
+iteration, over-suppressing idles the fleet.
+
+## Why the membership rule requires the dispatcher amendment
+
+The review's mitigating argument was "the dispatcher keeps the trigger when it
+defers at cap, so a freed pane re-evaluates without a fresh wake." The
+defer-at-cap retention is real (:1613) — but it only covers ticks that
+*deferred*. The common drain path is the steady-state consume:
+
+1. N claimable tasks arrive ⇒ scout fires. Dispatcher fans out to all idle panes
+   (say 4 of N=30), `dispatched=4 > 0`, steady state ⇒ **trigger consumed**.
+2. Each pane's claim removes a `task` item. Today that flips the hash and
+   re-arms the trigger, so freed panes keep getting dispatched — **the
+   claim-churn wake is the drainage pump.** Under the membership rule those
+   re-arms are exactly what gets suppressed.
+3. With no pending trigger, a freed pane is only rescued by the periodic rearm —
+   which requires **zero active workers**. One long-running task blocks
+   re-dispatch of every freed pane for its whole duration; drainage degrades
+   from continuous to cap-sized waves at ≥300 s granularity.
+
+So Phase 3: at the steady-state consume, for claim-counted lanes
+(`claim_headroom >= 0`), **consume only when this tick's launches covered the
+claimable headroom (`dispatched >= claim_headroom`); otherwise keep the
+trigger** and log it. The uncapped path (`claim_headroom == -1`) keeps today's
+consume-on-success, so only the worker lane changes. A retained trigger is cheap
+and already-bounded: with no idle pane, `dispatch_role` returns above the
+resolver; when a pane frees, it is dispatched from the retained trigger and the
+resolver re-reads the fresh projection slice; if the remaining claimable items
+are ones every worker refuses, the empty-exit backoff (#2698) consumes the
+trigger after the streak cap exactly as today.
+
+## Role scoping
+
+New module-level `PER_KIND_TRIGGER_ROLES = frozenset({"worker"})` beside
+`PROJECTORS`. `update_role_trigger` takes the per-kind path only for roles in
+the allowlist; every other role — including the kind-carrying opus-reviewer and
+epic-steward — keeps the existing bare-hash whole-projection code path
+byte-for-byte. Extending suppression to opus-reviewer is real but unmeasured
+work — file it as a follow-up once the worker lane proves out. A pleasant
+consequence: the existing `test_role_trigger_empty.py` suite runs under role
+name `"r"` (not allowlisted), so it becomes the byte-identical regression proof
+for the legacy path with zero modification.
+
+## Approach
+
+**Phase 0 — baseline probe.** Confirm `worker` shows `suppressed == 0`
+pre-change. Bail path: any worker suppression ⇒ premise wrong ⇒ stop, post the
+reading, re-plan. Keep the counter as a permanent `log()` diagnostic —
+post-change it doubles as the live evidence.
+
+**Phase 1 — scout: per-kind partition behind the allowlist.** For allowlisted
+roles, bucket projection items by `item.get("kind", "")` (defensive default
+bucket). Compute per-item `stable_hash`, per-kind sorted hash lists.
+
+**Phase 2 — scout: membership fire rule + fmt-2 seen file.** Payload:
+`{"fmt": 2, "kinds": {"<kind>": ["<item-hash>", ...]}}`, written via the
+existing `write_atomic`. Rule: unchanged payload ⇒ early-return False, no write.
+Changed ⇒ write, then fire iff any kind has `set(new) - set(old)` non-empty;
+else write the `.empty-suppressed` marker and return False. The empty-projection
+case falls out. Marker semantics widen from "last write was an empty-projection
+suppression" to "last write was a suppression (no new items)". Legacy read: a
+bare-hex or unparseable seen file ⇒ all per-kind sets absent ⇒ every non-empty
+kind fires ⇒ at most one extra fire on upgrade (the deliberately safe direction;
+the opposite error is #561's permanently-idle mode).
+
+**Phase 3 — dispatcher: retain-while-uncovered.** Gate the steady-state
+`rm -f "$trigger_file"` on coverage; on the keep branch, log once per window
+(reuse the `CAP_DEFER_LOGGED` pattern). Every other consume/defer path is
+untouched, including the empty-exit backoff.
+
+**Phase 4 — `fleet-debug` + tests.** Parse both seen formats; for fmt-2 roles
+show per-kind item counts.
+
+## Affected files
+
+- `scripts/fleet/fleet-state-scout` — per-kind path, `PER_KIND_TRIGGER_ROLES`,
+  module-level helpers (the test suite loads the script via `SourceFileLoader`)
+- `scripts/fleet/fleet-dispatcher` — steady-state consume gate (Phase 3)
+- `scripts/fleet/fleet-debug` — dual-format seen parsing + per-kind display
+- `scripts/fleet/tests/test_role_trigger_empty.py` — new per-kind cases
+- `scripts/fleet/tests/test_fleet_debug_triggers.py` — fmt-2 fixture
+- `scripts/fleet/tests/test_dispatcher_claimable_cap.sh` — retention cases
+- `.fleet/plans/issue-2700.md` — this plan
+
+## Acceptance criteria
+
+1. **Pure removal from a still-non-empty lane suppresses**: `task×2 → task×1`,
+   other kinds unchanged ⇒ new hashes recorded, marker written, trigger NOT
+   touched.
+2. Sub-lane drain to zero with another lane non-empty (`pr×1 → pr×0`, `task×N`
+   unchanged) ⇒ suppressed.
+3. Positive controls (the fix cannot pass by never firing): `pr×0 → pr×1` fires;
+   an item modification (same `id`, `blocked_by` changed) fires; a simultaneous
+   remove+add across two kinds fires.
+4. Whole-projection-empty transition still suppresses; empty → non-empty still
+   fires (existing tests, unmodified).
+5. Non-allowlisted roles byte-identical: the existing suite under role `"r"`
+   passes unmodified, plus one new case feeding an opus-reviewer-shaped
+   projection (mixed kind-less + `plan_review` items) through a non-allowlisted
+   role and asserting legacy behavior.
+6. Upgrade: seen file containing a legacy bare-hex hash ⇒ exactly one fire on
+   the next non-empty tick, fmt-2 written, quiet thereafter; never a
+   permanently-idle role.
+7. Dispatcher: a steady-state tick with `dispatched < claim_headroom` keeps the
+   trigger; `dispatched >= claim_headroom` consumes; uncapped lanes
+   (`claim_headroom == -1`) consume as today;
+   `test_dispatcher_empty_exit_backoff.sh` passes unmodified.
+8. Phase 0 probe reading posted on this issue (pre-change: worker
+   `suppressed == 0`).
+9. `fleet-positive-control` run for the new scout cases against the pre-fix ref
+   reports MEANINGFUL (the pure-removal case fires pre-change).
+10. **Live post-change check** (restored from rev 1 per plan-review binding
+    constraint 1): against the real worker projection's item shapes, a pure
+    removal of one `pr` item while `tasks_open` stays non-empty suppresses and
+    writes the `worker.empty-suppressed` marker. Corroboration only — the
+    hermetic cases (1-3) are the real proof — but it is the one criterion that
+    would catch a rule correct in a fixture and inert against live item shapes.
+    Assert on `touch()` behaviour in the tests; treat the marker as the
+    live-run signal.
+
+## Gotchas
+
+- **Over-suppression is the dangerous direction** — it silently idles the fleet.
+  Phase 3 is the counterweight, not polish: do not land Phase 2 without it. The
+  residual safety nets (300 s rearm at zero-active, empty-streak backoff,
+  defer-path retention) all remain as backstops.
+- The seen-file compare must be on the **serialized fmt-2 payload**, not the
+  legacy whole-projection hash — otherwise the early-return path re-fires
+  forever on a stable projection after upgrade.
+- Never clear the `.empty-suppressed` marker on the unchanged-hash early return
+  (no write happened there — the marker means "the most recent *write* was a
+  suppression").
+- `queue-manager` / `queue-manager-ingest` inline compares are deliberate
+  non-consumers of the suppression — don't "unify" them.
+- The dispatcher edit sits between `LAST_ROLE_DISPATCH_COUNT` bookkeeping and
+  the `else` branch — keep the boot-window and `DISPATCH_MORE` keeps above it
+  untouched, and keep the new condition off the uncapped path.
+- **`fleet_poll_topology` followers** (binding constraint 2): `:28` and `:77`
+  recompute `seen-hashes/` on followers rather than shipping them, so there is
+  no cross-host fmt-2 migration. A follower's first post-upgrade tick is the
+  ordinary legacy-read path (one fire, settles).
+- **Re-anchor by symbol, not line** (binding constraint 3): with #2915 / #2934 /
+  #2953 in flight, line numbers drift. Grep the targets at implementation time.
+- Engine-public artifact: keep issue references engine-side only.
+
+## Task shape
+
+Single opus task, one PR. The scout rule, dispatcher retention, debug surface,
+and tests form one contract change; any split ships a regression window.

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -17,7 +17,7 @@ section below for which files apply.
 | `issues/<repo>/<N>.json` | scout | `fleet-issue view` | Full issue detail (body + comments + labels + state). Cached for issues in `needs_plan` / `human_approved`. |
 | `repos.json` | `fleet-up` | reviewer / merger roles | One-shot owner/repo slug map: `{"engine": "jakildev/IrredenEngine", "game": "jakildev/irreden"}`. |
 | `triggers/<role>` | scout | `fleet-babysit` | Empty file touched whenever this role's projection changed. Drives `fleet-babysit`'s long-back-off wake-up. |
-| `seen-hashes/<role>` | scout | scout | Hash of the last projection — internal trigger-detection state. |
+| `seen-hashes/<role>` | scout | scout, `fleet-debug triggers` | Last-projection fingerprint — internal trigger-detection state. **Two formats:** a bare 16-hex whole-projection hash for most roles, and for the scout's `PER_KIND_TRIGGER_ROLES` (today: `worker`) a `{"fmt":2,"kinds":{<kind>:[<item-hash>,…]}}` payload, because that lane's suppression is decided per sub-lane (#2700). A new reader must handle both; an unparseable file reads as all-new and fires once rather than idling (#561). |
 
 `<repo>` keys: `engine`, `game`. Match the `repos.<key>` slots in
 `state.json`.

--- a/scripts/fleet/fleet-debug
+++ b/scripts/fleet/fleet-debug
@@ -32,8 +32,14 @@ Subcommands
   triggers            Read-only dump of per-role fleet dispatch state: pending
                       trigger (+ mtime/content), last seen projection hash,
                       projection slice size + generated_at, and whether the last
-                      hash write was an empty-projection suppression (#2181).
-                      Never mutates any ~/.fleet/state file.
+                      hash write was a suppression (#2181). Never mutates any
+                      ~/.fleet/state file.
+                      seen= prints `fmt2[kind=N,...]` for roles using per-kind
+                      suppression (#2700) and a bare hash for the rest. Those
+                      roles also sit at trigger=pending far more often by
+                      design — the dispatcher now retains the trigger while
+                      claimable headroom is uncovered, so a standing worker
+                      trigger is normal, not a stuck one.
 
 Options
   --batch             Non-interactive crash triage: run immediately, then print
@@ -153,12 +159,30 @@ def _trigger_col(role):
 def _seen_col(role):
     path = SEEN_DIR / role
     try:
-        h = path.read_text().strip()
+        raw = path.read_text().strip()
     except FileNotFoundError:
         return "-"
     except OSError:
         return "unreadable"
-    return f"{h[:12]}({_mtime(path)})"
+    # Two on-disk formats. Legacy: a bare 16-hex whole-projection hash.
+    # fmt-2 (#2700, roles in the scout's PER_KIND_TRIGGER_ROLES): a
+    # {"fmt":2,"kinds":{<kind>:[<item-hash>,...]}} payload, because suppression
+    # for those roles is decided per sub-lane — collapsing it back to one hash
+    # would hide which lane actually moved. Show per-kind item counts instead.
+    if raw.startswith("{"):
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict) and data.get("fmt") == 2:
+            kinds = data.get("kinds")
+            if isinstance(kinds, dict):
+                body = ",".join(
+                    f"{kind or '<none>'}={len(hashes)}"
+                    for kind, hashes in sorted(kinds.items())
+                ) or "empty"
+                return f"fmt2[{body}]({_mtime(path)})"
+    return f"{raw[:12]}({_mtime(path)})"
 
 
 def _projection_col(role):

--- a/scripts/fleet/fleet-debug
+++ b/scripts/fleet/fleet-debug
@@ -34,6 +34,13 @@ Subcommands
                       projection slice size + generated_at, and whether the last
                       hash write was a suppression (#2181). Never mutates any
                       ~/.fleet/state file.
+                      suppressed= is yes iff the last hash write deliberately
+                      skipped arming the trigger. The rule is per-role: an empty
+                      projection on the bare-hash path, widening for the
+                      per-kind roles to "no kind gained an item", which includes
+                      a pure removal from a still-non-empty lane (#2700). For
+                      those roles it does NOT mean the projection was empty —
+                      read seen= to tell which rule applied.
                       seen= prints `fmt2[kind=N,...]` for roles using per-kind
                       suppression (#2700) and a bare hash for the rest. Those
                       roles also sit at trigger=pending far more often by
@@ -71,7 +78,8 @@ USAGE
 
 # `fleet-debug triggers` — read-only dump of per-role dispatch state
 # (pending trigger, last seen projection hash, projection slice size, and
-# whether the last hash write was an empty-projection suppression, #2181).
+# whether the last hash write was a suppression — an empty projection on the
+# bare-hash path, or no kind gaining an item on the per-kind path, #2181/#2700).
 # A subcommand, not a build target: every build target is IR*-named, so
 # `triggers` can't collide with one. Anything else falls through to the
 # debugger-launcher path below. State dir resolves from $HOME so tests can
@@ -90,7 +98,7 @@ PROJECTIONS_DIR = STATE / "projections"
 # Canonical dispatch roles. Sync sources: fleet-state-scout PROJECTORS and
 # fleet-dispatcher DISPATCHED_ROLES. queue-manager / queue-manager-ingest
 # spawn inline non-LLM subprocesses and never get a trigger file or an
-# empty-suppression marker, so those two columns read n/a for them.
+# suppression marker, so those two columns read n/a for them.
 CANONICAL = [
     "worker",
     "sonnet-reviewer",
@@ -203,6 +211,13 @@ def _projection_col(role):
 
 
 def _suppressed_col(role):
+    # Column reads `suppressed=`, not `empty-suppressed=`: on the per-kind path
+    # (#2700) the marker means "no kind gained an item", so a pure removal from
+    # a still-non-empty lane sets it on a lane that is never empty. The on-disk
+    # file name keeps the `.empty-suppressed` suffix on purpose, so existing
+    # markers and both readers stay valid — fleet-state-scout's marker-invariant
+    # comment owns that rationale. The two spellings differ deliberately; don't
+    # reconcile them by renaming the file.
     if role in NO_TRIGGER:
         return "n/a"
     marker = SEEN_DIR / f"{role}{SUPPRESS_SUFFIX}"
@@ -221,7 +236,7 @@ for role in roles:
         f"trigger={_trigger_col(role)}  "
         f"seen={_seen_col(role)}  "
         f"proj={_projection_col(role)}  "
-        f"empty-suppressed={_suppressed_col(role)}"
+        f"suppressed={_suppressed_col(role)}"
     )
 PYEOF
 fi

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1945,6 +1945,7 @@ dispatch_role() {
     if (( dispatched > 0 )) && empty_streak_over_cap "$role"; then
         rm -f "$trigger_file"
         reset_empty_streak "$role"
+        unset "CAP_DEFER_LOGGED[$role-uncovered]"
         log "$role: ${EMPTY_STREAK_CAP} consecutive fast exits (<${EMPTY_EXIT_SECONDS}s, no claim) — standing down; scout re-arms on new work"
         return
     fi
@@ -1954,6 +1955,7 @@ dispatch_role() {
     # per gap — regardless of how many fired this tick or the boot-window
     # state. This is what spreads the fleet-up burst to ~one launch per tick.
     if [[ -n "$gap_blocked" ]]; then
+        unset "CAP_DEFER_LOGGED[$role-uncovered]"
         if (( dispatched > 0 )); then
             log "$role: dispatched $dispatched; min-gap (${DISPATCH_MIN_GAP_SECONDS}s) deferring remaining idle panes — trigger kept"
         else

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1988,9 +1988,19 @@ dispatch_role() {
             log "$role: dispatched class=$DISPATCH_CLASS; other classes still queued — trigger kept"
             return
         fi
-        # Steady state (or boot window with cap saturated): at least
-        # one pane took the work and headroom is filled, consume the
-        # trigger.
+        # Steady state (or boot window with cap saturated): at least one pane
+        # took the work. Consume the trigger only if this tick's launches
+        # actually COVERED the claimable headroom — see
+        # should_retain_trigger_for_coverage for why `dispatched > 0` alone
+        # does not mean they did.
+        if should_retain_trigger_for_coverage "$dispatched" "$claim_headroom"; then
+            if [[ -z "${CAP_DEFER_LOGGED[$role-uncovered]+x}" ]]; then
+                log "$role: dispatched $dispatched of $claim_headroom claimable; trigger kept for freed panes"
+                CAP_DEFER_LOGGED["$role-uncovered"]=1
+            fi
+            return
+        fi
+        unset "CAP_DEFER_LOGGED[$role-uncovered]"
         rm -f "$trigger_file"
     else
         # Every idle pane already had a record (still settling in
@@ -2014,6 +2024,36 @@ should_retain_trigger_for_fanout_race() {
     local role="$1" active="$2"
     local cap="${ROLE_CONCURRENCY[$role]:-0}"
     if (( cap > 0 && SECONDS < BOOT_FANOUT_WINDOW_SECONDS && active < cap )); then
+        return 0
+    fi
+    return 1
+}
+
+# Decide whether to retain a per-role trigger after a steady-state dispatch
+# tick because this tick's launches did not cover the claimable headroom
+# (#2700). Returns 0 (retain) when the lane is claim-counted and
+# `dispatched < claim_headroom`; 1 (consume) otherwise, which includes every
+# uncapped lane (claim_headroom<0 — non-worker roles and the legacy
+# fallthrough), so only claim-counted lanes change behaviour.
+#
+# `dispatched > 0` does NOT imply the headroom was covered: the fan-out loop
+# also exits on idle-pane exhaustion, so 1 launch against 8 claimable items
+# reaches the steady-state branch. Consuming there is only safe while something
+# re-arms the trigger as panes free up, and per-kind suppression (#2700) removes
+# that pump — the scout no longer fires on the claim that empties a task slot.
+# The remaining rescue, the periodic rearm, requires ZERO active workers, so one
+# long-running task would stall re-dispatch of every freed pane for its whole
+# duration. Retention is what replaces the pump.
+#
+# A retained trigger is cheap and already bounded: with no idle pane
+# dispatch_role returns above the resolver, and the empty-exit backoff still
+# consumes it on a no-pick streak.
+#
+# Extracted so the dispatcher's trigger tests can drive the decision without
+# spinning up the full main loop.
+should_retain_trigger_for_coverage() {
+    local dispatched="$1" claim_headroom="$2"
+    if (( claim_headroom >= 0 && dispatched < claim_headroom )); then
         return 0
     fi
     return 1
@@ -2479,6 +2519,25 @@ case "${1:-}" in
             exit 2
         fi
         if should_retain_trigger_for_fanout_race "$2" "$3"; then
+            echo "retain"
+        else
+            echo "consume"
+        fi
+        exit 0
+        ;;
+    --coverage-retain-check)
+        # Test/debug: print `retain` or `consume` for a steady-state tick that
+        # dispatched <n> panes against <claim-headroom> claimable items (#2700).
+        # A negative headroom is the uncapped lane and always consumes.
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --coverage-retain-check <dispatched> <claim-headroom>" >&2
+            exit 2
+        fi
+        if ! [[ "$2" =~ ^[0-9]+$ && "$3" =~ ^-?[0-9]+$ ]]; then
+            echo "fleet-dispatcher --coverage-retain-check: <dispatched> must be a non-negative integer and <claim-headroom> an integer" >&2
+            exit 2
+        fi
+        if should_retain_trigger_for_coverage "$2" "$3"; then
             echo "retain"
         else
             echo "consume"

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -178,7 +178,7 @@ Engine build / run (everyday dev)
       lldb/gdb. Use --batch to run once and print all thread backtraces.
   fleet-debug triggers
       Read-only per-role dispatch-state dump (trigger / seen-hash / projection
-      slice / empty-suppression #2181). See "Parallel-agent fleet" below.
+      slice / suppression #2181). See "Parallel-agent fleet" below.
 
   fleet-run [--build-dir <dir>] [--timeout N] <exe-name> [args...]
       Finds the built binary under build/, cd's beside data/shaders/scripts.
@@ -230,8 +230,10 @@ Parallel-agent fleet (tmux + Claude)
   fleet-debug triggers           read-only per-role dispatch-state dump: pending
                                  trigger + mtime/content, last seen projection
                                  hash, projection slice size + generated_at, and
-                                 whether the last hash write was an empty-
-                                 projection suppression (#2181). Diagnoses why a
+                                 whether the last hash write was a suppression
+                                 — an empty projection, widening to "no kind
+                                 gained an item" for the per-kind roles
+                                 (#2181, #2700). Diagnoses why a
                                  role woke / didn't wake without hand-reading
                                  ~/.fleet/state/{triggers,seen-hashes,projections}
   fleet-dispatcher               transient-claude dispatcher (worker panes)

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -2399,6 +2399,22 @@ PROJECTORS = {
     "epic-steward": project_epic_steward,
 }
 
+# Roles whose wake suppression is evaluated PER SUB-LANE instead of over the
+# whole projection (#2700). The whole-projection `if not projection:` test in
+# update_role_trigger is unreachable for a union lane: project_worker unions
+# four kinds and one of them (task) is structurally never empty, so every hash
+# change fires — including the dominant class of change, a pure REMOVAL (a task
+# claimed, a feedback label cleared, a merge closing an issue). Those provably
+# reduce available work, yet each fans out every idle pane.
+#
+# Explicit allowlist rather than "bucket by item shape": kind-carrying items are
+# NOT unique to the worker lane. project_opus_reviewer emits kind-less PR items
+# AND {kind: "plan_review"} issue items, and project_epic_steward's items all
+# carry kinds, so shape-keyed bucketing would silently change those roles'
+# suppression semantics. Every role outside this set keeps the bare-hash
+# whole-projection path byte-for-byte.
+PER_KIND_TRIGGER_ROLES = frozenset({"worker"})
+
 
 # ---------------------------------------------------------------------------
 # Per-role slices (full-record projections written to disk).
@@ -2687,11 +2703,91 @@ def read_json_retry(path, attempts=3, backoff=0.05):
     raise last
 
 
+def kind_hashes(projection):
+    """Bucket a projection's items by `kind` -> sorted list of per-item hashes.
+
+    Items without a `kind` (or non-dict items) fall into the "" bucket, so a
+    projector that grows a kind-less item shape degrades to whole-lane
+    behaviour for that bucket rather than raising.
+    """
+    kinds = {}
+    for item in projection:
+        kind = item.get("kind", "") if isinstance(item, dict) else ""
+        kinds.setdefault(kind, []).append(stable_hash(item))
+    return {kind: sorted(hashes) for kind, hashes in sorted(kinds.items())}
+
+
+def seen_kind_hashes(text):
+    """Parse a seen file's fmt-2 payload into its per-kind hash map.
+
+    A legacy bare-hex hash (or any unparseable content) yields {} — every kind
+    then reads as all-new, which fires ONCE on upgrade and settles on the next
+    tick. That direction is deliberate: the opposite error (treating unknown
+    state as "nothing new") is #561's permanently-idle role.
+    """
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(data, dict) or data.get("fmt") != 2:
+        return {}
+    kinds = data.get("kinds")
+    return kinds if isinstance(kinds, dict) else {}
+
+
+def update_role_trigger_per_kind(role: str, projection) -> bool:
+    """Fire iff some kind's item set gained an item absent from its old set.
+
+    Pure removal from a still-non-empty lane suppresses; a modification
+    (same id, changed field) re-hashes as remove+add, so the new item is
+    absent from the old set and it fires. The whole-projection-empty case is
+    subsumed: no kind can hold a new item, so it suppresses as before.
+    """
+    new_kinds = kind_hashes(projection)
+    payload = json.dumps({"fmt": 2, "kinds": new_kinds},
+                         sort_keys=True, separators=(",", ":"))
+    seen_file = SEEN_DIR / role
+    suppressed_marker = SEEN_DIR / f"{role}.empty-suppressed"
+    try:
+        old_text = seen_file.read_text().strip()
+    except FileNotFoundError:
+        old_text = ""
+    # Compare the SERIALIZED fmt-2 payload, never a whole-projection hash: an
+    # unchanged projection must take the no-write early return, or the upgrade
+    # tick's format change re-fires forever against a stable lane.
+    if payload == old_text:
+        return False
+    old_kinds = seen_kind_hashes(old_text)
+    write_atomic(seen_file, payload + "\n")
+    added = {kind: len(set(hashes) - set(old_kinds.get(kind, ())))
+             for kind, hashes in new_kinds.items()}
+    added = {kind: n for kind, n in added.items() if n}
+    counts = ", ".join(f"{k or '<none>'}={len(v)}" for k, v in new_kinds.items())
+    if not added:
+        # This write was a suppression — record the marker. As on the legacy
+        # path, never clear it on the unchanged-payload early return above (no
+        # write happened there), or "last write" semantics silently drift.
+        write_atomic(suppressed_marker, stable_hash(payload) + "\n")
+        log(f"{role}: no new items in any kind ({counts}) — trigger not armed")
+        return False
+    (TRIGGERS_DIR / role).touch()
+    suppressed_marker.unlink(missing_ok=True)
+    gained = ", ".join(f"{kind or '<none>'}+{n}" for kind, n in added.items())
+    log(f"{role}: new items in {gained} ({counts}) — trigger armed")
+    return True
+
+
 def update_role_trigger(role: str, projection) -> bool:
+    if role in PER_KIND_TRIGGER_ROLES:
+        return update_role_trigger_per_kind(role, projection)
     new_hash = stable_hash(projection)
     seen_file = SEEN_DIR / role
     # Marker invariant: present iff the most recent hash *write* for this role
-    # was an empty-projection suppression. The on-disk state can't otherwise
+    # was a suppression. On this path that means an empty projection; on the
+    # per-kind path (PER_KIND_TRIGGER_ROLES) it widens to "no kind gained an
+    # item", which includes pure removals from a still-non-empty lane. The
+    # file name stays ".empty-suppressed" so `fleet-debug triggers` and the
+    # existing tests keep reading one marker. The on-disk state can't otherwise
     # distinguish "suppressed" (hash advanced, trigger deliberately skipped)
     # from "dispatched then consumed" (trigger touched, dispatcher rm'd it),
     # so `fleet-debug triggers` reads this marker for its suppression column.

--- a/scripts/fleet/tests/test_dispatcher_claimable_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_claimable_cap.sh
@@ -100,6 +100,49 @@ printf '{"role":"worker","pane":"%%8","class":"opus","dispatched_at":"x"}\n' \
     > "$DISPATCH_DIR/pane-8.json"
 assert_eq "$(recent opus 90)" "1" "epoch-less opus record skipped; fresh one still counts"
 
+# --- T6: steady-state trigger retention while headroom is uncovered ----------
+# #2700. `dispatched > 0` does not imply the fan-out covered the claimable
+# headroom — the loop also exits on idle-pane exhaustion. Before per-kind
+# suppression, consuming there was survivable because every claim re-armed the
+# scout trigger; suppression removes those re-arms, so an uncovered tick must
+# keep the trigger for panes that free up later.
+#
+# The hook is probed by INSPECTING the subject, never by invoking it blind:
+# fleet-dispatcher's inspection-hook `case` has no `*)` usage arm, so an
+# unrecognized flag falls through to `main` and starts the daemon loop. A
+# positive control against a ref predating this hook would hang forever instead
+# of failing. Absence counts as a FAILURE, not a skip — on the pre-fix ref the
+# hook genuinely is missing, which is exactly what the control must report (a
+# skip would be a vacuous pass).
+echo "T6: consume only when the tick covered the claimable headroom"
+if ! grep -q -- '--coverage-retain-check)' "$DISPATCHER"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: --coverage-retain-check hook absent from the subject"
+else
+retain() {
+    "$DISPATCHER" --coverage-retain-check "$1" "$2"
+}
+assert_eq "$(retain 1 8)" "retain" "1 dispatched of 8 claimable -> trigger kept"
+assert_eq "$(retain 7 8)" "retain" "7 dispatched of 8 claimable -> trigger kept"
+assert_eq "$(retain 8 8)" "consume" "8 dispatched of 8 claimable -> headroom covered, consume"
+assert_eq "$(retain 9 8)" "consume" "overshoot still consumes"
+assert_eq "$(retain 0 8)" "retain" "zero dispatched with claimable work -> kept"
+assert_eq "$(retain 3 0)" "consume" "zero headroom -> nothing left to cover, consume"
+assert_eq "$(retain 0 0)" "consume" "zero headroom, zero dispatched -> consume"
+
+# The uncapped lane (claim_headroom == -1) is every non-worker role and the
+# legacy fallthrough: it must keep today's consume-on-success exactly.
+assert_eq "$(retain 1 -1)" "consume" "uncapped lane consumes as before"
+assert_eq "$(retain 0 -1)" "consume" "uncapped lane consumes regardless of count"
+
+echo "T7: argument validation"
+assert_eq "$("$DISPATCHER" --coverage-retain-check 2>&1 >/dev/null | head -1)" \
+    "usage: fleet-dispatcher --coverage-retain-check <dispatched> <claim-headroom>" \
+    "missing args -> usage"
+"$DISPATCHER" --coverage-retain-check x 3 >/dev/null 2>&1 && rc=0 || rc=$?
+assert_eq "$rc" "2" "non-numeric dispatched -> exit 2"
+fi
+
 echo
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_debug_triggers.py
+++ b/scripts/fleet/tests/test_fleet_debug_triggers.py
@@ -117,6 +117,49 @@ class FleetDebugTriggers(unittest.TestCase):
         roles = [ln.split()[0] for ln in r.stdout.splitlines() if ln.strip()]
         self.assertNotIn("worker.empty-suppressed", roles)
 
+    def test_fmt2_seen_file_reports_per_kind_counts(self):
+        # #2700: roles in the scout's PER_KIND_TRIGGER_ROLES write a per-kind
+        # payload instead of a bare hash. Collapsing it to one hash would hide
+        # which sub-lane moved, which is the whole point of the format.
+        self._write(self.seen / "worker", json.dumps({
+            "fmt": 2,
+            "kinds": {
+                "task": ["a" * 16, "b" * 16],
+                "pr": ["c" * 16],
+                "needs_plan": [],
+            },
+        }) + "\n")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        self.assertIn("fmt2[needs_plan=0,pr=1,task=2]", lines["worker"])
+        # The raw JSON must not leak into the column.
+        self.assertNotIn('"fmt"', lines["worker"])
+
+    def test_fmt2_empty_kinds_reports_empty(self):
+        self._write(self.seen / "worker",
+                    json.dumps({"fmt": 2, "kinds": {}}) + "\n")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        self.assertIn("fmt2[empty]", lines["worker"])
+
+    def test_legacy_bare_hash_still_reports_truncated_hash(self):
+        # The other roles keep the bare-hash format; both must render.
+        self._write(self.seen / "merger", "69f1c07810ac0000\n")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        self.assertIn("seen=69f1c07810ac(", lines["merger"])
+
+    def test_unparseable_json_seen_file_degrades(self):
+        # Starts with "{" but is not valid JSON — must not raise.
+        self._write(self.seen / "worker", "{ torn payload\n")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        self.assertIn("worker", lines)
+
     def test_read_only(self):
         (self.triggers / "worker").write_text("\n")
         self._write(self.seen / "worker", "caa618b4c02edc35\n")

--- a/scripts/fleet/tests/test_fleet_debug_triggers.py
+++ b/scripts/fleet/tests/test_fleet_debug_triggers.py
@@ -52,6 +52,17 @@ class FleetDebugTriggers(unittest.TestCase):
     def _write(self, path, text):
         path.write_text(text)
 
+    def _assert_suppressed(self, line, value):
+        # The two-space column separator is load-bearing here: "suppressed=yes"
+        # is a substring of "empty-suppressed=yes", so a bare assertIn on the
+        # short form matches either spelling and pins nothing. Anchoring on the
+        # separator, plus asserting the `empty-` form is absent, is what makes
+        # this discriminate — the column must NOT carry the `empty-` prefix,
+        # since for per-kind roles (#2700) a suppression does not imply an
+        # empty projection.
+        self.assertIn(f"  suppressed={value}", line)
+        self.assertNotIn("empty-suppressed=", line)
+
     def test_full_state_reports_every_role(self):
         # A pending trigger with content, a suppressed role, a dict projection.
         (self.triggers / "merger").write_text("llm\n")
@@ -72,16 +83,16 @@ class FleetDebugTriggers(unittest.TestCase):
                      "queue-manager-ingest"):
             self.assertIn(role, lines)
         # worker: suppressed marker present, 4 projection items, generated_at.
-        self.assertIn("empty-suppressed=yes", lines["worker"])
+        self._assert_suppressed(lines["worker"], "yes")
         self.assertIn("4 items @ 2026-07-02T06:00:00Z", lines["worker"])
         self.assertIn("caa618b4c02e", lines["worker"])
         # merger: pending trigger with content, no suppression.
         self.assertIn('pending(', lines["merger"])
         self.assertIn('"llm"', lines["merger"])
-        self.assertIn("empty-suppressed=no", lines["merger"])
+        self._assert_suppressed(lines["merger"], "no")
         # queue-manager(-ingest): never get triggers/markers -> n/a.
-        self.assertIn("empty-suppressed=n/a", lines["queue-manager"])
-        self.assertIn("empty-suppressed=n/a", lines["queue-manager-ingest"])
+        self._assert_suppressed(lines["queue-manager"], "n/a")
+        self._assert_suppressed(lines["queue-manager-ingest"], "n/a")
 
     def test_missing_and_torn_projections_degrade(self):
         # worker projection absent; sonnet-reviewer projection is torn JSON.
@@ -110,12 +121,17 @@ class FleetDebugTriggers(unittest.TestCase):
 
     def test_marker_file_is_not_listed_as_a_role(self):
         # `worker.empty-suppressed` must feed the worker's column, never appear
-        # as its own role line.
+        # as its own role line. The on-disk suffix carries the `empty-` prefix
+        # that the column label does not — a deliberate asymmetry, so this also
+        # pins that the file name is spelled `.empty-suppressed` while the
+        # column it feeds reads `suppressed=`.
         self._write(self.seen / "worker.empty-suppressed", "abc\n")
         r = self._run()
         self.assertEqual(r.returncode, 0, r.stderr)
         roles = [ln.split()[0] for ln in r.stdout.splitlines() if ln.strip()]
         self.assertNotIn("worker.empty-suppressed", roles)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        self._assert_suppressed(lines["worker"], "yes")
 
     def test_fmt2_seen_file_reports_per_kind_counts(self):
         # #2700: roles in the scout's PER_KIND_TRIGGER_ROLES write a per-kind

--- a/scripts/fleet/tests/test_role_trigger_empty.py
+++ b/scripts/fleet/tests/test_role_trigger_empty.py
@@ -17,9 +17,25 @@ An `<role>.empty-suppressed` marker in SEEN_DIR records whether the most
 recent hash write was such a suppression, so `fleet-debug triggers` (#2185)
 can report it — the on-disk state can't otherwise tell "suppressed" from
 "dispatched then consumed". The marker invariants are exercised below too.
+
+Three classes, because #2700 split the rule by role:
+
+  - `UpdateRoleTriggerEmpty` — the whole-projection rule above, run under
+    role "r". "r" is deliberately NOT in PER_KIND_TRIGGER_ROLES, so this
+    class is the unmodified byte-for-byte pin on the legacy path.
+  - `UpdateRoleTriggerPerKind` — the per-sub-lane membership rule for
+    allowlisted roles (today: "worker"). The whole-projection test is
+    structurally unreachable for a union lane, so suppression there keys on
+    "did some kind GAIN an item" instead, and the seen file becomes the
+    fmt-2 per-kind payload.
+  - `UpdateRoleTriggerLegacyPathPreserved` — feeds an opus-reviewer-shaped
+    projection (kind-less PR items mixed with {kind: "plan_review"} issue
+    items) through a non-allowlisted role, pinning that kind-carrying items
+    alone do NOT opt a role into the per-kind path.
 """
 import importlib.machinery
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -121,6 +137,289 @@ class UpdateRoleTriggerEmpty(unittest.TestCase):
         _mod.update_role_trigger("r", [])
         self.assertFalse(_mod.update_role_trigger("r", []))  # unchanged empty
         self.assertTrue(self._suppressed_marker("r").exists())
+
+
+def _task(n, blocked_by="(none)"):
+    return {"kind": "task", "repo": "engine", "id": f"#{n}",
+            "blocked_by": blocked_by}
+
+
+def _pr(n, labels=("fleet:needs-fix",)):
+    return {"kind": "pr", "repo": "engine", "pr": n, "labels": sorted(labels)}
+
+
+def _needs_plan(n):
+    return {"kind": "needs_plan", "repo": "engine", "issue": n}
+
+
+class UpdateRoleTriggerPerKind(unittest.TestCase):
+    """Per-sub-lane suppression for union projections (#2700).
+
+    The whole-projection `if not projection:` test is unreachable for the
+    worker lane: it unions four kinds and `task` is structurally never empty,
+    so every hash change fires — including pure REMOVALS (a task claimed, a
+    feedback label cleared, a merge closing an issue), which provably reduce
+    available work yet fan out every idle pane.
+
+    Role "worker" is in PER_KIND_TRIGGER_ROLES; role "r" (used by the suite
+    above, unmodified) is not, which makes that suite the legacy-path pin.
+    """
+
+    ROLE = "worker"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        base = Path(self._tmp.name)
+        self._orig_seen = _mod.SEEN_DIR
+        self._orig_triggers = _mod.TRIGGERS_DIR
+        _mod.SEEN_DIR = base / "seen-hashes"
+        _mod.TRIGGERS_DIR = base / "triggers"
+        _mod.SEEN_DIR.mkdir(parents=True)
+        _mod.TRIGGERS_DIR.mkdir(parents=True)
+
+    def tearDown(self):
+        _mod.SEEN_DIR = self._orig_seen
+        _mod.TRIGGERS_DIR = self._orig_triggers
+        self._tmp.cleanup()
+
+    def _fire(self, projection):
+        return _mod.update_role_trigger(self.ROLE, projection)
+
+    def _trigger_exists(self):
+        return (_mod.TRIGGERS_DIR / self.ROLE).exists()
+
+    def _consume(self):
+        (_mod.TRIGGERS_DIR / self.ROLE).unlink()
+
+    def _marker(self):
+        return _mod.SEEN_DIR / f"{self.ROLE}.empty-suppressed"
+
+    def _seen_kinds(self):
+        raw = (_mod.SEEN_DIR / self.ROLE).read_text()
+        return json.loads(raw)["kinds"]
+
+    def test_worker_is_allowlisted_and_others_are_not(self):
+        self.assertIn("worker", _mod.PER_KIND_TRIGGER_ROLES)
+        for role in ("opus-reviewer", "sonnet-reviewer", "merger",
+                     "smoke-worker", "epic-steward"):
+            self.assertNotIn(role, _mod.PER_KIND_TRIGGER_ROLES)
+
+    # --- AC 1: pure removal from a still-non-empty lane suppresses ----------
+
+    def test_pure_removal_from_non_empty_lane_suppresses(self):
+        # The criterion the whole-projection rule cannot express, and the
+        # dominant wake class: a task got claimed, the lane still holds 1.
+        self._fire([_task(1), _task(2), _pr(9)])
+        self._consume()
+        self.assertFalse(self._fire([_task(1), _pr(9)]))
+        self.assertFalse(self._trigger_exists())
+        # The hash still advanced, so the flip back is seen as a change.
+        self.assertEqual(len(self._seen_kinds()["task"]), 1)
+        self.assertTrue(self._marker().exists())
+
+    def test_pr_lane_drain_with_tasks_unchanged_suppresses(self):
+        # AC 2: sub-lane -> zero while another lane stays non-empty. The
+        # feedback PR was claimed; `task` items keep the projection non-empty.
+        self._fire([_task(1), _task(2), _pr(9)])
+        self._consume()
+        self.assertFalse(self._fire([_task(1), _task(2)]))
+        self.assertFalse(self._trigger_exists())
+        self.assertNotIn("pr", self._seen_kinds())
+
+    def test_semantic_conflict_claim_drop_suppresses(self):
+        conflict = {"kind": "semantic_conflict", "repo": "engine", "pr": 7}
+        self._fire([_task(1), conflict])
+        self._consume()
+        self.assertFalse(self._fire([_task(1)]))
+        self.assertFalse(self._trigger_exists())
+
+    # --- AC 3: positive controls (the fix cannot pass by never firing) ------
+
+    def test_new_item_in_empty_lane_fires(self):
+        self._fire([_task(1)])
+        self._consume()
+        self.assertTrue(self._fire([_task(1), _pr(9)]))
+        self.assertTrue(self._trigger_exists())
+
+    def test_item_modification_fires(self):
+        # Same id, blocked_by discharged: re-hashes as remove+add, so the new
+        # item is absent from the old set. Unblocking IS new work.
+        self._fire([_task(1, blocked_by="#2385"), _task(2)])
+        self._consume()
+        self.assertTrue(self._fire([_task(1, blocked_by="(none)"), _task(2)]))
+        self.assertTrue(self._trigger_exists())
+
+    def test_pr_label_swap_fires(self):
+        self._fire([_task(1), _pr(9, labels=["fleet:needs-fix"])])
+        self._consume()
+        self.assertTrue(self._fire([_task(1), _pr(9, labels=["fleet:has-nits"])]))
+        self.assertTrue(self._trigger_exists())
+
+    def test_simultaneous_remove_and_add_across_kinds_fires(self):
+        self._fire([_task(1), _task(2), _pr(9)])
+        self._consume()
+        # task 2 leaves, needs_plan 5 arrives.
+        self.assertTrue(self._fire([_task(1), _pr(9), _needs_plan(5)]))
+        self.assertTrue(self._trigger_exists())
+
+    def test_new_item_added_within_same_kind_fires(self):
+        self._fire([_task(1)])
+        self._consume()
+        self.assertTrue(self._fire([_task(1), _task(2)]))
+        self.assertTrue(self._trigger_exists())
+
+    # --- AC 4: the whole-projection-empty case is subsumed ------------------
+
+    def test_transition_to_empty_suppresses(self):
+        self._fire([_task(1)])
+        self._consume()
+        self.assertFalse(self._fire([]))
+        self.assertFalse(self._trigger_exists())
+        self.assertEqual(self._seen_kinds(), {})
+        self.assertTrue(self._marker().exists())
+
+    def test_empty_to_non_empty_fires(self):
+        self._fire([_task(1)])
+        self._consume()
+        self._fire([])
+        self.assertTrue(self._fire([_task(2)]))
+        self.assertTrue(self._trigger_exists())
+
+    def test_suppression_leaves_pending_trigger_pending(self):
+        # Suppression skips the touch; it never clears an armed trigger.
+        self._fire([_task(1), _task(2)])
+        self.assertTrue(self._trigger_exists())
+        self._fire([_task(1)])
+        self.assertTrue(self._trigger_exists())
+
+    # --- no-write / marker semantics ---------------------------------------
+
+    def test_unchanged_projection_is_inert(self):
+        self._fire([_task(1), _pr(9)])
+        self._consume()
+        self.assertFalse(self._fire([_task(1), _pr(9)]))
+        self.assertFalse(self._trigger_exists())
+
+    def test_unchanged_projection_does_not_rewrite_seen_file(self):
+        # The compare is on the serialized fmt-2 payload, so a stable lane
+        # must take the early return — otherwise the upgrade tick's format
+        # change re-fires forever.
+        self._fire([_task(1)])
+        seen = _mod.SEEN_DIR / self.ROLE
+        before = seen.stat().st_mtime_ns
+        self.assertFalse(self._fire([_task(1)]))
+        self.assertEqual(seen.stat().st_mtime_ns, before)
+
+    def test_unchanged_projection_leaves_marker_intact(self):
+        self._fire([_task(1), _task(2)])
+        self._consume()
+        self._fire([_task(1)])
+        self.assertTrue(self._marker().exists())
+        self.assertFalse(self._fire([_task(1)]))
+        self.assertTrue(self._marker().exists())
+
+    def test_fire_clears_marker(self):
+        self._fire([_task(1), _task(2)])
+        self._consume()
+        self._fire([_task(1)])
+        self.assertTrue(self._marker().exists())
+        self._fire([_task(1), _task(3)])
+        self.assertFalse(self._marker().exists())
+
+    def test_item_order_does_not_matter(self):
+        self._fire([_task(1), _task(2)])
+        self._consume()
+        self.assertFalse(self._fire([_task(2), _task(1)]))
+        self.assertFalse(self._trigger_exists())
+
+    # --- AC 6: upgrade from the legacy bare-hex seen file -------------------
+
+    def test_legacy_seen_file_fires_once_then_settles(self):
+        seen = _mod.SEEN_DIR / self.ROLE
+        seen.write_text(_mod.stable_hash([_task(1)]) + "\n")
+        projection = [_task(1)]
+        # Unparseable as fmt-2 => every kind reads as all-new => one fire.
+        self.assertTrue(self._fire(projection))
+        self.assertTrue(self._trigger_exists())
+        self.assertEqual(json.loads(seen.read_text())["fmt"], 2)
+        self._consume()
+        # Quiet thereafter on the same projection.
+        self.assertFalse(self._fire(projection))
+        self.assertFalse(self._trigger_exists())
+
+    def test_legacy_seen_file_with_empty_projection_suppresses(self):
+        seen = _mod.SEEN_DIR / self.ROLE
+        seen.write_text(_mod.stable_hash([_task(1)]) + "\n")
+        self.assertFalse(self._fire([]))
+        self.assertFalse(self._trigger_exists())
+
+    def test_corrupt_seen_file_fires_once_never_idles(self):
+        # The safe direction: unknown state must not read as "nothing new"
+        # (that is #561's permanently-idle role).
+        (_mod.SEEN_DIR / self.ROLE).write_text("{not json\n")
+        self.assertTrue(self._fire([_task(1)]))
+        self.assertTrue(self._trigger_exists())
+
+    def test_kindless_items_degrade_to_one_bucket(self):
+        # Defensive default bucket: a projector that grows a kind-less item
+        # must not raise, and behaves whole-lane for that bucket.
+        self._fire([{"repo": "engine", "pr": 1}])
+        self._consume()
+        self.assertFalse(self._fire([]))
+        self.assertFalse(self._trigger_exists())
+
+
+class UpdateRoleTriggerLegacyPathPreserved(unittest.TestCase):
+    """AC 5: kind-carrying items on a NON-allowlisted role keep old semantics.
+
+    project_opus_reviewer emits kind-less PR items AND {kind: "plan_review"}
+    issue items, so a shape-keyed implementation ("bucket by item shape; a
+    single-lane role reduces to one bucket") would have silently changed this
+    role's suppression. The allowlist is what prevents that, and this pins it.
+    """
+
+    ROLE = "opus-reviewer"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        base = Path(self._tmp.name)
+        self._orig_seen = _mod.SEEN_DIR
+        self._orig_triggers = _mod.TRIGGERS_DIR
+        _mod.SEEN_DIR = base / "seen-hashes"
+        _mod.TRIGGERS_DIR = base / "triggers"
+        _mod.SEEN_DIR.mkdir(parents=True)
+        _mod.TRIGGERS_DIR.mkdir(parents=True)
+
+    def tearDown(self):
+        _mod.SEEN_DIR = self._orig_seen
+        _mod.TRIGGERS_DIR = self._orig_triggers
+        self._tmp.cleanup()
+
+    def _projection(self, prs, plan_reviews):
+        items = [{"repo": "engine", "pr": n} for n in prs]
+        items += [{"kind": "plan_review", "repo": "engine", "issue": n}
+                  for n in plan_reviews]
+        return items
+
+    def test_pure_removal_while_non_empty_still_fires(self):
+        # Today's semantics for a non-allowlisted role — preserved, not fixed.
+        _mod.update_role_trigger(self.ROLE, self._projection([1, 2], [7]))
+        (_mod.TRIGGERS_DIR / self.ROLE).unlink()
+        self.assertTrue(
+            _mod.update_role_trigger(self.ROLE, self._projection([1], [7])))
+        self.assertTrue((_mod.TRIGGERS_DIR / self.ROLE).exists())
+
+    def test_seen_file_stays_bare_hash(self):
+        projection = self._projection([1], [7])
+        _mod.update_role_trigger(self.ROLE, projection)
+        self.assertEqual((_mod.SEEN_DIR / self.ROLE).read_text().strip(),
+                         _mod.stable_hash(projection))
+
+    def test_transition_to_empty_still_suppresses(self):
+        _mod.update_role_trigger(self.ROLE, self._projection([1], [7]))
+        (_mod.TRIGGERS_DIR / self.ROLE).unlink()
+        self.assertFalse(_mod.update_role_trigger(self.ROLE, []))
+        self.assertFalse((_mod.TRIGGERS_DIR / self.ROLE).exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `update_role_trigger`'s transition-to-nothing-to-do suppression was
  **structurally unreachable** for the `worker` role. That lane unions four
  kinds and one of them (`task`) is never empty, so `if not projection:` never
  held — every hash change armed the trigger, including the dominant class of
  change, a pure **removal** (a task claimed, a feedback label cleared, a merge
  closing an issue). Each of those provably *reduces* available work, yet fanned
  out every idle pane.
- Suppression is now decided **per sub-lane** for roles in a new
  `PER_KIND_TRIGGER_ROLES` allowlist (today: `worker`): fire iff some kind's
  item set gained an item absent from its old set. Modifications re-hash as
  remove+add, so unblocking and re-verdicts still fire.
- Seen file becomes `{"fmt":2,"kinds":{<kind>:[<item-hash>,…]}}`. A legacy bare
  hash reads as all-new and fires **once** on upgrade — the safe direction; the
  opposite error is #561's permanently-idle role.
- **Dispatcher amendment is load-bearing, not hardening.** Drainage was pumped
  by the scout re-arming on every claim, and this change removes exactly those
  re-arms. Without a replacement, the only rescue for a freed pane is the
  periodic rearm, which requires *zero* active workers — so one long-running
  task would stall re-dispatch of every freed pane for its whole duration. The
  steady-state consume now retains the trigger while claimable headroom is
  uncovered, on claim-counted lanes only.

### Why the allowlist is explicit rather than shape-keyed

Kind-carrying items are **not** unique to the worker lane: `project_opus_reviewer`
emits kind-less PR items *alongside* `{kind: "plan_review"}` issue items, and
`project_epic_steward`'s items all carry kinds. Bucketing by item shape would
have silently changed those two roles' suppression semantics. Every role outside
the allowlist keeps the bare-hash whole-projection path byte-for-byte.

## Test plan

- [x] `run_all.sh` full fleet suite: **125 suites, 124 passed**. The single
      failure is `test_cross_repo_shared_file_parity.sh`, which reproduces
      identically on `origin/master` (comment-only drift in a downstream copy,
      already tracked in the repo that owns the fix) — not from this change.
- [x] `test_role_trigger_empty.py` — 33 tests, green. Three classes: the legacy
      whole-projection suite (unmodified, run under non-allowlisted role `"r"`),
      the new per-kind suite, and an opus-reviewer-shaped legacy-path pin.
- [x] `test_dispatcher_claimable_cap.sh` T6/T7 and
      `test_dispatcher_empty_exit_backoff.sh` (unmodified) both green.
- [x] `test_fleet_debug_triggers.py` — fmt-2 rendering, legacy bare hash, and a
      torn-payload degradation case, green.
- [x] `ruff check scripts/` clean; `bash -n scripts/fleet/fleet-dispatcher` clean.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| 1. Pure removal from a still-non-empty lane suppresses | `test_pure_removal_from_non_empty_lane_suppresses` | `task×2 → task×1` with `pr` unchanged: hashes recorded, marker written, trigger NOT touched |
| 2. Sub-lane drain to zero, another lane non-empty | `test_pr_lane_drain_with_tasks_unchanged_suppresses`, `test_semantic_conflict_claim_drop_suppresses` | `pr×1 → pr×0` with `task×N` unchanged ⇒ suppressed |
| 3. Positive controls (cannot pass by never firing) | `test_new_item_in_empty_lane_fires`, `test_item_modification_fires`, `test_pr_label_swap_fires`, `test_simultaneous_remove_and_add_across_kinds_fires` | each fires; `blocked_by #2385 → (none)` re-hashes as remove+add ⇒ arms |
| 4. Whole-projection-empty still suppresses; empty → non-empty fires | `test_transition_to_empty_suppresses`, `test_empty_to_non_empty_fires` + the unmodified legacy suite | subsumed — no kind can hold a new item |
| 5. Non-allowlisted roles byte-identical | `UpdateRoleTriggerLegacyPathPreserved` + existing suite under role `"r"`, unmodified | opus-reviewer-shaped projection (kind-less PR items + `plan_review` items) keeps bare-hash path; `test_pure_removal_while_non_empty_still_fires` pins that it still fires |
| 6. Upgrade path: one fire, then quiet; never permanently idle | `test_legacy_seen_file_fires_once_then_settles`, `test_corrupt_seen_file_fires_once_never_idles` | legacy bare-hex ⇒ exactly one fire, fmt-2 written, inert thereafter |
| 7. Dispatcher retain/consume + backoff untouched | `test_dispatcher_claimable_cap.sh` T6/T7; `test_dispatcher_empty_exit_backoff.sh` | `1 of 8 → retain`, `8 of 8 → consume`, `9 of 8 → consume`, uncapped `-1 → consume`; backoff suite unmodified and green |
| 8. Phase 0 probe posted (pre-change worker `suppressed == 0`) | [issue comment](https://github.com/jakildev/IrredenEngine/issues/2700#issuecomment-5227228268) | zero `.empty-suppressed` markers have ever been written for any role; `worker` seen file was 17 bytes = bare legacy hash |
| 9. Positive control MEANINGFUL | `fleet-positive-control scripts/fleet/tests/test_role_trigger_empty.py origin/master` | **MEANINGFUL: 9 of 33 assertions fail** against pre-fix `a9459315b` (24 pass = non-regression) |
| 10. Live post-change check against real item shapes | `project_worker` over the live `state.json`, both scout versions | see below |

### AC-10 — live differential, not just a post-change assertion

Drove **both** scout versions through the real 57-item worker projection
(`kinds={'task': 25, 'needs_plan': 29, 'pr': 3}`), armed each, consumed the
trigger as the dispatcher would, then removed exactly one `pr` item while the
`task` lane stayed at 25:

```
PRE  (origin/master): fired=True   trigger_touched=True   marker=False  seen=legacy-bare-hash(16 chars)
POST (this branch):   fired=False  trigger_touched=False  marker=True   seen=fmt2

[state-scout] worker: new items in needs_plan+29, pr+3, task+25 (needs_plan=29, pr=3, task=25) — trigger armed
[state-scout] worker: no new items in any kind (needs_plan=29, pr=2, task=25) — trigger not armed
```

Same input, same host, same tick: master fires and fans out every idle pane;
this branch suppresses and writes the marker. Those two log lines are also the
permanent `log()` diagnostic Phase 0 asked to keep.

## Reviewer notes

- **A standing `worker` trigger is now normal, not stuck.** The dispatcher
  deliberately retains it while claimable headroom is uncovered;
  `fleet-debug triggers` documents this in its help text so the next person
  reading `trigger=pending` doesn't diagnose a hang.
- `docs/agents/FLEET-CACHE.md`'s `seen-hashes/<role>` row claimed "Hash of the
  last projection", which this change makes false for allowlisted roles — the
  row now documents both on-disk formats and the fail-open direction.
- The `--coverage-retain-check` hook is probed by **inspecting** the subject
  before invoking it: `fleet-dispatcher`'s inspection-hook `case` has no `*)`
  usage arm, so an unrecognized flag falls through to `main` and starts the
  daemon. A positive control against a ref predating the hook would otherwise
  hang instead of failing, so absence is asserted as a FAILURE rather than a
  skip.

Closes #2700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
