### PR TITLE
fleet: role-sharing lint reaches the skill-sharing lane (#2893)

### DIFF
--- a/docs/design/skill-sharing.md
+++ b/docs/design/skill-sharing.md
@@ -185,12 +185,14 @@ repo would otherwise fork it.
 
 ### CI validation
 
-A lint check can assert that (a) every wrapper's `## Deltas` table answers
-every delta key its canonical flow names, and (b) every canonical flow has at
-least one wrapper. A grep over `docs/agents/skills/*.md` for bold
-`**delta keys**` cross-referenced against each `SKILL.md`'s Deltas table
-would catch an unanswered key after a flow gains a new one. Out of scope
-while the set is four skills; revisit when wrappers start missing keys.
+`fleet-validate-roles` (`scripts/fleet/fleet_validate_roles.py`, #2893) now
+enforces this, as the skill lane of the same lint `role-sharing.md` documents
+shipping at #1667: every canonical flow's `## Repo deltas this flow needs`
+table must have a stem-paired `.claude/skills/<stem>/SKILL.md` whose
+`## Deltas` table answers every declared key. Pre-existing gaps land in a
+ratchet baseline (`SKILL_WRAPPER_MISSING_KEY_BASELINE` /
+`SKILL_NO_WRAPPER_BASELINE`) rather than being repaired inline, since
+`.claude/skills/**/SKILL.md` is gated self-config no worker class can push.
 
 ### When to factor a new skill
 

--- a/docs/design/skill-sharing.md
+++ b/docs/design/skill-sharing.md
@@ -183,13 +183,16 @@ promoted to `docs/agents/skills/procedures/` and referenced the same way.
 Out of scope for the first pass — promote a procedure only once a second
 repo would otherwise fork it.
 
-### CI validation
+### Lint enforcement
 
 `fleet-validate-roles` (`scripts/fleet/fleet_validate_roles.py`, #2893) now
-enforces this, as the skill lane of the same lint `role-sharing.md` documents
-shipping at #1667: every canonical flow's `## Repo deltas this flow needs`
-table must have a stem-paired `.claude/skills/<stem>/SKILL.md` whose
-`## Deltas` table answers every declared key. Pre-existing gaps land in a
+checks this as its **skill lane** — the same lint whose **role lane**
+`role-sharing.md` documents shipping at #1667. Every canonical flow's
+`## Repo deltas this flow needs` table must have a stem-paired
+`.claude/skills/<stem>/SKILL.md` whose `## Deltas` table answers every
+declared key. As on the role lane, nothing runs it automatically today — no
+CI job, hook, or install step invokes it — so it stays a cue-driven check,
+not a merge gate. Pre-existing gaps land in a
 ratchet baseline (`SKILL_WRAPPER_MISSING_KEY_BASELINE` /
 `SKILL_NO_WRAPPER_BASELINE`) rather than being repaired inline, since
 `.claude/skills/**/SKILL.md` is gated self-config no worker class can push.

--- a/scripts/fleet/fleet-validate-roles
+++ b/scripts/fleet/fleet-validate-roles
@@ -75,39 +75,56 @@ def main():
     print()
 
     if result["empty"]:
-        print("No *-protocol.md files declare `## Repo deltas this flow needs` — "
-              "nothing to validate.")
+        print("No *-protocol.md / docs/agents/skills/*.md files declare "
+              "`## Repo deltas this flow needs` — nothing to validate.")
         print()
-        print("This is expected on a tree where no protocol has opt-ed in yet.")
+        print("This is expected on a tree where no flow has opt-ed in yet.")
         return 0
 
     root_labels = [label for root, label in repo_roots if Path(root).is_dir()]
 
+    protocols_by_lane = {}
     for proto in result["protocols"]:
-        keys_str = ", ".join("**%s**" % k for k in proto["keys"])
-        print("Protocol: %s  (%d key%s: %s)"
-              % (proto["name"], len(proto["keys"]),
-                 "" if len(proto["keys"]) == 1 else "s", keys_str))
+        protocols_by_lane.setdefault(proto.get("lane", "role"), []).append(proto)
 
-        for repo_info in proto["repos"]:
-            label = repo_info["label"]
-            if repo_info["no_wrapper"]:
-                for f in repo_info["findings"]:
-                    tag = "WARN" if f["severity"] == "warn" else "FAIL"
-                    print("  %-4s  [%s] %s" % (tag, label, f["msg"]))
-            else:
-                for wr in repo_info["wrappers"]:
-                    wp_name = Path(wr["path"]).name
-                    if wr["n_errors"] == 0 and wr["n_warnings"] == 0:
-                        print("  PASS  [%s] %s" % (label, wp_name))
-                    elif wr["n_errors"] > 0:
-                        print("  FAIL  [%s] %s" % (label, wp_name))
-                    else:
-                        print("  WARN  [%s] %s" % (label, wp_name))
-                    for f in wr["findings"]:
-                        tag = "WARN" if f["severity"] == "warn" else "ERR "
-                        print("          - [%s] %s" % (tag, f["msg"]))
+    for lane_info in result.get("lanes", []):
+        lane_label = lane_info["label"]
+        if lane_info["n_flows"] == 0:
+            print("WARN  lane=%s resolved to 0 flow(s) — check the glob path"
+                  % lane_label)
+        else:
+            print("Lane %s: %d flow(s), %d wrapper(s) covered."
+                  % (lane_label, lane_info["n_flows"], lane_info["n_wrappers"]))
         print()
+
+        for proto in protocols_by_lane.get(lane_label, []):
+            keys_str = ", ".join("**%s**" % k for k in proto["keys"])
+            print("Protocol: %s  (%d key%s: %s)"
+                  % (proto["name"], len(proto["keys"]),
+                     "" if len(proto["keys"]) == 1 else "s", keys_str))
+
+            for repo_info in proto["repos"]:
+                label = repo_info["label"]
+                if repo_info["no_wrapper"]:
+                    if not repo_info["findings"]:
+                        print("  BASE  [%s] %s (baselined no-wrapper gap)"
+                              % (label, proto["name"]))
+                    for f in repo_info["findings"]:
+                        tag = "WARN" if f["severity"] == "warn" else "FAIL"
+                        print("  %-4s  [%s] %s" % (tag, label, f["msg"]))
+                else:
+                    for wr in repo_info["wrappers"]:
+                        wp_name = Path(wr["path"]).name
+                        if wr["n_errors"] == 0 and wr["n_warnings"] == 0:
+                            print("  PASS  [%s] %s" % (label, wp_name))
+                        elif wr["n_errors"] > 0:
+                            print("  FAIL  [%s] %s" % (label, wp_name))
+                        else:
+                            print("  WARN  [%s] %s" % (label, wp_name))
+                        for f in wr["findings"]:
+                            tag = "WARN" if f["severity"] == "warn" else "ERR "
+                            print("          - [%s] %s" % (tag, f["msg"]))
+            print()
 
     n_proto = len(result["protocols"])
     n_err = result["n_errors"]

--- a/scripts/fleet/fleet-validate-roles
+++ b/scripts/fleet/fleet-validate-roles
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""fleet-validate-roles — lint the role-sharing contract.
+"""fleet-validate-roles — lint the role-sharing and skill-sharing contracts.
 
-Checks that every ``docs/agents/*-protocol.md`` declaring
+Checks both lanes: every ``docs/agents/*-protocol.md`` (role lane) and every
+``docs/agents/skills/*.md`` (skill lane) declaring
 ``## Repo deltas this flow needs`` has a matching wrapper in each fleet-enabled
-repo root, and that every wrapper's ``## Deltas`` table answers all delta keys
-the protocol requires.
+repo root — a ``.claude/commands/role-*.md`` citing the protocol, or a
+stem-paired ``.claude/skills/<stem>/SKILL.md`` — and that every wrapper's
+``## Deltas`` table answers all delta keys the flow requires.
 
     fleet-validate-roles                          # engine + game (if present)
     fleet-validate-roles --repo-root /path/to/r  # explicit root(s)
@@ -41,7 +43,8 @@ def _default_repo_roots():
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Lint the role-sharing contract across fleet-enabled repos.")
+        description="Lint the role-sharing and skill-sharing contracts "
+                    "across fleet-enabled repos.")
     parser.add_argument(
         "--repo-root", action="append", metavar="PATH",
         help="Repo root to check (repeatable). Default: engine + game if present. "

--- a/scripts/fleet/fleet_validate_roles.py
+++ b/scripts/fleet/fleet_validate_roles.py
@@ -1,10 +1,21 @@
-"""Role-sharing contract validator (#1667).
+"""Role-sharing / skill-sharing contract validator (#1667, #2893).
 
-Enforces the role-wrapper pattern introduced in ``docs/design/role-sharing.md``:
-every ``docs/agents/*-protocol.md`` that declares a ``## Repo deltas this flow
-needs`` table must have, in each fleet-enabled repo root, a
-``.claude/commands/role-*.md`` whose body references the protocol filename AND
-whose ``## Deltas`` table answers every bold ``**key**`` the protocol declares.
+Enforces the wrapper pattern shared by ``docs/design/role-sharing.md`` and
+``docs/design/skill-sharing.md`` across two lanes:
+
+  role  — every ``docs/agents/*-protocol.md`` that declares a ``## Repo
+          deltas this flow needs`` table must have, in each fleet-enabled
+          repo root, a ``.claude/commands/role-*.md`` that references the
+          protocol filename AND whose ``## Deltas`` table answers every
+          bold ``**key**`` the protocol declares.
+  skill — every ``docs/agents/skills/<stem>.md`` that declares the same
+          table must have a stem-paired ``.claude/skills/<stem>/SKILL.md``
+          whose ``## Deltas`` table answers every declared key. Stem
+          pairing (not cite-scan) is deliberate here: every conforming
+          skill wrapper carries its own ``## Deltas`` table, so a cite-scan
+          predicate misidentifies a wrapper that merely mentions a sibling
+          flow in prose as a wrapper *of* that sibling (#2893's first plan
+          revision bounced on exactly this — see the false-pairing test).
 
 Severity split (mirrors fleet_validate_stack):
   error   — unambiguous violation (missing required delta key in a present wrapper)
@@ -15,6 +26,13 @@ Severity split (mirrors fleet_validate_stack):
 Alias map: ``DELTA_KEY_ALIASES`` maps protocol-key-name → list of accepted
 alternative wrapper key names. Used for legacy wrapper key names that haven't
 been renamed yet; lint accepts any alias as equivalent to the canonical key.
+
+Baselines (skill lane only): a pre-existing, tracked violation that can't be
+repaired in the same PR because its fix surface (``.claude/skills/**/SKILL.md``)
+is gated self-config no worker class can push. Follows the
+``header_global_baseline`` idiom in ``cmake/run_header_convention_checks.cmake``
+— a pair may leave the baseline, never join it. Each entry names the issue
+that owns its repair.
 
 Pure file I/O — no subprocess / gh calls.
 
@@ -32,6 +50,20 @@ WARN = "warn"
 # renamed yet (the rename itself is deferred).
 DELTA_KEY_ALIASES = {}
 
+# (flow_stem, missing_key) -> owning issue. A pair may leave this baseline,
+# never join it (cmake/run_header_convention_checks.cmake's
+# header_global_baseline is the precedent). Skill lane only.
+SKILL_WRAPPER_MISSING_KEY_BASELINE = {
+    ("commit-and-push", "sha-pin token"): 2912,
+}
+
+# flow_stem -> owning issue, for flows with no conforming stem-paired
+# wrapper at all. --strict promotes this WARN to an error, so it needs the
+# same baseline cover as a missing key. Skill lane only.
+SKILL_NO_WRAPPER_BASELINE = {
+    "attach-screenshots": 2312,
+}
+
 _REPO_DELTAS_HDR_RE = re.compile(
     r"^##\s+Repo deltas this flow needs\s*$",
     re.MULTILINE,
@@ -40,9 +72,13 @@ _WRAPPER_DELTAS_HDR_RE = re.compile(
     r"^##\s+Deltas\b",
     re.MULTILINE,
 )
-# Matches `| **key-name** |` (table first-column bold key)
+# Matches `| **key name** |` (table first-column bold key). The character
+# class deliberately allows spaces — the skills lane names its keys in prose
+# (`**default branch**`, `**raw URL base**`), and a class that excludes the
+# space makes those rows invisible to both extraction sides (#2893: 53 of 63
+# skill-lane keys were silently unseen before this widened).
 _DELTA_KEY_RE = re.compile(
-    r"^\|\s*\*\*([A-Za-z0-9_-]+)\*\*\s*\|",
+    r"^\|\s*\*\*([^*|]+)\*\*\s*\|",
     re.MULTILINE,
 )
 
@@ -83,16 +119,36 @@ def find_protocols(repo_root):
     return results
 
 
+def find_skill_flows(repo_root):
+    """Return sorted docs/agents/skills/*.md files that declare Repo deltas.
+
+    Mirrors find_protocols() verbatim, over the skill-sharing lane's canonical
+    flow directory instead of the role lane's.
+    """
+    flows_dir = Path(repo_root) / "docs" / "agents" / "skills"
+    if not flows_dir.is_dir():
+        return []
+    results = []
+    for f in sorted(flows_dir.glob("*.md")):
+        try:
+            text = _norm(f.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        if _REPO_DELTAS_HDR_RE.search(text):
+            results.append(f)
+    return results
+
+
 def _extract_keys(path, header_re):
     try:
         text = _norm(Path(path).read_text(encoding="utf-8", errors="replace"))
     except OSError:
         return []
-    return _DELTA_KEY_RE.findall(_section_body(text, header_re))
+    return [k.strip() for k in _DELTA_KEY_RE.findall(_section_body(text, header_re))]
 
 
 def extract_protocol_keys(protocol_path):
-    """Return the ordered list of delta key names declared in the protocol."""
+    """Return the ordered list of delta key names declared in the protocol/flow."""
     return _extract_keys(protocol_path, _REPO_DELTAS_HDR_RE)
 
 
@@ -107,6 +163,10 @@ def find_wrappers(repo_root, protocol_filename):
     ignored here; a protocol with no true wrapper in the repo still surfaces via
     the caller's no-wrapper WARN, which also covers the half-written-wrapper
     case (referenced the protocol, never added its Deltas table).
+
+    Exact for the role lane's shape (multiple protocol-citing docs can exist
+    per repo, and only true wrappers carry ``## Deltas``) but NOT reused for
+    the skill lane — see find_skill_wrapper()'s docstring for why.
     """
     cmds_dir = Path(repo_root) / ".claude" / "commands"
     if not cmds_dir.is_dir():
@@ -123,18 +183,56 @@ def find_wrappers(repo_root, protocol_filename):
     return results
 
 
+def find_skill_wrapper(repo_root, flow_path):
+    """Return the single stem-paired .claude/skills/<stem>/SKILL.md, or [].
+
+    The skill lane's wrapper-identification predicate is stem pairing
+    (``docs/agents/skills/<stem>.md`` ↔ ``.claude/skills/<stem>/SKILL.md``),
+    not the role lane's cite-scan. Cite-scan is exact only when a citing-only
+    file has no ``## Deltas`` table of its own; on the skill lane every
+    conforming wrapper carries a Deltas table *for its own flow*, so cite-scan
+    can't tell "wrapper of X" from "wrapper of Y that happens to cite X in
+    prose" — reproduced as the false-pairing test in
+    tests/test_fleet_validate_roles.py. Stem pairing sidesteps the ambiguity
+    entirely, since the lane's layout is exactly 1:1.
+
+    Returns a list of 0 or 1 paths, mirroring find_wrappers()'s list contract
+    — a stem match with no ``## Deltas`` table is treated the same as no
+    match, the same half-written-wrapper handling the role lane uses.
+    """
+    stem = Path(flow_path).stem
+    wrapper = Path(repo_root) / ".claude" / "skills" / stem / "SKILL.md"
+    if not wrapper.is_file():
+        return []
+    try:
+        text = _norm(wrapper.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        return []
+    if not _WRAPPER_DELTAS_HDR_RE.search(text):
+        return []
+    return [wrapper]
+
+
 def extract_wrapper_keys(wrapper_path):
     """Return the ordered list of delta key names in the wrapper's ## Deltas section."""
     return _extract_keys(wrapper_path, _WRAPPER_DELTAS_HDR_RE)
 
 
-def validate_wrapper(protocol_keys, wrapper_path, aliases=None):
-    """Validate a single wrapper against the protocol's delta keys.
+def validate_wrapper(protocol_keys, wrapper_path, aliases=None,
+                      missing_key_baseline=None, baseline_key=None):
+    """Validate a single wrapper against the protocol/flow's delta keys.
+
+    ``missing_key_baseline``, keyed on ``(baseline_key, delta_key)``, drops a
+    missing-key finding entirely rather than reporting it — the skill lane's
+    ratchet for a tracked, unrepairable-in-this-PR gap (see
+    SKILL_WRAPPER_MISSING_KEY_BASELINE). The role lane never passes one.
 
     Returns a list of ``{"severity": str, "msg": str}`` findings.
     """
     if aliases is None:
         aliases = DELTA_KEY_ALIASES
+    if missing_key_baseline is None:
+        missing_key_baseline = {}
     wrapper_keys = extract_wrapper_keys(wrapper_path)
     wrapper_set = set(wrapper_keys)
     alias_targets = {alias: canon for canon, alts in aliases.items() for alias in alts}
@@ -143,6 +241,8 @@ def validate_wrapper(protocol_keys, wrapper_path, aliases=None):
     for key in protocol_keys:
         accepted = {key} | set(aliases.get(key, []))
         if not accepted & wrapper_set:
+            if (baseline_key, key) in missing_key_baseline:
+                continue
             findings.append({"severity": ERROR, "msg": "missing delta key `**%s**`" % key})
 
     proto_set = set(protocol_keys)
@@ -157,8 +257,35 @@ def validate_wrapper(protocol_keys, wrapper_path, aliases=None):
     return findings
 
 
-def validate_roles(repo_roots, aliases=None):
-    """Validate the role-sharing contract across repo_roots.
+def _role_find_wrappers(repo_root, proto_path):
+    return find_wrappers(repo_root, proto_path.name)
+
+
+# Each lane supplies its own flow glob and its own wrapper-identification
+# predicate; validate_roles(), validate_wrapper(), _extract_keys(), the
+# severity split, and the alias map are lane-agnostic and loop over this
+# table unchanged.
+LANES = [
+    {
+        "label": "role",
+        "find_flows": find_protocols,
+        "find_wrappers": _role_find_wrappers,
+        "no_wrapper_msg": "no role-*.md in %s/.claude/commands/ references %s",
+    },
+    {
+        "label": "skill",
+        "find_flows": find_skill_flows,
+        "find_wrappers": find_skill_wrapper,
+        "no_wrapper_msg": "no stem-paired %s/.claude/skills/<stem>/SKILL.md "
+                           "carries ## Deltas for %s",
+    },
+]
+
+
+def validate_roles(repo_roots, aliases=None,
+                    skill_missing_key_baseline=None,
+                    skill_no_wrapper_baseline=None):
+    """Validate the role-sharing and skill-sharing contracts across repo_roots.
 
     Parameters
     ----------
@@ -168,6 +295,9 @@ def validate_roles(repo_roots, aliases=None):
         downstream repos that should also have wrappers.
     aliases
         Override the module-level DELTA_KEY_ALIASES map.
+    skill_missing_key_baseline, skill_no_wrapper_baseline
+        Override the module-level skill-lane baselines (tests only — pass
+        ``{}`` to prove a gap would otherwise be reported).
 
     Returns a dict::
 
@@ -176,9 +306,10 @@ def validate_roles(repo_roots, aliases=None):
           "n_errors": int,
           "n_warnings": int,
           "empty": bool,
+          "lanes": [{"label": str, "n_flows": int, "n_wrappers": int}],
           "protocols": [
             {
-              "path": str, "name": str, "keys": [str],
+              "path": str, "name": str, "lane": str, "keys": [str],
               "repos": [
                 {
                   "label": str, "no_wrapper": bool,
@@ -192,80 +323,110 @@ def validate_roles(repo_roots, aliases=None):
     """
     if aliases is None:
         aliases = DELTA_KEY_ALIASES
+    if skill_missing_key_baseline is None:
+        skill_missing_key_baseline = SKILL_WRAPPER_MISSING_KEY_BASELINE
+    if skill_no_wrapper_baseline is None:
+        skill_no_wrapper_baseline = SKILL_NO_WRAPPER_BASELINE
 
     if not repo_roots:
-        return {"ok": True, "empty": True, "n_errors": 0, "n_warnings": 0, "protocols": []}
+        return {"ok": True, "empty": True, "n_errors": 0, "n_warnings": 0,
+                "protocols": [], "lanes": []}
 
     canonical_root = repo_roots[0][0]
-    protocols = find_protocols(canonical_root)
-
-    if not protocols:
-        return {"ok": True, "empty": True, "n_errors": 0, "n_warnings": 0, "protocols": []}
 
     total_errors = total_warnings = 0
     protocol_results = []
+    lane_summaries = []
 
-    for proto_path in protocols:
-        protocol_keys = extract_protocol_keys(proto_path)
-        proto_name = proto_path.name
-        repo_results = []
+    for lane in LANES:
+        is_skill_lane = lane["label"] == "skill"
+        flows = lane["find_flows"](canonical_root)
+        lane_wrapper_count = 0
 
-        for root, label in repo_roots:
-            root_path = Path(root)
-            if not root_path.is_dir():
-                continue
+        for proto_path in flows:
+            protocol_keys = extract_protocol_keys(proto_path)
+            proto_name = proto_path.name
+            flow_stem = proto_path.stem
+            repo_results = []
 
-            wrappers = find_wrappers(root, proto_name)
+            for root, label in repo_roots:
+                root_path = Path(root)
+                if not root_path.is_dir():
+                    continue
 
-            if not wrappers:
-                total_warnings += 1
+                wrappers = lane["find_wrappers"](root, proto_path)
+
+                if not wrappers:
+                    if is_skill_lane and flow_stem in skill_no_wrapper_baseline:
+                        repo_results.append({
+                            "label": label,
+                            "no_wrapper": True,
+                            "wrappers": [],
+                            "findings": [],
+                        })
+                        continue
+                    total_warnings += 1
+                    repo_results.append({
+                        "label": label,
+                        "no_wrapper": True,
+                        "wrappers": [],
+                        "findings": [
+                            {
+                                "severity": WARN,
+                                "msg": lane["no_wrapper_msg"] % (label, proto_name),
+                            }
+                        ],
+                    })
+                    continue
+
+                lane_wrapper_count += len(wrappers)
+                wrapper_results = []
+                for wp in wrappers:
+                    findings = validate_wrapper(
+                        protocol_keys, wp, aliases,
+                        missing_key_baseline=(
+                            skill_missing_key_baseline if is_skill_lane else None
+                        ),
+                        baseline_key=flow_stem if is_skill_lane else None,
+                    )
+                    e = sum(1 for f in findings if f["severity"] == ERROR)
+                    w = sum(1 for f in findings if f["severity"] == WARN)
+                    total_errors += e
+                    total_warnings += w
+                    wrapper_results.append({
+                        "path": str(wp),
+                        "findings": findings,
+                        "n_errors": e,
+                        "n_warnings": w,
+                        "ok": e == 0,
+                    })
+
                 repo_results.append({
                     "label": label,
-                    "no_wrapper": True,
-                    "wrappers": [],
-                    "findings": [
-                        {
-                            "severity": WARN,
-                            "msg": "no role-*.md in %s/.claude/commands/ references %s"
-                                   % (label, proto_name),
-                        }
-                    ],
-                })
-                continue
-
-            wrapper_results = []
-            for wp in wrappers:
-                findings = validate_wrapper(protocol_keys, wp, aliases)
-                e = sum(1 for f in findings if f["severity"] == ERROR)
-                w = sum(1 for f in findings if f["severity"] == WARN)
-                total_errors += e
-                total_warnings += w
-                wrapper_results.append({
-                    "path": str(wp),
-                    "findings": findings,
-                    "n_errors": e,
-                    "n_warnings": w,
-                    "ok": e == 0,
+                    "no_wrapper": False,
+                    "wrappers": wrapper_results,
+                    "findings": [],
                 })
 
-            repo_results.append({
-                "label": label,
-                "no_wrapper": False,
-                "wrappers": wrapper_results,
-                "findings": [],
+            protocol_results.append({
+                "path": str(proto_path),
+                "name": proto_name,
+                "lane": lane["label"],
+                "keys": protocol_keys,
+                "repos": repo_results,
             })
 
-        protocol_results.append({
-            "path": str(proto_path),
-            "name": proto_name,
-            "keys": protocol_keys,
-            "repos": repo_results,
+        lane_summaries.append({
+            "label": lane["label"],
+            "n_flows": len(flows),
+            "n_wrappers": lane_wrapper_count,
         })
 
     return {
         "ok": total_errors == 0,
-        "empty": False,
+        "empty": not protocol_results,
         "n_errors": total_errors,
         "n_warnings": total_warnings,
         "protocols": protocol_results,
+        "lanes": lane_summaries,
     }

--- a/scripts/fleet/tests/test_fleet_validate_roles.py
+++ b/scripts/fleet/tests/test_fleet_validate_roles.py
@@ -97,6 +97,46 @@ See [`docs/agents/{proto}`](../../docs/agents/{proto}).
     _write(Path(root) / ".claude" / "commands" / name, body)
 
 
+def _make_skill_flow(root, name, keys):
+    """Write a synthetic docs/agents/skills/<name> canonical flow doc."""
+    rows = "\n".join("| **%s** | desc |" % k for k in keys)
+    body = """\
+# Flow
+
+## Repo deltas this flow needs
+
+| Delta key | Description |
+|---|---|
+%s
+
+## Other section
+
+More text.
+""" % rows
+    _write(Path(root) / "docs" / "agents" / "skills" / name, body)
+
+
+def _make_skill_wrapper(root, stem, keys, extra_text=""):
+    """Write a synthetic .claude/skills/<stem>/SKILL.md wrapper."""
+    rows = "\n".join("| **%s** | value |" % k for k in keys)
+    body = """\
+---
+name: {stem}
+description: test
+---
+
+## Deltas (Test)
+
+| Delta key | Value |
+|---|---|
+{rows}
+
+## Responsibilities
+{extra}
+""".format(stem=stem, rows=rows, extra=extra_text)
+    _write(Path(root) / ".claude" / "skills" / stem / "SKILL.md", body)
+
+
 # ---------------------------------------------------------------------------
 # Group 1: passing tree
 # ---------------------------------------------------------------------------
@@ -251,6 +291,149 @@ class TestMissingDeltaKey(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["n_errors"], 0)
         self.assertEqual(result["n_warnings"], 1)
+
+    def test_multi_word_key_detected_as_missing(self):
+        # Pre-#2893, _DELTA_KEY_RE's character class excluded the space, so a
+        # multi-word key row like `**default branch**` was invisible to both
+        # extraction sides — this is the arm that discriminates the widened
+        # regex from a naive glob-only fix (which would leave this silent).
+        proto_keys = ["repo-slug", "default branch"]
+        _make_protocol(self.root, "test-protocol.md", proto_keys)
+        _make_wrapper(self.root, "role-test.md", "test-protocol.md", ["repo-slug"])
+        result = validate_roles([(self.root, "engine")])
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["n_errors"], 1)
+        errors = [
+            f for proto in result["protocols"]
+            for repo in proto["repos"]
+            for wr in repo["wrappers"]
+            for f in wr["findings"]
+            if f["severity"] == ERROR
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertIn("default branch", errors[0]["msg"])
+
+
+# ---------------------------------------------------------------------------
+# Group 2b: skill lane — stem pairing, false-pairing guard, baseline (#2893)
+# ---------------------------------------------------------------------------
+
+class TestSkillLane(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_skill_lane_missing_key_is_error_under_stem_pairing(self):
+        flow_keys = ["repo", "default branch"]
+        _make_skill_flow(self.root, "test-flow.md", flow_keys)
+        _make_skill_wrapper(self.root, "test-flow", ["repo"])
+        result = validate_roles([(self.root, "engine")])
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["n_errors"], 1)
+        errors = [
+            f for proto in result["protocols"]
+            for repo in proto["repos"]
+            for wr in repo["wrappers"]
+            for f in wr["findings"]
+            if f["severity"] == ERROR
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertIn("default branch", errors[0]["msg"])
+
+    def test_skill_wrapper_citing_sibling_flow_not_misvalidated(self):
+        # A wrapper citing a sibling flow's canonical doc in prose, while
+        # carrying its own ## Deltas table, must be validated ONLY against
+        # its own stem-paired flow — not the cited one. Reproduces the
+        # false-pairing shape that bounced #2893's first plan revision
+        # (assess-coding-improvement's wrapper cites review-pr.md in prose).
+        _make_skill_flow(self.root, "flow-a.md", ["key-a"])
+        _make_skill_flow(self.root, "flow-b.md", ["key-b1", "key-b2"])
+        body = """\
+---
+name: flow-a
+---
+
+See docs/agents/skills/flow-b.md for a related flow.
+
+## Deltas (Test)
+
+| Delta key | Value |
+|---|---|
+| **key-a** | value |
+"""
+        _write(Path(self.root) / ".claude" / "skills" / "flow-a" / "SKILL.md", body)
+        _make_skill_wrapper(self.root, "flow-b", ["key-b1", "key-b2"])
+        result = validate_roles([(self.root, "engine")])
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["n_errors"], 0)
+
+    def test_skill_lane_no_conforming_wrapper_is_warn(self):
+        _make_skill_flow(self.root, "orphan-flow.md", ["repo"])
+        result = validate_roles([(self.root, "engine")])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["n_errors"], 0)
+        self.assertEqual(result["n_warnings"], 1)
+
+    def test_baseline_suppresses_known_missing_key(self):
+        _make_skill_flow(self.root, "flow-c.md", ["key-c1"])
+        _make_skill_wrapper(self.root, "flow-c", [])
+        baseline = {("flow-c", "key-c1"): 9999}
+        result = validate_roles([(self.root, "engine")],
+                                 skill_missing_key_baseline=baseline,
+                                 skill_no_wrapper_baseline={})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["n_errors"], 0)
+
+    def test_baseline_does_not_silently_widen(self):
+        # A baselined (flow, key) pair must not suppress a DIFFERENT,
+        # non-baselined missing key on that same wrapper — the baseline
+        # names one tracked gap, not a blanket exemption.
+        _make_skill_flow(self.root, "flow-c.md", ["key-c1", "key-c2"])
+        _make_skill_wrapper(self.root, "flow-c", [])
+        baseline = {("flow-c", "key-c1"): 9999}
+        result = validate_roles([(self.root, "engine")],
+                                 skill_missing_key_baseline=baseline,
+                                 skill_no_wrapper_baseline={})
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["n_errors"], 1)
+        errors = [
+            f for proto in result["protocols"]
+            for repo in proto["repos"]
+            for wr in repo["wrappers"]
+            for f in wr["findings"]
+            if f["severity"] == ERROR
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertIn("key-c2", errors[0]["msg"])
+        self.assertNotIn("key-c1", errors[0]["msg"])
+
+    def test_baseline_no_wrapper_suppressed_under_strict(self):
+        # --strict promotes warns to errors; a baselined no-wrapper gap must
+        # not surface as a warning at all, or --strict would regress even
+        # though the default run stays green.
+        _make_skill_flow(self.root, "orphan-flow.md", ["repo"])
+        result = validate_roles([(self.root, "engine")],
+                                 skill_no_wrapper_baseline={"orphan-flow": 9999})
+        self.assertEqual(result["n_warnings"], 0)
+
+    def test_role_lane_key_count_unchanged_by_regex_widening(self):
+        engine_root = str(Path(__file__).parent.parent.parent.parent)
+        if not (Path(engine_root) / "docs" / "agents" / "architect-protocol.md").exists():
+            self.skipTest("architect-protocol.md not found — not running in engine repo")
+        result = validate_roles([(engine_root, "engine")])
+        role_protocols = [p for p in result["protocols"] if p.get("lane") == "role"]
+        self.assertEqual(len(role_protocols), 3)
+        self.assertEqual(sum(len(p["keys"]) for p in role_protocols), 31)
+        role_errors = sum(
+            wr["n_errors"]
+            for p in role_protocols
+            for repo in p["repos"]
+            for wr in repo["wrappers"]
+        )
+        self.assertEqual(role_errors, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Generalises `fleet_validate_roles.py` to a per-lane table so the delta-key
  contract lint reaches the skill-sharing lane (`docs/agents/skills/*.md` ↔
  `.claude/skills/*/SKILL.md`), not just the role lane (`docs/agents/*-protocol.md`
  ↔ `.claude/commands/role-*.md`).
- Widens `_DELTA_KEY_RE` to accept multi-word keys (`**default branch**`) — the
  skills lane names its keys in prose, and the old character class made 53 of
  63 keys invisible to extraction even on the correct lane.
- Skill lane uses **stem pairing**, not the role lane's cite-scan, as its
  wrapper-identification predicate — cite-scan misvalidates a wrapper that
  cites a sibling flow in prose while carrying its own `## Deltas` table
  (`assess-coding-improvement`'s wrapper cites `review-pr.md`; this is what
  bounced the first plan revision on this issue).
- The one real pre-existing gap (`commit-and-push` missing
  `**sha-pin token**`, #2912) and the one no-wrapper flow
  (`attach-screenshots`, #2312's unfinished stretch goal) land in a ratchet
  baseline — both fix surfaces are gated self-config no worker class can push
  in this PR.

## Test plan
- [x] `python3 -m unittest scripts.fleet.tests.test_fleet_validate_roles` — 28/28 pass
- [x] `bash scripts/fleet/tests/run_all.sh` — 124/125 (sole failure is the
      pre-existing `test_cross_repo_shared_file_parity.sh`, unrelated to this
      change — game #368)
- [x] `ruff check scripts/` — clean
- [x] `fleet-positive-control scripts/fleet/tests/test_fleet_validate_roles.py origin/master`
      → **MEANINGFUL: 6 of 28 assertions fail against origin/master (a9459315b)**

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Deleting one delta row from a skill wrapper (not baselined) exits non-zero, names the key; pre-fix silent | `fleet-positive-control` vs `origin/master` | MEANINGFUL: 6/28 fail pre-fix, incl. `test_skill_lane_missing_key_is_error_under_stem_pairing` and `test_multi_word_key_detected_as_missing` |
| False-pairing arm reports 0 findings against the cited flow | `test_skill_wrapper_citing_sibling_flow_not_misvalidated` | pass — `flow-a`'s wrapper citing `flow-b.md` in prose is validated only against its own stem-paired flow |
| Role lane still 3 flows / 31 keys / 0 errors | `test_role_lane_key_count_unchanged_by_regex_widening` + manual re-measure | `{'label': 'role', 'n_flows': 3, 'n_wrappers': 3}`, 31 keys total, 0 errors |
| Live tree passes with baseline in place; would fail without it (manual check) | `validate_roles([('.', 'engine')])` vs same call with `skill_missing_key_baseline={}, skill_no_wrapper_baseline={}` | with baseline: `ok=True errors=0`; baseline emptied: `ok=False errors=1 warnings=1` (exactly the tracked commit-and-push key + attach-screenshots no-wrapper) |
| Clean run prints per-lane coverage; zero-file lane flagged | `python3 scripts/fleet/fleet-validate-roles` | `Lane role: 3 flow(s), 3 wrapper(s) covered.` / `Lane skill: 8 flow(s), 7 wrapper(s) covered.` |
| Baselined entry doesn't suppress a different unanswered key on the same pair | `test_baseline_does_not_silently_widen` | pass — `key-c1` baselined and suppressed, `key-c2` on the same wrapper still reported |

Closes #2893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
