### PR TITLE
fleet: degraded skip no longer consumes the scout's projection edge (#2965)

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -220,6 +220,19 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   N is 1 because an age ceiling — not a tick count — does the sizing there
   (#2363, #2795). Copy whichever matches your call cadence; don't invent a
   third counter block by hand.
+- **A skip must never consume an edge-triggered lane's edge.** The scout's
+  two self-spawned lanes (`queue-manager` claim-cleanup,
+  `queue-manager-ingest`) compare their own projection hash inline instead of
+  routing through `update_role_trigger`, precisely because nothing re-arms
+  them — no watchdog, no periodic sweep. The seen-hash write therefore belongs
+  **after** every early-`continue` guard, never before it: recording the hash
+  and then skipping discards the change permanently, since the next tick
+  compares equal and skips too. A degraded tick swallowed an agent-approved
+  issue's ingest exactly this way, and the freshly-stamped seen-hash mtime —
+  the strongest available "this lane is healthy" signal — was the bug's own
+  fingerprint (#2965). Adding a guard to a hash-self-managing lane means
+  placing it above the write and covering the skip in
+  `tests/test_scout_degraded_fetch.py`.
 - **Unattended daemons timeout-guard their network calls.** The host's
   connections to GitHub intermittently black-hole (silent TCP death), so a
   hung `git fetch` / `gh …` in a fleet daemon (dispatcher loop, `fleet-rebase`,

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -3050,14 +3050,22 @@ def tick_once():
             except FileNotFoundError:
                 old_hash = ""
             if new_hash != old_hash:
-                write_atomic(seen_file, new_hash + "\n")
                 if state.get("degraded"):
                     # Skip reconcile/cleanup when fetch data is stale — comparing
                     # live claims against a potentially incomplete issue list would
                     # produce false-positive drift reports or unsafe auto-fixes.
+                    #
+                    # Leave the seen-hash UNWRITTEN. This lane and the ingest lane
+                    # below inline their own hash compare precisely because they
+                    # are edge-triggered with no re-arm (update_role_trigger's
+                    # docstring names the contract), so recording the hash here
+                    # would consume the edge and drop this sweep permanently — the
+                    # next tick compares equal and skips, however healthy the
+                    # freshly-stamped seen-hash looks (#2965).
                     log("queue-manager: skipping reconcile+cleanup (state degraded)")
                     triggers_fired.append("queue-manager(skipped-degraded)")
                     continue
+                write_atomic(seen_file, new_hash + "\n")
                 # cleanup --gh is GLOBAL stale-label reaping — run it only on
                 # the authoritative poller (leader, or a follower currently
                 # self-polling), else every follower re-multiplies the very
@@ -3113,11 +3121,15 @@ def tick_once():
             except FileNotFoundError:
                 old_hash = ""
             if new_hash != old_hash:
-                write_atomic(seen_file, new_hash + "\n")
                 if state.get("degraded"):
+                    # Seen-hash stays unwritten so the change survives the skip —
+                    # same edge-triggered no-rearm contract as the queue-manager
+                    # lane above; consuming it here strands the issue unqueued
+                    # for good (#2965).
                     log("queue-manager-ingest: skipping fleet-queue-ingest (state degraded)")
                     triggers_fired.append("queue-manager-ingest(skipped-degraded)")
                     continue
+                write_atomic(seen_file, new_hash + "\n")
                 try:
                     subprocess.Popen(
                         _fleet_script_argv(["fleet-queue-ingest"]),

--- a/scripts/fleet/tests/test_scout_degraded_fetch.py
+++ b/scripts/fleet/tests/test_scout_degraded_fetch.py
@@ -1,13 +1,16 @@
 """Tests for degraded-fetch handling in fleet-state-scout.
 
 Covers: failed fetch → last-known-good preserved + degraded marker;
-clean empty fetch → not degraded; no-previous-state first-run fallback.
+clean empty fetch → not degraded; no-previous-state first-run fallback;
+and the degraded SKIP in the two scout-spawned lanes leaving the projection
+edge intact (#2965).
 """
 import importlib.machinery
 import importlib.util
 import json
 import tempfile
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import patch
 
@@ -182,6 +185,126 @@ class TestScoutDegradedFetch(unittest.TestCase):
                 state = collect_state()
 
         self.assertNotIn("degraded", state)
+
+
+class TestDegradedSkipPreservesEdge(unittest.TestCase):
+    """#2965: the degraded skip must NOT consume the projection edge.
+
+    `queue-manager` (claim-cleanup) and `queue-manager-ingest` inline their own
+    hash compare instead of routing through update_role_trigger, precisely
+    because they are edge-triggered with no re-arm. Recording the seen-hash
+    before the degraded check therefore dropped the work permanently: the next
+    tick compared equal and skipped. Observed live as an agent-approved issue
+    left unqueued for 8h14m after a single degraded tick.
+    """
+
+    def _tick(self, tmp, projection, degraded, spawns):
+        """Run one tick_once() against a hermetic state dir.
+
+        `spawns` accumulates each subprocess.Popen argv so a caller can count
+        real spawns per lane. Returns nothing — assertions read `spawns` and
+        the seen-hash files under tmp.
+        """
+        state = {"generated_at": "2026-08-08T00:00:00Z", "repos": {}}
+        if degraded:
+            state["degraded"] = ["engine.tasks"]
+        # write_atomic keeps its temp beside the target, so every directory it
+        # writes into has to exist (production creates these at startup).
+        for sub in ("seen-hashes", "triggers", "projections"):
+            (Path(tmp) / sub).mkdir(exist_ok=True)
+
+        def _popen(argv, *a, **kw):
+            spawns.append(argv)
+            return None
+
+        # Both lanes are keyed on role name, so a two-entry PROJECTORS dict
+        # exercises exactly the branches under test and nothing else.
+        projectors = {
+            "queue-manager": lambda _s: projection,
+            "queue-manager-ingest": lambda _s: projection,
+        }
+        with ExitStack() as es:
+            p = es.enter_context
+            p(patch.object(_mod, "STATE_FILE", Path(tmp) / "state.json"))
+            p(patch.object(_mod, "SEEN_DIR", Path(tmp) / "seen-hashes"))
+            p(patch.object(_mod, "TRIGGERS_DIR", Path(tmp) / "triggers"))
+            p(patch.object(_mod, "PROJECTIONS_DIR", Path(tmp) / "projections"))
+            p(patch.object(_mod, "PROJECTORS", projectors))
+            p(patch.object(_mod, "SLICERS", {}))
+            p(patch.object(_mod, "GAME", Path(tmp) / "no-game"))
+            p(patch.object(_mod, "build_state", return_value=(state, False)))
+            p(patch.object(_mod.subprocess, "Popen", _popen))
+            for fn in ("_refresh_gh_token", "sample_github_rate_limit",
+                       "refresh_all_details", "_populate_done_tasks",
+                       "_populate_review_plan", "resolve_blocked_by",
+                       "resolve_human_approved_blockers",
+                       "resolve_needs_plan_blocked_by", "resolve_epic_children",
+                       "enrich_inflight_pr_tasks", "enrich_stackable_blocker_prs",
+                       "log"):
+                p(patch.object(_mod, fn))
+            _mod.tick_once()
+
+    @staticmethod
+    def _ingest_spawns(spawns):
+        return [a for a in spawns if any("fleet-queue-ingest" in str(x) for x in a)]
+
+    @staticmethod
+    def _cleanup_spawns(spawns):
+        # One claim-cleanup firing spawns several fleet-claim commands (cleanup
+        # --gh per repo + one reconcile); `reconcile` appears exactly once per
+        # firing, so it — not the fleet-claim count — is the per-tick unit.
+        return [a for a in spawns if any("reconcile" in str(x) for x in a)]
+
+    def _seen(self, tmp, role):
+        f = Path(tmp) / "seen-hashes" / role
+        return f.read_text().strip() if f.exists() else None
+
+    def test_degraded_skip_spawns_nothing_and_leaves_hash_unwritten(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spawns = []
+            self._tick(tmp, ["issue-1"], degraded=True, spawns=spawns)
+
+            self.assertEqual(self._ingest_spawns(spawns), [])
+            self.assertEqual(self._cleanup_spawns(spawns), [])
+            # The edge must still be pending — an unwritten hash is what makes
+            # the next clean tick re-fire.
+            self.assertIsNone(self._seen(tmp, "queue-manager-ingest"))
+            self.assertIsNone(self._seen(tmp, "queue-manager"))
+
+    def test_edge_survives_degraded_tick_and_fires_on_recovery(self):
+        """The regression: SAME projection, degraded then clean → still fires."""
+        with tempfile.TemporaryDirectory() as tmp:
+            spawns = []
+            self._tick(tmp, ["issue-1"], degraded=True, spawns=spawns)
+            self.assertEqual(self._ingest_spawns(spawns), [])
+
+            self._tick(tmp, ["issue-1"], degraded=False, spawns=spawns)
+            self.assertEqual(len(self._ingest_spawns(spawns)), 1)
+            self.assertEqual(len(self._cleanup_spawns(spawns)), 1)
+            self.assertIsNotNone(self._seen(tmp, "queue-manager-ingest"))
+
+    def test_clean_change_spawns_and_writes_hash(self):
+        """Control: the non-degraded path is unchanged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            spawns = []
+            self._tick(tmp, ["issue-1"], degraded=False, spawns=spawns)
+
+            self.assertEqual(len(self._ingest_spawns(spawns)), 1)
+            self.assertIsNotNone(self._seen(tmp, "queue-manager-ingest"))
+            # Unchanged projection on the next tick must NOT re-fire.
+            self._tick(tmp, ["issue-1"], degraded=False, spawns=spawns)
+            self.assertEqual(len(self._ingest_spawns(spawns)), 1)
+
+    def test_persistent_degradation_yields_exactly_one_spawn_on_recovery(self):
+        """N degraded ticks spawn nothing; recovery spawns once, not N times."""
+        with tempfile.TemporaryDirectory() as tmp:
+            spawns = []
+            for _ in range(3):
+                self._tick(tmp, ["issue-1"], degraded=True, spawns=spawns)
+            self.assertEqual(self._ingest_spawns(spawns), [])
+
+            self._tick(tmp, ["issue-1"], degraded=False, spawns=spawns)
+            self.assertEqual(len(self._ingest_spawns(spawns)), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `fleet-state-scout`'s two self-spawned lanes — `queue-manager` (claim-cleanup)
  and `queue-manager-ingest` — wrote their seen-hash **before** testing
  `state["degraded"]`, then `continue`d out without spawning. The projection
  edge was consumed and discarded, and because both lanes deliberately inline
  their own hash compare *instead of* routing through `update_role_trigger`
  (nothing re-arms them — no watchdog, no periodic sweep), nothing ever re-fired.
- Moves both `write_atomic(seen_file, ...)` calls below the degraded guard, so a
  change landing on a degraded tick survives it and fires on the next clean tick.
- Adds four regression cases to `test_scout_degraded_fetch.py` and the
  generalizable authoring rule to `scripts/fleet/CLAUDE.md`.

The failure was invisible from every normal vantage point: the issue queue and
`state.json` both looked clean, and the lane's freshly-stamped seen-hash mtime —
the strongest available "this lane is healthy" signal — was the bug's own
fingerprint.

## Test plan

- [x] `python3 scripts/fleet/tests/test_scout_degraded_fetch.py` — `Ran 10 tests … OK`
- [x] **Positive control**: the suite run against the pre-fix `a9459315b` fails
      **3** assertions; the **7** that still pass are the non-regression
      assertions. (7 + 3 = 10, the full suite.) Reported `MEANINGFUL` by
      `fleet-positive-control`.
- [x] `bash scripts/fleet/tests/run_all.sh` — `125 suite(s) — 124 passed, 1 failed`.
      The one failure is `test_cross_repo_shared_file_parity.sh`, the known
      pre-existing red on `master` (unrelated: this diff touches only the scout,
      its suite, and `scripts/fleet/CLAUDE.md`).
- [x] `ruff check scripts/` — `All checks passed!`
- [x] **Live repair**: ran `fleet-queue-ingest` by hand on the stranded lane;
      #2962 went from 8h14m unqueued to `fleet:queued` (`stamped 1 issue(s)`),
      and the scout's own cycle resumed normally at `18:05:03Z`.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Ingest branch: seen-hash not written when the degraded skip is taken | `python3 scripts/fleet/tests/test_scout_degraded_fetch.py` | `test_degraded_skip_spawns_nothing_and_leaves_hash_unwritten` PASS — no spawn, `seen-hashes/queue-manager-ingest` absent after a degraded tick |
| Same fix in the `queue-manager` claim-cleanup branch | same | same case also asserts `seen-hashes/queue-manager` is absent, and 0 `reconcile` spawns |
| Regression: degraded ⇒ unchanged seen + no spawn; next non-degraded tick with the **same** projection spawns exactly once | same | `test_edge_survives_degraded_tick_and_fires_on_recovery` PASS — 0 ingest spawns while degraded, exactly 1 after recovery, hash then written |
| Control preserved: changed projection + not degraded ⇒ spawn + hash write | same | `test_clean_change_spawns_and_writes_hash` PASS — 1 spawn, hash written, and an unchanged projection on the next tick does **not** re-fire |
| No re-fire storm: N degraded ticks ⇒ 0 spawns; recovery ⇒ exactly 1 | same | `test_persistent_degradation_yields_exactly_one_spawn_on_recovery` PASS — 3 degraded ticks → 0 spawns; recovery → 1 |
| `update_role_trigger` (2690–2733) not modified | `git diff origin/master...HEAD -- scripts/fleet/fleet-state-scout \| grep -E '^@@\|update_role_trigger'` | Both hunks are inside `tick_once()`; the only `update_role_trigger` occurrence in the diff is an added comment referencing it. The `.empty-suppressed` marker semantics are untouched. |

## Findings deferred

- **Same edge-consumption shape on the spawn-failure path.** In both lanes the
  seen-hash is now written before `subprocess.Popen` is attempted, so a spawn
  that raises (caught and logged as `failed to spawn …`) still consumes the
  edge. Left out of scope here because making it retry turns the failure into a
  per-tick retry loop, which this repo's `scripts/fleet/CLAUDE.md` rule
  ("an every-tick guard that warns must escalate-then-quiet") says needs a
  streak counter + alert file rather than a bare retry — a different change
  with its own design. **Filed as #2972** at the reviewer's request, with the
  shape reproduced end-to-end (`Popen` raising ⇒ hash written, 0 spawns, and the
  next healthy tick with the same projection still spawns 0) against both
  `origin/master` and this branch's head, so it is a pre-existing sibling rather
  than something this PR introduces.

Closes #2965

🤖 Generated with [Claude Code](https://claude.com/claude-code)

