### PR TITLE
fleet: fleet-dispatcher — add a catch-all arg arm so a bad flag exits non-zero (#2962)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -2538,6 +2538,13 @@ case "${1:-}" in
         fi
         exit 0
         ;;
+    "")
+        # No argument — daemon boot path, handled after esac below.
+        ;;
+    *)
+        echo "usage: fleet-dispatcher: unrecognized argument: $1" >&2
+        exit 2
+        ;;
 esac
 
 main "$@"

--- a/scripts/fleet/tests/test_dispatcher_arg_catchall.sh
+++ b/scripts/fleet/tests/test_dispatcher_arg_catchall.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Tests for the operator/test entry-point case block's catch-all arm (#2962):
+# an unrecognized first argument (or a one-char typo of a real flag) must exit
+# non-zero WITHOUT falling through into main() and starting the daemon loop.
+#
+# The daemon loop never returns, so this can't be probed by invoking the real
+# fleet-dispatcher with a bad flag directly — a regression would hang the
+# test. Instead, copy the script and replace the trailing `main "$@"` with a
+# marker (the same technique #2962's repro used), so a fall-through is
+# observable as output instead of a hang.
+
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$SCRIPT_DIR/tests/lib_assert.sh"
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+[[ -x "$DISPATCHER" ]] || { echo "test setup: fleet-dispatcher not found"; exit 1; }
+
+TMPROOT=""; cleanup(){ [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+PROBE="$TMPROOT/fd-probe.sh"
+
+cp "$DISPATCHER" "$PROBE"
+python3 - "$PROBE" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+tail = 'main "$@"'
+body = s.rstrip()
+assert body.endswith(tail), "fleet-dispatcher no longer ends in main \"$@\" -- update this test's probe"
+open(p, "w").write(body[: -len(tail)] + 'echo "REACHED_MAIN argv=$*"\n')
+PY
+chmod +x "$PROBE"
+
+run() { "$PROBE" "$@"; echo "rc=$?"; }
+
+echo "T1: --print-cap worker (positive control) -> prints cap, rc=0, no REACHED_MAIN"
+out=$(run --print-cap worker)
+assert_absent "$out" "REACHED_MAIN" "--print-cap worker does not reach main"
+assert_contains "$out" "rc=0" "--print-cap worker exits 0"
+
+echo "T2: --print-cap (usage-error control) -> usage message, rc=2, no REACHED_MAIN"
+out=$(run --print-cap 2>&1)
+assert_absent "$out" "REACHED_MAIN" "--print-cap (no role) does not reach main"
+assert_contains "$out" "rc=2" "--print-cap (no role) exits 2"
+
+echo "T3: --bogus-flag -> unrecognized, rc=2, no REACHED_MAIN"
+out=$(run --bogus-flag 2>&1)
+assert_absent "$out" "REACHED_MAIN" "--bogus-flag does not reach main"
+assert_contains "$out" "rc=2" "--bogus-flag exits 2"
+
+echo "T4: --print-caps worker (one-char typo) -> unrecognized, rc=2, no REACHED_MAIN"
+out=$(run --print-caps worker 2>&1)
+assert_absent "$out" "REACHED_MAIN" "--print-caps typo does not reach main"
+assert_contains "$out" "rc=2" "--print-caps typo exits 2"
+
+echo "T5: status (bare word) -> unrecognized, rc=2, no REACHED_MAIN"
+out=$(run status 2>&1)
+assert_absent "$out" "REACHED_MAIN" "bare 'status' does not reach main"
+assert_contains "$out" "rc=2" "bare 'status' exits 2"
+
+echo "T6: no argument -> must still reach main (the daemon boot path)"
+out=$(run)
+assert_contains "$out" "REACHED_MAIN argv=" "bare invocation still reaches main"
+assert_contains "$out" "rc=0" "bare invocation exits 0"
+
+summarize "fleet-dispatcher arg catch-all"


### PR DESCRIPTION
## Summary
- `fleet-dispatcher`'s operator/test entry-point `case` block had no `*)` arm — any unrecognized first argument (or a one-char typo of a real flag) fell through `esac` into `main "$@"`, silently starting the daemon loop at rc=0.
- Added an explicit `""` arm (preserves the bare-invocation daemon-boot path) followed by a `*)` catch-all that prints a usage message to stderr and exits 2, matching the existing usage-error arms.
- Added `scripts/fleet/tests/test_dispatcher_arg_catchall.sh`, reproducing the issue's exact repro table via the same safe probe technique (copy the script, replace the trailing `main "$@"` with a marker) so a regression is observable as output instead of hanging the test.

## Test plan
- [x] New suite passes standalone: `bash scripts/fleet/tests/test_dispatcher_arg_catchall.sh` — 12/12 assertions pass.
- [x] Positive control confirms the suite is meaningful: `fleet-positive-control scripts/fleet/tests/test_dispatcher_arg_catchall.sh origin/master` — `MEANINGFUL: 6 of 12 assertions fail against origin/master (a9459315b)` (exactly the 3 defect rows × 2 assertions each; both controls and the bare-invocation assertion pass pre-fix as expected).
- [x] Full suite: `bash scripts/fleet/tests/run_all.sh` — 125/126 passed; the sole failure is the pre-existing, documented `test_cross_repo_shared_file_parity.sh` (game #368), unrelated to this change.
- [x] `ruff check scripts/fleet/` — clean (no Python touched by this diff, ran for parity with repo convention).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| A `*)` arm added before `esac` that exits non-zero | `git diff` (this PR) | `*)` arm added at scripts/fleet/fleet-dispatcher:2544, prints usage to stderr, `exit 2` |
| The three defect rows exit non-zero without reaching `main` | probe test T3–T5 (`--bogus-flag`, `--print-caps worker`, `status`) | all three: `usage: fleet-dispatcher: unrecognized argument: ...` / `rc=2`, no `REACHED_MAIN` |
| Both control rows unchanged | probe test T1–T2 (`--print-cap worker`, `--print-cap`) | `--print-cap worker` → prints cap, `rc=0`; `--print-cap` → usage message, `rc=2`; neither reaches `main` |
| Bare `fleet-dispatcher` (no argument) still starts the daemon boot path | probe test T6 (no args) | `REACHED_MAIN argv=`, `rc=0` |

Closes #2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)