### PR TITLE
render: publish the jitter_probe rotation-gate bar on the pinned sweep (#2606)

### DIFF
--- a/.fleet/plans/issue-2606.md
+++ b/.fleet/plans/issue-2606.md
@@ -1,83 +1,94 @@
-## Plan: jitter_probe — per-axis excursion assertion for the rotation gate
+## Plan: jitter_probe rotation gate — derive the excursion bar on the `--pivot-origin` pinned sweep (measurement + docs, zero code)
 
 - **Issue:** #2606
 - **Model:** opus
 - **Date:** 2026-08-07
+- **Supersedes:** both prior `## Plan` comments (06:27Z — executed; its Phase 0 refuted the default-focus premise, see the 07:15Z bail. 07:52Z — bounced 10:57Z: its Phase 1 rebuilt a flag `--pivot-origin` already ships, with a provably identical effective camera). Both stay as audit trail; this plan follows the 10:57Z review's re-plan directions 1–4.
 
 ### Scope
 
-Close the scorer-model gap #2606 measures: `jitter_probe`'s default verdict cannot express "x stays pinned while y may translate", so a smooth systematic centroid migration (the `IR_PERAXIS_OVERFLOW_DISABLE=1` defect signature, +11.13px monotone on 2026-07-28) scores clean on the axis it corrupts. Add per-axis excursion assertions (`--max-excursion-x` / `--max-excursion-y`), make the excursion check the primary rotation-gate assertion in the docs, and lock the semantics with a hermetic synthetic test plus live positive-fire runs.
+Land the two ACs PR #2922 could not: a rotation gate on which the per-axis excursion assertion **fires on the defect and passes healthy runs** (AC2), and docs making that check the primary rotation-gate assertion with a published per-zoom bar (AC3). The re-anchor is the existing composition **`--yaw-sweep --pivot-origin`** — `RotationPivotMode::ORIGIN` removes the pivot-orbit term entirely, today, with zero new code. This task is **measurement + two doc surfaces only**; no flag ships (10:57Z direction 4: a `--yaw-sweep-pinned-focus` alias would reproduce `--pivot-origin` bit-for-bit, and ORIGIN's "no pivot term at all" dominates an explicit focus's "term that cancels to zero").
 
-Out of scope: the `--max-residual` bar, the #2469 accepted-residual table, and master's residual drift at zoom 4/8 — that is **#2907**'s (see Reconciliation).
+Out of scope: the residual criterion / `--max-residual` bar (#2907), the default-focus probe's composite redness (#2907), the pivot derive itself (#2641/#2758/#2548), and any change under `tools/`, `scripts/`, or demo sources.
 
-### Verified current state (2026-08-07, origin/master)
+### Verified current state (2026-08-07, origin/master + PR #2922 branch)
 
-- `tools/jitter_probe/main.cpp` (391 lines, read in full): default verdict = `reversals==0 && maxAbsResidual<=--max-residual` on **both** axes (`main.cpp:368-370`); `--stationary` = deviation-from-frame-0 ≤ `--max-deviation` on **both** axes (`main.cpp:337`). No per-axis-independent assertion exists anywhere in the scorer, and excursion (max−min of a centroid column) is computed nowhere — the negative claim is exhaustive over the tool's single source file.
-- The defect fixture exists on master: `IR_PERAXIS_OVERFLOW_DISABLE` presence-check at `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:504`.
-- **The issue's AC2 phrase "using the same captured sequences above" is no longer satisfiable.** Those sequences were build-dir transients (`save_files/screenshots/`, wiped per the #2814 recipe) and are gone; all populations must be re-captured. Master has also drifted since 2026-07-28: **#2907** measures the same canonical probe's x residual at 0.85/1.78/2.70px (z2/z4/z8) vs the 1.50px bar — red at z4/z8 on the *residual* criterion. AC2's healthy-master leg is therefore re-anchored to fresh same-session captures (Phase 0), and the composite exit code at z4/z8 is decoupled from this task (Acceptance 3).
-- Output consumers audited (full `git grep -l jitter_probe` sweep, every hit classified): the ONLY stdout parser is `scripts/pivot-verify.py:155-157`, which regex-parses the `--stationary` summary's `x: max_deviation=…px` lines. Nothing parses the default-mode summary. All other hits are docs/comments/CMake registration (`camera_pan_pivot_test.cpp:18` and `ir_args.cpp:11` are comments).
+- **The composition chain, each link verified against origin/master** (the 10:57Z review derived it; re-checked here rather than inherited):
+  - `--pivot-origin` registered at `creations/demos/shape_debug/main.cpp:750`, read at `:817`, applied **once at setup** at `:898-902` → `IRRender::setRotationPivotMode(RotationPivotMode::ORIGIN)` plus the exact log string `RotationPivotMode: ORIGIN (--pivot-origin) — Z-yaw pivots about the world origin` (`:901`) — the ready-made per-run **arm-identity marker** (10:57Z direction 2; no new plumbing).
+  - `applyShotCameraState` (`engine/video/src/auto_screenshot.cpp:28-46`) sets/clears the *focus* only, never the *mode* — the yaw-sweep shots' `hasPivotFocus_=false` clear is harmless under ORIGIN.
+  - `getEffectiveCameraIso` (`engine/render/src/ir_render.cpp:46-49`) tests ORIGIN **before** the focus branch and returns `cameraIso` unmodified — no pivot term is ever computed.
+  - `updateDefaultRotationPivotFocus` early-returns unless `mode == CAMERA_CENTER` with no explicit focus (`engine/render/src/render_manager.cpp:310`, guard at ~`:343` with the comment "ORIGIN mode ignores the focus entirely") — ORIGIN pays no depth readback.
+- **Candidate-set closure, restated mechanism-free** (the axis the 10:57Z bounce corrected): the requirement is "remove the pivot *orbit*", and the candidate set is the `RotationPivotMode` enum — **exactly two members**, `ORIGIN = 0, CAMERA_CENTER = 1` (`engine/render/include/irreden/render/ir_render_types.hpp:840`) — plus the per-shot explicit focus (`pivotFocusWorld_`/`hasPivotFocus_`, #1921). ORIGIN is CLI-reachable today; explicit focus has no yaw-sweep CLI path and would merely cancel to the identical value (`cameraYawPivotOffset(cameraIso, vec3(0), yaw) == cameraIso` at every yaw, `ir_math.hpp:1106` — the 10:57Z identity). There is no third mechanism.
+- **The fixture was designed for ORIGIN**: `--spin-shape` spawns ONE shape at `vec3(0.0f, 0.0f, 0.0f)` on the voxel, SDF, and "figure" paths alike (`main.cpp:2623-2662`), with the spawn comment "Under camera Z-yaw-about-origin the shape stays screen-centred". The composition pins **because** the fixture is origin-centred — the doc recipe must bind the two (see Gotchas).
+- **Census, stated fully** (10:57Z non-blocking note absorbed): `git grep -- --yaw-sweep` code hits are shape_debug's own registration/comments, `creations/demos/fog_demo/main.cpp:637` (comment), and `tools/jitter_probe/main.cpp:26` (comment) — all inert; remaining hits are docs/skills/plan files. `git grep -- --pivot-origin` hits are shape_debug-only (registration `:750`, getFlag `:817`, apply+log `:898-902`, comments). No script drives either flag; the only jitter_probe stdout parser is `scripts/pivot-verify.py`, which parses `--stationary` output only. Composing the two flags cannot break any harness.
+- **Tool base**: `--max-excursion-x/-y` and the `excursion=` print are **not** on origin/master (`git grep -e --max-excursion-x origin/master -- tools/jitter_probe/main.cpp` → no match); they ship on PR **#2922** (`claude/2606-jitter-probe-excursion`, `fleet:approved`, MERGEABLE, open), which also rewrote the two doc sections this plan edits further: `engine/render/CLAUDE.md:549-577` ("**do not put a bar on this probe yet** … re-derive the bar here from a post-#2641 capture") plus the `:942-950` historical-columns note, and `tools/jitter_probe/README.md:160-200` (flags section + 2026-08-07 note).
+- **The "wait for #2641" path those texts close on is dead**: PR #2758 (Closes #2641, `fleet:approved`, open) rules the default derive's cap-entry orbit **inherent** — it gates the orbit's growth, it does not remove it. The default-focus probe can never carry an excursion bar; the pinned probe is the durable home.
+- **Defect fixture unchanged**: `IR_PERAXIS_OVERFLOW_DISABLE` presence check at `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:504`.
 
 ### Approach
 
-**Phase 0 — premise probe: excursion still separates the populations on today's master.** The bar the docs will publish must be derived from *current* populations, not the dead 2026-07-28 captures (#2907 proves the tree moved). On one host/backend in one session, capture with the canonical recipe (`engine/render/CLAUDE.md` §"Verifying temporal stability": wipe → sweep → 6-digit glob → `--expect-frames`), archiving each population to its own directory immediately after capture:
+**Phase 0 — base + composition premise probe (bail-gated).**
+- Base: at branch time re-run the tool-base check above; if #2922 is unmerged, stack on `claude/2606-jitter-probe-excursion` (native stack). Never re-implement any tool piece.
+- Composition probe (10:57Z direction 1 — the statically-proven identity still gets its cheap measured confirmation): **one** capture, H4-pinned — canonical recipe + `--pivot-origin` (wipe → `IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep --pivot-origin --zoom 4 --auto-screenshot 6` → 6-digit glob, `--expect-frames 24`), ORIGIN log line asserted. **Expected reading**: x excursion in the pinned regime, ~1–3px (explicit-focus blocks pin at 0.94/1.27px re-verified live 2026-08-07; the pre-orbit 2026-07-28 table read 1.26px @ z4) — an order of magnitude under the 38.18px unpinned reading. **Bail**: if it lands in the tens-of-px regime *with the ORIGIN line asserted*, the composition premise is refuted — stop, post the measurement here, cross-comment #2641, park `fleet:needs-human`. Do not build the dependent phases.
+- A Phase-0 capture taken under the full protocol (wipe, identity assert, archive) is retained as population H4.
 
-- H2/H4/H8 — healthy voxel cylinder `--yaw-sweep`, zoom 2/4/8.
-- S4/S8 — SDF cylinder control (omit `--spin-shape-voxel`), zoom 4/8.
-- D2/D4/D8 — `IR_PERAXIS_OVERFLOW_DISABLE=1` voxel cylinder `--yaw-sweep`, zoom 2/4/8.
+**Phase 1 — populations + bar.** One host/backend, one session; archive each population (frames + engine log) before the next capture. Arms:
+- **U4** — healthy voxel z4 **unpinned** (differential control; expect ~38px x excursion per the 08-07 table — proves the flag changes the regime).
+- **H2/H4/H8** — healthy voxel, pinned (`--yaw-sweep --pivot-origin`), zoom 2/4/8 (H4 from Phase 0).
+- **S4/S8** — SDF control, pinned (omit `--spin-shape-voxel`).
+- **D2/D4/D8** — `IR_PERAXIS_OVERFLOW_DISABLE=1`, voxel, pinned.
 
-Hand-measure per-axis excursion (max−min of the `--verbose` centroid columns) for every population. Derive the per-zoom x-bar by the committed rule: **bar(z) = the smallest half-integer ≥ 2.5 × the max healthy x excursion at that zoom (voxel and SDF both count as healthy), and it must be ≤ 0.5 × the defect x excursion at that zoom.** (2026-07-28 reference: healthy 1.26–2.83px, SDF 2.00px, defect 11.13px @ z4 → z4 bar would land at 5.0; expect the same order today.) The 2.5× margin absorbs run-to-run noise on a noise-dominated statistic; the 0.5× ceiling keeps ≥2× headroom to the defect.
+Assert arm identity **per run from the engine log, never the argv**: zoom as received; the voxel-fixture log line present iff a voxel arm; the ORIGIN line present iff a pinned arm; the `Yaw-sweep: 24 shots` line present. Read x/y excursion from the tool's `excursion=` print; hand-derive H4 from `--verbose` centroids as the ±0.01px instrument cross-check.
 
-*Bail path:* if any zoom has no value satisfying both bounds, the premise (excursion separates healthy from defect on current master) is refuted — stop, post the full measurement table on #2606 and cross-reference it on #2907, and flag #2606 for re-plan noting the likely resolution is `Blocked by:` #2907. Do not build the dependent phases.
+**Bar rule (committed — carried verbatim from the vetted 06:27Z plan and its review):** per zoom, `bar(z)` = the smallest half-integer ≥ 2.5 × the max healthy x excursion at that zoom (voxel and SDF both count as healthy), and it must be ≤ 0.5 × the defect x excursion at that zoom. **Per-zoom bail** (06:37Z binding constraint 1): publish bars only for zooms that separate; a non-separating zoom is omitted from the doc table with a one-line note and its measurement posted here. Expected regime (context, never controls): healthy pinned ~1–3px, defect ~11px @ z4 (2026-07-28, measured before the orbit landed).
 
-**Phase 1 — the flags** (`tools/jitter_probe/main.cpp`):
-- Compute per-axis excursion = max−min of the centroid column over the **same valid-frame mask the fit uses**, unconditionally; append `excursion=%.2fpx` to the two default-mode axis summary lines, and the provided bars to the thresholds line.
-- Add `--max-excursion-x <px>` / `--max-excursion-y <px>`, each independently optional, gated on `parser.wasProvided(...)` (not a sentinel default). When provided, AND `excursion ≤ bar` for that axis into the default-mode SMOOTH verdict.
-- Combining either flag with `--stationary` is an argument error (exit 2, message) — prevents a silently-ignored assertion, and keeps the `--stationary` output path byte-identical for `pivot-verify.py`.
+**Whole-task bail** only if **no** zoom separates: the premise is then refuted on the pinned family too — post the full table here, cross-comment #2641/#2907, park the issue `fleet:needs-human` recommending close-or-rescope. No PR ships (unlike the 07:15Z bail there is no tool piece left to salvage — #2922 already banked it). A second refutation is a human call, not a fourth plan.
 
-**Phase 2 — hermetic semantics test** (`test/tools/jitter_probe_excursion_test.sh`, new; mirrors `ir_run_exit_code_test.sh`'s staged-fixture form): binary from `$JITTER_PROBE_BIN` else the default build path, SKIP + exit 0 with a message when absent (nothing in CI runs `test/tools/` — this is a hand/review artifact). Fixtures: an inline `python3` heredoc writes two 8-frame sequences of 48×48 binary PPMs (stb_image reads PPM — no PNG encoder needed): (A) a 12×12 white square stepping +2px/frame in x, y fixed; (B) x fixed, +2px/frame in y. Five assertions, one probe invocation each:
-1. A, default flags + `--reversal-eps 0.8` → **exit 0** — pins the blind spot (the OFF arm of the discriminating pair).
-2. A + `--max-excursion-x 5` → **exit 1** — 14px migration; the gate's positive fire.
-3. B + `--max-excursion-x 5` → **exit 0** — the issue's exact contract: x pinned while y translates 14px.
-4. B + `--max-excursion-y 5` → **exit 1** — axis independence, and proves case 3's pass is non-vacuous (same frames, mirrored assertion, opposite verdict).
-5. `--stationary --max-excursion-x 5` → **exit 2**.
+**Phase 2 — acceptance runs** (same session, re-scoring the archived populations):
+- **Positive fire + attribution:** each D arm at a separating zoom under the canonical score flags + `--max-excursion-x bar(z)` → exit 1; an isolation arm adds `--max-residual 99` → **still** exit 1, so the failure is attributable to the excursion criterion by construction (the exact "caught by accident" failure mode this issue documents).
+- **Healthy pass:** H2/H4/H8 + S4/S8 print x excursion ≤ bar(z) — gated on the printed x-axis summary line, not the composite exit; if any healthy pinned arm is composite-red via the residual axis, record the residuals and cross-comment #2907 (pinned-probe residuals discriminate "orbit-inflated fit" from "true floor" — free evidence either way).
+- **Differential:** pinned H4 x excursion ≤ 0.25 × unpinned U4 x excursion (expect ~3px vs ~38px; proves the flag was live and the orbit was the dominating term).
 
-**Phase 3 — live acceptance runs** (re-score the archived Phase-0 populations with the built tool):
-- Cross-check the instrument: tool-printed x excursion on H4 must equal the Phase-0 hand-derived max−min to ±0.01px.
-- D4 and D8 under the canonical flags + `--max-excursion-x bar(z)` → exit 1; then an isolation run adding `--max-residual 99` → still exit 1, so the failure is attributable to the excursion criterion by construction (not caught "by accident" via another axis — the exact failure mode the issue documents).
-- H2/H4/H8 + S4/S8: printed x excursion ≤ bar(z) for every population. Composite exit codes recorded as-is: z2 expected 0; z4/z8 follow #2907's state (red today via the residual axis) — record the residuals and cross-comment them on #2907. If #2907 has landed by implementation time, expect composite 0 at all three zooms and say so.
-
-**Phase 4 — docs** (AC3):
-- `tools/jitter_probe/README.md`: usage block gains the flags; rewrite §"Accepted floors, and the model's blind spot (#2469)" — the false-negative half is closed by the excursion assertion (keep the reversal-eps history); drop the "until #2606… read excursion by hand" paragraph.
-- `engine/render/CLAUDE.md` §"Verifying temporal stability": the canonical rotation-gate recipe gains `--max-excursion-x <bar(zoom)>` with the measured per-zoom bar table (populations, values, date, host); flip the "does not fire on the `IR_PERAXIS_OVERFLOW_DISABLE=1` runtime control" bullet to its measured opposite (fires via excursion: value vs bar); replace the closing "principled fix is #2606" paragraph. Do **not** touch the #2469 accepted-residual table or `--max-residual` — #2907 owns those.
+**Phase 3 — docs (AC3).**
+- `engine/render/CLAUDE.md` §"Verifying temporal stability": the rotation-recipe line gains `--pivot-origin` (with a comment binding it to the origin-centred `--spin-shape` fixture); the scoring line gains `--max-excursion-x <bar(zoom)>`; the recipe's log-assert guidance gains the ORIGIN-line check; **replace** the `:549-577` "do not put a bar yet … post-#2641 capture" close: the orbit is inherent (#2758), the pinned `--pivot-origin` sweep is the canonical rotation gate, and the unpinned sweep keeps **no** excursion bar (one line: its excursion measures the inherent pivot orbit; that surface belongs to pivot-verify). Publish the per-zoom bar table (populations, x values, y excursions recorded, date, host/backend). Reword the `:942-950` historical note to point at the pinned table instead of "until a post-#2641 capture".
+- `tools/jitter_probe/README.md`: the canonical rotation recipe (~`:187`) gains `--pivot-origin`; the "no separating value" / 2026-08-07 passage points at the CLAUDE.md bar table (single home for the numbers — no duplicated table to drift).
+- Untouched: `--max-residual` / accepted-residual text (#2907's), pivot-verify docs, `camera-yaw-pivot.md` (#2758's).
 
 ### Affected files
 
-- `tools/jitter_probe/main.cpp` — excursion computation + print, two flags, verdict, stationary-combination guard
-- `tools/jitter_probe/README.md` — flags + blind-spot section rewrite
-- `engine/render/CLAUDE.md` — recipe + bar table + limitation-paragraph replacement
-- `test/tools/jitter_probe_excursion_test.sh` — new hermetic semantics test
-- `.fleet/plans/issue-2606.md` — this plan, first commit of the PR (#1932)
+- `engine/render/CLAUDE.md` — recipe + bar table + replace the wait-for-#2641 close
+- `tools/jitter_probe/README.md` — pinned recipe line + table pointer
+- `.fleet/plans/issue-2606.md` — replaced with this plan (first commit of the PR, #1932)
+
+**No code changes.** No new flag, no demo edit, nothing under `tools/`/`scripts/`.
 
 ### Acceptance criteria
 
-1. **AC1 as filed:** the per-axis flags exist and are independently usable (test cases 3/4 prove independence on identical frames).
-2. **AC2 re-anchored** (filed wording depends on dead captures + a since-drifted master, per Verified current state): D4 exits 1 with the excursion criterion attributably firing (isolation run), and every freshly captured healthy population (H2/H4/H8, S4/S8) passes the excursion criterion (printed x excursion ≤ bar(z)). z2 composite exit 0. z4/z8 composite recorded either way with residuals cross-commented on #2907.
-3. **AC3 as filed:** both docs updated as Phase 4, carrying the measured table.
-4. The synthetic test ships and passes 5/5 against the freshly built binary (run log in the PR body).
-5. `pivot-verify.py`'s parse surface is untouched by construction (`--stationary` output byte-identical; combination guard makes the new flags unreachable in that mode) — stated in the PR body.
+1. **Positive fire, attributable:** at every separating zoom the D arm exits 1 under `--max-excursion-x bar(z)` AND under the isolation pair (`+ --max-residual 99`). Fixture: `IR_PERAXIS_OVERFLOW_DISABLE` (exists on master).
+2. Every healthy pinned population (H2/H4/H8, S4/S8) prints x excursion ≤ bar(z); the U4 differential shows ≥ 4× pinned-vs-unpinned separation.
+3. Docs per Phase 3 carry the measured table (values, populations, date, host/backend); the published recipe is `--yaw-sweep --pivot-origin`; the unpinned probe explicitly keeps no bar.
+4. **Zero code:** the PR diff touches only the two doc files plus `.fleet/plans/issue-2606.md`.
+5. Every capture's arm identity is asserted from the engine log (zoom-as-received; voxel iff voxel arm; ORIGIN line iff pinned arm) and the run logs are archived with the populations; the PR body carries the full table including y excursions.
 
 ### Gotchas
 
-- `IR_PERAXIS_OVERFLOW_DISABLE` is a `getenv != nullptr` presence check — `VAR=` (empty) counts as SET. Fully `unset` it for healthy arms and verify with `env`.
-- Wipe the screenshots dir before **every** capture (exact `find … -delete` form in the CLAUDE.md block); archive each population before the next capture; `--expect-frames` must match the actual post-wipe file count. Note a live doc inconsistency: #2907/#2605 report 24-frame sweeps from `--auto-screenshot 6`, while the CLAUDE.md recipe comment says the guard should equal the auto-screenshot count and passes 6 — trust the actual file count (the guard exits 2 on a mismatch); if it is 24, fix the stale comment line in the Phase-4 docs pass.
-- `fleet-run --timeout 0` goes **before** the target token, and redirect `fleet-build` output to a file + check `$?` — piping through `grep`/`head` masks a failed build as green and a stale binary then "passes".
-- Capture all populations on ONE host/backend in one session; the published bar table names its host. The 2026-07-28 numbers are context, never controls.
-- Keep the #2907 seam clean: if #2907's PR is in flight against the same CLAUDE.md section, whoever rebases second reconciles only the shared §temporal-stability paragraphs — the two tasks change disjoint criteria.
+- `IR_PERAXIS_OVERFLOW_DISABLE` is a `getenv != nullptr` **presence** check — `VAR=` (empty) counts as SET; fully `unset` it for healthy arms and verify with `env`.
+- Wipe the screenshots dir before EVERY capture (exact `find … -delete` form in the recipe); `--expect-frames 24` (`--auto-screenshot N` is per-shot warmup, not the shot count); archive each population immediately after its capture.
+- zsh does not word-split an unquoted `$spec` (the 07:15Z pass's live precedent) — assert every arm from the engine log, never from the argv you think you passed.
+- jitter_probe silently drops frames under ~50 foreground px (per-frame centroid validity floor) and aborts under 3 valid frames — confirm 24/24 valid frames per run. Under ORIGIN the origin-centred shape stays screen-centred so this should hold; a sudden valid-frame drop means the arm is not what you think it is.
+- `--pivot-origin` is applied once at demo setup and covers every shot of the run — never mix pinned and unpinned populations in one run.
+- `fleet-run --timeout` goes BEFORE the target token; redirect `fleet-build` output to a file and check `$?` — piping through `grep` masks a failed build, and a stale binary then "passes".
+- If #2922 merges mid-task, rebase normally; the Phase-0 base check is branch-time-only. Never re-implement the tool pieces.
 
 ### Reconciliation (siblings / in-flight)
 
-- **#2907** (open, needs-plan): the *residual*-axis drift on the same probe — the opposite failure class, per its own "Not #2606" ruling. This plan deliberately leaves the residual criterion untouched and hands #2907 free evidence (fresh residual readings cross-commented).
-- **PR #2850 / #2479** (design-blocked): same render domain; measured digit-identical to master on this probe (#2907's ruled-out section) — no interaction.
-- **pivot-verify / #2553**: `--stationary` consumer, parse surface audited and preserved.
-- **Merged #2605** (reversal-eps recipe + limitation docs) and **#2814** (`--expect-frames`): extended, not contradicted — the limitation text #2605 added is exactly what Phase 4 replaces.
+- **PR #2922** (`fleet:approved`, open, MERGEABLE) — the base (stack while unmerged); ships the AC1/AC4/AC5 tool surface plus the doc text Phase 3 edits further. This plan is the residual AC2+AC3.
+- **PR #2758 / #2641** (`fleet:approved`, open, needs-gl-host) — supplies the orbit-is-inherent premise. With no demo edit here, the shared-`main.cpp` seam the 07:52Z plan reconciled is gone (10:57Z note). Even if the owed GL-host leg overturned the inherent ruling, the ORIGIN-pinned gate stays valid — no pivot term is stricter than any future default derive.
+- **#2907** (open, needs-plan; residual axis, default-focus probe) — criterion untouched here; receives pinned-probe residual readings via cross-comment, which its re-planner can use to judge whether the default-probe redness is orbit-inflated.
+- **PR #2850 / #2479** (`fleet:wip`) — same render domain, measured digit-identical to master on this probe (#2907's ruled-out section); no interaction.
+- **#2469 / #2605** — the eps history stays; #2922 already rewrote the limitation text; Phase 3 only replaces its wait-for-#2641 close.
+
+---
+
+Not high-stakes per the PLANNING-PROTOCOL step-3 checklist: single committed approach (zero-code, directed by the 10:57Z review), two doc files, one PR, no public-contract change — `fleet:plan-review` only, no `human:review-plan`.
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -613,6 +613,20 @@ Three checks, in order:
    (recorded, not gated): healthy 0.21 / 0.11 / 0.06px, defect 2.64 / 5.27 /
    10.08px at zoom 2/4/8.
 
+   **At a zoom not in the table, re-derive — never interpolate, and never carry a
+   neighbouring row across.** z1 is omitted by the clause above, not by oversight:
+   healthy reads **0.93px** against **3.53px** for the defect arm, a separation of
+   only 3.8x against 10x/60x/363x at the published zooms, so the candidate bar
+   (smallest half-integer >= 2.5 x 0.93 = 2.5px) sits *above* its own ceiling
+   (0.5 x 3.53 = 1.765px) and no value satisfies the rule. Borrowing the adjacent
+   0.5px there **false-fires** — it exits 1 on a green z1 population (0.93 > 0.5),
+   reporting a healthy tree as a rotation regression. Upward is the harmless
+   direction: z16 healthy reads **0.04px**, 12x under that same 0.5px. The two
+   identical 0.5px rows are a rounding coincidence, not a plateau to read off.
+   (z1/z16 measured macOS/Metal 2026-08-08, same fixture and arm-identity
+   discipline as the table. The z16 pass is non-vacuous: `--max-excursion-x 0.03`
+   on those frames exits 1, so the flag is live on the population it clears.)
+
    **The bar belongs to the pinned probe only — the unpinned sweep carries no
    excursion bar.** Drop `--pivot-origin` and the same healthy z4 population reads
    **38.18px** instead of 0.18px (212x), because the **default** `CAMERA_CENTER`

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -543,8 +543,10 @@ Three checks, in order:
    # still yields a confident verdict (measured during #2469 — see
    # tools/jitter_probe/README.md §"Wipe before every capture").
    # --max-excursion-x is the primary rotation-gate assertion (#2606); the bar is
-   # per-zoom, from the table below. y is deliberately left unconstrained — on a
-   # yaw sweep it legitimately translates.
+   # per-zoom, from the table below, and applies to the pinned
+   # --yaw-sweep --pivot-origin population only — omit it when scoring
+   # --pan-sweep, where x translates by design. y is deliberately left
+   # unconstrained — on a yaw sweep it legitimately translates.
    build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 --expect-frames 24 \
        --max-excursion-x <bar(zoom)> \
        <save_files>/screenshots/screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -617,13 +617,13 @@ Three checks, in order:
    neighbouring row across.** z1 is omitted by the clause above, not by oversight:
    healthy reads **0.93px** against **3.53px** for the defect arm, a separation of
    only 3.8x against 10x/60x/363x at the published zooms, so the candidate bar
-   (smallest half-integer >= 2.5 x 0.93 = 2.5px) sits *above* its own ceiling
-   (0.5 x 3.53 = 1.765px) and no value satisfies the rule. Borrowing the adjacent
-   0.5px there **false-fires** — it exits 1 on a green z1 population (0.93 > 0.5),
-   reporting a healthy tree as a rotation regression. Upward is the harmless
-   direction: z16 healthy reads **0.04px**, 12x under that same 0.5px. The two
-   identical 0.5px rows are a rounding coincidence, not a plateau to read off.
-   (z1/z16 measured macOS/Metal 2026-08-08, same fixture and arm-identity
+   (smallest half-integer >= 2.5 x 0.93 = 2.325 → 2.5px) sits *above* its own
+   ceiling (0.5 x 3.53 = 1.765px) and no value satisfies the rule. Borrowing the
+   adjacent 0.5px there **false-fires** — it exits 1 on a green z1 population
+   (0.93 > 0.5), reporting a healthy tree as a rotation regression. Upward is the
+   harmless direction: z16 healthy reads **0.04px**, 12x under that same 0.5px.
+   The two identical 0.5px rows are a rounding coincidence, not a plateau to read
+   off. (z1/z16 measured macOS/Metal 2026-08-08, same fixture and arm-identity
    discipline as the table. The z16 pass is non-vacuous: `--max-excursion-x 0.03`
    on those frames exits 1, so the flag is live on the population it clears.)
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -523,9 +523,14 @@ Three checks, in order:
    # pan jitter (voxel box, yaw 45, zoom 4):
    IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 \
        --zoom 4 --auto-screenshot 6
-   # rotation jitter (voxel cylinder, Z-yaw-invariant probe):
+   # rotation jitter (voxel cylinder, Z-yaw-invariant probe). --pivot-origin is
+   # load-bearing, not optional: it selects RotationPivotMode::ORIGIN so the yaw
+   # pivots about the world origin, which is exactly where --spin-shape spawns
+   # its single fixture — the shape stays screen-centred and the centroid carries
+   # no pivot-orbit term. Without it the default CAMERA_CENTER focus contributes
+   # an orbit that dominates the metric (see the bar table below).
    IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep \
-       --zoom 4 --auto-screenshot 6
+       --pivot-origin --zoom 4 --auto-screenshot 6
    # then score the captured sequence (in order). --reversal-eps 0.8 retires the
    # reversal criterion on these probes (see "the reversal criterion" below).
    # The 6-digit glob matches full frames ONLY — ROI crops share the prefix and
@@ -537,9 +542,20 @@ Three checks, in order:
    # the only thing that catches a widened glob, since scoring the wrong set
    # still yields a confident verdict (measured during #2469 — see
    # tools/jitter_probe/README.md §"Wipe before every capture").
+   # --max-excursion-x is the primary rotation-gate assertion (#2606); the bar is
+   # per-zoom, from the table below. y is deliberately left unconstrained — on a
+   # yaw sweep it legitimately translates.
    build/tools/jitter_probe/jitter_probe --reversal-eps 0.8 --expect-frames 24 \
+       --max-excursion-x <bar(zoom)> \
        <save_files>/screenshots/screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png
    ```
+
+   **Assert the arm from the engine log, never from the argv you think you
+   passed.** The run logs `RotationPivotMode: ORIGIN (--pivot-origin) — Z-yaw
+   pivots about the world origin`; that line present (and `Spin-shape single
+   fixture: Cylinder (voxel-pool)` vs `(SDF)`, and `Yaw-sweep: 24 shots`, and the
+   zoom as *received*) is what makes a population what you labelled it. A silently
+   unpinned arm reads ~200x higher and looks like a real regression.
 
 3. **Read the verdict.** `jitter_probe` tracks the shape's centroid across the
    sequence and reports `SMOOTH` (0 direction-reversals, sub-pixel residual off
@@ -574,35 +590,47 @@ Three checks, in order:
      caught. A *systematic migration* class is not.
 
    The per-axis assertion that expresses "x stays pinned while y may translate"
-   now ships as `jitter_probe --max-excursion-x/-y` (#2606), and every default-mode
-   run prints `excursion=` per axis, so the by-hand max-min read is gone. **But do
-   not put a bar on this probe yet — there is no separating value to put.**
-   Re-measured on macOS/Metal 2026-08-07 (24-frame sweeps, same recipe, arm
-   identity asserted per run), x excursion:
+   ships as `jitter_probe --max-excursion-x/-y` (#2606), and every default-mode
+   run prints `excursion=` per axis, so the by-hand max-min read is gone. **On the
+   `--pivot-origin` pinned sweep it is the primary rotation-gate assertion, and
+   these are its bars** (macOS/Metal, 2026-08-08, 24-frame sweeps, one session,
+   arm identity asserted per run from the engine log):
 
-   | zoom | healthy voxel | SDF control | `IR_PERAXIS_OVERFLOW_DISABLE=1` |
-   |---|---|---|---|
-   | 2 | 19.97px | — | 13.75px |
-   | 4 | 38.18px | 44.00px | 27.92px |
-   | 8 | 76.81px | 82.00px | 54.63px |
+   | zoom | healthy voxel | SDF control | `IR_PERAXIS_OVERFLOW_DISABLE=1` | **bar** | separation |
+   |---|---|---|---|---|---|
+   | 2 | 0.62px | — | 6.23px | **2.0px** | 10x |
+   | 4 | 0.18px | 0.00px | 10.87px | **0.5px** | 60x |
+   | 8 | 0.06px | 0.00px | 21.79px | **0.5px** | 363x |
 
-   Two things changed since the 2026-07-28 table below. Excursion on this probe
-   is now ~30x larger and scales linearly with zoom — a world-space offset
-   projected to screen, present on the **SDF control too**, so it is camera-level,
-   not the per-axis store. And the defect arm reads **lower** than healthy at
-   every zoom (0.63-0.69x), so no one-sided `excursion <= bar` can separate them
-   in the intended direction.
+   Bar rule: the smallest half-integer >= 2.5x the max healthy x excursion at that
+   zoom (voxel and SDF both count as healthy), required to also be <= 0.5x the
+   defect excursion — so a published bar always has >=2.5x headroom below and
+   >=2x above. A zoom with no value satisfying both is omitted rather than
+   published thin; all three separate here by 10x or better. The defect arm fires
+   at every zoom, and *attributably*: re-running it with `--max-residual 99` still
+   exits 1, so the failure is the excursion criterion by construction rather than
+   another axis catching it by accident. y excursions for the same populations
+   (recorded, not gated): healthy 0.21 / 0.11 / 0.06px, defect 2.64 / 5.27 /
+   10.08px at zoom 2/4/8.
 
-   The dominating term is the **default** pivot focus's residual orbit — #2547's
-   depth-aware `CAMERA_CENTER` derive (landed 2026-07-31, after the 2026-07-28
-   table) with the 1-iso-unit cap-entry bias that **#2641** owns and measures
-   independently (12px at zoom 4 / 22px at zoom 8 on `--pivot-verify
-   center-axis`). `pivot-verify.py` is green throughout: its *explicit*-focus
-   blocks still pin at 0.94/1.27px. `--yaw-sweep` uses the *default* focus and
-   its probe is off the viewport-center ray, so it carries a larger orbit of the
-   same family. Until #2641 lands, this probe's excursion measures the pivot, not
-   the per-axis path — so use the flags on a probe whose pivot you control, and
-   re-derive the bar here from a post-#2641 capture.
+   **The bar belongs to the pinned probe only — the unpinned sweep carries no
+   excursion bar.** Drop `--pivot-origin` and the same healthy z4 population reads
+   **38.18px** instead of 0.18px (212x), because the **default** `CAMERA_CENTER`
+   focus (#2547, landed 2026-07-31) contributes a residual orbit with a
+   1-iso-unit cap-entry bias — the surface `pivot-verify.py` owns, and it is green
+   throughout (explicit-focus blocks pin at 0.94/1.27px). #2641 → PR **#2758**
+   (open, in review) root-causes that bias as *inherent* to the derive: the
+   composite stores a per-face sort key, not the metric depth at the sampled
+   trixel. **The bar above does not rest on that ruling** — ORIGIN removes the
+   pivot term outright rather than bounding it (`getEffectiveCameraIso`,
+   `engine/render/src/ir_render.cpp:47-49`, tests ORIGIN before the focus branch
+   and returns `cameraIso` unmodified), so no pivot term is stricter than any
+   future default derive, whichever way #2758 lands.
+
+   Free evidence for **#2907** from the same session: the pinned probe's x
+   *residual* reads 0.41 / 0.08 / 0.03px at zoom 2/4/8, while the unpinned z4 arm
+   reproduces #2907's 1.78px exactly. The default-focus probe's residual redness
+   is therefore orbit-inflated, not a floor of the per-axis path.
 
 **Jitter is NOT the same as cardinal byte-identity.** Confirm yaw-0 / static
 frames stay byte-identical (`img_diff`) *and* that motion is jitter-free
@@ -967,16 +995,19 @@ drift. Measured on macOS/Metal, 2026-07-28 (24-frame sweeps, one quadrant):
 | voxel cylinder, zoom 8 | 2.83px | 5 | 1.25px | 10.79px | 0 | 0.18px |
 | **SDF cylinder** (continuous-geometry control), zoom 4 / 8 | 2.00px | 0 | 1.43px | 4.00 / 10.00px | 0 | 0.95px |
 
-> **The excursion columns above no longer reproduce (re-measured 2026-08-07,
-> #2606).** Same recipe, same host/backend: x excursion is 19.97 / 38.18 / 76.81px
-> at zoom 2/4/8, ~30x this table. The cause is the default pivot focus's residual
-> orbit (#2547 → **#2641**), which post-dates this table and is camera-level — the
-> SDF control moved by the same order, and `pivot-verify.py`'s explicit-focus
-> blocks still pin at 0.94/1.27px. The **residual** columns are unaffected by that
-> re-measure and still reproduce at zoom 2 (0.85px); at zoom 4/8 they read
-> 1.78/2.70px against the 1.50px bar, which is **#2907**'s finding, not this one.
-> Treat the excursion columns as historical until a post-#2641 capture replaces
-> them; see §"Verifying temporal stability" for the current numbers.
+> **The excursion columns above are historical — they measure a probe the recipe
+> no longer uses (#2606).** This table predates #2547's default pivot focus
+> (landed 2026-07-31), whose residual orbit (#2641 → #2758, in review) dominates
+> the metric on an *unpinned* sweep: same recipe, same host/backend,
+> x excursion re-measured 19.97 / 38.18 / 76.81px at zoom 2/4/8 on 2026-08-07,
+> ~30x this table. The canonical rotation gate is now the **`--pivot-origin`
+> pinned** sweep, which removes the orbit rather than tolerating it and reads
+> 0.62 / 0.18 / 0.06px healthy — the live bar table lives in §"Verifying temporal
+> stability" and is the only place to read numbers for a gate. The **residual**
+> columns are unaffected by all of this and still reproduce at zoom 2 (0.85px);
+> at zoom 4/8 the unpinned probe reads 1.78/2.70px against the 1.50px bar, which
+> is **#2907**'s finding, not this one — and the pinned probe's 0.41/0.08/0.03px
+> says that redness is orbit-inflated.
 
 Three findings ground the accept, each measured rather than asserted:
 

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -66,14 +66,18 @@ find save_files/screenshots -name '*.png' -delete
 IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 --zoom 4 \
     --auto-screenshot 6
 # Rotation jitter — camera yaws within one cardinal quadrant (use a vertical
-# cylinder: its silhouette is Z-yaw-invariant, so any centroid wobble is jitter):
-IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep --zoom 4 \
-    --auto-screenshot 6
+# cylinder: its silhouette is Z-yaw-invariant, so any centroid wobble is jitter).
+# --pivot-origin pins the pivot; it is required to gate on excursion (see
+# "Picking a bar" below):
+IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep --pivot-origin \
+    --zoom 4 --auto-screenshot 6
 
 # Then point jitter_probe at the captured sequence (in order). The 6-digit glob
-# matches full frames ONLY; --expect-frames must equal the --auto-screenshot
-# count (see "Wipe before every capture" below for why both are load-bearing):
-build/tools/jitter_probe/jitter_probe --expect-frames 6 \
+# matches full frames ONLY; --expect-frames must equal the sweep's own shot-table
+# length, which is NOT the --auto-screenshot value (that is the per-shot warmup)
+# — each sweep logs its count, e.g. "Yaw-sweep: 24 shots". Read it from the log
+# ("Wipe before every capture" below has why both are load-bearing):
+build/tools/jitter_probe/jitter_probe --expect-frames 24 \
     save_files/screenshots/screenshot_[0-9][0-9][0-9][0-9][0-9][0-9].png
 ```
 
@@ -194,15 +198,28 @@ output path, and that path stays byte-identical for its one stdout consumer,
 [`test/tools/jitter_probe_excursion_test.sh`](../../test/tools/jitter_probe_excursion_test.sh)
 against synthetic fixtures, so they do not drift with the render tree.
 
-**Picking a bar is per-probe, and the canonical rotation probe cannot carry one
-yet.** A bar is only meaningful when the axis it gates is actually pinned. On
-the canonical `--yaw-sweep` cylinder that is currently false: re-measured
-2026-08-07 on macOS/Metal, healthy x excursion is 19.97 / 38.18 / 76.81px at
-zoom 2/4/8 — dominated by the **default** pivot focus's residual orbit (#2547 →
-**#2641**), which is camera-level (the SDF control moves as far) and swamps the
-per-axis signal. The `IR_PERAXIS_OVERFLOW_DISABLE=1` arm even reads *lower* than
-healthy, so no one-sided bar separates them. Use the flags on a probe whose
-pivot you control until #2641 lands; the full table and the re-derivation note
-live in [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Verifying
-temporal stability" and §"Accepted sub-pixel yaw-sweep centroid residual (voxel
-content) — #2469".
+**Picking a bar is per-probe, and the bar only means something on a probe whose
+pivot is pinned.** The canonical rotation probe therefore composes
+`--yaw-sweep --pivot-origin`:
+
+```bash
+IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep \
+    --pivot-origin --zoom 4 --auto-screenshot 6
+```
+
+`--pivot-origin` selects `RotationPivotMode::ORIGIN`, and `--spin-shape` spawns
+its single fixture at the world origin — so the shape stays screen-centred and
+the centroid carries no pivot term. On the *default* focus it would: that derive
+carries a residual orbit (#2547 → #2641, root-caused as inherent by the open PR
+#2758) which is camera-level (the SDF control moves as far), reads ~200x the
+pinned value, and is *lower* on the `IR_PERAXIS_OVERFLOW_DISABLE=1` arm than on
+healthy — so no one-sided bar separates the populations there, and the unpinned
+sweep deliberately carries no excursion bar. ORIGIN does not merely bound that
+term, it removes it, so the pinned bar is valid however #2758 lands.
+
+The measured per-zoom bars for the pinned probe (macOS/Metal, 2026-08-08) live
+in **one** place — [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md)
+§"Verifying temporal stability" — so there is no second copy to drift. Read the
+bar from there; §"Accepted sub-pixel yaw-sweep centroid residual (voxel content)
+— #2469" carries the historical pre-#2547 columns and says why they no longer
+describe a gate.


### PR DESCRIPTION
## Summary

- **Re-anchors the jitter_probe rotation gate on the pinned `--yaw-sweep --pivot-origin` sweep and publishes its per-zoom excursion bar.** #2922 shipped `--max-excursion-x/-y` with no bar to put on it: on the *default*-focus sweep the `CAMERA_CENTER` derive's residual orbit dominates the centroid, and the `IR_PERAXIS_OVERFLOW_DISABLE=1` arm read **lower** than healthy — no one-sided bar separated the populations in the intended direction.
- **`--pivot-origin` removes the orbit rather than bounding it.** `getEffectiveCameraIso` (`engine/render/src/ir_render.cpp:47-49`) tests `RotationPivotMode::ORIGIN` before the focus branch and returns `cameraIso` unmodified, and `--spin-shape` spawns its single fixture at the world origin — so the shape stays screen-centred and no pivot term reaches the metric. Same healthy z4 population: **0.18px pinned vs 38.18px unpinned (212x)**.
- **Zero code.** Two doc surfaces plus the plan file. No flag ships — `--pivot-origin` already existed; this task is measurement + docs, per the cleared plan v3.

## Measured populations

macOS/Metal, 2026-08-08, one session, 24-frame sweeps, **24/24 valid frames on every arm**, arm identity asserted per run from the engine log.

| pop | arm | zoom | x excursion | y excursion | x residual |
|---|---|---|---|---|---|
| H2 | healthy voxel, pinned | 2 | 0.62px | 0.21px | 0.41px |
| H4 | healthy voxel, pinned | 4 | 0.18px | 0.11px | 0.08px |
| H8 | healthy voxel, pinned | 8 | 0.06px | 0.06px | 0.03px |
| S4 | SDF control, pinned | 4 | 0.00px | 0.00px | 0.00px |
| S8 | SDF control, pinned | 8 | 0.00px | 0.00px | 0.00px |
| D2 | `IR_PERAXIS_OVERFLOW_DISABLE=1`, pinned | 2 | 6.23px | 2.64px | 0.58px |
| D4 | `IR_PERAXIS_OVERFLOW_DISABLE=1`, pinned | 4 | 10.87px | 5.27px | 0.52px |
| D8 | `IR_PERAXIS_OVERFLOW_DISABLE=1`, pinned | 8 | 21.79px | 10.08px | 0.99px |
| U4 | healthy voxel, **unpinned** (differential control) | 4 | 38.18px | 13.19px | 1.78px |

**Bars** by the committed rule (smallest half-integer >= 2.5x max healthy, required <= 0.5x defect): **z2 = 2.0px** (10x separation), **z4 = 0.5px** (60x), **z8 = 0.5px** (363x). All three published zooms separate. **z1 does not, and is omitted by the rule's own bail clause** — measured below.

### Off-calibration arms (added for the Opus recheck nit)

Second, independent session on the same host — same cylinder voxel-pool fixture, same 24-frame sweep, arm identity asserted per run from the engine log. These are **not** published bars; they are the evidence that the rule's omission clause is load-bearing rather than boilerplate, and they are what the plan's binding constraint 1 asks be recorded for a non-separating zoom.

| pop | arm | zoom | x excursion | y excursion | x residual |
|---|---|---|---|---|---|
| H1 | healthy voxel, pinned | 1 | 0.93px | 0.38px | 0.32px |
| D1 | `IR_PERAXIS_OVERFLOW_DISABLE=1`, pinned | 1 | 3.53px | 1.31px | 0.54px |
| H16 | healthy voxel, pinned | 16 | 0.04px | 0.03px | 0.02px |

- **z1 admits no bar.** Separation is only 3.8x (3.53 / 0.93) against 10x/60x/363x at the published zooms. The candidate bar is the smallest half-integer >= 2.5 x 0.93 = **2.5px**, but the rule also requires <= 0.5 x 3.53 = **1.765px**. No value satisfies both, so z1 is omitted rather than published thin.
- **The false-fire is measured, not argued.** Running the published **0.5px** bar against the green H1 population exits **1** — a healthy tree reported as a rotation regression. That is the concrete harm the new doc paragraph prevents.
- **Upward is the harmless direction.** H16 reads 0.04px, 12x under the same 0.5px bar. That pass is non-vacuous: `--max-excursion-x 0.03` on the identical frames exits 1, so the flag is demonstrably live on the population it clears.
- **The defect direction holds off-calibration too.** At z1 the kill-switch arm reads *higher* than healthy (3.53 vs 0.93px), so the re-anchor's premise is not an artifact of the three zooms it was derived on.

## Test plan

- [x] **Phase 0 premise probe** — H4 pinned capture, ORIGIN line asserted: x excursion **0.18px** against the plan's expected ~1-3px pinned regime. Bail not taken.
- [x] **Instrument cross-check** — hand-derived max-min of the H4 `--verbose` centroid column: x **0.1800px** vs the tool's `excursion=0.18px`, delta **0.0000px** (plan allows ±0.01px). y likewise exact.
- [x] **Vacuity control** — same frames, bar set *below* each measured healthy value (H2@0.6, H4@0.1, H8@0.05): all three exit **1**, so the healthy passes are non-vacuous and the flag is demonstrably live.
- [x] **Arm identity** — every run asserted from the engine log, never argv: ORIGIN line present iff pinned (U4 correctly has none), `Spin-shape single fixture: Cylinder (voxel-pool)` vs `(SDF)`, `Yaw-sweep: 24 shots`, zoom as *received*. Defect env verified present only on D arms (it is a `getenv != nullptr` presence check).
- [x] **Consumer safety** — `--stationary` output path untouched by construction; tree sweep confirms no script drives `--yaw-sweep` (all six non-markdown hits are C++ registrations/comments), so `scripts/pivot-verify.py`'s parse surface is unaffected.

## Acceptance evidence

| Criterion (plan v3) | Check run | Observed |
|---|---|---|
| **AC1** — defect fires at every separating zoom, attributably | `jitter_probe --reversal-eps 0.8 --expect-frames 24 --max-excursion-x <bar>` on D2/D4/D8, then again `+ --max-residual 99` | gate exit **1** at z2/z4/z8; isolation exit **1** at all three — failure is the excursion criterion by construction |
| **AC2** — healthy populations pass; U4 differential >= 4x | same flags on H2/H4/H8 + S4/S8; ratio vs U4 | all five composite exit **0** (`verdict=SMOOTH`), x excursion 0.62/0.18/0.06/0.00/0.00 <= bar; differential **212x** (need >= 4x) |
| **AC3** — docs carry the measured table; recipe is `--yaw-sweep --pivot-origin`; unpinned keeps no bar | `engine/render/CLAUDE.md` §"Verifying temporal stability" + `tools/jitter_probe/README.md` | table published with values/populations/date/host+backend; recipe and scoring line updated; unpinned "carries no excursion bar" stated in both |
| **AC4** — zero code; only the two docs + plan file | `git diff --stat origin/master...HEAD` | `.fleet/plans/issue-2606.md`, `engine/render/CLAUDE.md`, `tools/jitter_probe/README.md` — nothing else |
| **AC5** — arm identity asserted from the log; body carries the full table incl. y | per-run `arm.txt` archived beside each population's frames + engine log | see the populations table above; y excursions recorded for all nine arms |

## Notes for the reviewer

- **The bar does not rest on #2758's ruling.** #2641 → PR #2758 (open, currently `fleet:needs-fix`) root-causes the cap-entry bias as *inherent*; the docs attribute that rather than asserting it, because ORIGIN removes the pivot term outright — no pivot term is stricter than any future default derive, whichever way #2758 lands.
- **Free evidence for #2907** (residual axis, not this task's criterion): the pinned probe's x residual reads 0.41/0.08/0.03px at z2/4/8 while the unpinned z4 arm reproduces #2907's **1.78px exactly**. That points at #2907's redness being orbit-inflated rather than a floor of the per-axis path. Cross-commented there; criterion untouched here.
- **One in-scope correction the simplify pass surfaced**, in a file this PR already edits: the README's quick-start told readers `--expect-frames` must equal the `--auto-screenshot` count and passed `6`. A yaw sweep writes **24** (the engine logs `Yaw-sweep: 24 shots`), so the snippet exited 2 if run verbatim — it also contradicted `engine/render/CLAUDE.md:538-541`, which states the rule correctly. Fixed to the log-derived rule.
- **Reported, not fixed (out of scope):** `docs/design/camera-yaw-pivot.md:351-356` cites the #2469 table's 2.00px SDF x-excursion. It still resolves — that table is preserved as historical — but it is an *unpinned* figure; the pinned SDF control reads 0.00px.

Closes #2606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

