### PR TITLE
render: adopt the recursive GLSL include resolver for 4 shared fragments (#2811)

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -135,8 +135,10 @@ resolution (`resolveShaderIncludes`, `loadAndPreprocessMetalSource`), so a
 fragment that includes a prerequisite the wrapper already pulled in resolves
 to a suppressed duplicate rather than a second copy. That makes the
 self-include free **when the prerequisite reads no wrapper `#define`** —
-`ir_iso_common` and `ir_sun_projection` carry no preprocessor directive at
-all, so where they resolve can never cross one. A macro-parameterized
+the GLSL `ir_iso_common` / `ir_sun_projection` carry no preprocessor
+directive at all, and their Metal twins carry only a self-contained
+include guard plus `#include <metal_stdlib>`; neither reads a wrapper
+macro, so where they resolve can never cross one. A macro-parameterized
 fragment (`ir_voxel_face_select`, which reads the wrapper's
 `IR_VOXEL_FOG_GRID_BINDING`; the `c_voxel_to_trixel_stage_*_body` fragments,
 which read `IR_FEEDER_PASS` / `IR_STORE_WINNER_ELECTION`) stays in the

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -129,6 +129,21 @@ parameter).
 Shader file paths are stored in `render/shader_names.hpp`. Update that
 header when you add or rename a shader.
 
+**A fragment may self-include only a MACRO-FREE prerequisite.** Both
+resolvers are recursive with a visited-set cycle guard scoped to the whole
+resolution (`resolveShaderIncludes`, `loadAndPreprocessMetalSource`), so a
+fragment that includes a prerequisite the wrapper already pulled in resolves
+to a suppressed duplicate rather than a second copy. That makes the
+self-include free **when the prerequisite reads no wrapper `#define`** —
+`ir_iso_common` and `ir_sun_projection` carry no preprocessor directive at
+all, so where they resolve can never cross one. A macro-parameterized
+fragment (`ir_voxel_face_select`, which reads the wrapper's
+`IR_VOXEL_FOG_GRID_BINDING`; the `c_voxel_to_trixel_stage_*_body` fragments,
+which read `IR_FEEDER_PASS` / `IR_STORE_WINNER_ELECTION`) stays in the
+wrapper's explicit ordered include list, so its position relative to the
+`#define`s remains something the wrapper states rather than something a
+transitive include decides.
+
 ### Metal compute kernel threadgroup registry
 
 Every dispatchable Metal compute kernel (`engine/render/src/shaders/metal/c_*.metal`,

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1_body.glsl
@@ -13,10 +13,13 @@
 // `#define IR_STORE_WINNER_ELECTION {0|1}`, and the prerequisite includes,
 // then `#include` this body. GLSL's include resolver is now recursive with a
 // visited-set cycle guard (opengl_shader.cpp `resolveShaderIncludes`,
-// mirroring Metal's `loadAndPreprocessMetalSource`), so a fragment MAY now
-// self-include its own prerequisites — this file still lists NO `#include`s
-// of its own (no churn to the existing chain) and each wrapper MUST include,
-// IN THIS ORDER and with both macros defined FIRST, before it (the
+// mirroring Metal's `loadAndPreprocessMetalSource`), so fragments now
+// self-include their own prerequisites (ir_voxel_face_select.glsl,
+// ir_per_axis_lighting.glsl, ir_resolve_cardinal_emit.glsl,
+// ir_sun_shadow_sample.glsl) — this file still lists NO `#include`s of its
+// own because it has no fragment-level prerequisite beyond what the wrapper
+// chain below already supplies, and each wrapper MUST include, IN THIS
+// ORDER and with both macros defined FIRST, before it (the
 // ir_sun_shadow_sample.glsl idiom):
 //   #define IR_FEEDER_PASS {0|1}
 //   #define IR_STORE_WINNER_ELECTION {0|1}

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1_body.glsl
@@ -13,13 +13,21 @@
 // `#define IR_STORE_WINNER_ELECTION {0|1}`, and the prerequisite includes,
 // then `#include` this body. GLSL's include resolver is now recursive with a
 // visited-set cycle guard (opengl_shader.cpp `resolveShaderIncludes`,
-// mirroring Metal's `loadAndPreprocessMetalSource`), so fragments now
-// self-include their own prerequisites (ir_voxel_face_select.glsl,
+// mirroring Metal's `loadAndPreprocessMetalSource`), so a fragment may now
+// self-include a prerequisite that is MACRO-FREE: ir_iso_common.glsl and
+// ir_sun_projection.glsl carry no preprocessor directive at all, so where
+// they resolve can never cross a wrapper `#define`. That is what the four
+// self-including fragments do (ir_voxel_face_select.glsl,
 // ir_per_axis_lighting.glsl, ir_resolve_cardinal_emit.glsl,
-// ir_sun_shadow_sample.glsl) — this file still lists NO `#include`s of its
-// own because it has no fragment-level prerequisite beyond what the wrapper
-// chain below already supplies, and each wrapper MUST include, IN THIS
-// ORDER and with both macros defined FIRST, before it (the
+// ir_sun_shadow_sample.glsl). This body still lists NO `#include`s of its
+// own — not for want of prerequisites (it calls selectVoxelFace,
+// perAxisStoreFacePos, fogColumnReveal, pos3DtoPos2DIso below) but because
+// its prerequisite chain is macro-PARAMETERIZED: ir_voxel_face_select.glsl
+// reads the wrapper's IR_VOXEL_FOG_GRID_BINDING and this body reads
+// IR_FEEDER_PASS / IR_STORE_WINNER_ELECTION. Self-including them would lift
+// a macro-consuming include out of the ordered contract below, where a
+// future wrapper could resolve it above its own `#define`. Each wrapper MUST
+// include, IN THIS ORDER and with both macros defined FIRST, before it (the
 // ir_sun_shadow_sample.glsl idiom):
 //   #define IR_FEEDER_PASS {0|1}
 //   #define IR_STORE_WINNER_ELECTION {0|1}

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
@@ -12,10 +12,13 @@
 // supply the `#version`, the `#define IR_STORE_WINNER_ELECTION {0|1}`, and the
 // prerequisite includes, then `#include` this body. GLSL's include resolver is
 // now recursive with a visited-set cycle guard (mirroring Metal's
-// `loadAndPreprocessMetalSource`), so a fragment MAY now self-include its own
-// prerequisites — this file still lists NO `#include`s of its own (no churn
-// to the existing chain) and each wrapper MUST include, IN THIS ORDER and
-// with the macro defined FIRST, before it:
+// `loadAndPreprocessMetalSource`), so fragments now self-include their own
+// prerequisites (ir_voxel_face_select.glsl, ir_per_axis_lighting.glsl,
+// ir_resolve_cardinal_emit.glsl, ir_sun_shadow_sample.glsl) — this file still
+// lists NO `#include`s of its own because it has no fragment-level
+// prerequisite beyond what the wrapper chain below already supplies, and
+// each wrapper MUST include, IN THIS ORDER and with the macro defined
+// FIRST, before it:
 //   #define IR_STORE_WINNER_ELECTION {0|1}
 //   #define IR_VOXEL_FOG_GRID_BINDING 3
 //   #include "ir_iso_common.glsl"

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2_body.glsl
@@ -12,13 +12,21 @@
 // supply the `#version`, the `#define IR_STORE_WINNER_ELECTION {0|1}`, and the
 // prerequisite includes, then `#include` this body. GLSL's include resolver is
 // now recursive with a visited-set cycle guard (mirroring Metal's
-// `loadAndPreprocessMetalSource`), so fragments now self-include their own
-// prerequisites (ir_voxel_face_select.glsl, ir_per_axis_lighting.glsl,
-// ir_resolve_cardinal_emit.glsl, ir_sun_shadow_sample.glsl) — this file still
-// lists NO `#include`s of its own because it has no fragment-level
-// prerequisite beyond what the wrapper chain below already supplies, and
-// each wrapper MUST include, IN THIS ORDER and with the macro defined
-// FIRST, before it:
+// `loadAndPreprocessMetalSource`), so a fragment may now self-include a
+// prerequisite that is MACRO-FREE: ir_iso_common.glsl and
+// ir_sun_projection.glsl carry no preprocessor directive at all, so where
+// they resolve can never cross a wrapper `#define`. That is what the four
+// self-including fragments do (ir_voxel_face_select.glsl,
+// ir_per_axis_lighting.glsl, ir_resolve_cardinal_emit.glsl,
+// ir_sun_shadow_sample.glsl). This body still lists NO `#include`s of its
+// own — not for want of prerequisites (it calls selectVoxelFace,
+// perAxisStoreFacePos, fogColumnReveal, pos3DtoPos2DIso below) but because
+// its prerequisite chain is macro-PARAMETERIZED: ir_voxel_face_select.glsl
+// reads the wrapper's IR_VOXEL_FOG_GRID_BINDING and this body reads
+// IR_STORE_WINNER_ELECTION. Self-including them would lift a macro-consuming
+// include out of the ordered contract below, where a future wrapper could
+// resolve it above its own `#define`. Each wrapper MUST include, IN THIS
+// ORDER and with the macro defined FIRST, before it:
 //   #define IR_STORE_WINNER_ELECTION {0|1}
 //   #define IR_VOXEL_FOG_GRID_BINDING 3
 //   #include "ir_iso_common.glsl"

--- a/engine/render/src/shaders/ir_per_axis_lighting.glsl
+++ b/engine/render/src/shaders/ir_per_axis_lighting.glsl
@@ -6,7 +6,13 @@
 // path (breaking the residualYaw == 0 byte-identity guarantee). Only the four
 // lighting compute shaders include this file, AFTER ir_iso_common.glsl (whose
 // helpers — trixelFrameOffset, trixelOriginOffsetZ1, isoPixelToPos3D,
-// effectiveTrixelSubdivisionScale — this builds on).
+// effectiveTrixelSubdivisionScale — this builds on). GLSL's include resolver
+// is recursive with a visited-set cycle guard (opengl_shader.cpp
+// `resolveShaderIncludes`), so this fragment self-includes ir_iso_common.glsl
+// below to resolve those helpers and stay self-contained; a wrapper's earlier
+// include of ir_iso_common.glsl makes this a suppressed duplicate (mirrors
+// ir_per_axis_lighting.metal).
+#include "ir_iso_common.glsl"
 
 // Reconstruct the world-unit surface position of a per-axis trixel canvas cell.
 // The per-axis store (#1458: base-resolution encoding) keys each cell by its

--- a/engine/render/src/shaders/ir_resolve_cardinal_emit.glsl
+++ b/engine/render/src/shaders/ir_resolve_cardinal_emit.glsl
@@ -15,12 +15,12 @@
 // writes through. GLSL has no way to pass an SSBO as an argument, so the
 // scratch binding is a wrapper-supplied contract rather than a parameter —
 // the same reason the fog grid's image slot is a wrapper #define in
-// ir_voxel_face_select.glsl. The fragment includes nothing itself, so every
-// prerequisite must be pulled in by the wrapper ahead of this file. The
-// resolver is recursive with a visited-set cycle guard (#2514), so this
-// fragment MAY self-include its prerequisites instead — kept as-is to avoid
-// churn.
+// ir_voxel_face_select.glsl. The resolver is recursive with a visited-set
+// cycle guard (#2514), so this fragment self-includes ir_iso_common.glsl
+// below instead of relying solely on the wrapper chain — a wrapper's earlier
+// include of ir_iso_common.glsl makes this a suppressed duplicate.
 // Metal twin: metal/ir_resolve_cardinal_emit.metal — keep byte-identical math.
+#include "ir_iso_common.glsl"
 
 // Emit one micro-cell's two-pixel diamond region (#1724) into the resolve
 // scratch, in the MAIN-canvas cardinal distance layout.

--- a/engine/render/src/shaders/ir_sun_shadow_sample.glsl
+++ b/engine/render/src/shaders/ir_sun_shadow_sample.glsl
@@ -7,11 +7,15 @@
 // sun-shadow consumers recompile and the SDF / voxel / scatter shaders keep
 // their cardinal-yaw byte-identity (same rationale as ir_per_axis_lighting.glsl).
 //
-// Requires ir_sun_projection.glsl included FIRST by the top-level shader (this
-// file does not include it itself): the map-dim constants, the shared
-// sunSpaceProject basis, unpackSunDepth, and sunCascadeKernelInterior all
-// live there so the caster bake and this receiver lookup share one source
-// (#2083).
+// GLSL's include resolver is recursive with a visited-set cycle guard
+// (opengl_shader.cpp `resolveShaderIncludes`), so this fragment self-includes
+// ir_sun_projection.glsl below rather than relying solely on the top-level
+// shader including it first — a wrapper's earlier include of
+// ir_sun_projection.glsl makes this a suppressed duplicate. It supplies the
+// map-dim constants, the shared sunSpaceProject basis, unpackSunDepth, and
+// sunCascadeKernelInterior, so the caster bake and this receiver lookup
+// share one source (#2083).
+#include "ir_sun_projection.glsl"
 
 const float kShadowDarken = 0.45;
 const float kNormalBiasVoxels = 0.5;

--- a/engine/render/src/shaders/ir_voxel_face_select.glsl
+++ b/engine/render/src/shaders/ir_voxel_face_select.glsl
@@ -15,9 +15,12 @@
 // GLSL/MSL, which is why the functions were historically duplicated per stage.
 // Metal twin: metal/ir_voxel_face_select.metal — keep byte-identical math.
 // GLSL's include resolver is recursive with a visited-set cycle guard
-// (opengl_shader.cpp `resolveShaderIncludes`), so this fragment MAY now
-// self-include its own prerequisites instead of relying solely on the
-// wrapper chain above — kept as-is here to avoid churn.
+// (opengl_shader.cpp `resolveShaderIncludes`), so this fragment
+// self-includes its own prerequisites below rather than relying solely on
+// the wrapper chain above — the wrapper's earlier include of
+// ir_iso_common.glsl makes this a suppressed duplicate (the
+// ir_per_axis_lighting.metal idiom).
+#include "ir_iso_common.glsl"
 
 // Per-voxel analytic fog clip inputs (#2102), mirroring
 // c_voxel_visibility_compact + c_fog_to_trixel. The world fog canvas binds its

--- a/test/render/opengl_shader_include_test.cpp
+++ b/test/render/opengl_shader_include_test.cpp
@@ -188,6 +188,31 @@ TEST_F(GlslIncludeResolver, RecognizesIndentedDirectiveAndSkipsRepeats) {
     EXPECT_EQ(countOccurrences(resolved, "#include"), 0);
 }
 
+// A wrapper that includes A then B, where B also self-includes A, resolves
+// byte-identically to the same wrapper against a B that does not
+// self-include A. This is what makes it safe for a shared fragment to
+// self-include its own prerequisite — every existing wrapper already
+// includes that prerequisite first, so the canonical path is already in the
+// visited set when the fragment's own self-include is reached, and the
+// redundant directive is dropped as a no-op. See #2811.
+TEST_F(GlslIncludeResolver, SelfIncludedPrerequisiteIsANoOpWhenWrapperAlreadyIncludesIt) {
+    writeShader("prerequisite.glsl", "int prerequisiteSymbol = 1;\n");
+    writeShader("fragment_without_self_include.glsl", "int fragmentSymbol = 2;\n");
+    writeShader(
+        "fragment_with_self_include.glsl",
+        "#include \"prerequisite.glsl\"\nint fragmentSymbol = 2;\n"
+    );
+
+    const std::string withoutSelfInclude = resolve(
+        "#include \"prerequisite.glsl\"\n#include \"fragment_without_self_include.glsl\"\n"
+    );
+    const std::string withSelfInclude =
+        resolve("#include \"prerequisite.glsl\"\n#include \"fragment_with_self_include.glsl\"\n");
+
+    EXPECT_EQ(withSelfInclude, withoutSelfInclude);
+    EXPECT_EQ(countOccurrences(withSelfInclude, "int prerequisiteSymbol = 1;"), 1);
+}
+
 } // namespace
 
 #endif // IR_GRAPHICS_OPENGL


### PR DESCRIPTION
## Summary
- `ir_voxel_face_select.glsl`, `ir_per_axis_lighting.glsl`, `ir_resolve_cardinal_emit.glsl`, and `ir_sun_shadow_sample.glsl` each now `#include` their own prerequisite (`ir_iso_common.glsl` or `ir_sun_projection.glsl`), mirroring their Metal twins — closing the asymmetry #2514's recursive resolver was supposed to enable but nothing adopted.
- Re-worded the "fragments MAY now self-include" permission language in `c_voxel_to_trixel_stage_{1,2}_body.glsl` and `ir_voxel_face_select.glsl` to state the convention as live, not unused.
- Added `GlslIncludeResolver.SelfIncludedPrerequisiteIsANoOpWhenWrapperAlreadyIncludesIt` asserting the redundant-include no-op directly.

## Test plan
- [x] `IrredenEngineTest` built against a dedicated `-DIRREDEN_GRAPHICS_BACKEND=OPENGL` configure (macOS can compile+unit-test the GL backend, per prior #2751/#2514 precedent) — `GlslIncludeResolver.*` 9/9 pass, including the new case.
- [x] Full `IrredenEngineTest` run on that GL-backend build: 1545/1546 passed, 1 skipped (`GpuComputeDispatchTest.ClearSunShadowKernel…`, needs a live GL context). The one failure, `SaveTrait.InventoryIsComplete`, is a pre-existing master defect (#2834) — confirmed by an empty `git diff origin/master HEAD` on both files the assertion reads.
- [x] `fleet-build --target IRShapeDebug` (default macOS/Metal preset) — clean build.
- [x] `fleet-run IRShapeDebug --auto-screenshot 5` — `ir-run: RESULT=CLEAN exit=0`.
- [x] Re-swept all 52 registered GLSL wrappers with a faithful port of `resolveShaderIncludes` over the real tree: 0 missing / 0 misordered prerequisites (matches the issue's own pre-change measurement).

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| The four GLSL fragments each `#include` their own prerequisite, mirroring the Metal twin; wrapper chains unchanged | `git diff` (this PR) | 4 `#include` lines added, no wrapper `#include` lists touched |
| The three body-header include-order contracts re-worded from "MAY now self-include" to state they do | `git diff` (this PR) | `c_voxel_to_trixel_stage_1_body.glsl`, `c_voxel_to_trixel_stage_2_body.glsl`, `ir_voxel_face_select.glsl` all reworded |
| New gtest case for the redundant-include no-op, runnable on macOS via `-DIRREDEN_GRAPHICS_BACKEND=OPENGL` | `IrredenEngineTest --gtest_filter='GlslIncludeResolver.*'` | 9/9 pass incl. `SelfIncludedPrerequisiteIsANoOpWhenWrapperAlreadyIncludesIt` |
| Standing sweep stays at 0 missing/misordered | one-off Python port of `resolveShaderIncludes` over `engine/render/src/shaders/*.glsl` | `missing: []`, `misordered: []`, 52 wrappers checked |
| Normal cross-host smoke covers the GL runtime compile; no separate GL-host gate needed | N/A (informational, reviewer/merger-side) | this PR needs no `fleet:needs-gl-host` label — resolver assertion is a pure string/filesystem unit test |

**Skipped `attach-screenshots` / `render-debug-loop`.** Per `engine/render/CLAUDE.md`'s exception for "internal refactors with provably no runtime effect": the new gtest proves the redundant `#include` is dropped as a no-op by the resolver's visited set, and the tree-wide sweep proves every one of the 52 existing wrappers already includes the prerequisite first — so this diff cannot change any resolved shader **code**. Confirmed by a clean `IRShapeDebug --auto-screenshot` run on the default Metal preset above.

**Precision on that claim (Opus recheck, extended by the nit amend).** The resolved *source string* is not unchanged — reworded fragment header comments are inlined into it, so some registered programs resolve to a different string. The recheck measured 12 of 41 at head `d966df727`; the amend below adds comment text to 5 (the wrappers reaching the two body fragments). Resolved **code** — the same comparison with `//` stripped — is identical in both measurements, and that is the claim the no-op rests on. The comment delta is inert: `resolveShaderIncludes` has one production call site, the string goes straight to `glShaderSource`, and there is no engine-side program-binary or source-hash cache. Stated explicitly because "byte-identical" is the phrase a future reader will grep for when this convention is extended.

## Nit amend — `e07e5a2fd`

Addresses the Opus recheck's one nit: the `c_voxel_to_trixel_stage_{1,2}_body.glsl` headers justified their lack of self-includes with a reason that neither distinguishes them from the four self-including fragments nor holds (both bodies do call into `ir_voxel_face_select.glsl` and `ir_iso_common.glsl`). Replaced with the criterion that actually separates the two groups — **macro-dependence** — and recorded the rule in `engine/render/CLAUDE.md` §Shaders, since the criterion exists so a future fragment author copies a live convention and a body fragment's header is not where that author looks.

Verified rather than asserted: the amend is comment-only (0 changed lines in the shaders are non-`//`), and a faithful port of `resolveShaderIncludes` over all 41 registered programs, `d966df727` vs the amended tree, reports 5 differing in resolved source and **0** differing in resolved code. Positive control — one synthetic code line injected into the before-arm body makes the same comparator report 3 code-differing programs — so the 0 is not vacuous agreement.

Closes #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

