### PR TITLE
fleet: a second amend in one checkout no longer discards it (#2734)

### DIFF
--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -510,6 +510,24 @@ clone, the merger mid-rebase) — if the remote moved between the
 fetch in step a and the push here, the lease fails and the
 iteration exits clean for the next retry.
 
+**A second amend in the same checkout — the CI-came-back-red case.**
+A successful push spends the sentinel (it gains a third `consumed
+<iso8601>` line), so a plain second `fleet-pr-amend-push` refuses. That
+refusal is the *correct* place to be; land the follow-up commit with:
+
+```
+fleet-pr-amend-push --continue
+```
+
+`--continue` is fast-forward-only — it requires that HEAD descend
+`origin/<head-ref>` and then does a plain push, so it can never clobber.
+Do **not** answer that refusal by re-running `fleet-pr-checkout-detached`:
+that moves HEAD to the remote tip and would leave the commit you just made
+reachable from nothing. The wrapper now refuses to do so (#2734) and names
+the commits at risk; `--discard` is the opt-out, and it is the right answer
+only when the refusal reports every commit as `SUPERSEDED` (a merger rebase
+or force-push has since rewritten that branch).
+
 Do NOT invoke the `commit-and-push` skill here: it would try to
 `git push -u origin HEAD` (fails on detached HEAD) and then open a
 new PR (one already exists for this head ref). The wrapper handles

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -271,14 +271,22 @@ Parallel-agent fleet (tmux + Claude)
                                  as one unskippable step (loser exits ~1s
                                  touching nothing; releases the claim if the
                                  checkout fails so no fleet:amending-* dangles)
-  fleet-pr-checkout-detached <N> [--repo <slug>]
+  fleet-pr-checkout-detached <N> [--repo <slug>] [--discard]
                                  fetch a PR's head ref and check it out
                                  detached-HEAD, so the same branch can be
-                                 checked out in multiple worktrees at once
-  fleet-pr-amend-push            push a detached-HEAD amendment (from
+                                 checked out in multiple worktrees at once.
+                                 Refuses before moving HEAD when the current
+                                 HEAD carries commits no ref reaches (#2734);
+                                 --discard is the opt-out for commits it
+                                 reports as already merged/superseded
+  fleet-pr-amend-push [--continue]
+                                 push a detached-HEAD amendment (from
                                  fleet-pr-checkout-detached) back to the PR's
                                  head ref via --force-with-lease; reads the
-                                 head ref from .git/fleet-amend-ref
+                                 head ref from .git/fleet-amend-ref. --continue
+                                 lands a SECOND amend in the same checkout
+                                 (fast-forward only) instead of the misleading
+                                 "sentinel missing" refusal (#2734)
   fleet-nit-close-for-pr [--dry-run] [--repo <owner/repo>]
                                  close open fleet:nit-of-pr issues whose
                                  addressing PR has merged (merger step 1.5)

--- a/scripts/fleet/fleet-pr-amend-push
+++ b/scripts/fleet/fleet-pr-amend-push
@@ -13,9 +13,12 @@
 #
 # This wrapper reads the head ref name from the sentinel
 # `.git/fleet-amend-ref` (written by fleet-pr-checkout-detached) and
-# runs the push. On success it removes the sentinel so a subsequent
-# `commit-and-push` invocation in the same worktree falls back to
-# the normal (non-amend) flow.
+# runs the push. On success it MARKS the sentinel consumed (appends a
+# third `consumed <iso8601>` line) rather than deleting it, so a
+# subsequent `commit-and-push` invocation in the same worktree still
+# falls back to the normal (non-amend) flow — a consumed sentinel is
+# treated as absent by the routing path — while the head ref survives
+# for the diagnostic below.
 #
 # The `--force-with-lease` (vs plain `--force`) is the only safety
 # belt against a concurrent amendment from another worktree (another
@@ -24,13 +27,30 @@
 # fails, the wrapper exits non-zero, and the caller's role retries
 # on the next iteration.
 #
+# The second amend (#2734)
+# ------------------------
+# A follow-up amend in the same detached checkout — the common case
+# when CI comes back red on the first push — used to hit the
+# "sentinel missing" branch, which named the WRONG remedy: re-running
+# fleet-pr-checkout-detached moves HEAD to the remote tip and silently
+# orphans the commit just made. The consumed marker splits that
+# diagnostic (already-consumed vs never-ran) and `--continue` re-arms
+# the sentinel for exactly one more push on the strictly-safe path:
+# detached HEAD, HEAD descends origin/<head-ref>, PLAIN push. It is
+# never a force and never a lease, so there is nothing to clobber.
+#
 # Usage
 # -----
-#   fleet-pr-amend-push
+#   fleet-pr-amend-push [--continue]
+#
+#   --continue   land a follow-up amend on top of your own pushed tip
+#                (fast-forward only; refuses if HEAD does not descend
+#                origin/<head-ref>)
 #
 # Exit status:
-#   0  push succeeded; sentinel removed
-#   1  sentinel missing, push failed, or git in a bad state
+#   0  push succeeded; sentinel marked consumed
+#   1  sentinel missing or already consumed, push failed, or git in a
+#      bad state
 #   2  usage error
 #
 # Source of truth: scripts/fleet/fleet-pr-amend-push in the engine
@@ -38,18 +58,23 @@
 
 set -euo pipefail
 
-if [[ $# -gt 0 ]]; then
+continue_mode=0
+while [[ $# -gt 0 ]]; do
     case "$1" in
         -h|--help)
             awk 'NR==1 {next} /^#/ {print; next} {exit}' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
+        --continue)
+            continue_mode=1
+            shift
+            ;;
         *)
-            echo "fleet-pr-amend-push: takes no arguments" >&2
+            echo "fleet-pr-amend-push: unknown argument '$1' (accepts: --continue, --help)" >&2
             exit 2
             ;;
     esac
-fi
+done
 
 git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
 if [[ -z "$git_dir" ]]; then
@@ -78,16 +103,49 @@ fi
 
 sentinel="$git_dir/fleet-amend-ref"
 if [[ ! -f "$sentinel" ]]; then
-    echo "fleet-pr-amend-push: $sentinel missing — was fleet-pr-checkout-detached run in this worktree?" >&2
+    if [[ "$continue_mode" -eq 1 ]]; then
+        echo "fleet-pr-amend-push --continue: $sentinel missing — nothing to continue. Run fleet-pr-checkout-detached <N> first." >&2
+    else
+        echo "fleet-pr-amend-push: $sentinel missing — was fleet-pr-checkout-detached run in this worktree?" >&2
+    fi
     exit 1
 fi
 
 # Sentinel is two lines: head ref (line 1) + checkout-time base SHA (line 2;
 # absent on legacy sentinels written before the base-sha lease landed). The
-# base SHA is what makes the lease safe — see the push below.
-{ read -r head_ref; read -r base_sha; } < "$sentinel" 2>/dev/null || true
+# base SHA is what makes the lease safe — see the push below. A third
+# `consumed <iso8601>` line, written by mark_consumed on every success path,
+# means a prior push already spent this sentinel (#2734). The two-line reader
+# ignored it by construction, which is why legacy sentinels need no migration.
+{ read -r head_ref; read -r base_sha; read -r consumed_line; } < "$sentinel" 2>/dev/null || true
 if [[ -z "$head_ref" ]]; then
     echo "fleet-pr-amend-push: sentinel $sentinel is empty" >&2
+    exit 1
+fi
+
+consumed=0
+if [[ "${consumed_line:-}" =~ ^consumed([[:space:]]|$) ]]; then
+    consumed=1
+fi
+
+# mark_consumed — spend the sentinel without deleting it. The routing path
+# treats a consumed sentinel as absent (preserving the stale-routing hazard the
+# old `rm -f` existed for), but the retained head ref lets the branch below name
+# the real cause instead of sending the operator at fleet-pr-checkout-detached,
+# which discards the not-yet-pushed commit (#2734). base_sha may be empty on a
+# legacy sentinel — writing it back blank keeps the legacy-lease path intact.
+mark_consumed() {
+    printf '%s\n%s\nconsumed %s\n' \
+        "$head_ref" "$base_sha" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$sentinel"
+}
+
+if [[ "$consumed" -eq 1 && "$continue_mode" -eq 0 ]]; then
+    echo "fleet-pr-amend-push: sentinel already consumed by a successful push to origin/$head_ref ($consumed_line)." >&2
+    echo "  This is NOT a missing-setup error. Do NOT re-run fleet-pr-checkout-detached —" >&2
+    echo "  it moves HEAD to the remote tip and silently discards commits you have not" >&2
+    echo "  pushed yet (#2734)." >&2
+    echo "  To land a follow-up amend on top of your own pushed tip:" >&2
+    echo "      fleet-pr-amend-push --continue" >&2
     exit 1
 fi
 
@@ -102,6 +160,34 @@ if git symbolic-ref -q HEAD >/dev/null 2>&1; then
     echo "  expected: detached HEAD at origin/$head_ref (from fleet-pr-checkout-detached)" >&2
     echo "  if the sentinel is stale, remove it: rm $sentinel" >&2
     exit 1
+fi
+
+# --continue: re-arm a spent sentinel for exactly one more push, on the
+# strictly-safe branch only. Requires that HEAD descend origin/<head-ref>
+# post-fetch, then a PLAIN push — never a force, never a lease, so this adds no
+# push semantics over the fast-forward path below; it only re-opens the case
+# the header already documents as supported. The ancestor precondition is also
+# what stops a stale sentinel from routing a re-armed push to an unrelated ref,
+# so KEEP IT ADJACENT to the push — a later edit that separates them turns this
+# into a force.
+if [[ "$continue_mode" -eq 1 ]]; then
+    git fetch origin "$head_ref" >/dev/null 2>&1 || true
+    remote_tip=$(git rev-parse "origin/$head_ref" 2>/dev/null || echo "")
+    if [[ -z "$remote_tip" ]] || ! git merge-base --is-ancestor "$remote_tip" HEAD 2>/dev/null; then
+        echo "fleet-pr-amend-push --continue: REFUSING — HEAD does not descend origin/$head_ref, so this would not be a fast-forward." >&2
+        echo "  --continue only lands follow-up commits on top of a tip you already pushed." >&2
+        echo "  Preserve your work first, then re-base on the remote:" >&2
+        echo "      git branch amend-wip-\$(git rev-parse --short HEAD) HEAD" >&2
+        echo "      fleet-pr-checkout-detached <pr-number>   # safe once the commit is on a branch" >&2
+        exit 1
+    fi
+    if ! git push origin "HEAD:$head_ref"; then
+        echo "fleet-pr-amend-push --continue: fast-forward push failed (remote rejected)." >&2
+        exit 1
+    fi
+    mark_consumed
+    printf 'fleet-pr-amend-push: --continue fast-forwarded origin/%s (no force needed)\n' "$head_ref"
+    exit 0
 fi
 
 # Fast-forward fast path. Refresh the remote tip; if HEAD descends from it
@@ -119,7 +205,7 @@ if [[ -n "$remote_tip" ]] && git merge-base --is-ancestor "$remote_tip" HEAD 2>/
         echo "fleet-pr-amend-push: fast-forward push failed (remote rejected)." >&2
         exit 1
     fi
-    rm -f "$sentinel"
+    mark_consumed
     printf 'fleet-pr-amend-push: fast-forwarded origin/%s (no force needed)\n' "$head_ref"
     exit 0
 fi
@@ -143,9 +229,10 @@ if ! git push "$lease" origin "HEAD:$head_ref"; then
     exit 1
 fi
 
-# Clean up the sentinel so subsequent commit-and-push in this worktree
+# Spend the sentinel so subsequent commit-and-push in this worktree
 # falls back to the normal flow (or so a stale sentinel doesn't
-# accidentally route a future commit to the wrong ref).
-rm -f "$sentinel"
+# accidentally route a future commit to the wrong ref). Marked, not
+# removed — see mark_consumed.
+mark_consumed
 
 printf 'fleet-pr-amend-push: pushed HEAD to origin/%s\n' "$head_ref"

--- a/scripts/fleet/fleet-pr-checkout-detached
+++ b/scripts/fleet/fleet-pr-checkout-detached
@@ -29,9 +29,29 @@
 # this sentinel to know where to push the amendment, so the LLM
 # doesn't have to remember or pass the head ref name across steps.
 #
+# The orphan guard (#2734)
+# ------------------------
+# `git checkout --detach` moves HEAD unconditionally. If the current
+# HEAD carries a commit that no branch and no remote ref reaches — the
+# state a worker is in after committing an amendment it has not pushed
+# yet — the checkout orphans it, and git's own "leaving N commits
+# behind" warning used to be discarded along with stdout, so the loss
+# was silent and exited 0. This wrapper now refuses BEFORE moving HEAD
+# whenever `git rev-list HEAD --not --branches --remotes` is non-empty,
+# names the at-risk SHAs, and says for each whether an equivalent patch
+# is already upstream (superseded by a merger rebase / force-push —
+# safe to drop) or the commit exists nowhere else. `--discard` is the
+# opt-out for the former.
+#
 # Usage
 # -----
-#   fleet-pr-checkout-detached <pr-number> [--repo <slug>]
+#   fleet-pr-checkout-detached <pr-number> [--repo <slug>] [--discard]
+#
+#   --discard    proceed even though HEAD carries commits reachable from
+#                nothing else. Correct when the guard names commits the
+#                merger force-pushed past or a merged-and-pruned branch
+#                left behind; never reach for it to silence a refusal
+#                naming work you have not pushed.
 #
 # Side effects in CWD:
 #   - fetches origin/<head-ref> (or `pull/<N>/head` if the head ref is
@@ -41,7 +61,8 @@
 #
 # Exit status:
 #   0  on success
-#   1  on resolution / fetch / checkout failure
+#   1  on resolution / fetch / checkout failure, or an orphan-guard
+#      refusal (HEAD unmoved)
 #   2  on usage error
 #
 # Source of truth: scripts/fleet/fleet-pr-checkout-detached in the
@@ -50,7 +71,7 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-    echo "usage: fleet-pr-checkout-detached <pr-number> [--repo <slug>]" >&2
+    echo "usage: fleet-pr-checkout-detached <pr-number> [--repo <slug>] [--discard]" >&2
     exit 2
 fi
 
@@ -67,6 +88,7 @@ pr_number="$1"
 shift
 
 repo_slug=""
+discard=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --repo)
@@ -76,6 +98,18 @@ while [[ $# -gt 0 ]]; do
             fi
             repo_slug="$2"
             shift 2
+            ;;
+        --repo=*)
+            repo_slug="${1#--repo=}"
+            if [[ -z "$repo_slug" ]]; then
+                echo "fleet-pr-checkout-detached: --repo requires a value" >&2
+                exit 2
+            fi
+            shift
+            ;;
+        --discard)
+            discard=1
+            shift
             ;;
         *)
             echo "fleet-pr-checkout-detached: unknown arg '$1'" >&2
@@ -133,7 +167,122 @@ if ! git fetch origin "$head_ref" >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! git checkout --detach "origin/$head_ref" >/dev/null 2>&1; then
+# Orphan guard (#2734). Runs AFTER the fetch above — a commit that was just
+# pushed is reachable from the refreshed remote-tracking ref, so pre-fetch this
+# would false-fire immediately after a successful amend push. This is git's own
+# "leaving N commits behind" computation, NOT `origin/$head_ref..HEAD`: the
+# latter counts how far HEAD is ahead of the ref being checked out, which is
+# non-zero on every routine cross-PR checkout (a pool worktree stays detached at
+# the last PR's tip across iterations) and would refuse with nothing at risk.
+# HEAD on a named branch is reachable from --branches, so the count is 0 by
+# construction and the guard cannot fire there.
+orphan_count=$(git rev-list --count HEAD --not --branches --remotes 2>/dev/null || echo "")
+if ! [[ "$orphan_count" =~ ^[0-9]+$ ]]; then
+    # Fail closed: an empty/non-numeric count (unborn HEAD, corrupt ref) tests
+    # as "not non-zero", which would silently permit the checkout in exactly
+    # the case the guard could not evaluate.
+    echo "fleet-pr-checkout-detached: REFUSING — could not evaluate the orphan-commit guard (git rev-list returned '$orphan_count')." >&2
+    echo "  HEAD is unmoved. Check the repo state, or pass --discard if you are sure nothing here is worth keeping." >&2
+    exit 1
+fi
+
+if [[ "$orphan_count" -gt 0 && "$discard" -eq 0 ]]; then
+    echo "fleet-pr-checkout-detached: REFUSING — HEAD carries $orphan_count commit(s) reachable from no branch and no remote ref." >&2
+    echo "  Checking out origin/$head_ref would leave them behind, recoverable only via reflog. HEAD is unmoved." >&2
+    # Classify each at-risk commit so the refusal is actionable — a refusal that
+    # names a commit the merger already rebased past, with no way to tell it
+    # from unpushed work, teaches the reader to reach for --discard reflexively.
+    #
+    # The discriminator is PATCH-EQUIVALENCE (`git cherry`, which marks a commit
+    # '-' when an equivalent patch is already present upstream), not reachability
+    # from origin/master. Reachability cannot work here: the at-risk set is
+    # defined as `HEAD --not --branches --remotes`, so anything origin/master
+    # reaches is excluded from it by construction — an ancestor-of-origin/master
+    # test is vacuous on this set and reports every superseded commit as
+    # unpushed. Measured: a tip superseded by a merger force-push scores
+    # ancestor-of-master NO and `git cherry` '-'.
+    #
+    # Upstreams worth asking: the ref being checked out, the ref this worktree
+    # was last parked against (the merger-rebase case rewrites THAT one, and the
+    # sentinel is the only record of which it was), and master. Sweeping every
+    # refs/remotes/* instead is a patch-id pass per ref — 1778 of them on this
+    # repo — to catch rewrites on refs this worktree never touched.
+    #
+    # So the classification is best-effort and the message below must stay
+    # actionable when it comes back empty: a squash-merge that collapsed several
+    # commits into one changes the patch, and a rewrite on a ref none of the
+    # three names is invisible here. "Unclassified" therefore prints as "at
+    # risk", never as a claim that the commit is unpushed.
+    superseded_shas=" "
+    collect_superseded() {
+        local upstream="$1" mark sha
+        [[ -n "$upstream" ]] || return 0
+        git rev-parse --verify --quiet "$upstream" >/dev/null 2>&1 || return 0
+        while read -r mark sha; do
+            if [[ "$mark" == "-" && -n "$sha" ]]; then
+                superseded_shas="$superseded_shas$sha "
+            fi
+        done < <(git cherry "$upstream" HEAD 2>/dev/null)
+    }
+    collect_superseded "origin/$head_ref"
+    collect_superseded "origin/master"
+    parked_ref=""
+    if [[ -f "$(git rev-parse --git-dir)/fleet-amend-ref" ]]; then
+        read -r parked_ref < "$(git rev-parse --git-dir)/fleet-amend-ref" || parked_ref=""
+    fi
+    if [[ -n "$parked_ref" && "$parked_ref" != "$head_ref" ]]; then
+        collect_superseded "origin/$parked_ref"
+    fi
+
+    superseded=0
+    unclassified=0
+    while read -r sha; do
+        [[ -n "$sha" ]] || continue
+        detail=$(git log -1 --format='%cr  %s' "$sha" 2>/dev/null || echo "")
+        if [[ "$superseded_shas" == *" $sha "* ]]; then
+            superseded=$((superseded + 1))
+            printf '    %s  SUPERSEDED — this patch is already upstream (%s)\n' "${sha:0:12}" "$detail" >&2
+        else
+            unclassified=$((unclassified + 1))
+            printf '    %s  AT RISK — no ref reaches it, no upstream patch matches (%s)\n' "${sha:0:12}" "$detail" >&2
+        fi
+    done < <(git rev-list HEAD --not --branches --remotes 2>/dev/null | head -20)
+    if [[ "$orphan_count" -gt 20 ]]; then
+        # Say so rather than letting a truncated list read as the whole set.
+        printf '    … listing the newest 20 of %s; the rest are unshown, not absent.\n' "$orphan_count" >&2
+    fi
+
+    # "Every commit" only when every commit was actually classified — with the
+    # list truncated, the unshown ones carry no verdict.
+    if [[ "$superseded" -gt 0 && "$unclassified" -eq 0 && "$orphan_count" -le 20 ]]; then
+        echo "  Every commit above is superseded — this worktree was parked at a tip a merger" >&2
+        echo "  rebase or force-push has since rewritten. Nothing is at risk; re-run with:" >&2
+        echo "      fleet-pr-checkout-detached $pr_number --discard" >&2
+        exit 1
+    fi
+
+    # Unclassified commits: the timestamps above are the discriminator the
+    # classification could not supply. Give both remedies rather than assuming
+    # which case this is — the superseded case is invisible to `git cherry`
+    # whenever the rewrite landed on a ref none of the three upstreams names.
+    echo "  If a commit above is work from this session, preserve it before checking anything out:" >&2
+    echo "      git branch amend-wip-\$(git rev-parse --short HEAD) HEAD" >&2
+    echo "  If it is a follow-up amend for the PR this worktree is already on, push it instead:" >&2
+    echo "      fleet-pr-amend-push --continue" >&2
+    echo "  If the timestamps show a stale park (a merger rebase, force-push or squash-merge has" >&2
+    echo "  since rewritten that branch), nothing above is at risk — re-run with:" >&2
+    echo "      fleet-pr-checkout-detached $pr_number --discard" >&2
+    if [[ "$superseded" -gt 0 ]]; then
+        echo "  (The SUPERSEDED commits are safe to drop; --discard covers them once anything" >&2
+        echo "   marked AT RISK is preserved.)" >&2
+    fi
+    exit 1
+fi
+
+# stdout is discarded but stderr is NOT — git's "Warning: you are leaving N
+# commits behind" is the belt to the guard's braces, and swallowing it is what
+# made the loss silent (#2734).
+if ! git checkout --detach "origin/$head_ref" >/dev/null; then
     echo "fleet-pr-checkout-detached: git checkout --detach origin/$head_ref failed" >&2
     exit 1
 fi

--- a/scripts/fleet/tests/test_fleet_amend_push_scope.sh
+++ b/scripts/fleet/tests/test_fleet_amend_push_scope.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# Tests for fleet-pr-amend-push's #2402 worktree-scope assert: the push runs
-# from the cwd repo, so a stale amend-ref sentinel in a shared main clone would
-# route it from the wrong tree. The wrapper now calls fleet-assert-worktree
-# before touching the sentinel — refuse from a main clone, proceed from a
-# worktree.
+# Tests for fleet-pr-amend-push.
 #
-# Hermetic: `git init`s two sandbox repos (a "main clone" whose toplevel lacks
-# the /.claude/worktrees/ segment, and a worktree-shaped one) and drives the real
-# wrapper. No network is reached — the assert and the sentinel-missing check both
-# precede any git fetch/push.
+# Part 1 — the #2402 worktree-scope assert: the push runs from the cwd repo, so
+# a stale amend-ref sentinel in a shared main clone would route it from the
+# wrong tree. The wrapper calls fleet-assert-worktree before touching the
+# sentinel — refuse from a main clone, proceed from a worktree.
+#
+# Part 2 — the #2734 second-amend path: a successful push MARKS the sentinel
+# consumed instead of deleting it, so a follow-up amend in the same detached
+# checkout gets a diagnostic naming the real cause (and `--continue`) rather
+# than "sentinel missing", whose named remedy (re-run fleet-pr-checkout-detached)
+# silently discards the commit just made.
+#
+# Hermetic: part 1 `git init`s two sandbox repos (a "main clone" whose toplevel
+# lacks the /.claude/worktrees/ segment, and a worktree-shaped one) and drives
+# the real wrapper; part 2 adds a local bare repo as `origin` so the FF pushes
+# are real git pushes over the filesystem. No network is reached.
 
 set -uo pipefail
 
@@ -16,10 +23,14 @@ SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 source "$(dirname "$0")/lib_assert.sh"
 
 WRAPPER="$SCRIPT_DIR/fleet-pr-amend-push"
-[[ -x "$WRAPPER" ]] || { echo "test setup: fleet-pr-amend-push not executable at $WRAPPER" >&2; exit 1; }
+[[ -x "$WRAPPER" ]] || { echo "SKIP: fleet-pr-amend-push not executable at $WRAPPER" >&2; exit 3; }
 
 TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fleet-amend-scope.XXXXXX")
 trap '[[ -n "${TMPROOT:-}" ]] && rm -rf "$TMPROOT"' EXIT
+
+# The wrapper's worktree assert is path-shaped; an inherited assignment from the
+# surrounding fleet session would scope it to a real worktree instead.
+unset FLEET_ASSIGNED_WORKTREE FLEET_ALLOW_MAIN_CLONE 2>/dev/null || true
 
 MAIN="$TMPROOT/mainclone"
 WT="$TMPROOT/eng/.claude/worktrees/worker-3"
@@ -51,4 +62,123 @@ assert_eq "$rc" "1" "override reaches the sentinel-missing check (not the worktr
 assert_absent "$(cat "$TMPROOT/err")" "NOT a fleet worktree" \
     "override suppresses the worktree refusal"
 
-summarize "fleet-pr-amend-push scope-guard tests"
+echo "usage: an unknown argument is a usage error, --continue is not"
+rc=$( cd "$WT" && "$WRAPPER" --bogus >/dev/null 2>"$TMPROOT/err"; echo "$?" )
+assert_eq "$rc" "2" "unknown argument exits 2"
+assert_contains "$(cat "$TMPROOT/err")" "--continue" \
+    "usage error names the accepted flags"
+rc=$( cd "$WT" && "$WRAPPER" --continue >/dev/null 2>"$TMPROOT/err"; echo "$?" )
+assert_eq "$rc" "1" "--continue with no sentinel is a runtime refusal, not a usage error"
+assert_contains "$(cat "$TMPROOT/err")" "nothing to continue" \
+    "--continue names its own missing-sentinel case"
+
+# ----------------------------------------------------------------------
+# Part 2 — #2734: the second amend in one detached checkout.
+# ----------------------------------------------------------------------
+
+ORIGIN="$TMPROOT/origin.git"
+PR_WT="$TMPROOT/eng2/.claude/worktrees/worker-9"
+git init -q --bare "$ORIGIN"
+mkdir -p "$(dirname "$PR_WT")"
+git clone -q "$ORIGIN" "$PR_WT"
+git -C "$PR_WT" config user.email t@t
+git -C "$PR_WT" config user.name t
+
+echo base > "$PR_WT/f.txt"
+git -C "$PR_WT" add f.txt
+git -C "$PR_WT" commit -qm base
+git -C "$PR_WT" push -q origin HEAD:refs/heads/feature
+git -C "$PR_WT" fetch -q origin feature
+git -C "$PR_WT" checkout -q --detach origin/feature
+
+SENTINEL="$PR_WT/.git/fleet-amend-ref"
+write_sentinel() { printf '%s\n%s\n' "feature" "$(git -C "$PR_WT" rev-parse HEAD)" > "$SENTINEL"; }
+write_sentinel
+
+# amend_push <args...> → prints exit code; stderr in $TMPROOT/err, stdout in $TMPROOT/out
+amend_push() {
+    ( cd "$PR_WT" && "$WRAPPER" "$@" >"$TMPROOT/out" 2>"$TMPROOT/err"; echo "$?" )
+}
+
+echo "first amend: fast-forwards and marks the sentinel consumed (does not delete it)"
+echo "fix one" >> "$PR_WT/f.txt"
+git -C "$PR_WT" commit -qam "first fix"
+rc=$(amend_push)
+assert_eq "$rc" "0" "first amend-push succeeds"
+assert_contains "$(cat "$TMPROOT/out")" "fast-forwarded" "first push took the FF path"
+if [[ -f "$SENTINEL" ]]; then ok "sentinel survives the push (marked, not removed)"; else bad "sentinel survives the push (marked, not removed)"; fi
+assert_contains "$(sed -n '3p' "$SENTINEL")" "consumed" "line 3 records the consumption"
+assert_eq "$(sed -n '1p' "$SENTINEL")" "feature" "line 1 still carries the head ref"
+
+echo "second amend: the diagnostic names the real cause, not a missing setup step"
+echo "fix two" >> "$PR_WT/f.txt"
+git -C "$PR_WT" commit -qam "second fix"
+LOST=$(git -C "$PR_WT" rev-parse HEAD)
+rc=$(amend_push)
+assert_eq "$rc" "1" "second bare amend-push refuses"
+assert_contains "$(cat "$TMPROOT/err")" "already consumed" \
+    "refusal names the consumed sentinel"
+assert_contains "$(cat "$TMPROOT/err")" "fleet-pr-amend-push --continue" \
+    "refusal names the non-destructive recovery"
+assert_absent "$(cat "$TMPROOT/err")" "was fleet-pr-checkout-detached run in this worktree" \
+    "refusal does NOT steer at the destructive remedy"
+
+echo "--continue: lands the second amend on the fast-forward path"
+rc=$(amend_push --continue)
+assert_eq "$rc" "0" "--continue succeeds"
+assert_eq "$(git -C "$PR_WT" rev-parse origin/feature)" "$LOST" \
+    "the commit CI demanded is now the remote tip"
+assert_contains "$(sed -n '3p' "$SENTINEL")" "consumed" \
+    "--continue re-marks the sentinel (one push per --continue)"
+
+echo "--continue refuses when HEAD does not descend the remote tip"
+git -C "$PR_WT" checkout -q --detach "$(git -C "$PR_WT" rev-parse origin/feature~2)"
+echo divergent > "$PR_WT/f.txt"
+git -C "$PR_WT" commit -qam "divergent rewrite"
+rc=$(amend_push --continue)
+assert_eq "$rc" "1" "--continue refuses a non-fast-forward"
+assert_contains "$(cat "$TMPROOT/err")" "does not descend" \
+    "refusal explains why"
+assert_contains "$(cat "$TMPROOT/err")" "git branch" \
+    "refusal names the preserve-first remedy"
+assert_eq "$(git -C "$PR_WT" rev-parse origin/feature)" "$LOST" \
+    "--continue never force-pushed: the remote tip is unchanged"
+
+echo "anti-clobber (#1338/#1340) survives the mark-consumed rewrite"
+# Non-FF push, leased against the sentinel's checkout-time base SHA, while
+# another agent has moved origin/feature since that checkout: the lease must
+# still REFUSE rather than clobber. Only the sentinel's disposal changed here,
+# but that disposal sits on the same path.
+git -C "$PR_WT" checkout -q --detach origin/feature
+write_sentinel                                    # base_sha == the current tip
+OTHER="$TMPROOT/other"
+git clone -q "$ORIGIN" "$OTHER" 2>/dev/null
+git -C "$OTHER" config user.email o@o
+git -C "$OTHER" config user.name o
+git -C "$OTHER" checkout -q -B feature origin/feature
+echo "another agent's commit" >> "$OTHER/f.txt"
+git -C "$OTHER" commit -qam "concurrent push"
+git -C "$OTHER" push -q origin feature
+THEIRS=$(git -C "$OTHER" rev-parse HEAD)
+git -C "$PR_WT" commit -q --amend -m "amended, does not descend their push"
+rc=$(amend_push)
+assert_eq "$rc" "1" "the lease refuses when origin/feature moved since checkout"
+assert_contains "$(cat "$TMPROOT/err")" "push REFUSED" "refusal names the moved ref"
+git -C "$PR_WT" fetch -q origin feature
+assert_eq "$(git -C "$PR_WT" rev-parse origin/feature)" "$THEIRS" \
+    "the other agent's commit was not clobbered"
+assert_absent "$(sed -n '3p' "$SENTINEL")" "consumed" \
+    "a REFUSED push does not spend the sentinel"
+
+echo "legacy one-line sentinel still routes normally (no migration needed)"
+git -C "$PR_WT" fetch -q origin feature
+git -C "$PR_WT" checkout -q --detach origin/feature
+printf 'feature\n' > "$SENTINEL"
+echo "fix three" >> "$PR_WT/f.txt"
+git -C "$PR_WT" commit -qam "third fix"
+rc=$(amend_push)
+assert_eq "$rc" "0" "a two-field-less legacy sentinel is treated as live, not consumed"
+assert_absent "$(cat "$TMPROOT/err")" "already consumed" \
+    "legacy sentinel is not misread as consumed"
+
+summarize "fleet-pr-amend-push tests (scope guard + second amend)"

--- a/scripts/fleet/tests/test_fleet_checkout_detached_orphan_guard.sh
+++ b/scripts/fleet/tests/test_fleet_checkout_detached_orphan_guard.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Tests for fleet-pr-checkout-detached's #2734 orphan guard: the wrapper must
+# refuse, before moving HEAD, when the current HEAD carries commits reachable
+# from no branch and no remote ref — and must NOT refuse on the routine
+# cross-PR re-checkout, which is what the bounced `origin/<ref>..HEAD`
+# predicate did.
+#
+# The positive-fire pair is the point of this suite: only running BOTH arms
+# distinguishes the shipped predicate (`HEAD --not --branches --remotes`) from
+# the one that was rejected. A third arm covers the benign-orphan case — a tip
+# a merger force-push superseded — where the refusal must classify the commit
+# as superseded rather than as work to preserve.
+#
+# Hermetic: a local bare repo stands in for `origin` (pushes and fetches are
+# filesystem operations, no network) and `gh` is stubbed on PATH. The stub
+# models `gh pr view <N> [--repo <slug>] --json headRefName -q <expr>` and
+# rejects anything outside that surface the way the real binary does, so the
+# suite cannot certify a call gh would refuse (#2781).
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$(dirname "$0")/lib_assert.sh"
+
+WRAPPER="$SCRIPT_DIR/fleet-pr-checkout-detached"
+[[ -x "$WRAPPER" ]] || { echo "SKIP: fleet-pr-checkout-detached not executable at $WRAPPER" >&2; exit 3; }
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fleet-detach-orphan.XXXXXX")
+trap '[[ -n "${TMPROOT:-}" ]] && rm -rf "$TMPROOT"' EXIT
+
+unset FLEET_ASSIGNED_WORKTREE FLEET_ALLOW_MAIN_CLONE 2>/dev/null || true
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+cat >"$BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+# Minimal `gh` stub: models `gh pr view <N> [--repo <slug>] --json headRefName
+# -q <expr>` and nothing else. Unmodelled commands, flags and field selections
+# exit 1 with a message on stderr, mirroring how the real binary rejects them,
+# so a wrapper edit that starts passing something gh would refuse fails here
+# instead of being silently certified (#2781).
+set -uo pipefail
+[[ "${1:-}" == "pr" && "${2:-}" == "view" ]] || { echo "unknown command: ${*}" >&2; exit 1; }
+shift 2
+pr="${1:-}"; shift 2>/dev/null || true
+[[ "$pr" =~ ^[0-9]+$ ]] || { echo "expected a PR number, got '$pr'" >&2; exit 1; }
+json=""; jq_expr=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)   [[ $# -ge 2 ]] || { echo "--repo requires a value" >&2; exit 1; }; shift 2 ;;
+        --json)   [[ $# -ge 2 ]] || { echo "--json requires a value" >&2; exit 1; }; json="$2"; shift 2 ;;
+        -q|--jq)  [[ $# -ge 2 ]] || { echo "-q requires a value" >&2; exit 1; }; jq_expr="$2"; shift 2 ;;
+        *)        echo "unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+[[ "$json" == "headRefName" ]] || { echo "unmodelled --json '$json'" >&2; exit 1; }
+[[ "$jq_expr" == ".headRefName" ]] || { echo "unmodelled -q '$jq_expr'" >&2; exit 1; }
+printf '%s\n' "${FAKE_HEAD_REF:-feature-b}"
+GHEOF
+chmod +x "$BIN/gh"
+
+echo "stub fidelity: the gh stub rejects what the real binary rejects"
+rc=$( "$BIN/gh" pr view 7 --jsonx headRefName >/dev/null 2>&1; echo "$?" )
+assert_eq "$rc" "1" "stub rejects an unknown flag (so it cannot certify one)"
+rc=$( "$BIN/gh" pr list >/dev/null 2>&1; echo "$?" )
+assert_eq "$rc" "1" "stub rejects an unmodelled subcommand"
+rc=$( "$BIN/gh" pr view 7 --json headRefName -q .headRefName >/dev/null 2>&1; echo "$?" )
+assert_eq "$rc" "0" "stub answers the exact call the wrapper makes"
+
+# ----------------------------------------------------------------------
+# Sandbox: bare origin + a worktree-shaped clone with branches A and B.
+# ----------------------------------------------------------------------
+ORIGIN="$TMPROOT/origin.git"
+WT="$TMPROOT/eng/.claude/worktrees/worker-4"
+git init -q --bare "$ORIGIN"
+mkdir -p "$(dirname "$WT")"
+git clone -q "$ORIGIN" "$WT" 2>/dev/null
+git -C "$WT" config user.email t@t
+git -C "$WT" config user.name t
+
+echo base > "$WT/f.txt"
+git -C "$WT" add f.txt
+git -C "$WT" commit -qm M1
+git -C "$WT" push -q origin HEAD:refs/heads/master
+
+git -C "$WT" checkout -q -b feature-a
+echo a1 > "$WT/a.txt"; git -C "$WT" add a.txt; git -C "$WT" commit -qm A1
+echo a2 >> "$WT/a.txt"; git -C "$WT" commit -qam A2
+git -C "$WT" push -q origin feature-a
+
+git -C "$WT" checkout -q -B feature-b master
+echo b1 > "$WT/b.txt"; git -C "$WT" add b.txt; git -C "$WT" commit -qm B1
+git -C "$WT" push -q origin feature-b
+
+git -C "$WT" fetch -q origin
+# Park the way fleet-pr-checkout-detached parks: detached, with NO local branch
+# holding the tip. Leaving the local branches in place makes --branches reach
+# every tip and the predicate read 0 for the wrong reason.
+git -C "$WT" checkout -q --detach origin/feature-a
+git -C "$WT" branch -q -D feature-a feature-b master
+
+# detach <ref...> → run the wrapper from the worktree; exit code on stdout,
+# stderr in $TMPROOT/err.
+detach() {
+    ( cd "$WT" && PATH="$BIN:$PATH" "$WRAPPER" "$@" >/dev/null 2>"$TMPROOT/err"; echo "$?" )
+}
+
+echo "positive-fire 1: benign cross-PR re-checkout SUCCEEDS (nothing at risk)"
+before=$(git -C "$WT" rev-parse HEAD)
+rc=$(detach 42)
+assert_eq "$rc" "0" "detached at PR A's fully pushed tip, checking out B succeeds"
+assert_eq "$(git -C "$WT" rev-parse HEAD)" "$(git -C "$WT" rev-parse origin/feature-b)" \
+    "HEAD moved to origin/feature-b"
+assert_absent "$(cat "$TMPROOT/err")" "REFUSING" "no refusal on the benign path"
+if [[ -f "$WT/.git/fleet-amend-ref" ]]; then ok "sentinel written on success"; else bad "sentinel written on success"; fi
+assert_eq "$(sed -n '1p' "$WT/.git/fleet-amend-ref")" "feature-b" "sentinel names the head ref"
+[[ "$before" != "$(git -C "$WT" rev-parse HEAD)" ]] && ok "the two arms are distinguishable (HEAD actually moved)" \
+    || bad "the two arms are distinguishable (HEAD actually moved)"
+
+echo "positive-fire 2: one unpushed commit on top REFUSES, HEAD unmoved"
+echo unpushed >> "$WT/b.txt"
+git -C "$WT" commit -qam "the fix commit CI demanded"
+AT_RISK=$(git -C "$WT" rev-parse HEAD)
+rc=$(detach 43)
+assert_eq "$rc" "1" "refuses when HEAD carries an unpushed commit"
+assert_eq "$(git -C "$WT" rev-parse HEAD)" "$AT_RISK" "HEAD is unmoved by the refusal"
+assert_contains "$(cat "$TMPROOT/err")" "REFUSING" "refusal is loud"
+assert_contains "$(cat "$TMPROOT/err")" "${AT_RISK:0:12}" "refusal names the at-risk SHA"
+assert_contains "$(cat "$TMPROOT/err")" "AT RISK" "does not claim the fresh commit is superseded"
+assert_contains "$(cat "$TMPROOT/err")" "git branch" "names the preserve-first remedy"
+assert_contains "$(cat "$TMPROOT/err")" "fleet-pr-amend-push --continue" \
+    "names the push-it-instead remedy"
+
+echo "--discard: the documented opt-out proceeds, and git's own warning is no longer swallowed"
+rc=$(detach 43 --discard)
+assert_eq "$rc" "0" "--discard proceeds past the guard"
+assert_eq "$(git -C "$WT" rev-parse HEAD)" "$(git -C "$WT" rev-parse origin/feature-b)" \
+    "HEAD moved despite the orphan commit"
+# The checkout's stderr redirect used to discard "Warning: you are leaving N
+# commits behind" along with stdout, which is what made the loss silent.
+assert_contains "$(cat "$TMPROOT/err")" "leaving" \
+    "git's leaving-commits-behind warning reaches stderr"
+
+echo "positive-fire 3: a tip superseded by a force-push is classified SUPERSEDED"
+# Realistic shape: a second worktree parks on PR A the way the fleet parks it
+# (through the wrapper, so the sentinel records feature-a), then another agent
+# rebases and force-pushes that branch. The sentinel is the only record of which
+# ref was rewritten — the ref being checked out is a different PR entirely.
+WT3="$TMPROOT/eng/.claude/worktrees/worker-6"
+git clone -q "$ORIGIN" "$WT3" 2>/dev/null
+git -C "$WT3" config user.email t@t
+git -C "$WT3" config user.name t
+git -C "$WT3" fetch -q origin
+rc=$( cd "$WT3" && PATH="$BIN:$PATH" FAKE_HEAD_REF=feature-a "$WRAPPER" 50 >/dev/null 2>&1; echo "$?" )
+assert_eq "$rc" "0" "setup: worker-6 parks on PR A through the wrapper"
+git -C "$WT3" branch -q -D master
+PARKED=$(git -C "$WT3" rev-parse HEAD)
+
+# Another agent advances master, rebases feature-a onto it, and force-pushes.
+# (Rebasing onto a master the branch already sits on is a no-op that leaves the
+# SHAs unchanged — this arm would then pass for the wrong reason.)
+git -C "$WT" checkout -q -B advance-master origin/master
+echo m2 >> "$WT/f.txt"
+git -C "$WT" commit -qam M2
+git -C "$WT" push -q origin advance-master:master
+git -C "$WT" fetch -q origin
+git -C "$WT" checkout -q -B rebase-tmp origin/feature-a
+git -C "$WT" rebase -q origin/master >/dev/null 2>&1
+git -C "$WT" push -q -f origin rebase-tmp:feature-a
+git -C "$WT" checkout -q --detach origin/feature-b
+git -C "$WT" branch -q -D rebase-tmp advance-master
+
+git -C "$WT3" fetch -q origin --prune
+assert_eq "$(git -C "$WT3" rev-list --count HEAD --not --branches --remotes)" "2" \
+    "setup: the parked tip's 2 commits are now reachable from nothing"
+rc=$( cd "$WT3" && PATH="$BIN:$PATH" "$WRAPPER" 51 >/dev/null 2>"$TMPROOT/err"; echo "$?" )
+assert_eq "$rc" "1" "still refuses — the commits are genuinely reachable from nothing"
+assert_eq "$(git -C "$WT3" rev-parse HEAD)" "$PARKED" "HEAD is unmoved by the refusal"
+assert_contains "$(cat "$TMPROOT/err")" "SUPERSEDED" \
+    "classifies the rewritten commits as superseded, not as work to preserve"
+assert_contains "$(cat "$TMPROOT/err")" "--discard" \
+    "points at --discard as the correct response for this case"
+assert_absent "$(cat "$TMPROOT/err")" "AT RISK" \
+    "does not tell the agent to preserve a commit the merger already rebased past"
+
+echo "the classification is not vacuous: reachability-from-master could never say this"
+for s in $(git -C "$WT3" rev-list HEAD --not --branches --remotes); do
+    if git -C "$WT3" merge-base --is-ancestor "$s" origin/master 2>/dev/null; then
+        bad "at-risk SHA ${s:0:8} is an ancestor of origin/master (unexpected)"
+    else
+        ok "at-risk SHA ${s:0:8} is NOT an ancestor of origin/master — the reachability test cannot classify it"
+    fi
+done
+
+echo "fail-closed: a guard that cannot evaluate refuses rather than permitting"
+# `git rev-list --count HEAD …` yields an empty string on an unborn HEAD, and an
+# empty string tests as "not non-zero" — the guard must not read that as clean.
+EMPTY_WT="$TMPROOT/eng/.claude/worktrees/worker-5"
+mkdir -p "$EMPTY_WT"
+git -C "$EMPTY_WT" init -q
+git -C "$EMPTY_WT" remote add origin "$ORIGIN"
+git -C "$EMPTY_WT" fetch -q origin
+rc=$( cd "$EMPTY_WT" && PATH="$BIN:$PATH" "$WRAPPER" 45 >/dev/null 2>"$TMPROOT/err"; echo "$?" )
+assert_eq "$rc" "1" "unborn HEAD refuses instead of silently permitting"
+assert_contains "$(cat "$TMPROOT/err")" "could not evaluate" \
+    "refusal names the un-evaluable guard rather than a bogus at-risk list"
+
+echo "usage: --discard and --repo= parse, unknown flags do not"
+rc=$( cd "$WT" && PATH="$BIN:$PATH" "$WRAPPER" 46 --bogus >/dev/null 2>&1; echo "$?" )
+assert_eq "$rc" "2" "unknown flag is a usage error"
+rc=$( cd "$WT" && PATH="$BIN:$PATH" "$WRAPPER" 46 --repo= >/dev/null 2>&1; echo "$?" )
+assert_eq "$rc" "2" "an empty --repo= is rejected exactly as the space form is"
+
+summarize "fleet-pr-checkout-detached orphan-guard tests (#2734)"


### PR DESCRIPTION
## Summary

`fleet-pr-amend-push` consumed its sentinel with `rm -f` on **every** success
path (`:122` FF, `:149` lease), so the follow-up amend a red-CI run demands hit
the "sentinel missing" branch at `:80-83`. That message named the one remedy
that destroys the commit: `fleet-pr-checkout-detached` moves HEAD to the remote
tip, and its `git checkout --detach … >/dev/null 2>&1` swallowed git's own
"leaving N commits behind" warning — silent loss, exit 0.

- **`fleet-pr-amend-push`** marks the sentinel consumed (a third
  `consumed <iso8601>` line) instead of deleting it. The routing path still
  treats a consumed sentinel as **absent**, so the `:145-147` stale-routing
  hazard the deletion existed for is preserved exactly; the retained head ref
  is what lets the diagnostic split *never-ran* from *already-spent*.
- **`fleet-pr-amend-push --continue`** re-arms it for exactly one more push, on
  the strictly-safe branch only: detached HEAD, post-fetch
  `merge-base --is-ancestor origin/<ref> HEAD`, then a **plain** push. Never a
  force, never a lease — it re-opens the case `:107-110` already documents as
  supported and adds no push semantics.
- **`fleet-pr-checkout-detached`** refuses **before** mutating HEAD when
  `git rev-list HEAD --not --branches --remotes` is non-empty, names the at-risk
  commits (age + subject), classifies each, and stops swallowing stderr at
  `:136`. `--discard` is the opt-out.

## One deliberate deviation from the plan review's binding constraint 1

The review prescribed classifying each at-risk SHA by *"whether it is an
ancestor of `origin/master` (merged → safe)"*. **That test cannot fire.** The
at-risk set is defined as `HEAD --not --branches --remotes`, and `origin/master`
is a remote-tracking ref — so anything it reaches is excluded from the set by
construction. Shipping it would have satisfied the constraint's letter with a
structurally vacuous check, the same failure shape as the predicate the first
review bounced.

Measured on the review's **own** named benign case (a parked tip a merger
force-push superseded), in a throwaway repo:

| predicate | S1 superseded tip | S2 genuine unpushed commit |
|---|---|---|
| orphan count (`HEAD --not --branches --remotes`) | 1 (guard fires) | 1 (guard fires) |
| `merge-base --is-ancestor <sha> origin/master` | **NO** → reports it as work to preserve | NO |
| `git cherry origin/<ref> HEAD` | **`-`** → superseded | `+` → at risk |

So the **intent** of constraint 1 ships, via patch-equivalence rather than
reachability: a SUPERSEDED commit is labelled as such and pointed at
`--discard`; anything unclassified prints as `AT RISK` (never as a claim that
it is unpushed) and the refusal gives **both** remedies plus the timestamps, so
it stays actionable in the cases `git cherry` cannot decide (a squash-merge that
collapsed several commits changes the patch). The upstreams asked are the ref
being checked out, the ref the sentinel records this worktree was last parked
against, and master — sweeping all 1778 `refs/remotes/*` is a patch-id pass per
ref to catch rewrites on branches this worktree never touched.

Constraint 2 (**no vacuous pass**) ships as specified: a non-numeric
`rev-list --count` result — unborn HEAD, corrupt ref — is a **refusal**, not a
permit, and has its own test arm.

## Test plan

- [x] `test_fleet_amend_push_scope.sh` extended (per the plan: extend, don't add
      a `test_fleet_pr_amend_push.sh`) — **32 passed, 0 failed**
- [x] `test_fleet_checkout_detached_orphan_guard.sh` added — **32 passed, 0
      failed**. Named deliberately per the first review's *"extend that or name
      the new file deliberately"*: its subject is the **other** script, and it
      needs a `gh` stub the amend-push suite has no use for.
- [x] **Positive control** (`fleet-positive-control … origin/master @5a1fdc9ec`):
      orphan-guard suite fails **14** of 29 assertions against the pre-fix ref
      (15 pass = the non-regression arms); amend-push suite fails **16** of 32
      (16 pass). Both **MEANINGFUL**.
- [x] `bash scripts/fleet/tests/run_all.sh` — **129 suites, 128 passed, 1
      failed**. The failure is `test_cross_repo_shared_file_parity.sh`
      (`auto-rereview.yml` drift with the downstream repo), red on `origin/master`
      before this branch and unrelated — game PRs #372/#366 are the pending sync.
- [x] `gh` stub models the real binary's arg surface and **rejects** what it
      rejects (unknown flag, unmodelled subcommand), with fidelity assertions —
      per `scripts/fleet/CLAUDE.md` (#2781).
- [x] Guard cost on the real engine repo (1778 remote refs): `rev-list --count`
      **0.019 s** — the classification's `git cherry` runs only on the refusal
      path, never the common one.
- [x] `bash -n` clean on both wrappers; `--help` on both emits header only, no
      code leak.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| Second `fleet-pr-amend-push` names the real cause + a non-destructive recovery | `test_fleet_amend_push_scope.sh` | `ok: refusal names the consumed sentinel` / `ok: refusal names the non-destructive recovery` / `ok: refusal does NOT steer at the destructive remedy` |
| `fleet-pr-checkout-detached` refuses non-zero, **before** mutating HEAD, naming the at-risk SHA | `test_fleet_checkout_detached_orphan_guard.sh` | `ok: refuses when HEAD carries an unpushed commit` / `ok: HEAD is unmoved by the refusal` / `ok: refusal names the at-risk SHA` |
| Git's "leaving N commits behind" warning no longer swallowed at `:136` | same suite, `--discard` arm | `ok: git's leaving-commits-behind warning reaches stderr` |
| Issue-body repro ends REACHABLE (or the checkout refuses) | same suite, positive-fire 2 | refuses at exit 1 with HEAD unmoved — the commit stays reachable from HEAD |
| **Positive-fire pair** — benign re-checkout succeeds / one unpushed commit refuses | same suite | `ok: detached at PR A's fully pushed tip, checking out B succeeds` **and** `ok: refuses when HEAD carries an unpushed commit`; a third assert proves HEAD actually moved on the benign arm, so the two arms are distinguishable |
| **Third positive-fire row** (constraint 1) — parked at a tip a force-push superseded | same suite, positive-fire 3 | `ok: classifies the rewritten commits as superseded` / `ok: points at --discard as the correct response` / `ok: does not tell the agent to preserve a commit the merger already rebased past`; plus an assert that the prescribed reachability test could never have said this |
| Guard cannot pass vacuously (constraint 2) | same suite, fail-closed arm | `ok: unborn HEAD refuses instead of silently permitting` |
| `--continue` refuses when HEAD does not descend `origin/<ref>` | `test_fleet_amend_push_scope.sh` | `ok: --continue refuses a non-fast-forward` / `ok: --continue never force-pushed: the remote tip is unchanged` |
| Legacy two-line sentinel still routes normally — no migration | same suite | `ok: a two-field-less legacy sentinel is treated as live, not consumed` |
| #1310/#1338/#1340 anti-clobber preserved | same suite | `ok: the lease refuses when origin/feature moved since checkout` / `ok: the other agent's commit was not clobbered` / `ok: a REFUSED push does not spend the sentinel` |
| Extended suite green under `bash` locally and in CI | `run_all.sh` + this PR's `fleet-tests.yml` run | 128/129 locally (see above); CI is the arbiter |

## Findings (not fixed here — out of this PR's scope)

- **`.claude/commands/role-worker.md` step h** still tells the worker only
  `fleet-pr-amend-push`, with no mention of `--continue`. That file is gated
  self-config no worker class can push. `docs/agents/FLEET-FEEDBACK-HANDLING.md`
  is updated in this PR and is the doc the feedback path actually routes
  through, so the guidance is reachable — but the role file will drift until a
  human applies it.
- **Pre-existing citation drift:** `fleet-pr-amend-push:113,131` and
  `fleet-pr-checkout-detached:154` cite `#1310` for the "dual-worker clobber".
  `#1310` resolves to *"render: smooth camera Z-yaw — T3"*. Left untouched
  (unrelated cleanup); new text in this PR cites `#1338`/`#1340`, which do
  resolve.
- **Candidate authoring rule for `scripts/fleet/CLAUDE.md`:** *a guard whose
  predicate can return empty must fail closed* — `count=$(git rev-list --count …)`
  yields `""` on error and `""` tests as "not non-zero", so the guard silently
  permits precisely when it could not evaluate. This diff is the exemplar
  (constraint 2). Flagged per simplify §9b rather than bundled.

Closes #2734

🤖 Generated with [Claude Code](https://claude.com/claude-code)
