### PR TITLE
build/cmake: fail loud on preprocessor-conditional Metal registry entries (#2983)

### DIFF
--- a/cmake/run_metal_kernel_registry_check.cmake
+++ b/cmake/run_metal_kernel_registry_check.cmake
@@ -56,6 +56,7 @@ set(in_registry FALSE)
 set(found_registry FALSE)
 set(found_terminator FALSE)
 set(registered_kernels "")
+set(conditional_depth 0)
 foreach(line IN LISTS pipeline_lines)
     if(NOT in_registry)
         if(line MATCHES "MTL::Size[ \t]+threadgroupSizeForFunctionName\\(")
@@ -67,6 +68,26 @@ foreach(line IN LISTS pipeline_lines)
     if(line STREQUAL "}")
         set(found_terminator TRUE)
         break()
+    endif()
+    # A preprocessor conditional defeats this scan the same way a comment
+    # does: an entry inside #if/#ifdef/#ifndef may never reach the compiled
+    # binary, and a source-text pass has no preprocessor to evaluate which
+    # branch the build takes. Skip conditional lines entirely -- a disabled
+    # entry then reads as absent, the same way a commented-out entry reads
+    # (#2899), and falls through to the existing "no entry in ..." failure
+    # below, which already names it.
+    if(line MATCHES "^[ \t]*#[ \t]*(if|ifdef|ifndef)([ \t(]|$)")
+        math(EXPR conditional_depth "${conditional_depth} + 1")
+        continue()
+    endif()
+    if(line MATCHES "^[ \t]*#[ \t]*endif([ \t]|$)")
+        if(conditional_depth GREATER 0)
+            math(EXPR conditional_depth "${conditional_depth} - 1")
+        endif()
+        continue()
+    endif()
+    if(conditional_depth GREATER 0)
+        continue()
     endif()
     string(REGEX MATCHALL "\"[A-Za-z0-9_]+\"" quoted_names "${line}")
     foreach(quoted_name IN LISTS quoted_names)

--- a/cmake/run_metal_scratch_consumer_check.cmake
+++ b/cmake/run_metal_scratch_consumer_check.cmake
@@ -197,6 +197,7 @@ set(in_list FALSE)
 set(found_list FALSE)
 set(found_terminator FALSE)
 set(listed_consumers "")
+set(conditional_depth 0)
 foreach(line IN LISTS pipeline_lines)
     if(NOT in_list)
         if(line MATCHES "bool[ \t]+functionUsesImageAtomicScratch\\(")
@@ -208,6 +209,27 @@ foreach(line IN LISTS pipeline_lines)
     if(line STREQUAL "}")
         set(found_terminator TRUE)
         break()
+    endif()
+    # A preprocessor conditional defeats this scan the same way it defeats the
+    # sibling run_metal_kernel_registry_check.cmake's scan: an entry inside
+    # #if/#ifdef/#ifndef may never reach the compiled binary, and a
+    # source-text pass has no preprocessor to evaluate which branch the build
+    # takes. Skip conditional lines entirely -- a disabled entry then reads as
+    # absent, the same way a commented-out entry reads (#2899), and falls
+    # through to the existing "absent from functionUsesImageAtomicScratch"
+    # failure below, which already names it.
+    if(line MATCHES "^[ \t]*#[ \t]*(if|ifdef|ifndef)([ \t(]|$)")
+        math(EXPR conditional_depth "${conditional_depth} + 1")
+        continue()
+    endif()
+    if(line MATCHES "^[ \t]*#[ \t]*endif([ \t]|$)")
+        if(conditional_depth GREATER 0)
+            math(EXPR conditional_depth "${conditional_depth} - 1")
+        endif()
+        continue()
+    endif()
+    if(conditional_depth GREATER 0)
+        continue()
     endif()
     # Comment-strip before harvesting names, for the same reason the kernel-side
     # scan does it. A commented-out entry is absent from the list as far as

--- a/scripts/fleet/tests/test_header_checks_standalone.sh
+++ b/scripts/fleet/tests/test_header_checks_standalone.sh
@@ -17,6 +17,9 @@
 #     checks ran (1 kernel scanned, _body fragment excluded as an entry point
 #     but still read through the wrapper's include chain)
 #   - an unregistered Metal compute kernel          → exit 1, names the kernel
+#   - a registry entry inside a preprocessor #if    → exit 1, names the kernel
+#     (#2983 — a source-text scan can't evaluate which branch the build
+#     takes, so it must read as absent, not present, same as a comment)
 #   - a registry with no bare "}" terminator line   → exit 1 (EOF guard, not
 #     a silent scan past the function into unrelated string literals)
 #   - a scratch consumer absent from the list       → exit 1, names the kernel
@@ -24,6 +27,8 @@
 #     UBO shape must NOT be flagged — negative control)
 #   - a commented-out list entry                    → exit 1 (the runtime stops
 #     binding for it, so it must read as absent, not present)
+#   - a list entry inside a preprocessor #if        → exit 1, names the kernel
+#     (#2983, same reasoning as the registry-side arm)
 #   - a hand-wrapped scratch declaration            → exit 1 (the qualifier test
 #     reads the declaration window, not the attribute's line)
 #   - an atomic neighbour on the slot's line        → exit 0 (that qualifier
@@ -194,6 +199,52 @@ assert_contains "$metal_out" "c_unregistered_kernel" \
 assert_absent "$metal_out" "c_fixture_kernel" \
     "registered kernel is not flagged as missing"
 
+# --- a registry entry inside a preprocessor conditional reads as absent -----
+# threadgroupSizeForFunctionName is scanned as source text with no
+# preprocessor, so it cannot evaluate which #if/#ifdef/#ifndef branch the
+# build takes -- an entry that exists only inside one may never reach the
+# compiled binary. It must fail exactly like an omitted entry, the same
+# "read as absent" contract #2899 established for comments (#2983). Direct
+# fixture write, not write_pipeline_cpp, since that helper has no conditional
+# shape.
+REGISTRY_CONDITIONAL="$TMPROOT/registry-conditional"
+make_fixture "$REGISTRY_CONDITIONAL"
+echo '// registry-conditional fixture kernel' \
+    > "$REGISTRY_CONDITIONAL/engine/render/src/shaders/metal/c_registry_conditional.metal"
+cat > "$REGISTRY_CONDITIONAL/engine/render/src/metal/metal_pipeline.cpp" <<'EOF'
+namespace IRRender {
+namespace {
+
+MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
+    if (functionName == "c_fixture_kernel") {
+        return MTL::Size(16, 16, 1);
+    }
+#if 0
+    if (functionName == "c_registry_conditional") {
+        return MTL::Size(16, 16, 1);
+    }
+#endif
+    return MTL::Size(1, 1, 1);
+}
+
+bool functionUsesImageAtomicScratch(const std::string &functionName) {
+    return false
+           || functionName == "c_fixture_kernel"
+        ;
+}
+
+}  // namespace
+}  // namespace IRRender
+EOF
+registry_conditional_out=$(run_checker "$REGISTRY_CONDITIONAL")
+registry_conditional_rc=$?
+assert_eq "1" "$registry_conditional_rc" \
+    "registry entry inside a preprocessor conditional exits 1"
+assert_contains "$registry_conditional_out" "c_registry_conditional" \
+    "failure names the kernel whose registry entry is inside a conditional"
+assert_contains "$registry_conditional_out" "no entry in" \
+    "a conditional registry entry is reported as absent, not present"
+
 # --- a registry without its bare "}" terminator fails, not false-cleans ------
 # The function-body scan ends on a line that is exactly "}"; if the function
 # is ever indented (namespace style change, moved into a block), the scan
@@ -279,6 +330,58 @@ assert_contains "$scratch_commented_out" "c_fixture_kernel" \
     "failure names the consumer whose entry was commented out"
 assert_contains "$scratch_commented_out" "absent from functionUsesImageAtomicScratch" \
     "a commented-out entry is reported as absent, not present"
+
+# --- a scratch list entry inside a preprocessor conditional reads as absent --
+# Same reasoning as the registry-side arm above (#2983): functionUsesImage-
+# AtomicScratch is scanned as source text with no preprocessor, so an entry
+# that exists only inside #if/#ifdef/#ifndef must fail exactly like an
+# omitted entry. The kernel itself declares the scratch (so it would
+# otherwise be a genuine expected consumer) and is registered unconditionally
+# in threadgroupSizeForFunctionName -- only its list entry is conditional.
+# Direct fixture write, not write_pipeline_cpp, since that helper has no
+# conditional shape.
+SCRATCH_CONDITIONAL="$TMPROOT/scratch-conditional"
+make_fixture "$SCRATCH_CONDITIONAL"
+cat > "$SCRATCH_CONDITIONAL/engine/render/src/shaders/metal/c_scratch_conditional.metal" <<'EOF'
+kernel void c_scratch_conditional(
+    device atomic_int* distanceScratch [[buffer(16)]],
+    uint3 gid [[thread_position_in_grid]]
+) {}
+EOF
+cat > "$SCRATCH_CONDITIONAL/engine/render/src/metal/metal_pipeline.cpp" <<'EOF'
+namespace IRRender {
+namespace {
+
+MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
+    if (functionName == "c_fixture_kernel") {
+        return MTL::Size(16, 16, 1);
+    }
+    if (functionName == "c_scratch_conditional") {
+        return MTL::Size(16, 16, 1);
+    }
+    return MTL::Size(1, 1, 1);
+}
+
+bool functionUsesImageAtomicScratch(const std::string &functionName) {
+    return false
+           || functionName == "c_fixture_kernel"
+#if 0
+           || functionName == "c_scratch_conditional"
+#endif
+        ;
+}
+
+}  // namespace
+}  // namespace IRRender
+EOF
+scratch_conditional_out=$(run_checker "$SCRATCH_CONDITIONAL")
+scratch_conditional_rc=$?
+assert_eq "1" "$scratch_conditional_rc" \
+    "scratch list entry inside a preprocessor conditional exits 1"
+assert_contains "$scratch_conditional_out" "c_scratch_conditional" \
+    "failure names the consumer whose list entry is inside a conditional"
+assert_contains "$scratch_conditional_out" "absent from functionUsesImageAtomicScratch" \
+    "a conditional list entry is reported as absent, not present"
 
 # --- a hand-wrapped scratch declaration is still caught ----------------------
 # The qualifier test reads the parameter's declaration window, not the physical


### PR DESCRIPTION
## Summary
- `run_metal_kernel_registry_check.cmake` and `run_metal_scratch_consumer_check.cmake` now skip lines inside a preprocessor conditional (`#if`/`#ifdef`/`#ifndef` … `#endif`, depth-tracked for nesting) when harvesting registry/list entries, so an entry that exists only inside one reads as absent and falls through to the checkers' existing "missing"/"absent" failures — the same "read as absent" contract #2899 established for comments, extended to the preprocessor-disabling shape.
- Added a firing arm per checker to `test_header_checks_standalone.sh` for the `#if 0` shape (direct fixture write, mirroring the existing indented-fixture pattern — `write_pipeline_cpp` has no conditional-entry parameter).

## Test plan
- [x] `bash scripts/fleet/tests/test_header_checks_standalone.sh` — 59 passed, 0 failed
- [x] `bash scripts/fleet/tests/run_all.sh --only test_header_checks_standalone` — 1 suite, 1 passed
- [x] `cmake --build build --target header-checks` — real tree still exits 0 at 31 compute kernel(s) / 8 declare the image-atomic scratch at buffer slot 16 (unchanged)

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Both checkers refuse a clean scan on a preprocessor conditional in their scanned range | `bash scripts/fleet/tests/test_header_checks_standalone.sh` | `ok: registry entry inside a preprocessor conditional exits 1` / `ok: scratch list entry inside a preprocessor conditional exits 1` |
| Test gains a firing arm per checker for the `#if 0` shape, asserting non-zero exit + kernel named | same run | `ok: failure names the kernel whose registry entry is inside a conditional` / `ok: failure names the consumer whose list entry is inside a conditional` |
| `fleet-positive-control` reports MEANINGFUL with exactly the new assertions failing pre-fix | `fleet-positive-control scripts/fleet/tests/test_header_checks_standalone.sh origin/master --include cmake` | `MEANINGFUL: 6 of 59 assertions fail against origin/master (5a1fdc9ec)` — the 6 are exactly the 2 new arms' 3 assertions each |
| Real tree unchanged at 31 kernels / 8 declare | `cmake -DPROJECT_ROOT="$PWD" -P cmake/run_header_checks_standalone.cmake` | `Metal kernel registry check scanned 31 compute kernel(s)` / `Metal scratch-consumer check scanned 31 compute kernel(s) ... (8 declare ...)`, `EXIT=0` |

Closes #2983

🤖 Generated with [Claude Code](https://claude.com/claude-code)