### PR TITLE
fleet: resolve needs-plan blockers with the live fallback (#2986)

### DIFF
--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -15,6 +15,15 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   `tempfile.TemporaryDirectory()` `cache_dir` instead. When migrating a
   fetcher's transport (e.g. `run_capture(gh)` → `conditional_get`), re-point
   *every* test mock at the new seam in the same PR.
+  The same duty applies when a function **acquires** its first network call
+  rather than changing an existing one: every suite already covering it was
+  written network-free and silently starts reaching live GitHub, so its
+  verdicts become a function of production state. Re-point those suites in the
+  same PR — and prefer fixtures that are obviously synthetic, since the tell is
+  easy to miss when the fixture uses plausible real IDs (#2986 added a live
+  fallback to `resolve_needs_plan_blocked_by`; the pre-existing suite's "open
+  blocker" fixture was a real issue number that had since closed, so the suite
+  failed on live state rather than on the code under test).
 - **A CLI stub models the tool's argument parsing, not just its endpoint.**
   A `gh` stub that matches a substring of `"$@"` and ignores flags accepts
   arguments the real binary rejects, so the suite certifies a call that has

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1477,14 +1477,18 @@ def _closed_issue_numbers(repo_state):
     }
 
 
-def resolve_blocked_by(state):
+def resolve_blocked_by(state, ref_cache=None):
     """Resolve blocked_by fields for all open tasks.
 
     Uses already-fetched closed_fleet_queued and recent_merged_prs for
     in-memory resolution; falls back to live gh issue view for refs not
     covered by either. Mutates state in place.
+
+    `ref_cache` lets the caller share one `_resolve_ref_satisfied` cache
+    across the resolvers that run in the same tick, so a ref appearing in
+    both this lane and the needs-plan lane costs one live call, not two.
     """
-    per_tick_cache: dict = {}
+    per_tick_cache: dict = {} if ref_cache is None else ref_cache
 
     for repo_key, repo_state in state["repos"].items():
         repo_slug = _REPO_SLUG_MAP.get(repo_key)
@@ -1559,9 +1563,20 @@ def resolve_human_approved_blockers(state):
     tasks.open-sourced _ingest_unblock_candidates, not off this flag.
 
     Resolution is in-memory only (closed_fleet_queued + merged `claude/<N>-*`
-    heads), mirroring resolve_blocked_by()'s cheap path — NO live gh here, so
-    the per-tick projection stays fast. `body` is popped after parsing so it
-    never bloats state.json or the per-role slices.
+    heads) — NO live gh here, so the per-tick projection stays fast. `body` is
+    popped after parsing so it never bloats state.json or the per-role slices.
+
+    This lane deliberately does NOT take the live `_resolve_ref_satisfied`
+    fallback its two siblings use (#2986). The distinction is what the flag
+    gates: resolve_blocked_by feeds pickup and resolve_needs_plan_blocked_by
+    feeds the planner dispatch, so a false positive there strands real work,
+    whereas this flag has gated nothing since #1527 (see the paragraph above)
+    and is read only for state.json visibility. Spending a live call per novel
+    unresolved ref, every tick, on a display-only field is the wrong trade for
+    a polling daemon built around conditional GETs. The visible cost is that an
+    entry here can read `blocked: true` after its blocker closed outside the
+    closed_fleet_queued window; the ingest path rechecks live and is unaffected.
+    If this flag ever regains a gating consumer, it needs the fallback too.
     """
     for repo_key, repo_state in state["repos"].items():
         closed_nums = _closed_issue_numbers(repo_state)
@@ -1600,19 +1615,34 @@ def resolve_human_approved_blockers(state):
                 break
 
 
-def resolve_needs_plan_blocked_by(state):
+def resolve_needs_plan_blocked_by(state, ref_cache=None):
     """Annotate each fleet:needs-plan issue with `blocked` — True when its
     `**Blocked by:**` predecessor is still open (#2287).
 
-    Mirrors resolve_human_approved_blockers(): in-memory only
-    (closed_fleet_queued + merged `claude/<N>-*` heads), no live gh, so the
-    per-tick projection stays fast. `body` is popped after parsing so it
-    never bloats state.json or the per-role slices. Without this, a
-    needs-plan issue explicitly parked behind an open blocker (e.g. #2258
-    held for #2280) kept projecting as plannable, firing a planner dispatch
-    every tick that found nothing to do on arrival.
+    In-memory first (closed_fleet_queued + merged `claude/<N>-*` heads), then
+    the same live `_resolve_ref_satisfied` fallback resolve_blocked_by() uses
+    for refs neither source covers (#2986). The fallback is NOT optional here:
+    `blocked` is a hard gate in two places — project_worker drops the issue so
+    it never wakes a planner dispatch, and the role slice drops it so it can
+    never be assigned as FLEET_PLAN_ISSUE. A false positive is therefore
+    permanent and silent, with no tier that still lists the issue.
+
+    Why the in-memory sources are not sufficient on their own: closed_fleet_queued
+    is both **windowed** (fetch_closed_fleet_queued takes a single page — 100
+    against a live population of 820) and **label-scoped** (`fleet:queued` only).
+    The second is the binding one — #2986's incident blocker #2310 carries no
+    labels at all, so it is absent from that set at *any* window size. Widening
+    the window (what #2856 did for fetch_human_approved) does not fix this lane.
+
+    `body` is popped after parsing so it never bloats state.json or the
+    per-role slices. Without the blocked flag at all, a needs-plan issue
+    explicitly parked behind an open blocker (e.g. #2258 held for #2280) kept
+    projecting as plannable, firing a planner dispatch every tick that found
+    nothing to do on arrival.
     """
+    per_tick_cache: dict = {} if ref_cache is None else ref_cache
     for repo_key, repo_state in state["repos"].items():
+        repo_slug = _REPO_SLUG_MAP.get(repo_key)
         closed_nums = _closed_issue_numbers(repo_state)
         merged_heads = [
             pr.get("headRefName", "") or ""
@@ -1641,11 +1671,20 @@ def resolve_needs_plan_blocked_by(state):
                     continue
                 if any(branch_matches_issue(h, ref, repo_key) for h in merged_heads):
                     continue
+                # Live fallback for the residual (#2986). Reached only by refs
+                # both in-memory sources missed, so it costs a call per *novel*
+                # unresolved ref per tick, shared with resolve_blocked_by's
+                # cache. _resolve_ref_satisfied fails closed (False on any gh
+                # error/timeout), so a flaky call leaves the issue blocked —
+                # the same conservative direction as before this fallback.
+                if repo_slug and _resolve_ref_satisfied(
+                        repo_slug, ref, per_tick_cache):
+                    continue
                 issue["blocked"] = True
                 break
 
 
-def resolve_epic_children(state):
+def resolve_epic_children(state, ref_cache=None):
     """Annotate each epic for the steward projection (#1664). Mutates state
     in place before the state write, mirroring resolve_blocked_by, so both
     project_epic_steward and slice_epic_steward stay pure functions of the
@@ -1669,8 +1708,12 @@ def resolve_epic_children(state):
     - else the rare _resolve_ref_satisfied live fallback (per-tick cached) —
       only unchecked children invisible to every list fetch land here (e.g.
       filed but not yet approved/queued).
+
+    `ref_cache` shares the tick's `_resolve_ref_satisfied` cache with the
+    blocked-by resolvers (#2986) — an epic child that is also some task's
+    blocker is then one live call for the tick, not two.
     """
-    per_tick_cache: dict = {}
+    per_tick_cache: dict = {} if ref_cache is None else ref_cache
     for repo_key, repo_state in state["repos"].items():
         repo_slug = _REPO_SLUG_MAP.get(repo_key)
         epics = repo_state.get("epics", [])
@@ -3036,10 +3079,14 @@ def tick_once():
             log(f"state degraded: {state['degraded']} — reconcile disabled this tick")
         _populate_done_tasks(state)
         _populate_review_plan(state)
-        resolve_blocked_by(state)
+        # One shared _resolve_ref_satisfied cache across every resolver in the
+        # tick, so a ref named by more than one of them (a task blocker that is
+        # also an epic child) costs a single live call (#2986).
+        ref_cache: dict = {}
+        resolve_blocked_by(state, ref_cache)
         resolve_human_approved_blockers(state)
-        resolve_needs_plan_blocked_by(state)
-        resolve_epic_children(state)
+        resolve_needs_plan_blocked_by(state, ref_cache)
+        resolve_epic_children(state, ref_cache)
         # enrich_inflight_pr_tasks must run before enrich_stackable_blocker_prs
         # — the stackable pass reads a task's `inflight_pr` field to suppress
         # a doomed offer on a task whose own issue already has an open PR

--- a/scripts/fleet/tests/test_needs_plan_blocked_by.py
+++ b/scripts/fleet/tests/test_needs_plan_blocked_by.py
@@ -8,6 +8,16 @@ dispatch every tick that found nothing to do on arrival.
 Mirrors test_queue_manager_projection.py's IngestHonorsBlockedBy, which
 covers the analogous resolve_human_approved_blockers() — in-memory only
 (closed_fleet_queued + merged claude/<N>-* heads), no live gh.
+
+Since #2986 the subject also takes a live `_resolve_ref_satisfied` fallback
+for refs neither in-memory source covers, so these cases must stub that seam
+or they reach the network — this suite's fixtures use real issue numbers
+(#2280 as the "open" predecessor), and #2280 has since closed, which turned
+`test_open_blocker_marks_issue_blocked` into a test of live GitHub state.
+The stub models "no ref resolves live", reproducing exactly the pre-#2986
+treatment of an unresolved ref, so every case below keeps its original
+meaning. Coverage of the fallback itself — including that the in-memory hits
+never reach it — lives in test_scout_needs_plan_live_fallback.py.
 """
 import importlib.machinery
 import importlib.util
@@ -40,6 +50,16 @@ def _state(*, needs_plan=None, closed=None, merged=None):
 
 
 class ResolveNeedsPlanBlockedBy(unittest.TestCase):
+
+    def setUp(self):
+        # Close the network seam (#2986). Replacing the helper outright means
+        # there is no path left to `gh`, so a fixture this suite does not model
+        # cannot silently fall through to live GitHub state.
+        self._orig_resolve = _mod._resolve_ref_satisfied
+        _mod._resolve_ref_satisfied = lambda repo_slug, ref, cache: False
+
+    def tearDown(self):
+        _mod._resolve_ref_satisfied = self._orig_resolve
 
     def _resolved(self, *, needs_plan, closed=None, merged=None):
         st = _state(needs_plan=needs_plan, closed=closed, merged=merged)

--- a/scripts/fleet/tests/test_scout_needs_plan_live_fallback.py
+++ b/scripts/fleet/tests/test_scout_needs_plan_live_fallback.py
@@ -40,6 +40,12 @@ resolve_needs_plan_blocked_by = _mod.resolve_needs_plan_blocked_by
 _BLOCKED_ISSUE = 2330
 _BLOCKER = "2310"
 
+# Synthetic game-repo numbers (criterion 4: the resolver is repo-generic, not
+# engine-only) — deliberately far from any real issue so the fixture can't be
+# mistaken for another live incident.
+_GAME_BLOCKED_ISSUE = 91
+_GAME_BLOCKER = "77"
+
 
 class _GhStub:
     """Emulates `gh issue view <ref> --repo <slug> --json state --jq .state`.
@@ -86,6 +92,25 @@ def _state(blocked_by="#" + _BLOCKER, closed=(), merged_heads=()):
     }}}
 
 
+def _two_repo_state():
+    """Both engine and game carry a needs-plan issue whose blocker is CLOSED
+    live only — neither in-memory source covers it. Criterion 4 (#2986): the
+    game repo's lane must resolve exactly like engine's, not stay pinned
+    blocked=True because the fixture never exercised a non-engine repo_key.
+    """
+    state = _state()
+    state["repos"]["game"] = {
+        "closed_fleet_queued": [],
+        "recent_merged_prs": [],
+        "needs_plan": [{
+            "number": _GAME_BLOCKED_ISSUE,
+            "labels": ["human:approved", "fleet:needs-plan"],
+            "body": f"**Area:** gameplay\n**Blocked by:** #{_GAME_BLOCKER}\n",
+        }],
+    }
+    return state
+
+
 def _run(state, stub):
     with patch.object(_mod.subprocess, "run", stub):
         resolve_needs_plan_blocked_by(state)
@@ -107,6 +132,23 @@ class NeedsPlanLiveFallback(unittest.TestCase):
     def test_merged_blocker_unblocks(self):
         """A `Blocked by:` naming a PR number that MERGED is satisfied too."""
         self.assertFalse(_run(_state(), _GhStub({_BLOCKER: "MERGED"})))
+
+    def test_game_repo_closed_blocker_outside_inmemory_sources_unblocks(self):
+        """Criterion 4 (#2986), with an explicit fixture rather than relying on
+        the resolver being provably repo-generic: the live fallback fires for
+        the game repo too, resolving against its own slug (jakildev/irreden),
+        and engine's resolution in the same tick is unaffected.
+        """
+        state = _two_repo_state()
+        stub = _GhStub({_BLOCKER: "CLOSED", _GAME_BLOCKER: "CLOSED"})
+        with patch.object(_mod.subprocess, "run", stub):
+            resolve_needs_plan_blocked_by(state)
+        self.assertFalse(state["repos"]["engine"]["needs_plan"][0]["blocked"])
+        self.assertFalse(state["repos"]["game"]["needs_plan"][0]["blocked"])
+        self.assertEqual(sorted(stub.calls), sorted([
+            ("jakildev/IrredenEngine", _BLOCKER),
+            ("jakildev/irreden", _GAME_BLOCKER),
+        ]))
 
     def test_open_blocker_still_blocks(self):
         """NEGATIVE CONTROL — the fallback must not be a gate that cannot fire.

--- a/scripts/fleet/tests/test_scout_needs_plan_live_fallback.py
+++ b/scripts/fleet/tests/test_scout_needs_plan_live_fallback.py
@@ -1,0 +1,169 @@
+"""Regression test for #2986: resolve_needs_plan_blocked_by resolved a
+needs-plan issue's `**Blocked by:** #N` against in-memory sources only
+(closed_fleet_queued + recent merged `claude/<N>-*` heads), with none of the
+live `_resolve_ref_satisfied` fallback its sibling resolve_blocked_by uses.
+
+Any blocker that closed outside those two sources therefore pinned the issue
+`blocked: True` forever — a hard gate in project_worker (never wakes a planner
+dispatch) and in the role slice (can never be assigned as FLEET_PLAN_ISSUE), so
+the false positive is permanent and silent.
+
+The live incident: engine #2330, `Blocked by: #2310`, with #2310 CLOSED since
+2026-07-09. #2310 carries no labels, so it is absent from the
+`labels=fleet:queued` closed set at *any* window size — widening the window
+(what #2856 did for fetch_human_approved) does not reach this lane.
+
+The `gh` stub models `gh issue view <N> --repo <slug> --json state --jq .state`
+argument-for-argument and raises on any call shape it does not model, per
+scripts/fleet/CLAUDE.md ("a CLI stub models the tool's argument parsing, not
+just its endpoint" / mock at a seam that fails closed). test_stub_fidelity
+pins that rejection so a later stub rewrite cannot silently reopen the hole.
+
+Hermetic per scripts/fleet/CLAUDE.md: no live GitHub, no live ~/.fleet.
+"""
+import importlib.machinery
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+resolve_needs_plan_blocked_by = _mod.resolve_needs_plan_blocked_by
+
+# The incident's real numbers, so a reader can line the fixture up with #2986.
+_BLOCKED_ISSUE = 2330
+_BLOCKER = "2310"
+
+
+class _GhStub:
+    """Emulates `gh issue view <ref> --repo <slug> --json state --jq .state`.
+
+    `states` maps ref -> the state string the real gh would print. A ref absent
+    from it is a fixture error, not a pass — the stub raises rather than
+    returning an empty stdout that the subject would read as "not satisfied".
+    """
+
+    def __init__(self, states, raises=False):
+        self.states = states
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, argv, **kwargs):
+        # Model the real argument vector; anything else is an unmodeled call.
+        # gh issue view <ref> --repo <slug> --json state --jq .state  == 10 args
+        if len(argv) != 10 or argv[:3] != ["gh", "issue", "view"]:
+            raise AssertionError(f"unmodeled gh invocation: {argv!r}")
+        ref = argv[3]
+        if argv[4] != "--repo" or argv[6] != "--json" or argv[8] != "--jq":
+            raise AssertionError(f"unmodeled gh flags: {argv!r}")
+        if argv[7] != "state" or argv[9] != ".state":
+            raise AssertionError(f"unmodeled gh json/jq program: {argv!r}")
+        self.calls.append((argv[5], ref))
+        if self.raises:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=10)
+        if ref not in self.states:
+            raise AssertionError(
+                f"fixture gap: no state planted for #{ref} (calls={self.calls})")
+        return subprocess.CompletedProcess(
+            argv, 0, stdout=self.states[ref] + "\n", stderr="")
+
+
+def _state(blocked_by="#" + _BLOCKER, closed=(), merged_heads=()):
+    return {"repos": {"engine": {
+        "closed_fleet_queued": [{"number": n} for n in closed],
+        "recent_merged_prs": [{"headRefName": h} for h in merged_heads],
+        "needs_plan": [{
+            "number": _BLOCKED_ISSUE,
+            "labels": ["human:approved", "fleet:needs-plan"],
+            "body": f"**Area:** render\n**Blocked by:** {blocked_by}\n",
+        }],
+    }}}
+
+
+def _run(state, stub):
+    with patch.object(_mod.subprocess, "run", stub):
+        resolve_needs_plan_blocked_by(state)
+    return state["repos"]["engine"]["needs_plan"][0]["blocked"]
+
+
+class NeedsPlanLiveFallback(unittest.TestCase):
+
+    def test_closed_blocker_outside_inmemory_sources_unblocks(self):
+        """THE FIX. Blocker in neither in-memory source, CLOSED live.
+
+        Fails against pre-fix code: with no fallback the ref stays unresolved
+        and the issue projects blocked=True forever.
+        """
+        stub = _GhStub({_BLOCKER: "CLOSED"})
+        self.assertFalse(_run(_state(), stub))
+        self.assertEqual(stub.calls, [("jakildev/IrredenEngine", _BLOCKER)])
+
+    def test_merged_blocker_unblocks(self):
+        """A `Blocked by:` naming a PR number that MERGED is satisfied too."""
+        self.assertFalse(_run(_state(), _GhStub({_BLOCKER: "MERGED"})))
+
+    def test_open_blocker_still_blocks(self):
+        """NEGATIVE CONTROL — the fallback must not be a gate that cannot fire.
+
+        Same code path, only the live verdict differs.
+        """
+        stub = _GhStub({_BLOCKER: "OPEN"})
+        self.assertTrue(_run(_state(), stub))
+        self.assertEqual(len(stub.calls), 1)
+
+    def test_gh_failure_fails_closed(self):
+        """A flaky/timing-out gh leaves the issue blocked — the conservative
+        direction, matching pre-fix behaviour rather than inverting it."""
+        self.assertTrue(_run(_state(), _GhStub({}, raises=True)))
+
+    def test_inmemory_hit_makes_no_live_call(self):
+        """The common path must not acquire a per-tick network cost: a blocker
+        already in closed_fleet_queued short-circuits before the fallback."""
+        stub = _GhStub({})  # any call at all is a fixture gap -> raises
+        self.assertFalse(_run(_state(closed=[int(_BLOCKER)]), stub))
+        self.assertEqual(stub.calls, [])
+
+    def test_merged_head_hit_makes_no_live_call(self):
+        stub = _GhStub({})
+        heads = [f"claude/{_BLOCKER}-light-volume-continuity"]
+        self.assertFalse(_run(_state(merged_heads=heads), stub))
+        self.assertEqual(stub.calls, [])
+
+    def test_cross_repo_ref_makes_no_live_call(self):
+        """A qualified cross-repo ref is deferred to the ingest's own check;
+        it must not be resolved (or blocked on) from this repo's lane."""
+        stub = _GhStub({})
+        self.assertFalse(_run(_state(blocked_by="Irreden#41"), stub))
+        self.assertEqual(stub.calls, [])
+
+    def test_ref_cache_is_shared_across_lanes(self):
+        """One live call per novel ref per tick, not one per lane."""
+        cache = {}
+        stub = _GhStub({_BLOCKER: "CLOSED"})
+        with patch.object(_mod.subprocess, "run", stub):
+            resolve_needs_plan_blocked_by(_state(), cache)
+            resolve_needs_plan_blocked_by(_state(), cache)
+        self.assertEqual(len(stub.calls), 1)
+
+    def test_stub_fidelity(self):
+        """The stub rejects the shapes it claims to reject — otherwise the
+        arms above certify a call the real gh would never accept."""
+        stub = _GhStub({_BLOCKER: "CLOSED"})
+        with self.assertRaises(AssertionError):
+            stub(["gh", "issue", "view", _BLOCKER])
+        with self.assertRaises(AssertionError):
+            stub(["gh", "pr", "view", _BLOCKER, "--repo", "x",
+                  "--json", "state", "--jq", ".state"])
+        with self.assertRaises(AssertionError):
+            stub(["gh", "issue", "view", _BLOCKER, "--repository", "x",
+                  "--json", "state", "--jq", ".state"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `resolve_needs_plan_blocked_by` now takes the same live `_resolve_ref_satisfied`
  fallback its sibling `resolve_blocked_by` has always used, for refs that neither
  in-memory source (`closed_fleet_queued`, recent merged head branches) covers.
- **The bug is a silent, permanent strand.** `blocked` gates twice —
  `fleet-state-scout:1989` drops the issue from `project_worker` (never wakes a
  planner dispatch) and `:2491` drops it from the role slice (can never be assigned
  as `FLEET_PLAN_ISSUE`). Engine **#2330** has been invisible to the planning lane
  since its blocker **#2310 closed 2026-07-09 — ~30 days**.
- **Widening the window is not the fix.** `closed_fleet_queued` is windowed (one
  page, 100 against a live population of 820) *and* label-scoped to `fleet:queued`.
  The label scope is the binding one: #2310 carries no labels at all, so it is
  absent from that set at **any** window size. Widening the window is what #2856 did
  for `fetch_human_approved`; it does not reach this lane.
- `resolve_human_approved_blockers` **deliberately** keeps its in-memory-only path.
  Its flag has gated nothing since #1527 and is read only for `state.json`
  visibility, so a live call per novel ref per tick is the wrong trade for a
  display-only field on a polling daemon built around conditional GETs. That
  reasoning now lives at the function instead of reading as an unexplained
  asymmetry.
- All three resolvers share one per-tick ref cache, so a ref named by more than one
  of them (a task blocker that is also an epic child) costs a single live call.

## Reviewer notes

Two things worth a look:

1. **The scope call.** I fixed the gating lane and documented why the cosmetic one
   stays in-memory, rather than fixing both. If you'd rather see symmetry, say so —
   it's a two-line change, but it adds live calls to a per-tick path for a field
   nothing reads for control flow.
2. **Test-hermeticity fallout.** Giving a previously network-free function its first
   network call silently de-hermeticized the existing suite: its "open blocker"
   fixture was a real issue number (`#2280`) that had since closed, so it began
   failing on live GitHub state rather than on the code. That suite now stubs the
   seam, and `scripts/fleet/CLAUDE.md`'s hermetic-tests rule is extended to cover a
   function *acquiring* a network call, not just *migrating* one.

## Test plan

- [x] New suite `test_scout_needs_plan_live_fallback.py` — **9/9 pass**.
- [x] **Positive control** via `fleet-positive-control` (the prescribed tool, not a
      hand-stage): `MEANINGFUL: 4 of 9 assertions fail against origin/master
      (5a1fdc9ec)`; the 5 that still pass are the non-regression assertions.
- [x] Negative arm present and passing — an **open** blocker still yields
      `blocked: True`, so the fallback is not a gate that cannot fire.
- [x] Fail-closed arm — a timing-out `gh` leaves the issue blocked (same
      conservative direction as before the fallback).
- [x] Cost arms — an in-memory hit, a merged-head hit, and a cross-repo ref each make
      **zero** live calls; the shared cache makes one call for a ref named twice.
- [x] Pre-existing `test_needs_plan_blocked_by.py` repaired and network-free again:
      **12/12 pass**, runtime `0.378s → 0.000s` (the live call is measurably gone).
- [x] `test_epic_steward_projection.py` **36/36** after wiring its resolver to the
      shared cache.
- [x] Full suite: `bash scripts/fleet/tests/run_all.sh` → **128 of 129 passed**. The
      one failure is `test_cross_repo_shared_file_parity.sh`, a **known master-red**
      (`auto-rereview.yml` drift = #2827, repair merge-gated) — unrelated to this
      change and red on `origin/master` too.
- [x] `ruff check scripts/` clean.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| 1 — fallback used for refs neither in-memory source covers, sharing a per-tick cache | `test_closed_blocker_outside_inmemory_sources_unblocks`, `test_ref_cache_is_shared_across_lanes` | `blocked=False` with exactly one recorded call; two resolver invocations share one cache → `len(calls) == 1` |
| 2 — regression test fails against pre-fix code, incl. the negative arm | `fleet-positive-control scripts/fleet/tests/test_scout_needs_plan_live_fallback.py origin/master` | `MEANINGFUL: 4 of 9 assertions fail against origin/master (5a1fdc9ec)`; `test_open_blocker_still_blocks` passes post-fix |
| 3 — scout produces `blocked: false` for #2330 | shipped resolver driven over the live cached closed-set + the real fetched body | `engine #2330: blocked True -> False` |
| 4 — the second repo's lane stays correct | same run, that repo's needs-plan rows | both rows `blocked True -> True` (their single `Blocked by:` refs are genuinely open); its closed-set is not truncating — 68 of 68 fetched |

Control fidelity note: every arm imports the **shipped** module
(`importlib.machinery.SourceFileLoader` on the real `fleet-state-scout`), and the
arm-1 value reproduces the live `state.json` exactly, which is what licenses the
rest.

Closes #2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
