### PR TITLE
engine/world: auto-capture disarms the wait-for-first-input gate

### DIFF
--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -578,6 +578,17 @@ same `config = { ... }` table — there is one source of truth per file.
   video recording until the first input arrives — used to keep capture
   clips from starting mid-loading-screen. If video recording is not
   starting, check these flags first.
+
+  **`m_waitForFirstUpdateInput` is force-disarmed under `--auto-screenshot`**
+  (see #2990). It is a live-operator affordance — it holds the sim at the
+  single priming `update()` until a real key press arrives — and a headless
+  capture has no input source, so the gate can never open. Left armed, the
+  whole capture window renders one frozen tick, silently defeating the
+  `enableFixedStep()` carve-out in the same `gameLoop()` block. The
+  auto-capture branch therefore clears the flag and logs the override at
+  INFO. `m_startRecordingOnFirstInput` is deliberately left armed:
+  `--auto-screenshot` is the screenshot path, not the video one, so there is
+  nothing for it to start.
 - **Release GPU/GL resources in `end()`, never in `~World()`.** `end()` runs
   during `gameLoop()` while the context is provably live, and is the canonical
   spot for device-resource teardown (it already drives `destroyAllEntities()`

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -208,6 +208,19 @@ void World::gameLoop() {
             // etc.) is deterministic and not starved by the uncapped
             // (vsync-off) loop racing through the frame-counted capture window.
             m_timeManager.enableFixedStep();
+            // ...and disarm `m_waitForFirstUpdateInput`. It holds the sim at
+            // the single priming tick until a real key press arrives, and a
+            // headless capture has no input source — so the gate can never
+            // open, and every frame of the capture window renders that one
+            // frozen tick, defeating the fixed step this block just armed.
+            // A live run keeps the gate.
+            if (m_waitForFirstUpdateInput) {
+                m_waitForFirstUpdateInput = false;
+                IRE_LOG_INFO(
+                    "Auto-capture active: ignoring start_updates_on_first_key_press so the "
+                    "sim advances during the capture window."
+                );
+            }
         }
         if (m_waitForFirstUpdateInput) {
             // Prime render-facing state so paused mode shows initialized voxels.


### PR DESCRIPTION
## Summary
- `World::gameLoop` armed a fixed step for `--auto-screenshot` ("advance the sim exactly one UPDATE tick per render frame") and then, three lines later, let `start_updates_on_first_key_press` hold the sim at the single priming `update()` until `IRInput::hasAnyButtonPressedThisFrame()` fired. A headless capture has no input source, so the gate never opened and the entire capture window rendered one frozen tick.
- Clear `m_waitForFirstUpdateInput` inside the existing `IRVideo::isAutoCaptureActive()` branch — beside the `enableFixedStep()` call it was defeating — and log the override at INFO so the case stops being silent.
- `m_startRecordingOnFirstInput` is deliberately left armed: `--auto-screenshot` is the screenshot path, not the video one.
- `engine/world/CLAUDE.md`'s gotcha for these two flags now records the carve-out.

## Test plan
- [x] Engine test suite: `fleet-run --timeout 600 IrredenEngineTest` → `1546 passed, 1 failed`. The one failure is `SaveTrait.InventoryIsComplete`, the pre-existing master-red baseline — unrelated to this diff (it touches no save trait).
- [x] `fleet-build --target format-changed` → formatted 1 file, scoped to changed lines.
- [x] `fleet-build --target IRDayCycle` clean after the change.
- [x] Live-path reasoning re-checked against the loop: with auto-capture inactive the branch is not entered, so `m_waitForFirstUpdateInput` keeps its config value and the gate behaves exactly as before.

## Acceptance evidence

Measured on macOS/arm64 at `5a1fdc9ec`. The one in-repo demo that sets the flag (`creations/demos/default/config.lua:63,98`) ships no `--auto-screenshot` support, so it cannot serve as the repro vehicle; the repro instead flips the flag on temporarily in `creations/demos/day_cycle/config.lua` (`start_updates_on_first_key_press = false` → `true`) and counts ticks with a temporary counter in `World::update()`. Neither the flag flip nor the counter is part of this diff.

| Criterion | Check run | Observed |
|---|---|---|
| An `--auto-screenshot N` run with the flag set advances UPDATE once per render frame, not once per run | `fleet-run --timeout 180 IRDayCycle --auto-screenshot 120`, counter in `World::update()` | **before:** 1 tick for the whole run (`[PROBE] UPDATE tick #1`, and nothing further). **after:** ticks `#1 #2 #3 #50 #100 …` — one per render frame |
| A live (non-auto-capture) run still honours the gate | source: the assignment sits inside `if (IRVideo::isAutoCaptureActive())` | branch not entered without auto-capture; `m_waitForFirstUpdateInput` keeps its config value, priming-tick-then-wait behaviour unchanged |
| The override is visible in the run log rather than silent | same run, flag armed | `[EngineLog] [info] Auto-capture active: ignoring start_updates_on_first_key_press so the sim advances during the capture window.` — emitted once |

## Notes for reviewer
- **No automated regression lock.** `World::gameLoop` needs a window and a live GL context, so there is no headless seam to assert this from; the acceptance table above is the verification. If you want a durable lock, the cheapest shape is a demo whose config sets the flag plus a render-verify reference that only matches an advanced sim — worth its own ticket rather than growing this one.
- **The guard is a no-op for every in-repo config — but not because nothing sets the flag.** `start_updates_on_first_key_press` defaults to `false`, and a tree-wide sweep (3986 files) finds exactly one in-repo setter: `creations/demos/default/config.lua:63,98` set it `true` in `config_1080_windowed` / `config_1080_windowed_vertical`, and line 107 (`config = config_1080_windowed_vertical`) makes it the active preset for `IRCreationDefault`. That demo is still unaffected, for a different reason: it never calls `IRVideo::createAutoScreenshotSystem`, which is the sole writer of the `g_autoCaptureActive` flag behind `isAutoCaptureActive()` (`engine/video/src/auto_screenshot.cpp:63,71`), so the changed branch is unreachable there regardless of the config value. Every other demo and editor leaves the flag `false`. So in-repo captures show no visual change from this PR — but if `--auto-screenshot` support is ever added to `default`, it *would* hit this behaviour change.
- **This is a real behaviour change for a downstream creation that set the flag.** Such a creation's `--auto-screenshot` capture previously ran exactly one UPDATE tick, and code may have been written against that (seeding state on the assumption the sim is frozen). Disarming the gate is still the right call — a frozen capture is the defect — but the change is not inert downstream, and I flagged it in #2990's body for the same reason.

Closes #2990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

