### PR TITLE
docs: fix build-game stale-cache remedy for the renamed-worktree case

### DIFF
--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -124,9 +124,35 @@ when it can derive the layout itself (bare preset, or the
 creation-worktree detection above, which targets the *enclosing* clone),
 so a dir bound to a specific engine worktree must be configured by hand
 once as shown. There is no `--build-dir` flag — the `IRREDEN_BUILD_DIR`
-env var is the override knob. If the cache in `$ENG/build-game` goes
-stale (worktree renamed/migrated, preset change), reconfigure in place:
-`cmake -S "$ENG" -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+env var is the override knob.
+
+**Stale-cache remedy — the fix depends on *what* went stale.**
+`CMakeCache.txt` records `CMAKE_CACHEFILE_DIR` and `CMAKE_HOME_DIRECTORY`
+as absolute paths; CMake refuses to reconfigure a cache whose recorded
+paths disagree with the invocation. That refusal looks like this:
+
+```
+CMake Error: The current CMakeCache.txt directory
+  .../build-game/CMakeCache.txt is different than the directory
+  .../<old-worktree>/build-game where CMakeCache.txt was created.
+CMake Error: The source ".../CMakeLists.txt" does not match the
+  source ".../<old-worktree>/CMakeLists.txt" used to generate cache.
+  Re-run cmake with a different source directory.
+```
+
+- **Same worktree, only `IRREDEN_USER_PROJECTS` or the preset changed** —
+  the recorded paths still match, so the in-place reconfigure works:
+  `cmake -S "$ENG" -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+- **Worktree renamed or migrated** — the recorded paths no longer match
+  the current ones, and no flag makes CMake adopt a cache whose
+  `CMAKE_HOME_DIRECTORY` disagrees with the source dir it's pointed at.
+  The in-place reconfigure above **fails** with the error shown; remove
+  the stale dir and re-run the one-time configure fresh:
+  `rm -rf "$ENG/build-game" && cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+  If directory removal is blocked by a permission layer, fall back to a
+  fresh sibling dir instead (e.g. `$ENG/build-game-<agent>`) and point
+  `IRREDEN_BUILD_DIR` at that — the stale directory is simply abandoned,
+  not fixed.
 
 Target selection stays with the caller (pick the `IR<Project>All` target
 matching what the PR touches), as does the **never build `IRGameAll`**

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -113,18 +113,25 @@ idempotent — reuse it across iterations):
 ENG=<your-engine-worktree-abs-path>
 GAME_WT=~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>
 # one-time configure (skip if $ENG/build-game/CMakeCache.txt exists):
-cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"
+cmake -S "$ENG" --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"
 # build the affected project's target via ir-build, pointed at that dir:
 IRREDEN_BUILD_DIR="$ENG/build-game" fleet-build --target IRIrredenAll
 ```
 
 `<host>-debug` is your host preset (`macos-debug` / `linux-debug` /
-`windows-debug`). You own this configure: `ir-build` only auto-configures
-when it can derive the layout itself (bare preset, or the
-creation-worktree detection above, which targets the *enclosing* clone),
-so a dir bound to a specific engine worktree must be configured by hand
-once as shown. There is no `--build-dir` flag — the `IRREDEN_BUILD_DIR`
-env var is the override knob.
+`windows-debug`). The `-S "$ENG"` is what the preset-snippet convention
+above requires — "if the recipe's expected CWD is not the engine root, the
+snippet must pass `-S <engine-root>` explicitly" — and this recipe's cwd is
+exactly that case: the game-PR flow `cd`s into the *game* worktree before
+building (role-worker step 1c). Run bare there and `--preset` resolves
+against the cwd instead, failing with `Could not read presets from
+<game-worktree>: File not found`.
+
+You own this configure: `ir-build` only auto-configures when it can derive
+the layout itself (bare preset, or the creation-worktree detection above,
+which targets the *enclosing* clone), so a dir bound to a specific engine
+worktree must be configured by hand once as shown. There is no
+`--build-dir` flag — the `IRREDEN_BUILD_DIR` env var is the override knob.
 
 **Stale-cache remedy — the fix depends on *what* went stale.**
 `CMakeCache.txt` records `CMAKE_CACHEFILE_DIR` and `CMAKE_HOME_DIRECTORY`
@@ -142,13 +149,24 @@ CMake Error: The source ".../CMakeLists.txt" does not match the
 
 - **Same worktree, only `IRREDEN_USER_PROJECTS` or the preset changed** —
   the recorded paths still match, so the in-place reconfigure works:
-  `cmake -S "$ENG" -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+  `cmake -S "$ENG" --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+  Carry `--preset` even when only `IRREDEN_USER_PROJECTS` changed. Without
+  it the reconfigure patches that one variable and leaves every other cached
+  value at whatever the *previous* preset wrote — so a genuine preset switch
+  is silently not applied, and the build keeps the old backend/compiler while
+  the command appears to succeed. With it, the preset's `cacheVariables` are
+  re-applied over the existing cache. The one thing `--preset` cannot change
+  in place is the **generator**: `windows-debug` is `MinGW Makefiles` where
+  `linux-debug` / `macos-debug` are `Unix Makefiles`, and a switch across
+  that boundary hard-errors with `generator : X Does not match the generator
+  used previously: Y` — that case belongs to the remove-and-reconfigure
+  bullet below, not here.
 - **Worktree renamed or migrated** — the recorded paths no longer match
   the current ones, and no flag makes CMake adopt a cache whose
   `CMAKE_HOME_DIRECTORY` disagrees with the source dir it's pointed at.
   The in-place reconfigure above **fails** with the error shown; remove
   the stale dir and re-run the one-time configure fresh:
-  `rm -rf "$ENG/build-game" && cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
+  `rm -rf "$ENG/build-game" && cmake -S "$ENG" --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"`.
   If directory removal is blocked by a permission layer, fall back to a
   fresh sibling dir instead (e.g. `$ENG/build-game-<agent>`) and point
   `IRREDEN_BUILD_DIR` at that — the stale directory is simply abandoned,


### PR DESCRIPTION
## Summary
- `docs/agents/BUILD.md`'s "Dedicated game build dir" stale-cache remedy prescribed an in-place `cmake -S ... -B $ENG/build-game` reconfigure for a renamed/migrated worktree — the exact case CMake's `CMAKE_CACHEFILE_DIR`/`CMAKE_HOME_DIRECTORY` path check refuses.
- Split the remedy: same-worktree config changes still reconfigure in place; a renamed/migrated worktree removes the stale dir and re-runs the one-time configure, with a fresh-sibling-dir fallback when removal is gated.
- Pasted the verbatim CMake error text so the section is findable by search.
- **(review nit, 2nd commit)** The in-place bucket claims to cover "or the preset changed", but its command carried no `--preset` — so that half of its own heading did not hold. Added `--preset`, stated the generator boundary it cannot cross, and brought all three commands into compliance with the `-S <engine-root>` convention this same file states 60 lines earlier.

## Test plan
- [x] Read the full "Dedicated game build dir" section before and after the edit to confirm the two remedy branches don't contradict the surrounding one-time-configure / `IRREDEN_BUILD_DIR` explanation.
- [x] Grepped the repo for other doc references to `build-game`'s stale-cache remedy to confirm no other doc needed updating (only `role-worker.md` references the dir generically, unaffected — it links to this section by anchor, which is unchanged).
- [x] Verified the changed file retains a trailing newline (non-clang-format text hygiene check).
- [x] Swept every other `cmake --preset` snippet in `docs/` for the same `-S` convention violation — all others are immediately preceded by `cd ~/src/IrredenEngine`, so their expected cwd *is* the engine root. The `build-game` recipe was the only violation.

## Acceptance evidence
| Criterion | Check run | Observed |
|---|---|---|
| Remedy correct for the renamed-worktree case (remove+reconfigure, in-place kept only for same-worktree cases) | `grep -n "Worktree renamed or migrated" docs/agents/BUILD.md` | `164:- **Worktree renamed or migrated** — ...` |
| Stale-cache symptom is greppable from the doc | `grep -n "CMake Error: The current CMakeCache.txt directory" docs/agents/BUILD.md` | `142:CMake Error: The current CMakeCache.txt directory` |
| Remedy is executable; gated-removal fallback named | `grep -n "sibling dir\|permission layer" docs/agents/BUILD.md` | `170:  If directory removal is blocked by a permission layer, fall back to a` / `171:  fresh sibling dir instead ...` |

## Review-nit evidence (2nd commit)

The nit's two suggested remedies were "drop `or the preset changed`" **or** "add `--preset`". Probed CMake 4.3.1 on a throwaway project to pick between them, then re-ran the chosen form against this repo.

| Probe | Command | Observed |
|---|---|---|
| In-place, **no** `--preset` (the pre-fix line) | `cmake -S <src> -B <dir> -DMYUSERPROJ=/second/path` | `PROBE BACKEND=OPENGL` — cache still holds the *previous* preset's value; a preset switch is silently not applied. Nit's diagnosis confirmed. |
| In-place **with** `--preset`, same generator | `cmake --preset bb-debug -B <dir> -D...` | `PROBE BACKEND=METAL` — the new preset's `cacheVariables` **are** re-applied over the existing cache. Remedy 2 works. |
| In-place with `--preset`, **different** generator | `cmake --preset cc-debug -B <dir>` (Ninja over a Unix Makefiles cache) | `CMake Error: Error: generator : Ninja / Does not match the generator used previously: Unix Makefiles` — hard error; belongs to the remove-and-reconfigure bullet. |
| `--preset` resolution vs cwd | `cmake --preset X -B <dir>` from a foreign cwd, with and without `-S` | Without `-S`: `Could not read presets from /tmp: File not found`. With `-S <src>`: configures clean. |

Real-repo verification, run from the **game** worktree cwd (the cwd `role-worker.md` step 1c leaves you in):

| Form | Result |
|---|---|
| Pre-fix one-time configure (`cmake --preset macos-debug -B ...`) | `CMake Error: Could not read presets from .../creations/game/.claude/worktrees/pool-3: File not found: .../CMakePresets.json` |
| Fixed one-time configure (`cmake -S "$ENG" --preset macos-debug -B ...`) | `rc=0`, `Configuring done (45.3s)`; cache records `IRREDEN_GRAPHICS_BACKEND=METAL`, `IRREDEN_USER_PROJECTS=<game worktree>`, `CMAKE_GENERATOR=Unix Makefiles` |
| Fixed in-place reconfigure (same command, existing cache) | `rc=0`, `Configuring done (7.7s)` |

| Nit item | Line | Resolution |
|---|---|---|
| `BUILD.md:143-145` — in-place bucket claims "or the preset changed" but the command has no `--preset` | `151-163` | Took the nit's remedy 2 (`add --preset`) over remedy 1 (`drop the clause`): the capability is real for same-generator switches, so the honest fix keeps it and names the boundary it can't cross (`windows-debug` = MinGW Makefiles vs `linux`/`macos-debug` = Unix Makefiles). |
| *(adjacent, found while probing)* one-time configure and remove-and-reconfigure commands omit `-S` | `116`, `122-128`, `169` | Both now pass `-S "$ENG"`, per the convention this file already states at `55-62`. |

Closes #2992

🤖 Generated with [Claude Code](https://claude.com/claude-code)
