### PR TITLE
fleet/scout: bound state.json under the Read tool's 256 KB cap

### DIFF
--- a/.fleet/plans/issue-2752.md
+++ b/.fleet/plans/issue-2752.md
@@ -1,0 +1,161 @@
+## Plan: fleet/scout: state.json is past the Read tool's 256KB cap (replan — Phase 3 committed)
+
+- **Issue:** #2752
+- **Model:** opus
+- **Date:** 2026-08-08
+- **Revision:** v2 — addresses the 2026-08-01 design-soundness bounce: Phase 3
+  is committed to a single arm (the review's arm (b)), the projected shortfall
+  is closed with one further committed reduction (not a menu), AC #3's fixture
+  is pinned label-absent, and arms (a)/(c) are dropped. Phases 1, 2, and the
+  guard phase carry over verbatim from v1 (renumbered; mapping below). All
+  numbers below re-measured this session (2026-08-08, macOS pool-1,
+  post-#2743).
+
+### Verified current state (re-measured 2026-08-08)
+
+- On-disk `~/.fleet/state/state.json` = **476.8 KB** (`os.path.getsize` =
+  488,274; cap = 262,144). Grew from 423 KB at filing — #2743 (merged via
+  PR #2915) lifted the `prs[]` window as v1's reconciliation predicted, so the
+  sequencing constraint from v1 is **resolved**: this plan measures against
+  the real window (27 engine + 19 game open PRs).
+- `reviews` = **218.6 KB (~46 % of the file)**: 101 non-empty bodies
+  (63 engine + 38 game), `med=max=2063 B` — still 62-of-63-at-the-cap shaped;
+  the per-body cap works, the aggregate is unbounded (unchanged root cause,
+  `_truncate_review_body`, `fleet-state-scout:180-192`).
+- **New measurement — 89.4 KB of the on-disk file is pretty-print
+  whitespace.** The same state serialized compact
+  (`separators=(",", ":")`) is 387.4 KB. The emitter is
+  `fleet-state-scout:3060`: `json.dumps(state, indent=2, sort_keys=True)`.
+  Review bodies are single JSON strings, so body-trimming and
+  whitespace-removal are **orthogonal, stacking** savings.
+- Latest-review-only body retention keeps 81.7 KB and drops **117.9 KB**
+  (measured by re-projecting the live cache).
+- **Arm (b) feasibility measured:** 8 live review bodies carry the
+  `Opus recheck required` phrase; the distance from the phrase-line start to
+  end-of-body is `[146, 150, 165, 181, 234, 261, 437, 539]` — max **539 B**,
+  so a 640 B tail preserves every live instance with headroom.
+- Consumer contract (re-verified at current line numbers): sonnet-reviewer
+  reads `reviews[].author` only (`role-sonnet-reviewer.md:72`); opus-reviewer
+  tests the **latest** review's `body` for the fixed phrase
+  (`role-opus-reviewer.md:101`), as one disjunct alongside the
+  `fleet:needs-opus-recheck` label (`:35`) — the phrase path must keep firing
+  independently of the label (`fleet-state-scout` documents the PR #1473
+  regression this guards). Both role docs are gated; this plan changes
+  neither the schema nor either predicate, so the whole fix stays
+  worker-applicable.
+
+### Ruled out / out of scope (carried from v1 + bounce, do not re-derive)
+
+- `closed_fleet_queued` (48 KB) — load-bearing (queue-manager projection
+  blocker-clearing, `tests/test_queue_manager_projection.py:273`; epic-steward
+  reads it). Do not drop.
+- `tasks.done` (41.4 KB) — internal derived mirror with **two live readers**
+  (trigger-hash feed `fleet-state-scout:2073`; role-projection slice `:2552`).
+  v1's arm (c) re-admitted it without resolving either reader — per the
+  bounce, it stays **out of scope**; the projection below clears the cap
+  without touching it. If it is ever dropped, that is its own issue resolving
+  both readers explicitly.
+- v1's arm (a) (drop `body` from non-candidate PRs) — dropped per the bounce:
+  as specified it saved zero bytes, and widened it kills the label-independent
+  phrase path.
+
+### Committed approach — four reductions + a guard, no menu
+
+All four reductions are committed; none is implementer's-choice. Projection
+arithmetic (measured basis above): 476.8 − 117.9 (P1) − 35.8 (P2) − 15.4 (P3)
+− 89.4 (P4) ≈ **218 KB**, under the 256 KB cap with ~38 KB headroom — and
+growth is now bounded per-PR (~200 B/review metadata + one ≤ 800 B body), so a
+45-PR window projects ~+8 KB over today, not +48.
+
+**Phase 1 — body only where a consumer reads it** *(v1 Phase 1, verbatim).*
+In the PR fetch (`_fetch_prs_graphql`), retain `body` on the **latest** review
+per PR (by `submittedAt`); emit `body: ""` for older ones; keep
+`author`/`state`/`submittedAt` on every entry. Schema unchanged. Saves
+117.9 KB measured.
+
+**Phase 2 — trim the unread head** *(v1 Phase 2, verbatim).* No code or role
+doc reads the 1024 B head; the phrase is a trailing line, covered by the tail.
+`REVIEW_BODY_HEAD` 1024 → **128**. Saves ~35.8 KB (≈40 kept bodies × 896 B).
+
+**Phase 3 — committed to the bounce's arm (b): minimal tail.**
+`REVIEW_BODY_TAIL` 1024 → **640**, chosen from the measured live maximum
+phrase-tail distance of 539 B (+19 % headroom). Saves ~15.4 KB. At
+implementation time, re-measure the phrase-tail distances against the
+then-live corpus (one python pass over the cache, as above); if any live
+instance exceeds 640, raise the constant to cover it and say so in the PR
+body — measured, never guessed.
+
+**Phase 4 (new) — compact emit for `state.json` only.** At
+`fleet-state-scout:3060`, emit with `separators=(",", ":")` (keep
+`sort_keys=True` — it is what makes ticks diffable). Saves **89.4 KB**
+measured, fully orthogonal to Phases 1–3. Consumer audit (done this session):
+every reader parses JSON — `read_json_retry` sites in the scout, the
+dispatcher's stdlib `generated_at` parse (`fleet-dispatcher:2100-2116`),
+`fleet-epic-status` (python), `fleet-up` (existence check only,
+`fleet-up:1327-1338`), the leader-bundle protocol (verbatim text + parse).
+No line-oriented (grep/sed) consumer exists. Scope guard: the per-PR/issue
+detail caches (`:1064`, `:1103`) and the role projections (`:3178`) **keep**
+`indent=2` — they are small and human-read; only the oversized aggregate goes
+compact. Debug ergonomics: `python3 -m json.tool` / `jq .` reflate on demand.
+
+**Phase 5 — regression guard + doc correction** *(v1 Phase 4, verbatim).*
+Scout logs loudly when the emitted on-disk size exceeds ~200 KB; correct
+`docs/agents/FLEET-CACHE.md:13` to state the **invariant** ("must stay under
+the 256 KB Read cap") rather than a point-in-time size.
+
+Do not ship on a projected number: re-measure `os.path.getsize` on the live
+host after the change (46 open PRs across repos today), alongside acceptance
+test 2's deterministic synthetic bound.
+
+### Affected files
+
+- `scripts/fleet/fleet-state-scout` — Phases 1–5 (fetch projection, the two
+  constants, the emit call, the size guard)
+- `docs/agents/FLEET-CACHE.md` — Phase 5 invariant wording
+- `scripts/fleet/tests/test_state_projection_size.py` — new (acceptance below)
+
+### Acceptance criteria
+
+1. **Both predicates still fire** (new test): fixture PR whose **latest**
+   review body contains `Opus recheck required` and an older review that does
+   not — **fixture carries NO `fleet:needs-opus-recheck` label** (pinned per
+   the bounce: the label-absent input is the one that can regress) — the
+   opus-reviewer predicate (latest-body phrase test) must select it after the
+   projection. A PR with zero reviews must still satisfy sonnet-reviewer's
+   `reviews[].author`-empty predicate. **Positive control:** flip the
+   fixture's phrase to absent and assert the predicate stops firing.
+2. **Size bound (the test that fails today):** synthesize 45 PRs × 3 reviews ×
+   oversized bodies, run the full projection + emit path, assert the emitted
+   **on-disk bytes** < 262,144 (i.e. the bound covers Phases 1–4 together,
+   including the compact emit).
+3. **Phrase survives truncation at the new constants:** a body shaped like the
+   live maximum (phrase line starting 539 B from the end) still contains the
+   phrase after `_truncate_review_body` with HEAD=128/TAIL=640.
+4. Existing scout tests stay green (hermetic — mock at a fail-closed seam,
+   never the live API, per `scripts/fleet/CLAUDE.md`).
+
+### Sibling / in-flight reconciliation
+
+- **#2743 — merged** (PR #2915); measurements above are post-merge. The v1
+  sequencing constraint is discharged.
+- Open scout-touching PRs #2964 (per-kind trigger suppression) and #2967
+  (degraded-skip projection edge) touch the trigger/projection machinery, not
+  `_truncate_review_body` / `_fetch_prs_graphql` / the `STATE_FILE` emit —
+  disjoint hunks in the same file; merge-order independent (worst case a
+  trivial textual rebase).
+- No open PR or sibling issue touches the review-retention path.
+
+### Gotchas
+
+- The phrase path is **independent of the label by design**
+  (`fleet-state-scout`'s own comment documents the PR #1473 regression);
+  nothing in Phases 1–4 may condition body retention on the label.
+- `sort_keys=True` stays in the Phase 4 emit — dropping it would make every
+  tick a full-file diff for the leader-bundle change detection.
+- The scout is the *writer*; roles read the file through parse-based
+  extraction. No role-doc edit is needed anywhere in this plan (all consumers
+  keep working unchanged), which is what keeps the fix inside the ungated
+  worker surface.
+- One task, one PR. Phases are one commit each or grouped; test file lands
+  with them.
+

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -10,7 +10,7 @@ section below for which files apply.
 
 | Path | Producer | Reader | Purpose |
 |---|---|---|---|
-| `state.json` | scout | every role | List-shape state: open PRs (with labels, reviews, mergeable), needs-plan / human-approved issues (number + title + labels + updatedAt), open `fleet:queued` issue rows. ~32 KB. |
+| `state.json` | scout | every role | List-shape state: open PRs (with labels, reviews, mergeable), needs-plan / human-approved issues (number + title + labels + updatedAt), open `fleet:queued` issue rows. **Must stay under the 256 KB Read-tool cap** — see the size invariant below. |
 | `projections/<role>.json` | scout (slicers) | the named role | Pre-filtered per-role slice with full records (e.g. the worker lane's `tasks_open` + `feedback_prs`). ~5 KB. **Prefer this over `state.json`** when you only need your own role's items. |
 | `prs/<repo>/<N>.json` | scout | `fleet-pr view`/`comments` | Full PR detail: body, conversation comments, review summaries, inline review threads, files-changed list. Refreshed only when the list query's `updatedAt` advances. |
 | `diffs/<repo>/<N>-<sha>.diff` | scout | `fleet-pr diff` | Raw `gh pr diff` output, keyed by head SHA. Refreshed on rebase only; old SHAs garbage-collected. |
@@ -28,6 +28,30 @@ When the cache is fresh, do **NOT** bypass it for `gh pr list` or
 `gh issue list --label …`.
 One Read replaces what used to be 3-6 fan-out gh/git calls per role
 per startup.
+
+### Size invariant: `state.json` must stay under 256 KB (#2752)
+
+Every role's startup step reads `state.json` with the **Read tool**, which
+hard-errors above **256 KB**. That is a standing invariant on the writer, not a
+point-in-time measurement: the file drifted from a documented "~32 KB" to
+476 KB unnoticed, and the only symptom was every role failing its own first
+step. Two things hold the line, and a change to the projection must keep both:
+
+- **The scout emits `state.json` compact** (`separators=(",", ":")`,
+  `sort_keys=True` retained for diffability). Only this aggregate is compact;
+  the small human-read caches (`prs/`, `issues/`, `projections/`) keep
+  `indent=2`. Reflate on demand with `python3 -m json.tool` or `jq .`.
+- **`prs[].reviews` retains a body only on the latest review per PR**, capped
+  at head + tail (`REVIEW_BODY_HEAD` / `REVIEW_BODY_TAIL`). The tail is sized
+  from the measured live corpus so the opus reviewer's `Opus recheck required`
+  phrase test keeps firing; do not lower it without re-measuring.
+
+The scout warns at **7/8 of the cap (224 KB)** and writes
+`${FLEET_ALERTS_DIR:-~/.fleet/alerts}/state-scout-state-size` for as long as
+the condition holds. Measured 2026-08-08 on a 46-open-PR tree, the file emits at
+**205.7 KB** (down from 510 KB), so there is ~18 KB of growth room before the
+first warning and ~50 KB before the hard cap. If you add a field to the
+projection, check that alert.
 
 `state.json` and `projections/<role>.json` carry an ISO-8601
 `generated_at` field. If it is more than ~5 minutes old, the scout

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -130,6 +130,13 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   inlining. `test_smoke_worker_projection.py`'s `TwoCopiesAgree` is the
   reference shape. Bash reaches `fleet_task_class.py` the other way, through a
   CLI arm (`--plan-pick`, `--smoke-check`), never an import.
+- **`state.json` has a hard size ceiling; don't widen the projection without
+  checking it.** Every role reads it through the Read tool's 256 KB cap, so the
+  scout emits it **compact** and retains a review body only on the latest review
+  per PR — do not "tidy" either back. The scout warns and writes an alert past
+  7/8 of the cap. Invariant + the measured budget:
+  [`docs/agents/FLEET-CACHE.md`](../../docs/agents/FLEET-CACHE.md) §"Size
+  invariant".
 - **Concurrently-read state writers use `write_atomic`, never plain
   `write_text`.** A JSON/state/cache file that another process may read
   mid-write is persisted with the module's `write_atomic()` helper

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -177,16 +177,25 @@ def run_capture(cmd, cwd=None):
     return proc.stdout
 
 
-REVIEW_BODY_HEAD = 1024
-REVIEW_BODY_TAIL = 1024
+# Both constants are sized against the ONE predicate that reads a review body:
+# the opus reviewer's fixed-phrase test for "Opus recheck required"
+# (role-opus-reviewer.md). It matches a TRAILING line, so only the tail is
+# load-bearing — nothing reads the head, which is why it is small.
+#
+# The tail is sized from the measured live corpus: across the 8 review bodies
+# carrying the phrase, the distance from the phrase line's start to end-of-body
+# was [146, 150, 165, 181, 234, 261, 437, 539] B, so 640 covers the maximum with
+# ~19% headroom. Re-measure before lowering — a tail that clips the phrase
+# silently disables the recheck lane (the PR #1473 regression). See #2752.
+REVIEW_BODY_HEAD = 128
+REVIEW_BODY_TAIL = 640
 
 
 def _truncate_review_body(body):
-    # Reviewer roles only need enough of the body to filter on phrases like
-    # "Opus recheck required" (typically near the end) and skim the gist
-    # (typically at the start). Storing full bodies bloats state.json since
-    # every role re-reads the cache each iteration; cap at head + tail with
-    # an ellipsis between when oversized.
+    # Cap an oversized body at head + tail with an ellipsis between. Note this
+    # bounds each body individually; the AGGREGATE (n_PRs × n_reviews) is bounded
+    # separately, by retaining a body only on the latest review per PR — see
+    # _fetch_prs_graphql.
     if not body or len(body) <= REVIEW_BODY_HEAD + REVIEW_BODY_TAIL:
         return body
     return body[:REVIEW_BODY_HEAD] + "\n…[truncated]…\n" + body[-REVIEW_BODY_TAIL:]
@@ -300,14 +309,31 @@ def _fetch_prs_graphql(repo):
     for pr in prs:
         pr["labels"] = sorted(label["name"] for label in pr.get("labels", []))
         pr["author"] = pr.get("author", {}).get("login", "")
+        # #2752 — retain a body only on the LATEST review per PR. Exactly two
+        # consumers read this array: the sonnet reviewer tests reviews[].author
+        # (has any fleet review landed yet), and the opus reviewer tests the
+        # LATEST review's body for "Opus recheck required". No consumer reads an
+        # older review's body, and retaining them made `reviews` ~46% of
+        # state.json — enough to push the file past the 256 KB Read-tool cap that
+        # every role hits at startup. The schema is unchanged (older entries keep
+        # the key, valued ""), so neither predicate moves.
+        raw_reviews = pr.get("reviews", []) or []
+        latest_index = max(
+            range(len(raw_reviews)),
+            key=lambda i: (raw_reviews[i].get("submittedAt") or "", i),
+            default=-1,
+        )
         pr["reviews"] = [
             {
                 "author": rev.get("author", {}).get("login", ""),
-                "body": _truncate_review_body(rev.get("body", "")),
+                "body": (
+                    _truncate_review_body(rev.get("body", ""))
+                    if i == latest_index else ""
+                ),
                 "state": rev.get("state", ""),
                 "submittedAt": rev.get("submittedAt", ""),
             }
-            for rev in pr.get("reviews", [])
+            for i, rev in enumerate(raw_reviews)
         ]
         # Derive here, while body is live, so the signal survives both the
         # post-enrich body-pop and fetch_prs's 304 reuse of body-stripped
@@ -2702,6 +2728,108 @@ def write_atomic(path: Path, payload: str) -> None:
         raise
 
 
+# --- state.json size guard -------------------------------------------------
+#
+# Every fleet role reads state.json at startup through the Read tool, which HARD
+# ERRORS past 256 KB — so the file's size is a standing invariant on this writer,
+# not a statistic. Nothing watched it before, and the only symptom of the drift
+# past the cap was every role failing its own first step. This guard makes the
+# next drift operator-visible while there is still headroom. See #2752.
+STATE_SIZE_READ_CAP_BYTES = 256 * 1024
+# 7/8 of the cap (224 KB), expressed as a fraction so the two can't drift apart.
+# Sized against the MEASURED post-fix file (205.7 KB on a 46-open-PR tree), not a
+# round number: a threshold below that would fire on every tick from day one,
+# which is the same spam-hides-the-outage failure the escalate-then-quiet
+# machinery below exists to avoid.
+STATE_SIZE_WARN_BYTES = STATE_SIZE_READ_CAP_BYTES * 7 // 8
+# Loud on the tick that crosses, then only every Nth tick — the scout ticks every
+# ~30s and the condition persists until a human acts, so an unconditional warn is
+# spam that hides the outage (scripts/fleet/CLAUDE.md, escalate-then-quiet).
+STATE_SIZE_WARN_REPEAT_TICKS = 120
+
+_state_size_over_streak = 0
+
+
+def _alerts_dir() -> Path:
+    return Path(os.environ.get("FLEET_ALERTS_DIR") or (Path.home() / ".fleet" / "alerts"))
+
+
+def _state_size_alert_path() -> Path:
+    return _alerts_dir() / "state-scout-state-size"
+
+
+def check_state_size(size_bytes: int) -> None:
+    # Best-effort throughout: a read-only $HOME must never break the emit path
+    # this is guarding.
+    global _state_size_over_streak
+    kb = size_bytes / 1024.0
+    if size_bytes < STATE_SIZE_WARN_BYTES:
+        if _state_size_over_streak:
+            log(f"state.json back under the warn threshold ({kb:.1f} KB)")
+            try:
+                _state_size_alert_path().unlink()
+            except OSError:
+                pass
+        _state_size_over_streak = 0
+        return
+
+    _state_size_over_streak += 1
+    over_cap = size_bytes >= STATE_SIZE_READ_CAP_BYTES
+    if _state_size_over_streak == 1 or _state_size_over_streak % STATE_SIZE_WARN_REPEAT_TICKS == 0:
+        log(
+            f"state.json is {kb:.1f} KB — "
+            + (
+                "PAST the 256 KB Read-tool cap; every role's startup read now "
+                "hard-errors. Shrink the projection (see #2752)."
+                if over_cap else
+                f"over the {STATE_SIZE_WARN_BYTES // 1024} KB warn threshold and "
+                "approaching the 256 KB Read-tool cap. Shrink the projection."
+            )
+            + f" [tick {_state_size_over_streak}]"
+        )
+    # Rewritten every tick, not just at the escalation: once stderr goes quiet the
+    # file is the only standing signal, and a write-once alert would freeze its
+    # count and let a triage pass silence a still-live condition permanently.
+    try:
+        path = _state_size_alert_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_atomic(
+            path,
+            f"state.json size guard\n"
+            f"size_bytes={size_bytes}\n"
+            f"size_kb={kb:.1f}\n"
+            f"warn_threshold_kb={STATE_SIZE_WARN_BYTES // 1024}\n"
+            f"read_cap_kb={STATE_SIZE_READ_CAP_BYTES // 1024}\n"
+            f"past_read_cap={'yes' if over_cap else 'no'}\n"
+            f"consecutive_ticks={_state_size_over_streak}\n"
+            f"issue=#2752\n",
+        )
+    except OSError:
+        pass
+
+
+def emit_state(state) -> int:
+    """Serialize + atomically write `state.json`, returning its on-disk bytes.
+
+    This aggregate emits COMPACT, and must stay that way: it is the largest file
+    the scout writes and every role reads it through the Read tool's 256 KB cap,
+    where pretty-print whitespace alone costs ~90 KB. `sort_keys=True` stays — it
+    is what keeps a tick's diff proportional to what actually changed, which the
+    leader-bundle change detection relies on. Every consumer parses JSON
+    (audited: the scout's own read_json_retry sites, fleet-dispatcher's
+    generated_at parse, fleet-epic-status, the leader-bundle protocol; fleet-up
+    only tests existence), so there is no line-oriented reader to break, and
+    `python3 -m json.tool` / `jq .` reflate it on demand for debugging. The small
+    human-read caches (per-PR/issue details, role projections) keep indent=2.
+    See #2752 and docs/agents/FLEET-CACHE.md §"Size invariant".
+    """
+    payload = json.dumps(state, separators=(",", ":"), sort_keys=True) + "\n"
+    write_atomic(STATE_FILE, payload)
+    size = len(payload.encode("utf-8"))
+    check_state_size(size)
+    return size
+
+
 def read_json_retry(path, attempts=3, backoff=0.05):
     # Script-side cache readers can still lose the race against a concurrent
     # os.replace on a slow filesystem; one short retry recovers instead of
@@ -3057,7 +3185,7 @@ def tick_once():
         for _repo_state in state["repos"].values():
             for _pr in _repo_state.get("prs", []):
                 _pr.pop("body", None)
-    write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
+    emit_state(state)
 
     if authoritative:
         # Detail caches (prs/ diffs/ issues/) come from GitHub only on the

--- a/scripts/fleet/tests/test_state_projection_size.py
+++ b/scripts/fleet/tests/test_state_projection_size.py
@@ -1,0 +1,414 @@
+"""Tests for state.json's size bound and the review-body retention it rests on (#2752).
+
+Every fleet role's startup step reads `~/.fleet/state/state.json` with the Read
+tool, which HARD ERRORS above 256 KB. The file reached 476.8 KB: `prs[].reviews`
+was ~46% of it (a body retained on every review of every open PR, each capped at
+2 KB but with an unbounded aggregate), and 89.4 KB was `indent=2` whitespace.
+
+Two things are being guarded, and they need different kinds of test:
+
+- **The size bound** is the acceptance gate. TestSizeBound drives the SHIPPED
+  projection (`_fetch_prs_graphql`) and the SHIPPED emit (`emit_state`), never a
+  re-implementation of either — a test that re-serialized the fixture itself
+  would only be a change-detector on its own arithmetic. TestFixtureFidelity
+  proves the fixture can express the bug: serialized the pre-fix way (every body
+  retained, indent=2) the same input blows the cap, so a green TestSizeBound is
+  the projection's doing and not a too-small fixture.
+
+- **The two consumer predicates** must keep firing across the trim.
+  TestConsumerPredicates models them from the role docs (they are gated files;
+  this plan changes neither) and pins the input that can actually regress: the
+  opus predicate's fixture carries NO `fleet:needs-opus-recheck` label, so the
+  label disjunct cannot mask a broken phrase path — the PR #1473 regression the
+  scout's own comment documents. Each predicate arm ships a positive control
+  that flips the input and asserts the predicate stops firing.
+
+Against the pre-fix `origin/master` the suite splits three ways, and the split is
+the honest read of its worth: **3 arms FAIL behaviourally** (the two
+latest-review-retention arms, which run against master's own
+`_fetch_prs_graphql`, and the size bound, which falls back to the pre-fix emit
+shape so it reports the real byte count instead of erroring), **8 ERROR** on
+symbols this fix introduces (`emit_state`, `check_state_size`, the size
+constants — the fix's own contract, not a control), and the rest pass as
+non-regression assertions.
+
+Import the script via importlib because it has no .py extension.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+_REPO = "jakildev/IrredenEngine"
+_READ_CAP_BYTES = 256 * 1024
+
+# The phrase the opus reviewer greps the LATEST review body for
+# (.claude/commands/role-opus-reviewer.md). It lands as a trailing line, which is
+# why only REVIEW_BODY_TAIL is load-bearing.
+_PHRASE = "Opus recheck required"
+
+# The plan's fixture scale: enough PRs and reviews that the pre-fix projection
+# clears the cap on its own, close to the live tree (46 open PRs across repos).
+_PR_COUNT = 45
+_REVIEWS_PER_PR = 3
+_FIRST_PR = 2000
+
+# Live review bodies measured at the cap (median == max == 2063 B); oversize the
+# fixture past head+tail so _truncate_review_body actually engages.
+_BODY_FILLER = "x" * 4000
+
+
+def _body(with_phrase: bool) -> str:
+    tail = f"\n{_PHRASE}: the winner-election kernel needs a determinism pass.\n"
+    return _BODY_FILLER + (tail if with_phrase else "\nLooks good to me.\n")
+
+
+def _review(day: int, with_phrase: bool = False, author: str = "jakildev") -> dict:
+    return {
+        "author": {"login": author},
+        "body": _body(with_phrase),
+        "state": "COMMENTED",
+        "submittedAt": f"2026-08-{day:02d}T00:00:00Z",
+    }
+
+
+def _pr(n: int, reviews=None, labels=None) -> dict:
+    return {
+        "number": n,
+        "title": f"render: some change {n}",
+        "headRefName": f"claude/{n - 500}-some-task",
+        "headRefOid": f"{n:040d}",
+        "baseRefName": "master",
+        "author": {"login": "jakildev"},
+        "labels": [{"name": name} for name in (labels if labels is not None
+                                               else ["fleet:approved"])],
+        "mergeable": "MERGEABLE",
+        "isDraft": False,
+        # Reviews arrive oldest-first from gh; the phrase rides the LATEST one.
+        "reviews": reviews if reviews is not None else [
+            _review(day=1 + i, with_phrase=(i == _REVIEWS_PER_PR - 1))
+            for i in range(_REVIEWS_PER_PR)
+        ],
+        "updatedAt": "2026-08-08T00:00:00Z",
+        "body": "",
+    }
+
+
+_FIXTURE = [_pr(n) for n in range(_FIRST_PR, _FIRST_PR + _PR_COUNT)]
+
+
+def _fake_gh(argv, cwd=None):
+    """Stand in for `gh pr list`, modelling its argument parsing (CLAUDE.md).
+
+    Fails closed on any argv shape it does not model, so a rewrite of the call
+    site cannot quietly slip past this suite.
+    """
+    if argv[:3] != ["gh", "pr", "list"]:
+        raise AssertionError(f"unmodelled command: {argv!r}")
+    for required in ("--repo", "--state", "--json"):
+        if required not in argv:
+            raise AssertionError(f"gh pr list requires {required}: {argv!r}")
+    if "--limit" in argv:
+        raw = argv[argv.index("--limit") + 1]
+        if not raw.lstrip("-").isdigit() or int(raw) < 1:
+            raise AssertionError(f"gh rejects --limit {raw!r}")
+    return json.dumps(_FIXTURE)
+
+
+def _project(prs):
+    """Run the SHIPPED fetch projection over `prs`, returning the emitted records."""
+    with patch.object(_mod, "run_capture", side_effect=lambda a, cwd=None: json.dumps(prs)):
+        return _mod._fetch_prs_graphql(_REPO)
+
+
+def _latest_review(pr):
+    """The opus reviewer's own selection rule: sort reviews[] by submittedAt."""
+    reviews = pr.get("reviews") or []
+    if not reviews:
+        return None
+    return sorted(reviews, key=lambda r: r.get("submittedAt") or "")[-1]
+
+
+def _opus_candidate(pr, fleet_login="jakildev"):
+    """role-opus-reviewer.md step 5, the two label-independent-vs-label disjuncts.
+
+    The phrase path must fire on its own — a PR carrying no
+    `fleet:needs-opus-recheck` label is exactly the input that regresses when a
+    body is trimmed away.
+    """
+    if "fleet:needs-opus-recheck" in pr.get("labels", []):
+        return True
+    latest = _latest_review(pr)
+    return bool(latest) and _PHRASE in (latest.get("body") or "")
+
+
+def _sonnet_candidate(pr, fleet_login="jakildev"):
+    """role-sonnet-reviewer.md step 5: no fleet review yet."""
+    return not any(r.get("author") == fleet_login for r in pr.get("reviews") or [])
+
+
+class TestFixtureFidelity(unittest.TestCase):
+    """Without this, a green size bound could just mean the fixture was small."""
+
+    def test_fixture_blows_the_cap_under_the_pre_fix_serialization(self):
+        # Pre-fix shape: a truncated body on EVERY review, pretty-printed.
+        prefix = [
+            dict(pr, reviews=[
+                {
+                    "author": r["author"]["login"],
+                    "body": r["body"][:1024] + "\n…[truncated]…\n" + r["body"][-1024:],
+                    "state": r["state"],
+                    "submittedAt": r["submittedAt"],
+                }
+                for r in pr["reviews"]
+            ])
+            for pr in _FIXTURE
+        ]
+        state = {"repos": {"engine": {"prs": prefix}}}
+        size = len(json.dumps(state, indent=2, sort_keys=True).encode("utf-8"))
+        self.assertGreater(
+            size, _READ_CAP_BYTES,
+            f"fixture serializes to {size} B pre-fix — it must exceed the "
+            f"{_READ_CAP_BYTES} B cap or TestSizeBound proves nothing")
+
+    def test_stub_fails_closed_on_an_unmodelled_command(self):
+        with self.assertRaises(AssertionError):
+            _fake_gh(["gh", "issue", "list", "--repo", _REPO])
+
+
+class TestSizeBound(unittest.TestCase):
+    """The acceptance gate: shipped projection + shipped emit, under the cap."""
+
+    def test_emitted_state_is_under_the_read_tool_cap(self):
+        with patch.object(_mod, "run_capture", side_effect=_fake_gh):
+            prs = _mod._fetch_prs_graphql(_REPO)
+        state = {"generated_at": "2026-08-08T00:00:00Z",
+                 "repos": {"engine": {"prs": prs}}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            with patch.object(_mod, "STATE_FILE", path), \
+                    patch.dict("os.environ", {"FLEET_ALERTS_DIR": str(Path(tmp) / "alerts")}), \
+                    patch.object(_mod, "log", side_effect=lambda m: None):
+                # emit_state is this fix's own surface. Falling back to the
+                # pre-fix emit shape when it is absent keeps THIS arm — the
+                # acceptance gate — a behavioural control: on the pre-fix tree it
+                # goes red with the real byte count rather than erroring on a
+                # missing attribute, so the number in the failure message is the
+                # harm itself.
+                emit = getattr(_mod, "emit_state", None)
+                if emit is None:
+                    payload = json.dumps(state, indent=2, sort_keys=True) + "\n"
+                    _mod.write_atomic(path, payload)
+                    size = len(payload.encode("utf-8"))
+                else:
+                    size = emit(state)
+                on_disk = path.stat().st_size
+        self.assertEqual(size, on_disk, "returned size must be the on-disk size")
+        self.assertLess(
+            size, _READ_CAP_BYTES,
+            f"emitted state.json is {size} B — past the Read tool's "
+            f"{_READ_CAP_BYTES} B cap, so every role's startup read hard-errors")
+
+    def test_emit_is_compact_and_still_key_sorted(self):
+        state = {"b": 1, "a": {"d": 2, "c": 3}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            with patch.object(_mod, "STATE_FILE", path), \
+                    patch.object(_mod, "log", side_effect=lambda m: None):
+                _mod.emit_state(state)
+            text = path.read_text()
+        self.assertNotIn(": ", text, "compact emit must not pad separators")
+        self.assertNotIn("\n  ", text, "compact emit must not indent")
+        self.assertLess(text.index('"a"'), text.index('"b"'),
+                        "sort_keys must stay on — the leader bundle diffs this file")
+        self.assertEqual(json.loads(text), state, "must still round-trip")
+
+
+class TestLatestReviewBodyRetention(unittest.TestCase):
+    """Phase 1: the aggregate bound. Bodies survive only on the latest review."""
+
+    def test_only_the_latest_review_keeps_a_body(self):
+        pr = _project([_pr(_FIRST_PR)])[0]
+        bodies = [r["body"] for r in pr["reviews"]]
+        self.assertTrue(bodies[-1], "the latest review must keep its body")
+        self.assertEqual(bodies[:-1], [""] * (len(bodies) - 1),
+                         "older reviews must emit an empty body")
+
+    def test_latest_is_chosen_by_submitted_at_not_list_order(self):
+        # gh's ordering is not a contract; the opus reviewer sorts by submittedAt,
+        # so the projection must agree even when the newest arrives first.
+        out_of_order = [_review(day=9, with_phrase=True), _review(day=2)]
+        pr = _project([_pr(_FIRST_PR, reviews=out_of_order)])[0]
+        self.assertIn(_PHRASE, pr["reviews"][0]["body"],
+                      "the newest review by submittedAt keeps the body")
+        self.assertEqual(pr["reviews"][1]["body"], "")
+
+    def test_metadata_is_retained_on_every_review(self):
+        pr = _project([_pr(_FIRST_PR)])[0]
+        for review in pr["reviews"]:
+            self.assertEqual(review["author"], "jakildev")
+            self.assertTrue(review["submittedAt"])
+            self.assertEqual(review["state"], "COMMENTED")
+
+    def test_a_pr_with_no_reviews_still_projects_an_empty_list(self):
+        pr = _project([_pr(_FIRST_PR, reviews=[])])[0]
+        self.assertEqual(pr["reviews"], [])
+
+
+class TestConsumerPredicates(unittest.TestCase):
+    """Both role-doc predicates keep firing across the trim, each with a control."""
+
+    def test_opus_phrase_predicate_fires_without_the_label(self):
+        pr = _project([_pr(_FIRST_PR, labels=["fleet:approved"])])[0]
+        self.assertNotIn("fleet:needs-opus-recheck", pr["labels"],
+                         "fixture must be label-absent or the phrase path is masked")
+        self.assertTrue(
+            _opus_candidate(pr),
+            "the opus recheck phrase must survive the projection on its own")
+
+    def test_opus_phrase_predicate_control_stops_firing_when_absent(self):
+        reviews = [_review(day=1 + i, with_phrase=False) for i in range(_REVIEWS_PER_PR)]
+        pr = _project([_pr(_FIRST_PR, reviews=reviews, labels=["fleet:approved"])])[0]
+        self.assertFalse(
+            _opus_candidate(pr),
+            "predicate fires on an input with no phrase — the arm above is vacuous")
+
+    def test_opus_predicate_ignores_the_phrase_on_a_stale_review(self):
+        # The role doc says LATEST. A phrase on a superseded review must not
+        # re-arm the lane — and the trim is what makes that structural.
+        reviews = [_review(day=1, with_phrase=True), _review(day=5, with_phrase=False)]
+        pr = _project([_pr(_FIRST_PR, reviews=reviews, labels=["fleet:approved"])])[0]
+        self.assertFalse(_opus_candidate(pr))
+
+    def test_opus_label_disjunct_is_independent_of_any_body(self):
+        pr = _project([_pr(_FIRST_PR, reviews=[],
+                           labels=["fleet:needs-opus-recheck"])])[0]
+        self.assertTrue(_opus_candidate(pr))
+
+    def test_sonnet_unreviewed_predicate_fires(self):
+        pr = _project([_pr(_FIRST_PR, reviews=[])])[0]
+        self.assertTrue(_sonnet_candidate(pr),
+                        "a PR with no reviews must still read as unreviewed")
+
+    def test_sonnet_predicate_control_stops_firing_once_reviewed(self):
+        pr = _project([_pr(_FIRST_PR)])[0]
+        self.assertFalse(
+            _sonnet_candidate(pr),
+            "predicate fires on a reviewed PR — the arm above is vacuous. "
+            "reviews[].author must survive the body trim")
+
+
+class TestPhraseSurvivesTruncation(unittest.TestCase):
+    """Phase 2/3: the constants are sized from the measured live corpus."""
+
+    # Largest measured distance from the phrase line's start to end-of-body
+    # across the 8 live bodies carrying it (2026-08-08).
+    _MAX_LIVE_TAIL_DISTANCE = 539
+
+    def test_tail_covers_the_measured_live_maximum(self):
+        self.assertGreaterEqual(
+            _mod.REVIEW_BODY_TAIL, self._MAX_LIVE_TAIL_DISTANCE,
+            "REVIEW_BODY_TAIL must cover the longest live phrase tail or the "
+            "opus recheck lane silently stops firing")
+
+    def test_phrase_at_the_live_maximum_distance_survives(self):
+        suffix = f"{_PHRASE}: " + "y" * (self._MAX_LIVE_TAIL_DISTANCE - len(_PHRASE) - 2)
+        body = "z" * 8000 + "\n" + suffix
+        self.assertIn(_PHRASE, _mod._truncate_review_body(body))
+
+    def test_truncation_actually_engages_on_an_oversized_body(self):
+        # Control: without this, the arm above would pass on a body short enough
+        # to skip truncation entirely.
+        body = "z" * 8000 + "\n" + _PHRASE
+        self.assertIn("…[truncated]…", _mod._truncate_review_body(body))
+
+    def test_a_short_body_is_returned_verbatim(self):
+        self.assertEqual(_mod._truncate_review_body("short"), "short")
+
+
+class TestSizeGuard(unittest.TestCase):
+    """Phase 5: the drift that produced this issue must be operator-visible."""
+
+    def setUp(self):
+        _mod._state_size_over_streak = 0
+
+    def _run(self, size_bytes, alerts_dir):
+        logged = []
+        with patch.dict("os.environ", {"FLEET_ALERTS_DIR": str(alerts_dir)}), \
+                patch.object(_mod, "log", side_effect=logged.append):
+            _mod.check_state_size(size_bytes)
+        return logged
+
+    def test_silent_below_the_warn_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            alerts = Path(tmp) / "alerts"
+            logged = self._run(_mod.STATE_SIZE_WARN_BYTES - 1, alerts)
+        self.assertEqual(logged, [], f"must not warn under threshold: {logged!r}")
+
+    def test_warns_and_writes_an_alert_on_the_crossing_tick(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            alerts = Path(tmp) / "alerts"
+            logged = self._run(_mod.STATE_SIZE_WARN_BYTES + 1, alerts)
+            alert = (alerts / "state-scout-state-size").read_text()
+        self.assertTrue(any("state.json is" in m for m in logged), repr(logged))
+        self.assertIn("consecutive_ticks=1", alert)
+        self.assertIn("past_read_cap=no", alert)
+
+    def test_quiets_after_the_crossing_but_keeps_refreshing_the_alert(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            alerts = Path(tmp) / "alerts"
+            first = self._run(_mod.STATE_SIZE_WARN_BYTES + 1, alerts)
+            second = self._run(_mod.STATE_SIZE_WARN_BYTES + 1, alerts)
+            alert = (alerts / "state-scout-state-size").read_text()
+        self.assertTrue(first, "the crossing tick must be loud")
+        self.assertEqual(second, [], f"an every-tick warn is spam: {second!r}")
+        self.assertIn("consecutive_ticks=2", alert,
+                      "a write-once alert would freeze its count while the "
+                      "condition is still live")
+
+    def test_names_the_read_cap_once_past_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            alerts = Path(tmp) / "alerts"
+            logged = self._run(_mod.STATE_SIZE_READ_CAP_BYTES + 1, alerts)
+            alert = (alerts / "state-scout-state-size").read_text()
+        self.assertTrue(any("PAST the 256 KB Read-tool cap" in m for m in logged),
+                        repr(logged))
+        self.assertIn("past_read_cap=yes", alert)
+
+    def test_all_clear_logs_once_and_removes_the_alert(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            alerts = Path(tmp) / "alerts"
+            self._run(_mod.STATE_SIZE_WARN_BYTES + 1, alerts)
+            cleared = self._run(_mod.STATE_SIZE_WARN_BYTES - 1, alerts)
+            self.assertTrue(any("back under" in m for m in cleared), repr(cleared))
+            self.assertFalse((alerts / "state-scout-state-size").exists())
+            quiet = self._run(_mod.STATE_SIZE_WARN_BYTES - 1, alerts)
+        self.assertEqual(quiet, [], f"all-clear must fire once: {quiet!r}")
+
+    def test_warn_threshold_leaves_headroom_under_the_read_cap(self):
+        self.assertLess(_mod.STATE_SIZE_WARN_BYTES, _mod.STATE_SIZE_READ_CAP_BYTES)
+        self.assertEqual(_mod.STATE_SIZE_READ_CAP_BYTES, _READ_CAP_BYTES)
+
+    def test_warn_threshold_sits_above_the_measured_post_fix_size(self):
+        # A threshold under the file's own steady-state size fires on every tick
+        # from day one — a guard that is always on reports nothing. Measured
+        # 2026-08-08 by re-projecting the live cache (46 open PRs) through this
+        # change: 522,206 B -> 210,642 B.
+        measured_post_fix_bytes = 210_642
+        self.assertGreater(
+            _mod.STATE_SIZE_WARN_BYTES, measured_post_fix_bytes,
+            "warn threshold must sit above the measured post-fix size or the "
+            "guard is permanently tripped")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Every fleet role reads `~/.fleet/state/state.json` at startup through the Read tool, which **hard-errors above 256 KB**. The file had reached **510 KB**, so that startup step was unfollowable for every role — the defect is the file, and the workaround (a python heredoc) had quietly become the only way in.
- **Latest-review-only body retention.** `prs[].reviews` was ~46% of the file: a body on every review of every open PR. Only the *latest* review's body has a reader (the opus reviewer's `Opus recheck required` phrase test); the sonnet reviewer reads `reviews[].author` alone. Older entries now emit `""` — the key stays, so the schema and both predicates are unchanged, and no gated role doc needs editing.
- **Truncation constants sized from the live corpus.** `REVIEW_BODY_HEAD` 1024 → 128 (nothing reads the head); `REVIEW_BODY_TAIL` 1024 → 640, from the measured maximum phrase-tail distance of 539 B across the eight live bodies carrying the phrase.
- **Compact emit for `state.json` only.** ~90 KB was `indent=2` whitespace. Every consumer parses JSON (audit below), so there is no line-oriented reader to break; `sort_keys` stays because the leader-bundle change detection diffs this file. The small human-read caches (`prs/`, `issues/`, `projections/`) keep `indent=2`.
- **A guard, because nothing watched the writer.** The drift from a documented "~32 KB" to 510 KB was invisible until roles started failing. The scout now warns and writes `${FLEET_ALERTS_DIR:-~/.fleet/alerts}/state-scout-state-size` past 7/8 of the cap — loud on the crossing tick, quiet thereafter, alert refreshed every tick while live (`scripts/fleet/CLAUDE.md` escalate-then-quiet).

Two things worth a reviewer's attention:

1. **The warn threshold is 7/8 of the cap (224 KB), not the plan's "~200 KB".** The plan's number predated the measurement: the post-fix file emits at **205.7 KB**, so a 200 KB threshold would have fired on every tick from day one — a guard that is always on reports nothing. It is now expressed as a fraction of the cap so the two cannot drift apart.
2. **Consumer audit re-run independently** rather than inherited from the plan: `fleet-dispatcher:2117` (`json.loads`), `fleet_poll_topology.py:261` (verbatim text into the bundle, parsed on the far side), `fleet-epic-status` (python), `fleet-up:1327-1338` (existence test only), plus the scout's own `read_json_retry` sites. No `grep`/`sed`/`awk` reader exists. The **follower** path was the one worth checking: it parses the leader's text, overlays host-local fields, and returns the dict into the same `emit_state`, so followers get the compact emit too.

## Test plan

- [x] `python3 scripts/fleet/tests/test_state_projection_size.py` — 25 tests, all green.
- [x] **Positive control** (`fleet-positive-control … origin/master`): **MEANINGFUL — 11 of 25 assertions fail against `5a1fdc9ec`**. Three of those are behavioural inversions (`test_only_the_latest_review_keeps_a_body`, `test_latest_is_chosen_by_submitted_at_not_list_order`, and the size bound, which reports `AssertionError: 329012 not less than 262144`); the other eight ERROR on symbols this PR introduces (`emit_state`, `check_state_size`, the constants) and are the fix's own contract, not controls. The size bound deliberately falls back to the pre-fix emit shape when `emit_state` is absent so the acceptance gate goes *red with the real byte count* instead of erroring.
- [x] `bash scripts/fleet/tests/run_all.sh` — **129 suites, 128 passed, 1 failed**. The failure is `test_cross_repo_shared_file_parity.sh` (`.github/workflows/auto-rereview.yml` drifted engine↔downstream) — **pre-existing red on `master`**, untouched by this diff.
- [x] `ruff check scripts/` — clean.
- [x] Live re-measurement (see the evidence table) — not a projection.

## Acceptance evidence

| Criterion (from the `## Plan` comment) | Check run | Observed |
|---|---|---|
| 1. Both predicates still fire; opus fixture is **label-absent**; positive control flips | `python3 scripts/fleet/tests/test_state_projection_size.py -k TestConsumerPredicates` | 6 arms green: phrase fires with no `fleet:needs-opus-recheck` label; control with the phrase removed stops firing; a phrase on a *superseded* review does not fire; the label disjunct still fires with zero reviews; sonnet's unreviewed predicate fires and its control stops firing once reviewed |
| 2. Size bound — 45 PRs × 3 reviews × oversized bodies, full projection + emit, on-disk < 262,144 | `TestSizeBound.test_emitted_state_is_under_the_read_tool_cap` | **62,870 B** emitted (returned size asserted equal to `stat().st_size`). Same fixture serialized the pre-fix way = **330,859 B** (`TestFixtureFidelity`), i.e. the fixture can express the bug — and the arm reports exactly that on `master`: `329012 not less than 262144` |
| 3. Phrase survives truncation at the new constants (539 B tail) | `TestPhraseSurvivesTruncation` | Phrase recovered from a body whose phrase line starts 539 B from the end; `REVIEW_BODY_TAIL` (640) asserted ≥ the measured live maximum; a control asserts truncation actually engaged (`…[truncated]…` present), so the arm is not passing on a body too short to truncate |
| 4. Existing scout tests stay green (hermetic) | `bash scripts/fleet/tests/run_all.sh` | 128/129 pass; the one failure is the pre-existing cross-repo parity red on `master` |
| "Do not ship on a projected number — re-measure on the live host" | Live cache (46 open PRs) re-projected through the shipped `_truncate_review_body` + the shipped emit | **522,206 B → 210,642 B** (510.0 KB → 205.7 KB), **50.3 KB under the cap**. Plan projected ~218 KB. The running scout daemon still executes pre-merge code (#2768), so this is the live *data* re-projected through the new path, not a post-restart file read — called out rather than dressed up as a daemon observation |

The 205.7 KB figure is also pinned as a regression assertion
(`test_warn_threshold_sits_above_the_measured_post_fix_size`), so lowering the
warn threshold under the file's own steady-state size fails the suite instead of
shipping a permanently-tripped guard.

## Notes

- Growth is now bounded per-PR (~200 B of review metadata + one ≤ 800 B body), so the window widening #2743 landed no longer scales the file by review count.
- `docs/agents/FLEET-CACHE.md` gains a **Size invariant** section (the old row asserted a point-in-time "~32 KB", which is what rotted); `scripts/fleet/CLAUDE.md` gains a one-line authoring rule pointing at it, so the next person widening the projection meets the constraint where they are working.
- Out of scope, per the plan's own ruled-out list: `closed_fleet_queued` (load-bearing for blocker clearing) and `tasks.done` (two live readers) both stay.

Closes #2752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
