### PR TITLE
fleet: live-first per-record cache readers (#2837)

### DIFF
--- a/.fleet/plans/issue-2837.md
+++ b/.fleet/plans/issue-2837.md
@@ -1,0 +1,158 @@
+## Plan: the per-record cache readers serve a stale snapshot with no warning
+
+- **Issue:** #2837
+- **Model:** opus — two shared fleet-infra readers every role calls, with a
+  GitHub-quota discipline (#1394) constraining the fix shape
+- **Date:** 2026-08-09 (re-plan; supersedes the 2026-08-04 plan bounced by the
+  06:07 plan review. Plan-review cleared 2026-08-09T04:27:02Z.)
+
+Widened beyond the issue title by the 2026-08-04T17:32 scope comment:
+`fleet-issue view` carries the same defect, and its lane (plan review) fails
+the same structural way.
+
+### Scope
+
+Two scripts — `scripts/fleet/fleet-pr`, `scripts/fleet/fleet-issue` — their
+regression tests, and the non-gated doc surfaces that state the wrapper
+contract: `docs/agents/FLEET-CACHE.md` § "Per-item drill-ins",
+`docs/agents/FLEET-FEEDBACK-HANDLING.md` § "Reading the feedback", both
+scripts' module docstrings, `scripts/fleet/fleet-help`'s two index entries,
+and one sentence in `docs/agents/skills/start-next-task.md`. No change to the
+scout, to `state.json`'s shape, or to any other `fleet-*` tool; no
+scout-cadence change; `fleet-pr view` / `diff` keep their cache reads (they
+gain only a stderr snapshot line).
+
+**No gated edits required.** One cosmetic residual:
+`.claude/skills/start-next-task/SKILL.md:44-46` describes the old direction
+("cache-aware … falls back to `gh issue view`"); that file is gated and the
+sentence is a resilience description rather than a contract, so the PR body
+flags it as a one-line human-applied follow-up rather than blocking on it.
+
+### Verified current state (2026-08-09)
+
+- Neither script has changed since the issue was filed. The defect is live.
+- Zero open PRs in either repo touch either file.
+- Record keys, confirmed against live records and the scout's fetch sites
+  (`fleet-state-scout:985` PRs, `:1020` issues):
+  - per-PR: `_cached_at, body, comments, files, headRefOid, inlineComments,
+    number, reviews, updatedAt`
+  - per-issue: `_cached_at, body, comments, labels, number, state, title,
+    updatedAt`
+- **Reader enumeration.** Per-record cache readers are **exactly two**:
+  `fleet-pr` (`prs/`, `diffs/`) and `fleet-issue` (`issues/`). Every other
+  `.fleet/state` reader touches `state.json`'s top-level arrays, which sit
+  under the `generated_at` staleness contract already enforced at the protocol
+  layer. `fleet_poll_topology.py` names the subdirs for follower sync only.
+  The two scripts share **no code** — each is standalone by install design,
+  with deliberately duplicated `repo_slug` / `DEFAULT_SLUGS` helpers. What
+  they share is the *policy*.
+
+### Root cause
+
+No staleness axis in either script. `fleet-pr`'s `read_cached_pr()` returns
+`None` only on `FileNotFoundError` / `JSONDecodeError`; `fleet-issue`'s
+`cmd_view` is the same shape. A present-but-stale record is indistinguishable
+from a current one, and in both trigger lanes (feedback pickup, plan review)
+the triggering event postdates the snapshot **by construction**.
+FLEET-CACHE.md's producer contract — per-record refresh only when the list
+query's `updatedAt` advances — explains the window: scout-tick timing, not a
+missing producer mechanism.
+
+### Design: live-first, cache-on-failure
+
+The bounced plan's probe-then-fallback guard is strictly dominated at these
+call sites: the fallback is itself one `gh` invocation, so the guard costs 1
+call when fresh and 2 when stale, versus 1 unconditional call for always-live
+— and the guard additionally needs a comparison field, clock semantics, and a
+probe-failure degradation path. Live-first dissolves all three at once.
+
+- **`fleet-pr comments <N>` and `fleet-issue view <N>` fetch from `gh` at
+  invocation.** On `gh` failure (nonzero exit — offline, rate-limited), fall
+  back to the cached record with a loud stderr warning naming the snapshot.
+  One live attempt, no retry.
+- **Both paths render through the same code.** `cmd_comments`'s live path
+  fetches `gh pr view <N> --json comments,reviews` plus the inline-comments
+  endpoint the scout already uses, assembles the same detail-dict shape, and
+  feeds the **existing** print loops — `[path:line]` inline items are
+  preserved on the live path and the output format is identical across
+  live/cached. (Today's miss path `exec`s `gh pr view --comments`, a
+  *different* format that drops inline items — so the current fallback already
+  violates the one-item-per-output-line checklist contract; this closes that
+  too.)
+- **`fleet-pr view` / `diff` stay snapshot reads**, with one always-on stderr
+  line so a snapshot read is never silent. Display of an in-file timestamp
+  only — no freshness computation, no mtime (consistent with the
+  `lint_state_mtime.py` ratchet).
+- **The per-issue cache becomes the resilience layer, not dead weight.**
+  After this change `issues/<repo>/<N>.json` has no primary reader — its role
+  is degraded-mode serving when `gh` fails. FLEET-CACHE.md's table says so, so
+  the producer doesn't read as write-only.
+
+**#1394 (no polling) holds:** both commands run once per dispatched iteration
+— one-shot call sites, not loops. Live-first adds at most two API calls at
+those sites and removes zero caching from any polling path.
+
+### Steps
+
+1. `scripts/fleet/fleet-pr` — restructure `cmd_comments` to live-first; on any
+   `gh` failure fall back to `read_cached_pr` plus the stderr snapshot warning;
+   when both miss, exit nonzero. Update the module docstring.
+2. `scripts/fleet/fleet-pr` — always-on stderr snapshot line for `cmd_view` and
+   `cmd_diff`, sourced from `_cached_at` (diff: the head SHA in the filename).
+3. `scripts/fleet/fleet-issue` — reorder `cmd_view` to live-first: the existing
+   fallback block becomes the primary path; the cache read becomes the failure
+   path with the same stderr snapshot warning. Docstring likewise.
+4. Docs: `FLEET-CACHE.md` (miss-policy paragraph, wrapper-table rows, layout
+   rows, the opus-reviewer full-body-recovery note at §"Per-role projections"),
+   `FLEET-FEEDBACK-HANDLING.md` § "Reading the feedback",
+   `docs/agents/skills/start-next-task.md`, and `fleet-help`'s two index
+   entries.
+5. Tests in `scripts/fleet/tests/`, using `HOME=$(mktemp -d)` with a crafted
+   stale record and a PATH-shimmed `gh`:
+   - stale record + shim returning a newer review → the newer review appears
+     (**fails on master**: master never invokes `gh` when the record parses);
+   - shim exiting nonzero → cached data served AND stderr names `_cached_at`;
+   - inline-comment fixture on the live path → the `[path:line]` item renders;
+   - the same stale-record pair for `fleet-issue view`, with a `## Plan`
+     comment postdating the snapshot (the observed plan-review failure mode);
+   - parity assertion: both scripts' failure-path warning shape checked by the
+     same test, so the mirrored policies can't drift silently.
+
+### Verification
+
+- Positive control: step 5's first bullet fails against current `master`.
+- Live repro of the original window: stamp a comment on a PR the scout has
+  already cached, then run `fleet-pr comments <N>` before the next scout tick;
+  it appears where today it is silently absent.
+- `scripts/fleet/tests/run_all.sh` green otherwise; `ruff check scripts/` clean.
+- Confirm `fleet-pr view` / `diff` behavior is unchanged except the stderr
+  line, and that `read_cached_pr` has no other caller.
+
+### Gotchas
+
+- **No freshness comparison anywhere** — not `updatedAt` probes, not
+  `_cached_at` TTLs, not `st_mtime` (`lint_state_mtime.py` hard-fails new mtime
+  freshness reads on the scout cache; `_cached_at` is local wall-clock and
+  skew-sensitive). Live-first needs none of them — that is the point of the
+  shape.
+- One live attempt, then the cache — never retry-until-fresh (#1394).
+- Keep the scripts standalone; do not introduce a shared module for ~10 lines
+  of policy. The standalone-with-mirrored-helpers architecture is deliberate;
+  let step 5's parity test hold the mirror.
+- `cmd_comments`'s live path replaces an `exec`-style fallback with in-process
+  rendering — preserve exit codes: live failure + cache miss together must exit
+  nonzero like today's cache-miss + `gh`-failure path.
+- Symlinked installs pick the fix up on merge; panes mid-iteration keep the
+  loaded copy (#2768's reload gap) — no immediate fleet-wide effect.
+
+### Acceptance-criteria mapping
+
+- **AC 1** (current-or-flagged, naming snapshot time): live-first = current as
+  of invocation; the `gh`-failure path emits the stderr warning naming
+  `_cached_at`. Applies to both commands.
+- **AC 2** (repro the window): Verification bullet 2, plus the master-failing
+  regression test as the durable form.
+- **AC 3** (tool and docs agree): step 4 covers every surface that states the
+  contract, and names the one gated sentence as a human-applied residual.
+- **AC 4** (no new polling loop): one-shot live calls at one-shot call sites;
+  the failure path never retries.

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -12,9 +12,9 @@ section below for which files apply.
 |---|---|---|---|
 | `state.json` | scout | every role | List-shape state: open PRs (with labels, reviews, mergeable), needs-plan / human-approved issues (number + title + labels + updatedAt), open `fleet:queued` issue rows. ~32 KB. |
 | `projections/<role>.json` | scout (slicers) | the named role | Pre-filtered per-role slice with full records (e.g. the worker lane's `tasks_open` + `feedback_prs`). ~5 KB. **Prefer this over `state.json`** when you only need your own role's items. |
-| `prs/<repo>/<N>.json` | scout | `fleet-pr view`/`comments` | Full PR detail: body, conversation comments, review summaries, inline review threads, files-changed list. Refreshed only when the list query's `updatedAt` advances. |
+| `prs/<repo>/<N>.json` | scout | `fleet-pr view`; `fleet-pr comments` **only when `gh` fails** | Full PR detail: body, conversation comments, review summaries, inline review threads, files-changed list. Refreshed only when the list query's `updatedAt` advances. |
 | `diffs/<repo>/<N>-<sha>.diff` | scout | `fleet-pr diff` | Raw `gh pr diff` output, keyed by head SHA. Refreshed on rebase only; old SHAs garbage-collected. |
-| `issues/<repo>/<N>.json` | scout | `fleet-issue view` | Full issue detail (body + comments + labels + state). Cached for issues in `needs_plan` / `human_approved`. |
+| `issues/<repo>/<N>.json` | scout | `fleet-issue view` **only when `gh` fails** | Full issue detail (body + comments + labels + state). Cached for issues in `needs_plan` / `human_approved`. Since #2837 this is a **resilience layer**, not a primary reader — `fleet-issue view` fetches live and reaches for this only on a `gh` failure. |
 | `repos.json` | `fleet-up` | reviewer / merger roles | One-shot owner/repo slug map: `{"engine": "jakildev/IrredenEngine", "game": "jakildev/irreden"}`. |
 | `triggers/<role>` | scout | `fleet-babysit` | Empty file touched whenever this role's projection changed. Drives `fleet-babysit`'s long-back-off wake-up. |
 | `seen-hashes/<role>` | scout | scout | Hash of the last projection — internal trigger-detection state. |
@@ -39,16 +39,35 @@ cache and re-introduces the rate-limit burst).
 ## Per-item drill-ins
 
 Use the `fleet-pr` and `fleet-issue` wrappers for per-item lookups.
-Both read the corresponding cache file and fall back to live `gh`
-on cache miss (with a `cache miss for <repo>#<N>; falling back to
-gh` line on stderr so misses are visible in pane logs):
+They split into two policies, and the split is load-bearing (#2837):
 
-| Wrapper | Replaces |
-|---|---|
-| `fleet-pr view <N> [--repo engine\|game]` | `gh pr view <N> --comments` |
-| `fleet-pr diff <N> [--repo engine\|game]` | `gh pr diff <N>` |
-| `fleet-pr comments <N> [--repo engine\|game]` | `gh pr view <N> --comments` + `gh api repos/.../pulls/<N>/comments` + `gh api repos/.../pulls/<N>/reviews` (merged) |
-| `fleet-issue view <N> [--repo engine\|game]` | `gh issue view <N> --repo <slug> --json number,title,state,labels,body,comments` |
+- **Live-first** — `fleet-pr comments` and `fleet-issue view` fetch
+  from GitHub at invocation. Both are read by roles that were woken
+  **by** the event they need to see (the verdict review that stamps a
+  feedback label; the `## Plan` comment that stamps
+  `fleet:plan-review`), so the triggering item always postdates the
+  snapshot and a cache read there is *structurally* guaranteed to drop
+  it. On a `gh` failure they serve the cached record with a loud
+  `serving cached snapshot from <_cached_at>; newer comments/reviews
+  may be missing` line on stderr. One live attempt, never a retry loop
+  (#1394).
+- **Snapshot reads** — `fleet-pr view` and `fleet-pr diff` read the
+  cache as before (their callers want the cheap record), and each now
+  prints its snapshot stamp to stderr so a stale read is never silent.
+  A genuine cache miss still emits `cache miss for <repo>#<N>; falling
+  back to gh`.
+
+| Wrapper | Policy | Replaces |
+|---|---|---|
+| `fleet-pr view <N> [--repo engine\|game]` | snapshot | `gh pr view <N> --comments` |
+| `fleet-pr diff <N> [--repo engine\|game]` | snapshot | `gh pr diff <N>` |
+| `fleet-pr comments <N> [--repo engine\|game]` | live-first | `gh pr view <N> --json comments,reviews` + `gh api repos/.../pulls/<N>/comments` (merged) |
+| `fleet-issue view <N> [--repo engine\|game]` | live-first | `gh issue view <N> --repo <slug> --json number,title,state,labels,body,comments` |
+
+The two scripts are standalone by install design and share no code,
+so this policy is **mirrored, not factored**. `test_fleet_cache_reader_freshness.sh`
+pins the mirror with a parity assertion on the emitted fallback note;
+change one script's wording and that test fails.
 
 ### What stays direct
 
@@ -79,7 +98,11 @@ just the items that role works on:
 **opus-reviewer:** review bodies longer than 2 KB are stored as
 head + tail with an `…[truncated]…` separator (the verdict line
 typically lives in the tail); for full-body context fetch with
-`fleet-pr view <N>`.
+`fleet-pr comments <N>`, which prints full review bodies and is the
+live-first subcommand. Do **not** use `fleet-pr view <N>` here: it is a
+snapshot read, so the review body a reviewer is recovering — the one
+that triggered its own pickup — is exactly the item its snapshot
+predates (#2837).
 
 **Read the projection first.** It's ~5 KB vs. ~32 KB for full
 state.json — significant per-iteration token savings. Fall back to

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -157,7 +157,17 @@ fleet-pr comments <N>
 ```
 
 One wrapper call surfaces the timeline, review summaries, and
-inline comments. Build an explicit checklist with **one item per
+inline comments. `comments` is **live-first** (#2837): it fetches from
+GitHub at invocation, so the output is current as of the moment you
+run it — including the verdict review that stamped the label and woke
+you, which by construction postdates the scout's snapshot. If `gh` is
+unreachable it degrades to the cached snapshot and says so loudly on
+stderr (`serving cached snapshot from <time>; newer comments/reviews
+may be missing`). **Read that line if it appears** — it is the one case
+where the output can be incomplete, and the missing item is likely the
+one you were dispatched for.
+
+Build an explicit checklist with **one item per
 output line** — every `[comment …]`, `[review …]` summary, and
 `[path:line]` inline comment is a separate item. The human (or
 reviewer) may post several comments and several inline threads

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -82,7 +82,8 @@ For each `fleet:needs-plan` issue:
 
 1. **Read the full issue thread** — title, body, and every comment.
    The plan is often seeded in a comment, and the human may have left
-   scope refinements there too. Use the cache-aware wrapper:
+   scope refinements there too. Use the wrapper — it reads live, so the
+   `## Plan` comment that woke you is present:
    `fleet-issue view <N>` (engine; for game issues add `--repo game`).
    Do **not** use bare `gh issue view <N>` — it omits comments by
    default and silently drops context.

--- a/docs/agents/skills/start-next-task.md
+++ b/docs/agents/skills/start-next-task.md
@@ -183,8 +183,9 @@ Default. `MODE=standard`, `BASE=<remote>/<default-branch>`. Proceed.
 ### 5. Derive a new branch name
 
 - **Fleet stack mode:** `<branch prefix><issue#>-<short-topic>`. Pull the
-  topic from the issue title (`fleet-issue view <issue#>`, falling back to
-  `gh issue view <issue#>`). Prefer a name the user already gave.
+  topic from the issue title (`fleet-issue view <issue#>` — it reads live and
+  falls back to the scout's cached snapshot only if `gh` is unreachable).
+  Prefer a name the user already gave.
 - **Cursor stack mode:** `<branch prefix><area>-<topic>`, no issue-number
   prefix. Derive from the conversation; the user usually names the next
   slice when cueing the stack. If not, ask. Example: a tuning slice stacked

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -260,7 +260,9 @@ Parallel-agent fleet (tmux + Claude)
                                  fleet-down --summary for coverage)
   witness [--once]               detect stale heartbeats (architects only)
   fleet-pr view|diff|comments <N> [--repo engine|game]
-                                 read scout's per-PR cache + gh fallback
+                                 comments: live gh read (cache only if gh
+                                 fails, warned on stderr); view/diff: scout's
+                                 per-PR snapshot, stamped on stderr
   fleet-pr-clear-feedback-labels <N> [--repo …] [--labels …]
                                  idempotently strip feedback labels from a PR
                                  (skips absent labels; one --remove-label per
@@ -283,7 +285,9 @@ Parallel-agent fleet (tmux + Claude)
                                  close open fleet:nit-of-pr issues whose
                                  addressing PR has merged (merger step 1.5)
   fleet-issue view <N> [--repo engine|game]
-                                 read scout's per-issue cache + gh fallback
+                                 live gh read of an issue + its comments; falls
+                                 back to scout's per-issue cache only if gh
+                                 fails, warned on stderr
   fleet-gh-poll <owner/repo> <path> [--param k=v]… [--accept MIME]
                                  conditional GitHub REST GET (If-None-Match +
                                  ETag cache); prints the body, exits 0=changed

--- a/scripts/fleet/fleet-issue
+++ b/scripts/fleet/fleet-issue
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""fleet-issue — read scout's per-issue cache, fall back to gh on cache miss.
+"""fleet-issue — live-first issue reads, with the scout's cache as the fallback.
 
 Subcommand:
   view <N>      full issue body + comments + labels + state
@@ -7,10 +7,21 @@ Subcommand:
 Repo selection:
   --repo {engine,game}  default: engine
 
-The scout caches issues that hit `needs_plan` or `human_approved` in
-state.json. Other issues (closed, unlabeled) are not in the cache by
-design — the cache miss path covers those by exec'ing `gh issue view`
-directly.
+Cache policy (#2837):
+  `view` fetches from GitHub at invocation. Its consumers — the planner and the
+  plan reviewer — are woken BY the `## Plan` comment and label swap that
+  postdate the scout's snapshot, so reading the cache first is structurally
+  guaranteed to drop the triggering comment. Serving that snapshot silently
+  produced the worst outcome available: a plan reviewer seeing `fleet:needs-plan`
+  with no plan present, whose correct-looking action is to bounce a sound plan.
+
+  On a `gh` failure the cached record is served with a loud stderr warning
+  naming the snapshot time. One live attempt, never a retry loop (#1394). The
+  per-issue cache is therefore a resilience layer, not the primary reader.
+
+Keep the cache-fallback wording in sync with fleet-pr: the two scripts are
+standalone by install design and share no code, so the policy is mirrored and
+pinned by tests/test_fleet_cache_reader_freshness.sh's parity assertion.
 
 Source of truth: scripts/fleet/fleet-issue in the engine repo.
 Installed to ~/bin/fleet-issue by scripts/fleet/install.sh.
@@ -31,6 +42,12 @@ DEFAULT_SLUGS = {
     "game": "jakildev/irreden",
 }
 
+# Mirrored verbatim in fleet-pr — see the module docstring.
+CACHE_FALLBACK_NOTE = (
+    "serving cached snapshot from {stamp}; "
+    "newer comments/reviews may be missing"
+)
+
 
 def repo_slug(repo_key):
     try:
@@ -44,42 +61,65 @@ def warn(msg):
     print(f"fleet-issue: {msg}", file=sys.stderr)
 
 
-def cmd_view(args):
-    path = ISSUES_DIR / args.repo / f"{args.issue_number}.json"
-    detail = None
-    try:
-        detail = json.loads(path.read_text())
-    except FileNotFoundError:
-        warn(f"cache miss for {args.repo}#{args.issue_number}; falling back to gh")
-    except json.JSONDecodeError as e:
-        warn(f"cache file {path} is corrupt: {e}; falling back to gh")
+def snapshot_stamp(detail):
+    return (detail or {}).get("_cached_at") or "unknown"
 
+
+def read_cached_issue(repo_key, issue_number):
+    path = ISSUES_DIR / repo_key / f"{issue_number}.json"
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        warn(f"cache file {path} is corrupt: {e}")
+        return None
+
+
+def fetch_live_issue(slug, issue_number):
+    result = subprocess.run(
+        [
+            "gh", "issue", "view", str(issue_number),
+            "--repo", slug,
+            "--json", "number,title,state,labels,body,comments",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        return None
+    try:
+        detail = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        warn(f"gh json output is corrupt: {e}")
+        return None
+    # gh returns labels as [{name, color, ...}]; normalize to strings so both
+    # paths render identically (the scout already stores them as strings).
+    detail["labels"] = [
+        (la["name"] if isinstance(la, dict) else la)
+        for la in detail.get("labels", [])
+    ]
+    return detail
+
+
+def cmd_view(args):
+    slug = repo_slug(args.repo)
+    if slug is None:
+        warn(f"unknown repo key: {args.repo}")
+        return 2
+
+    detail = fetch_live_issue(slug, args.issue_number)
     if detail is None:
-        slug = repo_slug(args.repo)
-        if slug is None:
-            warn(f"unknown repo key: {args.repo}")
-            return 2
-        result = subprocess.run(
-            [
-                "gh", "issue", "view", str(args.issue_number),
-                "--repo", slug,
-                "--json", "number,title,state,labels,body,comments",
-            ],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            sys.stderr.write(result.stderr)
-            return result.returncode
-        try:
-            detail = json.loads(result.stdout)
-        except json.JSONDecodeError as e:
-            warn(f"gh json output is corrupt: {e}")
+        # Offline / rate-limited: degrade to the snapshot rather than erroring
+        # the planning lane — but never silently.
+        detail = read_cached_issue(args.repo, args.issue_number)
+        if detail is None:
+            warn(
+                f"live fetch failed and no cached record for "
+                f"{args.repo}#{args.issue_number}"
+            )
             return 1
-        # gh returns labels as [{name, color, ...}]; normalize to strings
-        detail["labels"] = [
-            (la["name"] if isinstance(la, dict) else la)
-            for la in detail.get("labels", [])
-        ]
+        warn(CACHE_FALLBACK_NOTE.format(stamp=snapshot_stamp(detail)))
 
     print(f"# Issue #{detail['number']}: {detail.get('title', '')}")
     labels = detail.get("labels", [])
@@ -98,13 +138,15 @@ def cmd_view(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Read scout's per-issue cache.")
+    parser = argparse.ArgumentParser(
+        description="Live-first issue reads, scout cache as fallback.",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
     sp = sub.add_parser("view")
     sp.add_argument("issue_number", type=int)
     sp.add_argument(
         "--repo", default="engine", choices=["engine", "game"],
-        help="Which cached repo to read (default: engine).",
+        help="Which repo to read (default: engine).",
     )
     args = parser.parse_args()
     sys.exit(cmd_view(args))

--- a/scripts/fleet/fleet-pr
+++ b/scripts/fleet/fleet-pr
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""fleet-pr — read scout's per-PR cache, fall back to gh on cache miss.
+"""fleet-pr — per-PR reads: `comments` is live-first, `view`/`diff` are snapshots.
 
 Subcommands:
   view <N>      full PR detail (body + comments + reviews + inline review threads)
@@ -9,10 +9,21 @@ Subcommands:
 Repo selection:
   --repo {engine,game}  default: engine
 
-Cache miss policy: prints a single `fleet-pr: cache miss for <repo>#<N>;
-falling back to gh` line to stderr, then exec's the equivalent live `gh`
-call. Agents that prefer to know about cache misses can grep stderr;
-silent agents see normal stdout regardless.
+Cache policy (#2837):
+  `comments` fetches from GitHub at invocation. Its consumer — the feedback
+  lane's "one item per output line, none may be dropped" checklist — is woken
+  BY the review that postdates the scout's snapshot, so reading the cache there
+  is structurally guaranteed to drop the triggering item. On a `gh` failure it
+  serves the cached record with a loud stderr warning naming the snapshot time.
+  One live attempt, never a retry loop (#1394).
+
+  `view` and `diff` stay snapshot reads — their callers want the cheap cached
+  record — and each prints its snapshot stamp to stderr so a stale read is
+  never silent.
+
+Keep the cache-fallback wording in sync with fleet-issue: the two scripts are
+standalone by install design and share no code, so the policy is mirrored and
+pinned by tests/test_fleet_cache_reader_freshness.sh's parity assertion.
 
 Source of truth: scripts/fleet/fleet-pr in the engine repo.
 Installed to ~/bin/fleet-pr by scripts/fleet/install.sh.
@@ -36,6 +47,13 @@ DEFAULT_SLUGS = {
     "game": "jakildev/irreden",
 }
 
+# Mirrored verbatim in fleet-issue — see the module docstring.
+CACHE_FALLBACK_NOTE = (
+    "serving cached snapshot from {stamp}; "
+    "newer comments/reviews may be missing"
+)
+SNAPSHOT_HINT = "'comments' is the live subcommand"
+
 
 def repo_slug(repo_key):
     try:
@@ -47,6 +65,10 @@ def repo_slug(repo_key):
 
 def warn(msg):
     print(f"fleet-pr: {msg}", file=sys.stderr)
+
+
+def snapshot_stamp(detail):
+    return (detail or {}).get("_cached_at") or "unknown"
 
 
 def read_cached_pr(repo_key, pr_number):
@@ -68,6 +90,47 @@ def fallback_gh(args, gh_cmd):
     return subprocess.run(gh_cmd + ["--repo", slug]).returncode
 
 
+def run_gh_json(cmd):
+    """Run a JSON-emitting gh command. None on nonzero exit or bad JSON."""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        warn(f"gh json output is corrupt: {e}")
+        return None
+
+
+def fetch_live_pr(slug, pr_number):
+    """Fetch conversation + reviews + inline threads, shaped like the cache.
+
+    Returns None when the conversation fetch itself fails, so the caller can
+    degrade to the snapshot. A failure of the inline endpoint alone is marked
+    rather than fatal — falling back to the whole snapshot there would trade a
+    fresh review away for an inline list that is empty on every cached record.
+    """
+    detail = run_gh_json([
+        "gh", "pr", "view", str(pr_number), "--repo", slug,
+        "--json", "number,comments,reviews",
+    ])
+    if detail is None:
+        return None
+
+    # Inline review comments live on a different endpoint than `gh pr view`'s
+    # comments/reviews fields; the scout merges both (fetch_pr_inline_comments)
+    # so the live path must too, or every [path:line] item silently vanishes
+    # from the one output the checklist contract calls complete.
+    inline = run_gh_json(["gh", "api", f"repos/{slug}/pulls/{pr_number}/comments"])
+    if inline is None:
+        detail["inlineComments"] = []
+        detail["_inline_unavailable"] = True
+    else:
+        detail["inlineComments"] = inline
+    return detail
+
+
 def cmd_view(args):
     detail = read_cached_pr(args.repo, args.pr_number)
     if detail is None:
@@ -75,6 +138,8 @@ def cmd_view(args):
         return fallback_gh(args, [
             "gh", "pr", "view", str(args.pr_number), "--comments",
         ])
+
+    warn(f"snapshot as of {snapshot_stamp(detail)}; {SNAPSHOT_HINT}")
 
     print(f"# PR #{detail['number']}: {detail.get('title', '')}")
     print()
@@ -125,6 +190,8 @@ def cmd_diff(args):
             reverse=True,
         )
         if candidates:
+            head_sha = candidates[0].stem.split("-", 1)[-1]
+            warn(f"snapshot diff for head {head_sha}; {SNAPSHOT_HINT}")
             sys.stdout.write(candidates[0].read_text())
             return 0
 
@@ -133,12 +200,30 @@ def cmd_diff(args):
 
 
 def cmd_comments(args):
-    detail = read_cached_pr(args.repo, args.pr_number)
+    slug = repo_slug(args.repo)
+    if slug is None:
+        warn(f"unknown repo key: {args.repo}")
+        return 2
+
+    detail = fetch_live_pr(slug, args.pr_number)
     if detail is None:
-        warn(f"cache miss for {args.repo}#{args.pr_number}; falling back to gh")
-        return fallback_gh(args, [
-            "gh", "pr", "view", str(args.pr_number), "--comments",
-        ])
+        # Offline / rate-limited: degrade to the snapshot rather than erroring
+        # the feedback lane — but never silently.
+        detail = read_cached_pr(args.repo, args.pr_number)
+        if detail is None:
+            warn(
+                f"live fetch failed and no cached record for "
+                f"{args.repo}#{args.pr_number}"
+            )
+            return 1
+        warn(CACHE_FALLBACK_NOTE.format(stamp=snapshot_stamp(detail)))
+    elif detail.pop("_inline_unavailable", False):
+        cached = read_cached_pr(args.repo, args.pr_number)
+        detail["inlineComments"] = (cached or {}).get("inlineComments", [])
+        warn(
+            f"inline-comment endpoint failed; inline items below are from the "
+            f"cached snapshot ({snapshot_stamp(cached)}) and may be incomplete"
+        )
 
     any_output = False
     for c in detail.get("comments", []):
@@ -168,14 +253,16 @@ def cmd_comments(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Read scout's per-PR cache.")
+    parser = argparse.ArgumentParser(
+        description="Per-PR reads: comments live-first, view/diff from cache.",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
     for name, fn in [("view", cmd_view), ("diff", cmd_diff), ("comments", cmd_comments)]:
         sp = sub.add_parser(name)
         sp.add_argument("pr_number", type=int)
         sp.add_argument(
             "--repo", default="engine", choices=["engine", "game"],
-            help="Which cached repo to read (default: engine).",
+            help="Which repo to read (default: engine).",
         )
         sp.set_defaults(handler=fn)
     args = parser.parse_args()

--- a/scripts/fleet/tests/test_fleet_cache_reader_freshness.sh
+++ b/scripts/fleet/tests/test_fleet_cache_reader_freshness.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Tests for #2837: the two per-record cache readers must not serve a stale
+# snapshot as if it were current.
+#
+# `fleet-pr comments` and `fleet-issue view` are both woken BY an event that
+# postdates the scout's snapshot — the verdict review that stamps a feedback
+# label, the `## Plan` comment that stamps fleet:plan-review — so a cache read
+# there structurally drops the one item its consumer was dispatched to read.
+# Both are now live-first, falling back to the cache only when `gh` fails, and
+# saying so loudly when they do.
+#
+# The first assertion in each pair is the positive control: it fails against
+# master by construction, because master never invokes `gh` when the cached
+# record parses.
+#
+# Hermetic: HOME is a mktemp dir (both scripts compute
+# `Path.home() / ".fleet" / "state"` at import, and neither honors a
+# FLEET_STATE_DIR override), and `gh` is a PATH shim. No network, no live
+# ~/.fleet.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+source "$(dirname "$0")/lib_assert.sh"
+
+FLEET_PR="$SCRIPT_DIR/fleet-pr"
+FLEET_ISSUE="$SCRIPT_DIR/fleet-issue"
+for exe in "$FLEET_PR" "$FLEET_ISSUE"; do
+    [[ -f "$exe" ]] || { echo "SKIP: subject under test missing at $exe" >&2; exit 3; }
+done
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fleet-cache-freshness.XXXXXX")
+trap '[[ -n "${TMPROOT:-}" ]] && rm -rf "$TMPROOT"' EXIT
+
+FAKE_HOME="$TMPROOT/home"
+SHIM_BIN="$TMPROOT/bin"
+mkdir -p "$FAKE_HOME/.fleet/state/prs/engine" \
+         "$FAKE_HOME/.fleet/state/issues/engine" \
+         "$FAKE_HOME/.fleet/state/diffs/engine" \
+         "$SHIM_BIN"
+
+STAMP="2026-08-04T05:44:25Z"
+
+# ----------------------------------------------------------------------
+# Fixtures. The cached records carry ONLY the pre-verdict material, exactly
+# as the scout would have written them one tick before the triggering event.
+# ----------------------------------------------------------------------
+cat > "$FAKE_HOME/.fleet/state/prs/engine/2683.json" <<EOF
+{
+  "_cached_at": "$STAMP",
+  "number": 2683,
+  "title": "cached title",
+  "body": "cached body",
+  "updatedAt": "$STAMP",
+  "headRefOid": "deadbeef",
+  "files": [],
+  "inlineComments": [],
+  "comments": [
+    {"author": {"login": "jakildev"}, "createdAt": "2026-08-04T05:22:31Z",
+     "body": "STALE_ONLY_COMMENT"}
+  ],
+  "reviews": [
+    {"author": {"login": "jakildev"}, "state": "APPROVED",
+     "submittedAt": "2026-08-04T05:30:00Z", "body": "STALE_APPROVE_REVIEW"}
+  ]
+}
+EOF
+
+cat > "$FAKE_HOME/.fleet/state/issues/engine/2565.json" <<EOF
+{
+  "_cached_at": "$STAMP",
+  "number": 2565,
+  "title": "cached issue title",
+  "state": "OPEN",
+  "updatedAt": "$STAMP",
+  "labels": ["fleet:needs-plan", "fleet:planning-mac-pool-3"],
+  "body": "cached issue body",
+  "comments": [
+    {"author": {"login": "jakildev"}, "createdAt": "2026-07-28T00:00:00Z",
+     "body": "STALE_ONLY_ISSUE_COMMENT"}
+  ]
+}
+EOF
+
+# ----------------------------------------------------------------------
+# gh shim. GH_MODE picks the behaviour:
+#   live  — return material that postdates the snapshot
+#   fail  — exit nonzero on everything (offline / rate-limited)
+#   inline-fail — conversation succeeds, the inline endpoint does not
+# ----------------------------------------------------------------------
+cat > "$SHIM_BIN/gh" <<'SHIM'
+#!/usr/bin/env bash
+mode="${GH_MODE:-live}"
+[[ "$mode" == "fail" ]] && { echo "gh: shim failure" >&2; exit 1; }
+
+# `gh api repos/<slug>/pulls/<N>/comments` — inline review threads.
+if [[ "${1:-}" == "api" ]]; then
+    if [[ "$mode" == "inline-fail" ]]; then
+        echo "gh: shim inline failure" >&2
+        exit 1
+    fi
+    cat <<'JSON'
+[{"path": "engine/render/src/foo.cpp", "line": 42,
+  "user": {"login": "jakildev"}, "body": "LIVE_INLINE_ITEM"}]
+JSON
+    exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+    cat <<'JSON'
+{"number": 2683,
+ "comments": [{"author": {"login": "jakildev"},
+               "createdAt": "2026-08-04T05:46:28Z",
+               "body": "LIVE_NEW_COMMENT"}],
+ "reviews": [{"author": {"login": "jakildev"}, "state": "CHANGES_REQUESTED",
+              "submittedAt": "2026-08-04T05:45:51Z",
+              "body": "LIVE_TRIGGERING_REVIEW"}]}
+JSON
+    exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+    cat <<'JSON'
+{"number": 2565, "title": "live issue title", "state": "OPEN",
+ "labels": [{"name": "fleet:plan-review"}, {"name": "human:approved"}],
+ "body": "live issue body",
+ "comments": [{"author": {"login": "jakildev"},
+               "createdAt": "2026-08-04T17:27:20Z",
+               "body": "LIVE_PLAN_COMMENT"}]}
+JSON
+    exit 0
+fi
+
+echo "gh: shim got an unexpected invocation: $*" >&2
+exit 64
+SHIM
+chmod +x "$SHIM_BIN/gh"
+
+# run <mode> <script> <args...> → stdout on fd1; stderr captured to $ERRFILE
+ERRFILE="$TMPROOT/err"
+run_reader() {
+    local mode="$1"; shift
+    HOME="$FAKE_HOME" PATH="$SHIM_BIN:$PATH" GH_MODE="$mode" \
+        python3 "$@" 2>"$ERRFILE"
+}
+
+# ----------------------------------------------------------------------
+echo "fleet-pr comments — live-first (positive control: fails on master)"
+# ----------------------------------------------------------------------
+out=$(run_reader live "$FLEET_PR" comments 2683)
+rc=$?
+assert_eq "$rc" "0" "comments exits 0 on the live path"
+assert_contains "$out" "LIVE_TRIGGERING_REVIEW" \
+    "the review that postdates the snapshot is present (master serves the cache and drops it)"
+assert_contains "$out" "LIVE_NEW_COMMENT" \
+    "the comment that postdates the snapshot is present"
+assert_absent "$out" "STALE_APPROVE_REVIEW" \
+    "the superseded cached approve is not served alongside the live verdict"
+assert_contains "$out" "[engine/render/src/foo.cpp:42]" \
+    "inline [path:line] items render on the live path (the fallback used to drop them)"
+
+echo "fleet-pr comments — gh failure degrades to the snapshot, loudly"
+out=$(run_reader fail "$FLEET_PR" comments 2683)
+rc=$?
+err=$(cat "$ERRFILE")
+assert_eq "$rc" "0" "comments still exits 0 when it degrades to the cache"
+assert_contains "$out" "STALE_APPROVE_REVIEW" "cached data is served when gh fails"
+assert_contains "$err" "serving cached snapshot from $STAMP" \
+    "the degraded read names the snapshot time on stderr"
+
+echo "fleet-pr comments — inline endpoint alone failing keeps the fresh review"
+out=$(run_reader inline-fail "$FLEET_PR" comments 2683)
+err=$(cat "$ERRFILE")
+assert_contains "$out" "LIVE_TRIGGERING_REVIEW" \
+    "a failed inline endpoint does not throw away the fresh conversation"
+assert_contains "$err" "inline-comment endpoint failed" \
+    "the inline degradation is announced rather than silent"
+
+echo "fleet-pr comments — no live, no cache ⇒ nonzero"
+out=$(run_reader fail "$FLEET_PR" comments 9999)
+rc=$?
+assert_eq "$rc" "1" "live failure with no cached record exits nonzero"
+
+# ----------------------------------------------------------------------
+echo "fleet-issue view — live-first (positive control: fails on master)"
+# ----------------------------------------------------------------------
+out=$(run_reader live "$FLEET_ISSUE" view 2565)
+rc=$?
+assert_eq "$rc" "0" "view exits 0 on the live path"
+assert_contains "$out" "LIVE_PLAN_COMMENT" \
+    "the ## Plan comment that postdates the snapshot is present (master drops it)"
+assert_contains "$out" "fleet:plan-review" \
+    "labels are current, not the snapshot's two-transitions-behind set"
+assert_absent "$out" "fleet:planning-mac-pool-3" \
+    "the stale planning claim is not shown as live"
+
+echo "fleet-issue view — gh failure degrades to the snapshot, loudly"
+out=$(run_reader fail "$FLEET_ISSUE" view 2565)
+rc=$?
+err=$(cat "$ERRFILE")
+assert_eq "$rc" "0" "view still exits 0 when it degrades to the cache"
+assert_contains "$out" "STALE_ONLY_ISSUE_COMMENT" "cached data is served when gh fails"
+assert_contains "$err" "serving cached snapshot from $STAMP" \
+    "the degraded read names the snapshot time on stderr"
+
+echo "fleet-issue view — no live, no cache ⇒ nonzero"
+run_reader fail "$FLEET_ISSUE" view 9999 >/dev/null
+assert_eq "$?" "1" "live failure with no cached record exits nonzero"
+
+# ----------------------------------------------------------------------
+echo "parity — the two mirrored policies cannot drift silently"
+# ----------------------------------------------------------------------
+# The scripts share no code by install design, so the identical wording is the
+# only thing holding the policy together. Compare the notes as emitted, not as
+# source literals.
+run_reader fail "$FLEET_PR" comments 2683 >/dev/null
+pr_note=$(sed -n 's/^fleet-pr: \(serving cached snapshot.*\)$/\1/p' "$ERRFILE")
+run_reader fail "$FLEET_ISSUE" view 2565 >/dev/null
+issue_note=$(sed -n 's/^fleet-issue: \(serving cached snapshot.*\)$/\1/p' "$ERRFILE")
+assert_eq "$pr_note" "$issue_note" \
+    "fleet-pr and fleet-issue emit an identical cache-fallback note"
+[[ -n "$pr_note" ]] && ok "the parity assertion compared a non-empty note" \
+    || bad "the parity assertion compared two empty strings (vacuous)"
+
+# ----------------------------------------------------------------------
+echo "snapshot subcommands — still cache reads, no longer silent"
+# ----------------------------------------------------------------------
+out=$(run_reader live "$FLEET_PR" view 2683)
+rc=$?
+err=$(cat "$ERRFILE")
+assert_eq "$rc" "0" "view exits 0 from the cache"
+assert_contains "$out" "STALE_APPROVE_REVIEW" "view still serves the snapshot"
+assert_contains "$err" "snapshot as of $STAMP" "view announces its snapshot time"
+assert_contains "$err" "'comments' is the live subcommand" \
+    "view points at the live subcommand"
+
+printf 'diff body\n' > "$FAKE_HOME/.fleet/state/diffs/engine/2683-abc1234.diff"
+out=$(run_reader live "$FLEET_PR" diff 2683)
+err=$(cat "$ERRFILE")
+assert_contains "$out" "diff body" "diff still serves the cached diff"
+assert_contains "$err" "snapshot diff for head abc1234" \
+    "diff names the head SHA it is serving"
+
+summarize "fleet cache-reader freshness tests (#2837)"


### PR DESCRIPTION
## Summary

- `fleet-pr comments` and `fleet-issue view` are now **live-first**: they fetch from `gh` at invocation and reach for the scout's per-record cache only when `gh` fails, warning loudly on stderr with the snapshot time. Both are woken *by* an event that postdates the snapshot (the verdict review that stamps a feedback label; the `## Plan` comment that stamps `fleet:plan-review`), so a cache read there is structurally guaranteed to drop the one item the role was dispatched to read.
- **Widened past the issue title** per the 2026-08-04T17:32 scope comment — `fleet-issue view` carries the same defect, and its failure mode is worse: a plan reviewer sees `fleet:needs-plan` with no plan present, and the correct-looking action on that evidence is to bounce a sound plan.
- Replaces the bounced plan's freshness-guard design rather than implementing it. The guard cost 1 API call when fresh and 2 when stale against 1 unconditional for always-live, and additionally needed a comparison field, clock semantics, and a probe-failure path. Live-first dissolves all three.
- Routing the live path through the **existing** print loops also closes a format divergence that exists on master today: the old miss path `exec`'d `gh pr view --comments`, a different format that emits no `[path:line]` inline items at all — already a violation of the "none may be dropped" checklist contract.
- `fleet-pr view` / `diff` stay snapshot reads (their callers want the cheap record) and now stamp `_cached_at` on stderr, so a stale read is never silent.

The two scripts are standalone by install design and share no code, so the policy is **mirrored, not factored** — a parity assertion in the new suite fails if one side's wording drifts.

## Test plan

- [x] New suite `scripts/fleet/tests/test_fleet_cache_reader_freshness.sh`: **27 passed, 0 failed**. Hermetic — `HOME=$(mktemp -d)` (neither script honors a state-dir override; both compute `Path.home()` at import) plus a PATH-shimmed `gh`.
- [x] **Positive control**: run against pre-fix `origin/master` (`5a1fdc9ec`) via `fleet-positive-control`, **15 of 27 assertions fail**; the 12 that pass are the non-regression assertions. Verdict: `MEANINGFUL`. The two headline controls both fire — *"the review that postdates the snapshot is present"* and *"the `## Plan` comment that postdates the snapshot is present"*.
- [x] The parity assertion carries its own **vacuity guard** — on master it correctly reports `FAIL: the parity assertion compared two empty strings (vacuous)` rather than passing on two empty strings.
- [x] `bash scripts/fleet/tests/run_all.sh`: **129 suites — 128 passed, 1 failed**. The one failure is `test_cross_repo_shared_file_parity.sh`, which reproduces on `master` and is filed as game #368 (`auto-rereview.yml` comment-only drift). Not from this diff.
- [x] `ruff check scripts/` — `All checks passed!`
- [x] `fleet-pr view` / `diff` behavior confirmed unchanged apart from the added stderr line (asserted in the suite).

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| **AC1** — output current as of invocation, or an explicit stderr staleness signal naming the snapshot time | new suite, `live` and `fail` shim modes, both commands | Live: `LIVE_TRIGGERING_REVIEW` / `LIVE_PLAN_COMMENT` present. Degraded: `fleet-pr: serving cached snapshot from 2026-08-04T05:44:25Z; newer comments/reviews may be missing` |
| **AC2** — reproduce the window; newest review present where today it is silently missing | `fleet-positive-control … origin/master` | `FAIL: the review that postdates the snapshot is present` on master, `ok:` after the fix. **Live-window repro measured on this PR** (snapshot `05:02:45Z`, comment `05:03:08Z`, reads `05:03:10Z`, snapshot unchanged): master emitted `no comments yet on engine#2998` — an affirmative false negative — while this branch printed the comment. See the AC2 comment below. |
| **AC3** — tool and docs agree on what the wrapper guarantees | doc sweep over every non-gated surface stating the contract | `FLEET-CACHE.md` (layout rows, miss-policy paragraph, wrapper table, the opus-reviewer full-body note), `FLEET-FEEDBACK-HANDLING.md` §"Reading the feedback", `PLANNING-PROTOCOL.md:85`, `docs/agents/skills/start-next-task.md`, `fleet-help` ×2, both module docstrings. One gated residual below. |
| **AC4** — no new per-iteration polling loop | `fleet-rules-sweep --pattern 'fleet-(pr comments\|issue view)' scripts` | 10 hits in 3 files, **zero of them callers** — `fleet-help` index text, one `fleet-up` comment, and the new test. Both commands are one-shot call sites; the failure path never retries. #1394 holds by construction. |

## Findings

**One doc surface the plan and its review both cleared, wrongly.** The plan review checked `PLANNING-PROTOCOL.md` (L85–88) and concluded it "instructs *which command* to run without stating cache-freshness semantics." Its actual wording was *"Use the **cache-aware** wrapper"* — which is a freshness-semantics claim, and it now states the retired direction. Caught by `simplify`'s §9a retired-entity paraphrase sweep, not by the literal-token grep the plan enumerated with; fixed in this PR. The generalizable form: a doc that *names* a tool is out of scope, but a doc that *characterizes* it is a contract surface, and the two look identical to a token grep.

**One gated residual — needs a human, one line.** `.claude/skills/start-next-task/SKILL.md:44-46` still reads *"`fleet-issue view <issue#>` is the cache-aware title lookup … it falls back to `gh issue view`."* The direction is now reversed. That file is gated self-config, so no worker class can apply it. The non-gated twin (`docs/agents/skills/start-next-task.md`) is fixed here. Suggested replacement:

> - `fleet-issue view <issue#>` is the title lookup used in step 5's fleet-stack branch-name derivation; it reads live and falls back to the scout's cached snapshot only if `gh` is unreachable.

**Deployment note (not a defect).** `fleet-pr` / `fleet-issue` are symlinked from `~/bin`, so the fix ships on merge with no install step — but panes mid-iteration keep the loaded copy (#2768's reload gap). No immediate fleet-wide effect.

Closes #2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
