### PR TITLE
fleet: worker feedback lane skips PRs under a live fleet:reviewing-* claim (#2801)

### DIFF
--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -68,6 +68,41 @@ collected five such iterations in 80 minutes — #2524). `fleet-claim
 amending-claim` refuses these claims as a backstop, but skip pre-claim
 so the iteration goes to work you can actually do.
 
+**Skip** PRs carrying a `fleet:reviewing-*` label held by another agent
+— a reviewer is mid-review right now. The two lanes' claim namespaces
+(`fleet:amending-*` vs `fleet:reviewing-*`) are **disjoint**, so neither
+claim excludes the other on its own: each lane has to know the other's
+prefix, and this skip is the worker-side half (`REVIEW_SKIP_PREFIXES` is
+the reviewer's). Without it, whichever lane claims second wins the right
+to invalidate the other's work. The amend path force-pushes, and
+`--force-with-lease` protects the *branch*, not the reviewer's *work*:
+the reviewer reads head X, you rewrite to Y, and their verdict lands on
+a diff nobody read (#2801; observed on PR #2850, where the amending
+claim was granted 26 s after the opus recheck started). As with
+`fleet:needs-gl-host`, the pickup-side skip is the load-bearing half and
+`fleet-claim amending-claim` refuses as a backstop. The label cannot
+strand a PR: the reviewer's `review-release` / verdict swap clears it,
+and `fleet-claim cleanup --gh`'s orphan sweep clears an abandoned one.
+
+**Skip** PRs carrying `fleet:needs-opus-recheck` — `fleet:has-nits`
+stamped alongside it is **not a verdict**. The sonnet reviewer sets no
+verdict label when its pass ends "Opus recheck required:"
+(REVIEWER-PROTOCOL.md), so those nits are mid-escalation and the pending
+opus pass owns the PR; amending now buys a guaranteed second nit
+round-trip once that pass lands. The PR is not parked —
+`project_opus_reviewer` still emits it, so the suppression *routes* the
+work to the lane that can finish it. When the opus reviewer swaps its
+verdict the marker drops and the PR re-enters this lane normally.
+
+Both exclusions are enforced in `fleet-state-scout`'s
+`worker_feedback_labels()`, the single admission test behind **both** the
+worker projection (the dispatch trigger) and `slice_worker`'s
+`feedback_prs` payload — so a PR under either signal is absent from
+`projections/worker.json` as well, not just from the trigger hash.
+Neither exclusion touches the `human:needs-fix` / `human:blocker` tiers:
+human feedback outranks an in-flight fleet review and keeps dispatching
+under both signals.
+
 ## Step a — claim the PR atomically (before anything else)
 
 Feedback pickup fans out: the dispatcher can launch your role into

--- a/scripts/fleet/CLAUDE.md
+++ b/scripts/fleet/CLAUDE.md
@@ -150,8 +150,18 @@ applies here too — see `docs/agents/CLAUDE-BASELINE.md` §Style.
   (`fleet:amending-*` vs `fleet:resolving-*`) provide **no** mutual
   exclusion — a PR matching two lanes' filters on one scout tick gets two
   panes force-pushing the same head branch, last writer wins (#2423: the
-  semantic-conflict lane had to learn to exclude feedback-owing PRs).
-  Check this whenever a lane is added or its label set widened.
+  semantic-conflict lane had to learn to exclude feedback-owing PRs;
+  #2801: the same for `fleet:reviewing-*` vs `fleet:amending-*`, where the
+  exclusion existed on the reviewer side only, so a worker could amend a PR
+  mid-review). Check this whenever a lane is added or its label set widened.
+  The exclusion is **directional** — closing one side leaves the hazard
+  live, and both lanes are woken by the same labels by design, so a
+  one-sided guard reads as complete while the race is untouched. A lane's
+  admission test must also be the **sole** one for that lane: an emit-site
+  filter that its `slice_<role>` twin doesn't share leaves every consumer
+  of the slice (class election, quiet check, `fleet-up`'s bootstrap
+  trigger) reading the unfiltered set (#2801 again — `project_worker` and
+  `slice_worker` now share `worker_feedback_labels()`).
 - **Path-containment checks normalize before the literal match.** A
   path-containment policy check (worktree guard, scope guard, allowlist)
   must normalize its input to canonical form *before* the literal match —

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -925,6 +925,61 @@ check_host_capability() {
     return 1
 }
 
+# --- cross-lane claim gate ------------------------------------------------
+
+check_no_foreign_review_claim() {
+    # Refuse an amending-claim on a PR another agent is actively reviewing
+    # (`fleet:reviewing-<host>-<agent>`). fleet:amending-* and
+    # fleet:reviewing-* are DISJOINT label namespaces, so _acquire_label_on's
+    # lex-min tie-break — which filters to labels startswith(prefix) — cannot
+    # see a live review claim and grants the amend immediately. The worker
+    # then force-pushes (fleet-pr-amend-push) and the reviewer's verdict lands
+    # on a diff nobody read (#2801; same hazard class scripts/fleet/CLAUDE.md
+    # flags for amending-*/resolving-*).
+    #
+    # The load-bearing fix is the pickup-side suppression in
+    # fleet-state-scout's worker_feedback_labels(); this is the backstop for a
+    # pane that already had the PR in context — notably role-worker step 0.5's
+    # reservation resume, which hand-scans raw state.json prs[] rather than
+    # the projection. Mirrors check_host_capability (#2524): runs BEFORE
+    # _cmd_pr_label_claim, mutates nothing on the refuse path. Placement is
+    # load-bearing — _acquire_label_on POSTs the label before it decides, so a
+    # guard inside it would strand a fleet:amending-* label on a PR the worker
+    # then abandons.
+    #
+    # Same-agent is a pass-through: an agent legitimately holding both (it
+    # reviewed, then picked the feedback up itself) is not a cross-lane race.
+    local pr="$1" agent="${2:-unknown}"
+
+    local info
+    info=$(fetch_issue_info "$pr") || true
+    [[ -z "$info" ]] && return 0
+
+    local labels=""
+    while IFS=$'\t' read -r key value; do
+        case "$key" in
+            labels) labels="$value" ;;
+        esac
+    done <<< "$info"
+
+    local host own_label
+    host=$(derive_host)
+    own_label="fleet:reviewing-${host}-${agent}"
+
+    local label
+    for label in $labels; do
+        case "$label" in
+            fleet:reviewing-*) ;;
+            *) continue ;;
+        esac
+        [[ "$label" == "$own_label" ]] && continue
+        echo "fleet-claim: refuse PR#${pr} — held by [${label}]; a reviewer is mid-review and an amend would force-push out from under it" >&2
+        return 1
+    done
+
+    return 0
+}
+
 # --- subcommands ----------------------------------------------------------
 
 cmd_claim() {
@@ -1740,6 +1795,12 @@ cmd_amending_claim() {
     # The load-bearing fix is the pickup-side skip in
     # FLEET-FEEDBACK-HANDLING.md; this catches stale-docs / raced claims.
     if [[ "${1:-}" =~ ^[0-9]+$ ]] && ! check_host_capability "$1"; then
+        return 1
+    fi
+    # Cross-lane backstop (#2801): a live fleet:reviewing-* held by another
+    # agent bars the amend. Sibling of the host gate above — same pre-acquire
+    # placement, same no-mutation-on-refuse contract.
+    if [[ "${1:-}" =~ ^[0-9]+$ ]] && ! check_no_foreign_review_claim "$1" "${2:-unknown}"; then
         return 1
     fi
     _cmd_pr_label_claim   "fleet:amending-" "amending-claim"   "$@"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1902,6 +1902,57 @@ def enrich_inflight_pr_tasks(state):
 # clears the stale label itself.
 _WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
 
+# The worker-side counterpart to the reviewer's fleet:amending-* skip
+# (REVIEW_SKIP_PREFIXES). fleet:reviewing-* and fleet:amending-* are disjoint
+# claim namespaces, so neither lane's claim excludes the other's on its own —
+# each lane has to know the other's prefix. Without this side, whichever lane
+# claims second wins the right to invalidate the other's work: the amend path
+# force-pushes, and --force-with-lease protects the branch, not the reviewer's
+# work, so the reviewer reads head X, the worker rewrites to Y, and the
+# verdict lands on a diff nobody read. Same hazard scripts/fleet/CLAUDE.md
+# flags for amending-*/resolving-*, resolved the same way
+# _semantic_conflict_claimable resolves that pair (#2801).
+WORKER_SKIP_PREFIXES = ("fleet:reviewing-",)
+# fleet:has-nits stamped ALONGSIDE fleet:needs-opus-recheck is not a verdict:
+# REVIEWER-PROTOCOL.md has the sonnet reviewer set NO verdict label in that
+# case, and OPUS_REVIEWER_FLAG_LABELS documents the marker as the escalation
+# signal. The pending opus pass owns the PR; dispatching the author now buys
+# a guaranteed second nit round-trip. Suppression here ROUTES the PR (the
+# opus-reviewer lane still emits it), it does not park it.
+WORKER_SKIP_LABELS = frozenset({"fleet:needs-opus-recheck"})
+# Only the fleet-owned tiers are suppressible. human:needs-fix /
+# human:blocker outrank an in-flight fleet review (FLEET-FEEDBACK-HANDLING.md
+# puts the human tiers first in its priority order) and keep emitting under
+# every skip signal above.
+_WORKER_SUPPRESSIBLE_LABELS = frozenset({
+    "fleet:needs-fix", "fleet:has-nits",
+}) | DESIGN_RESUME_LABELS
+
+
+def worker_feedback_labels(labels):
+    """The worker-relevant tiers this PR is dispatchable on right now.
+
+    Empty => no worker feedback work. Sole admission test for BOTH
+    project_worker (the trigger) and slice_worker (the payload every
+    downstream consumer reads); keep them on this one helper — a
+    projection-only guard leaves the class election
+    (fleet_task_class._yield_work_candidates), the terminally-unclaimable
+    quiet check, and fleet-up's bootstrap trigger reading the unfiltered
+    set, and FLEET-CACHE.md points roles at the slice.
+
+    Suppress, never mutate: the fleet:reviewing-* label's lifecycle belongs
+    to the reviewer's release/verdict swap and to `fleet-claim cleanup
+    --gh`'s orphan sweep, which is what keeps this from stranding a PR.
+    """
+    relevant = _WORKER_RELEVANT_LABELS & labels
+    if not relevant:
+        return frozenset()
+    if (WORKER_SKIP_LABELS & labels) or any(
+        label.startswith(p) for label in labels for p in WORKER_SKIP_PREFIXES
+    ):
+        relevant -= _WORKER_SUPPRESSIBLE_LABELS
+    return relevant
+
 
 def _semantic_conflict_claimable(pr, labels, head_labels):
     """True when role-worker step 1c would pick this PR up right now, so it
@@ -1937,6 +1988,13 @@ def _semantic_conflict_claimable(pr, labels, head_labels):
     # feedback fix. Feedback comes first (this PR's own stated priority), so a
     # conflicted PR generates no conflict-resolution pressure until the
     # feedback/design-resume label clears. Mirror in role-worker.md step 1c.
+    #
+    # Deliberately the RAW set, not worker_feedback_labels(): this test means
+    # "this PR owes feedback work, so the conflict lane stands down." Routing
+    # it through the suppression helper would make a reviewer's live claim
+    # *open* the conflict lane — and the resolver force-pushes too, so that is
+    # the identical hazard one lane over. Making all three call sites
+    # "consistent" is the wrong turn here (#2801).
     if labels & _WORKER_RELEVANT_LABELS:
         return False
     # An active fleet:resolving-<host>-<agent> claim means a worker is
@@ -2013,9 +2071,10 @@ def project_worker(state):
                 repo, pr["number"]
             ):
                 continue
-            if labels & _WORKER_RELEVANT_LABELS:
+            worker_labels = worker_feedback_labels(labels)
+            if worker_labels:
                 items.append({"kind": "pr", "repo": repo, "pr": pr["number"],
-                              "labels": sorted(labels & _WORKER_RELEVANT_LABELS)})
+                              "labels": sorted(worker_labels)})
             # Distinct kind so the hash keys on presence only — resolution
             # (label removed / PR merged) or a fleet:resolving-* claim drops
             # the item; transient label churn on the PR doesn't re-flip it.
@@ -2503,7 +2562,11 @@ def slice_worker(state):
             # woken worker iteration doesn't even surface it as a candidate.
             if "fleet:gated" in labels:
                 continue
-            if labels & (FEEDBACK_LABELS | DESIGN_RESUME_LABELS):
+            # Same admission test as project_worker's emit site — one helper,
+            # both sites. A projection-only guard would leave this payload
+            # unfiltered, and FLEET-CACHE.md tells every role to prefer the
+            # slice over state.json (#2801).
+            if worker_feedback_labels(labels):
                 out["feedback_prs"].append(_slice_pr_with_repo(repo_key, pr))
             if _semantic_conflict_claimable(pr, labels, head_labels):
                 out["semantic_conflict_prs"].append(

--- a/scripts/fleet/tests/test_fleet_claim_host_gate.sh
+++ b/scripts/fleet/tests/test_fleet_claim_host_gate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tests for fleet-claim's check_host_capability gate (issue-based, #1998).
+# Tests for fleet-claim's pre-acquire claim gates: check_host_capability
+# (issue-based, #1998) and check_no_foreign_review_claim (#2801).
 #
 # The gate refuses a `fleet:needs-gl-host` claim from a host that can't run
 # the OpenGL backend. GL-capable hosts are {linux, windows}; macOS GL is 4.1
@@ -18,6 +19,16 @@
 #   - gh failure soft-degrades to pass (exit 0)
 #   - amending-claim (#2524): mac host refuses a fleet:needs-gl-host PR,
 #     linux host passes it, an unlabeled PR passes on mac
+#   - amending-claim (#2801): a fleet:reviewing-* claim held by ANOTHER agent
+#     refuses the amend AND mutates no labels; same-host and cross-host
+#     foreign claims both refuse; the claiming agent's OWN reviewing label is
+#     a pass-through
+#
+# The #2801 arm asserts the PR's label set is untouched, not just the exit
+# code: _acquire_label_on POSTs the fleet:amending-* label BEFORE it decides
+# the lex-min, so a guard placed inside it would leave that label stranded on
+# a PR the worker then abandons. The gate therefore has to run ahead of
+# _cmd_pr_label_claim, and "no POST happened" is the assertion that pins it.
 
 set -euo pipefail
 
@@ -28,13 +39,18 @@ export FLEET_SKIP_CLONE_FRESHNESS=1
 SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
 
+# PASS/FAIL counters, ok/bad, and the summarize exit idiom (scripts/fleet's
+# convention — don't re-copy them). summarize's "passed: N  failed: M" line is
+# also what fleet-positive-control reads to score a control run; the
+# hand-rolled counters this replaces printed a tally the tool could not parse,
+# so the #2801 arms below had no scoreable positive control.
+source "$(dirname "$0")/lib_assert.sh"
+
 if [[ ! -x "$FLEET_CLAIM" ]]; then
     echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
     exit 1
 fi
 
-PASS=0
-FAIL=0
 TMPROOT=""
 
 cleanup() {
@@ -42,14 +58,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Exit-code assertions stay local, built on ok/bad (lib_assert.sh's documented
+# split: the assert_* family covers strings, tests define their own for exit
+# codes and path existence).
 assert_exit() {
     local actual_exit="$1" expected_exit="$2" msg="$3"
     if [[ "$actual_exit" -eq "$expected_exit" ]]; then
-        PASS=$((PASS + 1))
-        echo "  ok: $msg"
+        ok "$msg"
     else
-        FAIL=$((FAIL + 1))
-        echo "  FAIL: $msg"
+        bad "$msg"
         echo "        expected exit: $expected_exit"
         echo "        actual exit:   $actual_exit"
     fi
@@ -69,6 +86,11 @@ mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR"
 #   2003 — gh failure (soft-degrade contract)
 #   3001 — PR carrying fleet:needs-gl-host (GL-gated design-unblocked resume)
 #   3002 — PR without the label
+#   3003 — PR under ANOTHER agent's same-host review claim (mac-pool-9)
+#   3004 — PR under the claiming agent's OWN review claim (mac-test-agent)
+#   3005 — PR under another agent's CROSS-host review claim (linux-pool-2)
+# Every label-mutating `gh api ... --method POST` is appended to $GH_POST_LOG
+# so a test can assert the refuse path mutated nothing.
 # The `api` arm emulates the cross-host fleet:claim-* lock acquire so a
 # gate-passing claim runs through to success (echo the requested label back
 # as the lex-min winner). All issues carry fleet:opus so a stray ambient
@@ -97,6 +119,15 @@ case "$1 $2" in
             3002)
                 echo '{"state":"OPEN","labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"}],"body":""}'
                 ;;
+            3003)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:has-nits"},{"name":"fleet:reviewing-mac-pool-9"}],"body":""}'
+                ;;
+            3004)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:has-nits"},{"name":"fleet:reviewing-mac-test-agent"}],"body":""}'
+                ;;
+            3005)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:has-nits"},{"name":"fleet:reviewing-linux-pool-2"}],"body":""}'
+                ;;
             *)
                 echo '{"state":"OPEN","labels":[],"body":""}'
                 ;;
@@ -119,6 +150,7 @@ case "$1 $2" in
             shift || true
         done
         if [[ -n "$label" ]]; then
+            [[ -n "${GH_POST_LOG:-}" ]] && printf '%s\n' "$label" >> "$GH_POST_LOG"
             printf '[{"name":"%s"}]\n' "$label"
         else
             echo '[]'
@@ -190,6 +222,73 @@ echo "T9: mac host passes amending-claim on a PR without the label"
 actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3002 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 0 "mac + no host label PR → amending-claim exit 0"
 
-echo ""
-echo "PASS: $PASS  FAIL: $FAIL"
-[[ "$FAIL" -eq 0 ]]
+# --- #2801: cross-lane review-claim gate on amending-claim ------------------
+#
+# fleet:amending-* and fleet:reviewing-* are disjoint label namespaces, so
+# _acquire_label_on's lex-min tie-break — which filters the label list to
+# startswith(prefix) — is structurally blind to a live review claim and
+# grants the amend. The worker then force-pushes out from under the reviewer.
+
+export GH_POST_LOG="$TMPROOT/gh-post.log"
+
+assert_no_label_post() {
+    local msg="$1"
+    if [[ ! -s "$GH_POST_LOG" ]]; then
+        ok "$msg"
+    else
+        bad "$msg"
+        echo "        labels POSTed on the refuse path:"
+        sed 's/^/          /' "$GH_POST_LOG"
+    fi
+}
+
+# --- T10: another agent's same-host review claim refuses the amend ----------
+echo "T10: amending-claim refused under another agent's fleet:reviewing-*"
+: > "$GH_POST_LOG"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3003 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "mac + fleet:reviewing-mac-pool-9 → amending-claim exit 1"
+
+# --- T11: ...and the refuse path mutated no labels --------------------------
+# The failure mode is a mutation that outlives the refusal, so assert the
+# label set, not just the exit code. _acquire_label_on POSTs before it
+# decides; the gate must therefore run ahead of _cmd_pr_label_claim.
+echo "T11: the refusal mutates no labels"
+assert_no_label_post "refused amending-claim POSTed no label"
+
+# --- T12: the agent's OWN review claim is a pass-through --------------------
+# An agent legitimately holding both (it reviewed, then picked the feedback
+# up itself) is not a cross-lane race.
+echo "T12: own fleet:reviewing-<host>-<agent> does not block the amend"
+: > "$GH_POST_LOG"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3004 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "mac + own fleet:reviewing-mac-test-agent → amending-claim exit 0"
+
+# --- T13: a cross-host foreign review claim refuses too ---------------------
+# The reviewer may be on another machine; the guard keys on the label, not on
+# whether this host could have minted it.
+echo "T13: another host's fleet:reviewing-* also refuses"
+: > "$GH_POST_LOG"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3005 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "mac + fleet:reviewing-linux-pool-2 → amending-claim exit 1"
+assert_no_label_post "cross-host refusal POSTed no label"
+
+# --- T14: an unrelated PR is unaffected by the new gate ---------------------
+# Guards against the gate over-refusing: 3002 carries no reviewing label.
+echo "T14: PR with no review claim still amends"
+: > "$GH_POST_LOG"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" amending-claim 3002 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "mac + no fleet:reviewing-* → amending-claim exit 0"
+
+# --- T15: fidelity check for T11/T13's "no POST" assertion ------------------
+# assert_no_label_post is an emptiness test, so it passes for free if the
+# stub's GH_POST_LOG wiring ever breaks. T14 just granted a claim, which MUST
+# have POSTed the fleet:amending-* label — so a non-empty log here is what
+# makes the empty log above evidence rather than a no-op.
+echo "T15: the POST log records a granted claim (fidelity check)"
+if grep -q '^fleet:amending-mac-test-agent$' "$GH_POST_LOG" 2>/dev/null; then
+    ok "granted amending-claim POSTed fleet:amending-mac-test-agent"
+else
+    bad "granted amending-claim left no POST in the log — the GH_POST_LOG wiring is broken, so T11/T13 prove nothing"
+fi
+
+summarize "fleet-claim pre-acquire gates"

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -582,6 +582,173 @@ class AmendingClaimBarsReviewerPickup(unittest.TestCase):
         self.assertEqual(len(self._opus([_pr(101, labels=["fleet:needs-fix"])])), 1)
 
 
+class ReviewClaimBarsWorkerFeedbackPickup(unittest.TestCase):
+    """The mirror image of AmendingClaimBarsReviewerPickup, which did not
+    exist until #2801: fleet:amending-* and fleet:reviewing-* are DISJOINT
+    claim namespaces, so they provide no mutual exclusion. The reviewer side
+    was guarded (REVIEW_SKIP_PREFIXES); the worker side was not, so whichever
+    lane claimed second won the right to invalidate the other's work.
+    --force-with-lease protects the branch, not the reviewer's work: the
+    reviewer reads head X, the worker force-pushes Y, and the verdict lands
+    on a diff nobody read. Observed on PR #2850 (2026-08-09), where
+    fleet-pr-claim-feedback granted the amend 26 s after the opus recheck
+    started.
+
+    fleet:needs-opus-recheck is the second, independent term: has-nits
+    stamped ALONGSIDE it is not a verdict (the sonnet reviewer sets none in
+    that case), so the pending opus pass owns the PR.
+
+    Every case asserts BOTH emit sites. A projection-only guard would leave
+    slice_worker's feedback_prs[] unfiltered, and that payload drives the
+    class election, the terminally-unclaimable quiet check, and fleet-up's
+    bootstrap trigger — FLEET-CACHE.md points roles at the slice.
+    """
+
+    def _proj_prs(self, prs):
+        return [i for i in project_worker(_state(prs)) if i["kind"] == "pr"]
+
+    def _slice_prs(self, prs):
+        return slice_worker(_state(prs))["feedback_prs"]
+
+    def _both(self, prs):
+        return self._proj_prs(prs), self._slice_prs(prs)
+
+    # --- 1. live review claim suppresses the fleet verdict tiers ---------
+
+    def test_reviewing_claim_drops_has_nits_pr_at_both_sites(self):
+        # The two-run delta IS the assertion: the defect was that LIVE and
+        # minus-fleet:reviewing-* produced byte-identical output, i.e. the
+        # review claim contributed exactly zero suppression.
+        held_proj, held_slice = self._both([
+            _pr(101, labels=["fleet:has-nits", "fleet:reviewing-mac-pool-9"])])
+        free_proj, free_slice = self._both([
+            _pr(101, labels=["fleet:has-nits"])])
+
+        self.assertEqual(held_proj, [], "review claim must suppress the projection item")
+        self.assertEqual(held_slice, [], "review claim must suppress the slice payload")
+        self.assertEqual(len(free_proj), 1)
+        self.assertEqual(len(free_slice), 1)
+
+    def test_reviewing_claim_drops_needs_fix_pr_at_both_sites(self):
+        held_proj, held_slice = self._both([
+            _pr(101, labels=["fleet:needs-fix", "fleet:reviewing-mac-pool-5"])])
+        self.assertEqual(held_proj, [])
+        self.assertEqual(held_slice, [])
+
+    def test_reviewing_claim_drops_design_unblocked_pr_at_both_sites(self):
+        # design-unblocked is a fleet-owned tier too (DESIGN_RESUME_LABELS is
+        # folded into _WORKER_SUPPRESSIBLE_LABELS), so a resume must not
+        # force-push out from under a live review either.
+        held_proj, held_slice = self._both([
+            _pr(101, labels=["fleet:design-unblocked", "fleet:reviewing-mac-pool-5"])])
+        self.assertEqual(held_proj, [])
+        self.assertEqual(held_slice, [])
+
+    # --- 2. needs-opus-recheck is not a verdict --------------------------
+
+    def test_needs_opus_recheck_drops_has_nits_pr_at_both_sites(self):
+        held_proj, held_slice = self._both([
+            _pr(101, labels=["fleet:has-nits", "fleet:needs-opus-recheck"])])
+        free_proj, free_slice = self._both([
+            _pr(101, labels=["fleet:has-nits"])])
+
+        self.assertEqual(held_proj, [])
+        self.assertEqual(held_slice, [])
+        self.assertEqual(len(free_proj), 1)
+        self.assertEqual(len(free_slice), 1)
+
+    def test_needs_opus_recheck_pr_still_reaches_the_opus_reviewer(self):
+        # The suppression ROUTES the PR, it does not park it: the lane that
+        # can actually finish the escalation still sees it. This is what
+        # makes the skip safe without any TTL/liveness logic.
+        flagged = project_opus_reviewer(_state([
+            _pr(101, labels=["fleet:has-nits", "fleet:needs-opus-recheck"])]))
+        self.assertEqual(len(flagged), 1)
+
+    # --- 3. the human tiers are never suppressed ------------------------
+
+    def test_human_needs_fix_still_emitted_under_review_claim(self):
+        # Pins the deliberate carve-out: human feedback outranks an in-flight
+        # fleet review (FLEET-FEEDBACK-HANDLING.md priority order). Widening
+        # the drop to all of _WORKER_RELEVANT_LABELS is the easy wrong turn
+        # and would park human feedback behind a reviewer's claim.
+        proj, sliced = self._both([
+            _pr(101, labels=["human:needs-fix", "fleet:reviewing-mac-pool-9"])])
+        self.assertEqual(len(proj), 1)
+        self.assertEqual(proj[0]["labels"], ["human:needs-fix"])
+        self.assertEqual(len(sliced), 1)
+
+    def test_human_blocker_still_emitted_under_needs_opus_recheck(self):
+        proj, sliced = self._both([
+            _pr(101, labels=["human:blocker", "fleet:needs-opus-recheck"])])
+        self.assertEqual(len(proj), 1)
+        self.assertEqual(proj[0]["labels"], ["human:blocker"])
+        self.assertEqual(len(sliced), 1)
+
+    def test_mixed_tiers_under_review_claim_emit_only_the_human_tier(self):
+        # The emitted labels list is the dispatch's tier hint, so a PR
+        # carrying both must advertise only the tier that is actionable now.
+        proj, sliced = self._both([_pr(101, labels=[
+            "human:needs-fix", "fleet:has-nits", "fleet:reviewing-mac-pool-9",
+        ])])
+        self.assertEqual(len(proj), 1)
+        self.assertEqual(proj[0]["labels"], ["human:needs-fix"])
+        self.assertEqual(len(sliced), 1)
+
+    # --- 4. the skip is not a new churn source --------------------------
+
+    def test_review_claim_does_not_flip_hash_for_a_human_only_pr(self):
+        # The invariant this whole file exists for: a label the decision
+        # logic does not key on (here: for a PR whose decision it cannot
+        # change) must not re-fire the lane.
+        before = project_worker(_state([_pr(101, labels=["human:needs-fix"])]))
+        after = project_worker(_state([_pr(101, labels=[
+            "human:needs-fix", "fleet:reviewing-mac-pool-9"])]))
+        self.assertEqual(before, after)
+        self.assertEqual(stable_hash(before), stable_hash(after))
+
+    # --- 5. release-valve linkage ---------------------------------------
+
+    def test_clearing_the_review_claim_re_enters_the_pr_at_both_sites(self):
+        # Suppression that never lifts would strand a feedback PR, so this is
+        # the load-bearing assertion — not the suppression itself. Production
+        # clears the label two ways: the reviewer's own review-release /
+        # verdict swap, and `fleet-claim cleanup --gh`'s orphan fast path for
+        # a dead reviewer. That second half is proved by
+        # tests/test_fleet_claim_prlabel_orphan_sweep.sh (fixture PR 902:
+        # same-host label, no liveness marker -> swept). Keep the two suites
+        # cited together; this one alone only shows the projection reacts to
+        # a label clearing, never that anything in production clears it.
+        held = _pr(101, labels=["fleet:has-nits", "fleet:reviewing-mac-pool-9"])
+        cleared = _pr(101, labels=["fleet:has-nits"])
+
+        self.assertEqual(self._proj_prs([held]), [])
+        self.assertEqual(self._slice_prs([held]), [])
+        self.assertEqual(len(self._proj_prs([cleared])), 1)
+        self.assertEqual(len(self._slice_prs([cleared])), 1)
+        self.assertNotEqual(stable_hash(project_worker(_state([held]))),
+                            stable_hash(project_worker(_state([cleared]))))
+
+    # --- the wrong turn: the conflict lane must NOT open ------------------
+
+    def test_review_claim_does_not_open_the_semantic_conflict_lane(self):
+        # _semantic_conflict_claimable deliberately tests the RAW
+        # _WORKER_RELEVANT_LABELS, not worker_feedback_labels(). Routing it
+        # through the helper "for consistency" would let a reviewer's live
+        # claim hand the PR to the conflict lane instead — and the resolver
+        # force-pushes too, so that is the identical hazard one lane over.
+        prs = [_sc_pr(101, labels=[
+            "fleet:semantic-conflict", "fleet:has-nits",
+            "fleet:reviewing-mac-pool-9",
+        ])]
+        self.assertEqual(
+            [i for i in project_worker(_state(prs))
+             if i["kind"] == "semantic_conflict"],
+            [],
+        )
+        self.assertEqual(slice_worker(_state(prs))["semantic_conflict_prs"], [])
+
+
 class HumanDeferredDropsFromReviewers(unittest.TestCase):
     """fleet:human-deferred and fleet:needs-human PRs must not surface in
     reviewer projections (#1996 Gap 2).


### PR DESCRIPTION
## Summary
- `fleet:amending-*` and `fleet:reviewing-*` are **disjoint** claim namespaces, so neither excludes the other on its own — each lane has to know the other's prefix. Only the reviewer side knew (`REVIEW_SKIP_PREFIXES`), so whichever lane claimed second won the right to invalidate the other's work. `--force-with-lease` protects the *branch*, not the reviewer's *work*: the reviewer reads head X, the worker force-pushes Y, and the verdict lands on a diff nobody read.
- Add `worker_feedback_labels()` to `fleet-state-scout` as the **sole** admission test for the worker feedback lane, called from **both** emit sites — `project_worker` (the dispatch trigger) and `slice_worker` (the `feedback_prs` payload). A projection-only guard would leave the class election (`fleet_task_class._yield_work_candidates`), the terminally-unclaimable quiet check, and `fleet-up`'s bootstrap trigger reading the unfiltered set, and `FLEET-CACHE.md:14` tells every role to prefer the slice over `state.json`.
- Two skip signals: a foreign `fleet:reviewing-*`, and `fleet:needs-opus-recheck` (`fleet:has-nits` stamped alongside that marker is **not** a verdict — the sonnet reviewer sets none in that case, so the pending opus pass owns the PR). Both suppress only the **fleet-owned** tiers; `human:needs-fix` / `human:blocker` outrank an in-flight fleet review and keep dispatching.
- `check_no_foreign_review_claim` in `fleet-claim` backstops the one path that hand-scans raw `state.json` `prs[]` rather than the projection — step 0.5's reservation resume. It sits beside the #2524 host gate, **before** `_cmd_pr_label_claim`, because `_acquire_label_on` POSTs the label before it decides the lex-min.
- `_semantic_conflict_claimable` deliberately keeps testing the **raw** label set. Routing it through the helper would let a live review claim *open* the conflict lane — whose resolver force-pushes too. Pinned by a test.
- `docs/agents/FLEET-FEEDBACK-HANDLING.md`'s skip stanza gains both exclusions; `scripts/fleet/CLAUDE.md`'s disjoint-namespace rule gains #2801 as its second instance plus the directionality and sole-admission-test lessons.

## Test plan
- [x] `python3 scripts/fleet/tests/test_worker_projection.py` → `Ran 72 tests` / `OK` (was 61 on master; +11).
- [x] `bash scripts/fleet/tests/test_fleet_claim_host_gate.sh` → `fleet-claim pre-acquire gates: 16 passed, 0 failed` (was 9 on master; +7).
- [x] `bash scripts/fleet/tests/run_all.sh` → `128 suite(s) — 127 passed, 1 failed`. The one failure is `test_cross_repo_shared_file_parity.sh`, the pre-existing master-red baseline on `auto-rereview.yml` drift (game #368) — it reproduces on `origin/master` and touches no file in this diff.
- [x] `ruff check scripts/` → `All checks passed!`
- [x] Cited references verified: every cited path resolves at the base ref, and `#2850` confirmed a PR (`gh api .../issues/2850 --jq .has("pull_request")` → `true`), not an issue.

## Acceptance evidence

| Criterion | Check run | Observed |
|---|---|---|
| A `fleet:reviewing-*` label on an otherwise-eligible feedback PR ⇒ `project_worker` emits no `kind=pr` item; removing it emits one (two-run delta is the assertion) | `test_reviewing_claim_drops_has_nits_pr_at_both_sites`, `..._needs_fix_...`, `..._design_unblocked_...` | held ⇒ `[]` at both sites; cleared ⇒ exactly 1 at both. Pre-fix all three fail |
| **(plan rev-2 §4)** the suppression covers `slice_worker`, not just the projection | every case above asserts **both** `project_worker` and `slice_worker.feedback_prs` | one shared helper; a projection-only assertion is what let §4 through in rev-1 |
| `amending-claim` exits non-zero **mutating no labels** under another agent's live `fleet:reviewing-*` | `test_fleet_claim_host_gate.sh` T10/T11/T13 | `mac + fleet:reviewing-mac-pool-9 → amending-claim exit 1`; `refused amending-claim POSTed no label`. T12 pins same-agent as a pass-through; T15 is the fidelity check proving the POST log records a *granted* claim, so T11's emptiness is evidence rather than a no-op |
| `fleet:has-nits` + `fleet:needs-opus-recheck` not emitted; same PR without the marker is | `test_needs_opus_recheck_drops_has_nits_pr_at_both_sites` | suppressed at both sites; minus the marker ⇒ 1 at both. `test_needs_opus_recheck_pr_still_reaches_the_opus_reviewer` shows `project_opus_reviewer` still emits it — the skip **routes** the PR, it does not park it |
| Suppression is not permanent — the PR re-enters once the label clears | `test_clearing_the_review_claim_re_enters_the_pr_at_both_sites` | re-enters at both sites, hash flips. Paired in the test body with a pointer to `test_fleet_claim_prlabel_orphan_sweep.sh` (`6 passed, 0 failed` this session), which is what proves *production* clears an orphaned label |
| `FLEET-FEEDBACK-HANDLING.md`'s skip stanza names both exclusions, matching the code | doc diff | two stanzas added beside `fleet:needs-gl-host`, same "pickup-side skip is load-bearing, claim refuses as backstop" framing, plus the human-tier carve-out |
| Positive control: the new assertions go red against pre-fix `fleet-state-scout` / `fleet-claim` | `fleet-positive-control <suite> origin/master` | **MEANINGFUL: 6 of 72** (projection) and **MEANINGFUL: 4 of 16** (claim gate) fail against `5a1fdc9ec`. #2713 pre-fix assertion: `worker_feedback_labels`, `WORKER_SKIP_PREFIXES`, `check_no_foreign_review_claim` all grep **0** on `origin/master` |

### Live-state delta (the issue's own forensic shape, re-run on this branch)

Patched vs `origin/master` scout over the real `~/.fleet/state/state.json`, engine PR #2758:

| PR #2758 label set | master proj/slice | patched proj/slice |
|---|---|---|
| LIVE (as-is) | emitted/present | emitted/present |
| + `fleet:reviewing-mac-pool-5` | emitted/present | **SUPPRESSED/ABSENT** |
| + `fleet:needs-opus-recheck` | emitted/present | **SUPPRESSED/ABSENT** |
| + `human:needs-fix` + `reviewing-*` | emitted/present | emitted/present |

Row 1 is the no-collateral check: on the unmodified live snapshot the patch suppresses nothing. Row 4 is the human-tier carve-out holding on real data.

## Notes for reviewer
- **The hazard is live, not historical.** PR #2850's label timeline shows `fleet:reviewing-mac-pool-4`, `-pool-3` (×3) and `-pool-5` all landing between 04:01:32Z and 04:02:25Z today, and a `fleet:amending-mac-pool-3` at 02:24:34Z. `fleet:has-nits` / `fleet:needs-fix` are in **both** `OPUS_REVIEWER_FLAG_LABELS` and the worker's step-1 tier list by design, so both lanes wake on the same labels — this is the default state of every flagged PR.
- **`test_fleet_claim_host_gate.sh` moved onto `lib_assert.sh`.** Its hand-rolled `PASS:`/`FAIL:` tally is not a form `fleet-positive-control` can parse, so before the migration the new arms had no scoreable control (the tool ran them — 12 passed / 4 failed — then reported "the suite printed no tally"). The suite now ends in `summarize`, per `scripts/fleet/CLAUDE.md`'s "Bash tests source `tests/lib_assert.sh`" rule; the local `assert_exit` stays local, rebuilt on `ok`/`bad` as that rule prescribes.
- **`.claude/commands/role-worker.md` is deliberately untouched.** Plan rev-2 §6 corrected rev-1's claim that step 1 defers to this doc for its skip list — it does not, it carries an inline copy, which now trails by two entries. That file is gated self-config no worker class can push, so it is filed as **#2996** (no labels, human applies) rather than edited here. All three enforcement layers (projection, slice, claim guard) hold without it.
- **Scope note:** `project_opus_reviewer` still emits a PR under another agent's live `fleet:reviewing-*` (it calls `_review_skipped`, which only knows `fleet:amending-`). That is a separate lane with its own `review-claim` mutex and its own policy question — measured and scoped out in plan rev-2 §7, noted here so it reads as looked-at rather than missed.

Closes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
